### PR TITLE
fix(e2e): use automatic UID/GID to avoid GID conflict in build test

### DIFF
--- a/.github/workflows/act.yml
+++ b/.github/workflows/act.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           app-id: ${{ secrets.DEVSY_GITHUB_APP_ID }}
           private-key: ${{ secrets.DEVSY_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: run tests
         env:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -365,6 +365,7 @@ jobs:
         with:
           app-id: ${{ secrets.DEVSY_GITHUB_APP_ID }}
           private-key: ${{ secrets.DEVSY_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
 
       - name: run test
         if: matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true'

--- a/e2e/tests/build/testdata/docker-compose-features-context/.devcontainer/devcontainer.json
+++ b/e2e/tests/build/testdata/docker-compose-features-context/.devcontainer/devcontainer.json
@@ -11,8 +11,8 @@
       "installOhMyZsh": false,
       "installOhMyZshConfig": false,
       "username": "example",
-      "userUid": 1000,
-      "userGid": 1000
+      "userUid": "automatic",
+      "userGid": "automatic"
     }
   },
   "containerEnv": {

--- a/e2e/tests/up-docker-compose/testdata/docker-compose-env-file/.env
+++ b/e2e/tests/up-docker-compose/testdata/docker-compose-env-file/.env
@@ -1,1 +1,1 @@
-TAG=0-1.19-bullseye
+TAG=1

--- a/e2e/tests/up-docker-compose/testdata/docker-compose-features/.devcontainer.json
+++ b/e2e/tests/up-docker-compose/testdata/docker-compose-features/.devcontainer.json
@@ -4,7 +4,7 @@
   "service": "app",
   "workspaceFolder": "/workspaces",
   "features": {
-    "ghcr.io/loft-sh/devcontainer-features/vcluster:1.0.1": {
+    "ghcr.io/devsy-org/devcontainer-features/vcluster:1.0.1": {
       "version": "v0.24.1"
     }
   }

--- a/e2e/tests/up-docker-compose/testdata/docker-compose-features/.devcontainer.json
+++ b/e2e/tests/up-docker-compose/testdata/docker-compose-features/.devcontainer.json
@@ -4,7 +4,7 @@
   "service": "app",
   "workspaceFolder": "/workspaces",
   "features": {
-    "ghcr.io/devsy-org/devcontainer-features/vcluster:1.0.1": {
+    "ghcr.io/loft-sh/devcontainer-features/vcluster:1.0.1": {
       "version": "v0.24.1"
     }
   }

--- a/e2e/tests/up-features/testdata/docker-features-with-user-variable-in-dockerfile/Dockerfile
+++ b/e2e/tests/up-features/testdata/docker-features-with-user-variable-in-dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/devsy-org/test-images/base:ubuntu
+FROM docker.io/library/ubuntu:latest
 
 ARG USERNAME=ubuntu
 RUN useradd -m ${USERNAME}

--- a/e2e/tests/up-features/testdata/docker-features-with-user-variable-in-dockerfile/Dockerfile
+++ b/e2e/tests/up-features/testdata/docker-features-with-user-variable-in-dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/devsy-org/test-images/base:ubuntu
+FROM ghcr.io/devsy-org/test-images/ubuntu:latest
 
 ARG USERNAME=ubuntu
 RUN useradd -m ${USERNAME}

--- a/e2e/tests/up-features/testdata/docker-features-with-user-variable-in-dockerfile/Dockerfile
+++ b/e2e/tests/up-features/testdata/docker-features-with-user-variable-in-dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/devsy-org/test-images/ubuntu:latest
+FROM ghcr.io/devsy-org/test-images/base:ubuntu
 
 ARG USERNAME=ubuntu
 RUN useradd -m ${USERNAME}

--- a/e2e/tests/up-features/testdata/docker-features-with-user-variable-in-dockerfile/Dockerfile
+++ b/e2e/tests/up-features/testdata/docker-features-with-user-variable-in-dockerfile/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/ubuntu:latest
+FROM ghcr.io/devsy-org/test-images/ubuntu:latest
 
 ARG USERNAME=ubuntu
 RUN useradd -m ${USERNAME}

--- a/e2e/tests/up-features/testdata/docker-features-with-user-variable/Dockerfile
+++ b/e2e/tests/up-features/testdata/docker-features-with-user-variable/Dockerfile
@@ -1,4 +1,3 @@
-FROM ghcr.io/devsy-org/test-images/base:ubuntu
+FROM docker.io/library/ubuntu:latest
 
-RUN useradd -m ubuntu
 USER ${USERNAME:-ubuntu}

--- a/e2e/tests/up-features/testdata/docker-features-with-user-variable/Dockerfile
+++ b/e2e/tests/up-features/testdata/docker-features-with-user-variable/Dockerfile
@@ -1,3 +1,4 @@
-FROM ghcr.io/devsy-org/test-images/ubuntu:latest
+FROM ghcr.io/devsy-org/test-images/base:ubuntu
 
+RUN useradd -m ubuntu
 USER ${USERNAME:-ubuntu}

--- a/e2e/tests/up-features/testdata/docker-features-with-user-variable/Dockerfile
+++ b/e2e/tests/up-features/testdata/docker-features-with-user-variable/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/library/ubuntu:latest
+FROM ghcr.io/devsy-org/test-images/ubuntu:latest
 
 USER ${USERNAME:-ubuntu}

--- a/e2e/tests/up-features/testdata/docker-features-with-user-variable/Dockerfile
+++ b/e2e/tests/up-features/testdata/docker-features-with-user-variable/Dockerfile
@@ -1,3 +1,3 @@
-FROM ghcr.io/devsy-org/test-images/base:ubuntu
+FROM ghcr.io/devsy-org/test-images/ubuntu:latest
 
 USER ${USERNAME:-ubuntu}


### PR DESCRIPTION
## Summary
- The `common-utils` devcontainer feature fails with `groupadd: GID '1000' already exists` because the base image (`ghcr.io/devsy-org/test-images/python`) already has a `vscode` group at GID 1000
- Changed `userUid`/`userGid` from hardcoded `1000` to `"automatic"` so the feature picks non-conflicting IDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dev container configuration to use automatic user ID assignment.
  * Updated CI/CD workflows with repository owner configuration.
  * Updated test fixtures and build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->