### PR TITLE
fix: add contents write permission to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   build-cli:
     name: Build CLI Binary on ${{ matrix.runner }}


### PR DESCRIPTION
## Summary
- Add `permissions: contents: write` to the release workflow so the flatpak job can upload assets to the GitHub release
- The build-flatpak job was failing with "Resource not accessible by integration" when running `softprops/action-gh-release`