### PR TITLE
test(e2e): use x-access-token for GitHub App token credentials

### DIFF
--- a/.github/workflows/act.yml
+++ b/.github/workflows/act.yml
@@ -48,9 +48,11 @@ jobs:
         env:
           GH_USERNAME: ${{ github.repository_owner }}
           GH_ACCESS_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          GH_CREDENTIAL_USERNAME: x-access-token
         run: |
           GH_USERNAME="${GH_USERNAME}" \
             GH_ACCESS_TOKEN="${GH_ACCESS_TOKEN}" \
+            GH_CREDENTIAL_USERNAME="${GH_CREDENTIAL_USERNAME}" \
             KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
             PATH="${PATH}" \
             GOROOT="${GOROOT}" \

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -374,11 +374,13 @@ jobs:
           # NOTE: GitHub credentials are required for tests using private repos
           GH_USERNAME: ${{ github.repository_owner }}
           GH_ACCESS_TOKEN: ${{ steps.app-token.outputs.token || github.token }}
+          GH_CREDENTIAL_USERNAME: x-access-token
         run: |
           if [ "${{ runner.os }}" == "Linux" ]; then
             sudo \
               GH_USERNAME="${GH_USERNAME}" \
               GH_ACCESS_TOKEN="${GH_ACCESS_TOKEN}" \
+              GH_CREDENTIAL_USERNAME="${GH_CREDENTIAL_USERNAME}" \
               KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
               PATH="${PATH}" \
               GOROOT="${GOROOT}" \
@@ -386,6 +388,7 @@ jobs:
           else
             GH_USERNAME="${GH_USERNAME}" \
               GH_ACCESS_TOKEN="${GH_ACCESS_TOKEN}" \
+              GH_CREDENTIAL_USERNAME="${GH_CREDENTIAL_USERNAME}" \
               KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
               PATH="${PATH}" \
               GOROOT="${GOROOT}" \

--- a/e2e/tests/up/up_private_token.go
+++ b/e2e/tests/up/up_private_token.go
@@ -29,6 +29,12 @@ var _ = ginkgo.Describe(
 				ginkgo.Skip("GH_USERNAME and GH_ACCESS_TOKEN must be set")
 			}
 
+			// GitHub App tokens require "x-access-token" as the credential username
+			credUser := os.Getenv("GH_CREDENTIAL_USERNAME")
+			if credUser == "" {
+				credUser = username
+			}
+
 			f, err := setupDockerProvider(initialDir+"/bin", "docker")
 			framework.ExpectNoError(err)
 
@@ -41,7 +47,7 @@ var _ = ginkgo.Describe(
 				Run()
 			framework.ExpectNoError(err)
 
-			gitCredentialString := []byte("https://" + username + ":" + token + "@github.com")
+			gitCredentialString := []byte("https://" + credUser + ":" + token + "@github.com")
 			err = os.WriteFile(credentialPath, gitCredentialString, 0o600)
 			framework.ExpectNoError(err)
 


### PR DESCRIPTION
## Summary
- Fix `up-private-token` test failing with "repository not found" when using GitHub App tokens
- GitHub App tokens require `x-access-token` as the git credential username, not the org name
- Add `GH_CREDENTIAL_USERNAME` env var to workflows and test