### PR TITLE
fix(ci): use skevetter forks for unmigrated GitHub Actions

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: devsy-org/pr-size-labeler@v1
+      - uses: skevetter/pr-size-labeler@v1
         with:
           xs_label: "size/xs"
           xs_max_size: "10"

--- a/.github/workflows/workflow-approval.yml
+++ b/.github/workflows/workflow-approval.yml
@@ -16,7 +16,7 @@ jobs:
           app-id: ${{ secrets.DEVSY_GITHUB_APP_ID }}
           private-key: ${{ secrets.DEVSY_GITHUB_APP_PRIVATE_KEY }}
 
-      - uses: devsy-org/automatic-approve-action@v2
+      - uses: skevetter/automatic-approve-action@v2
         with:
           token: ${{ steps.app-token.outputs.token }}
           workflows: "commit.yml,lint.yml,pr-ci.yml,pre-commit.yml"


### PR DESCRIPTION
## Summary
- Update `pr-size-labeler` action from `devsy-org` → `skevetter` (not yet migrated)
- Update `automatic-approve-action` from `devsy-org` → `skevetter` (not yet migrated)