### PR TITLE
feat: add zap-based pkg/log and CLI verbosity flags

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -58,11 +58,12 @@ func AgentPersistentPreRunE(
 		log.Default.MakeRaw()
 	}
 
-	if globalFlags.Quiet {
+	switch {
+	case globalFlags.Quiet:
 		log.Default.SetLevel(logrus.FatalLevel)
-	} else if globalFlags.Debug {
+	case globalFlags.Debug:
 		log.Default.SetLevel(logrus.DebugLevel)
-	} else if os.Getenv(config.EnvDebug) == config.BoolTrue {
+	case os.Getenv(config.EnvDebug) == config.BoolTrue:
 		log.Default.SetLevel(logrus.DebugLevel)
 	}
 

--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -58,7 +58,7 @@ func AgentPersistentPreRunE(
 		log.Default.MakeRaw()
 	}
 
-	if globalFlags.Silent {
+	if globalFlags.Quiet {
 		log.Default.SetLevel(logrus.FatalLevel)
 	} else if globalFlags.Debug {
 		log.Default.SetLevel(logrus.DebugLevel)

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -15,8 +15,9 @@ type GlobalFlags struct {
 	Owner     platform.OwnerFilter
 
 	LogOutput string
+	Verbosity int
+	Quiet     bool
 	Debug     bool
-	Silent    bool
 }
 
 // SetGlobalFlags applies the global flags.
@@ -32,8 +33,8 @@ func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 	flags.StringVar(
 		&globalFlags.LogOutput,
 		"log-output",
-		"plain",
-		"The log format to use. Can be either plain, raw or json",
+		"text",
+		"The log format to use. Can be text, json, or logfmt",
 	)
 	flags.StringVar(&globalFlags.Context, "context", "", "The context to use")
 	flags.StringVar(
@@ -42,13 +43,20 @@ func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 		"",
 		"The provider to use. Needs to be configured for the selected context",
 	)
-	flags.BoolVar(&globalFlags.Debug, "debug", false, "Prints the stack trace if an error occurs")
-	flags.BoolVar(
-		&globalFlags.Silent,
-		"silent",
-		false,
-		"Run in silent mode and prevents any devsy log output except panics & fatals",
+	flags.CountVarP(
+		&globalFlags.Verbosity,
+		"verbose",
+		"v",
+		"Increase log verbosity (-v=info, -vv=debug, -vvv=trace)",
 	)
+	flags.BoolVarP(
+		&globalFlags.Quiet,
+		"quiet",
+		"q",
+		false,
+		"Suppress all log output except fatal errors",
+	)
+	flags.BoolVar(&globalFlags.Debug, "debug", false, "Enable debug logging (equivalent to -vv)")
 
 	flags.Var(&globalFlags.Owner, "owner", "Show pro workspaces for owner")
 	_ = flags.MarkHidden("owner")

--- a/cmd/pro/pro.go
+++ b/cmd/pro/pro.go
@@ -3,7 +3,6 @@ package pro
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/cmd/pro/add"
@@ -15,12 +14,11 @@ import (
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
 // NewProCmd returns a new command.
-func NewProCmd(flags *flags.GlobalFlags, streamLogger *log.StreamLogger) *cobra.Command {
+func NewProCmd(flags *flags.GlobalFlags) *cobra.Command {
 	globalFlags := &proflags.GlobalFlags{GlobalFlags: flags}
 	proCmd := &cobra.Command{
 		Use:           "pro",
@@ -30,20 +28,6 @@ func NewProCmd(flags *flags.GlobalFlags, streamLogger *log.StreamLogger) *cobra.
 		Args:          cobra.NoArgs,
 		PersistentPreRunE: func(c *cobra.Command, _ []string) error {
 			globalFlags = proflags.SetGlobalFlags(c.PersistentFlags())
-			if flags.Silent {
-				streamLogger.SetLevel(logrus.FatalLevel)
-			}
-			if flags.Debug {
-				streamLogger.SetLevel(logrus.DebugLevel)
-			}
-
-			if os.Getenv(config.EnvDebug) == config.BoolTrue {
-				log.Default.SetLevel(logrus.DebugLevel)
-			}
-			if flags.LogOutput == "json" {
-				log.Default.SetFormat(log.JSONFormat)
-			}
-
 			return nil
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -17,10 +16,8 @@ import (
 	"github.com/devsy-org/devsy/cmd/provider"
 	"github.com/devsy-org/devsy/cmd/use"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/telemetry"
-	log2 "github.com/devsy-org/log"
-	"github.com/devsy-org/log/terminal"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh"
@@ -36,24 +33,12 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cobraCmd *cobra.Command, args []string) error {
-			if globalFlags.LogOutput == "json" {
-				log2.Default.SetFormat(log2.JSONFormat)
-			} else if globalFlags.LogOutput == "raw" {
-				log2.Default.SetFormat(log2.RawFormat)
-			} else if globalFlags.LogOutput != "plain" {
-				return fmt.Errorf(
-					"unrecognized log format %s, needs to be either plain, raw or json",
-					globalFlags.LogOutput,
-				)
-			}
-
-			if globalFlags.Silent {
-				log2.Default.SetLevel(logrus.FatalLevel)
-			} else if globalFlags.Debug {
-				log2.Default.SetLevel(logrus.DebugLevel)
-			} else if os.Getenv(config.EnvDebug) == config.BoolTrue {
-				log2.Default.SetLevel(logrus.DebugLevel)
-			}
+			log.Init(log.Config{
+				Verbosity: globalFlags.Verbosity,
+				Quiet:     globalFlags.Quiet,
+				Debug:     globalFlags.Debug || os.Getenv(config.EnvDebug) == config.BoolTrue,
+				Format:    globalFlags.LogOutput,
+			})
 
 			if globalFlags.DevsyHome != "" {
 				_ = os.Setenv(config.EnvHome, globalFlags.DevsyHome)
@@ -98,19 +83,13 @@ func Execute() {
 		}
 
 		if globalFlags.Debug {
-			log2.Default.Fatalf("%+v", err)
+			log.Fatalf("%+v", err)
 		} else {
 			if rootCmd.Annotations == nil ||
 				rootCmd.Annotations[agent.AgentExecutedAnnotation] != config.BoolTrue {
-				if terminal.IsTerminalIn {
-					log2.Default.Error("Try using the --debug flag to see a more verbose output")
-				} else if os.Getenv(config.EnvUI) == config.BoolTrue {
-					log2.Default.Error(
-						"Try enabling Debug mode under Settings to see a more verbose output",
-					)
-				}
+				log.Error("Try using -v or --debug flag to see more verbose output")
 			}
-			log2.Default.Fatal(err)
+			log.Fatal(err)
 		}
 	}
 }
@@ -129,7 +108,7 @@ func BuildRoot() *cobra.Command {
 	rootCmd.AddCommand(ide.NewIDECmd(globalFlags))
 	rootCmd.AddCommand(machine.NewMachineCmd(globalFlags))
 	rootCmd.AddCommand(context.NewContextCmd(globalFlags))
-	rootCmd.AddCommand(pro.NewProCmd(globalFlags, log2.Default))
+	rootCmd.AddCommand(pro.NewProCmd(globalFlags))
 	rootCmd.AddCommand(NewUpCmd(globalFlags))
 	rootCmd.AddCommand(NewDeleteCmd(globalFlags))
 	rootCmd.AddCommand(NewSSHCmd(globalFlags))
@@ -179,7 +158,7 @@ func inheritFlagsFromEnvironment(flags *flag.FlagSet) {
 			// set the variable holding the flag's value to the default supplied by the environment
 			err := flag.Value.Set(value)
 			if err != nil {
-				log2.Default.Fatalf(
+				log.Fatalf(
 					"failed to set flag %s from the environment variable %s with value %s: %+v",
 					flag.Name,
 					environmentVariable,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,13 +99,13 @@ func Execute() {
 		}
 
 		if globalFlags.Debug {
-			log.Fatalf("%+v", err)
+			log2.Default.Fatalf("%+v", err)
 		} else {
 			if rootCmd.Annotations == nil ||
 				rootCmd.Annotations[agent.AgentExecutedAnnotation] != config.BoolTrue {
-				log.Error("Try using -v or --debug flag to see more verbose output")
+				log2.Default.Error("Try using -v or --debug flag to see more verbose output")
 			}
-			log.Fatal(err)
+			log2.Default.Fatal(err)
 		}
 	}
 }
@@ -174,7 +174,7 @@ func inheritFlagsFromEnvironment(flags *flag.FlagSet) {
 			// set the variable holding the flag's value to the default supplied by the environment
 			err := flag.Value.Set(value)
 			if err != nil {
-				log.Fatalf(
+				log2.Default.Fatalf(
 					"failed to set flag %s from the environment variable %s with value %s: %+v",
 					flag.Name,
 					environmentVariable,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/telemetry"
+	log2 "github.com/devsy-org/log"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh"
@@ -39,6 +41,20 @@ func NewRootCmd() *cobra.Command {
 				Debug:     globalFlags.Debug || os.Getenv(config.EnvDebug) == config.BoolTrue,
 				Format:    globalFlags.LogOutput,
 			})
+
+			// Configure the old logger too, until the migration is complete.
+			if globalFlags.LogOutput == "json" {
+				log2.Default.SetFormat(log2.JSONFormat)
+			} else if globalFlags.LogOutput == "raw" {
+				log2.Default.SetFormat(log2.RawFormat)
+			}
+
+			switch {
+			case globalFlags.Quiet:
+				log2.Default.SetLevel(logrus.FatalLevel)
+			case globalFlags.Debug || os.Getenv(config.EnvDebug) == config.BoolTrue:
+				log2.Default.SetLevel(logrus.DebugLevel)
+			}
 
 			if globalFlags.DevsyHome != "" {
 				_ = os.Setenv(config.EnvHome, globalFlags.DevsyHome)

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/docker/go-connections v0.6.0
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-logr/logr v1.4.3
+	github.com/go-logr/zapr v1.3.0
 	github.com/gofrs/flock v0.13.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-cmp v0.7.0
@@ -53,6 +54,7 @@ require (
 	github.com/tonistiigi/fsutil v0.0.0-20251211185533-a2aa163d723f
 	github.com/u-root/u-root v0.16.0
 	go.uber.org/atomic v1.11.0
+	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.50.0
 	golang.org/x/mod v0.35.0
 	golang.org/x/sync v0.20.0
@@ -276,7 +278,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect

--- a/pkg/log/levels.go
+++ b/pkg/log/levels.go
@@ -1,0 +1,29 @@
+package log
+
+import "go.uber.org/zap/zapcore"
+
+// Verbosity levels mapped from CLI flags.
+const (
+	LevelTrace = 3
+	LevelDebug = 2
+	LevelInfo  = 1
+	LevelWarn  = 1
+	LevelError = 0
+	LevelFatal = 0
+)
+
+// VerbosityToLevel converts a -v count (0-3) to a zapcore.Level.
+// 0 = error+fatal only, 1 = +warn+info, 2 = +debug, 3 = trace (mapped to zap Debug-1).
+func VerbosityToLevel(verbosity int) zapcore.Level {
+	switch {
+	case verbosity >= 3:
+		// Trace: use a custom level below Debug
+		return zapcore.DebugLevel - 1
+	case verbosity >= 2:
+		return zapcore.DebugLevel
+	case verbosity >= 1:
+		return zapcore.InfoLevel
+	default:
+		return zapcore.ErrorLevel
+	}
+}

--- a/pkg/log/logfmt.go
+++ b/pkg/log/logfmt.go
@@ -1,0 +1,121 @@
+package log
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+)
+
+var logfmtPool = buffer.NewPool()
+
+type logfmtEncoder struct {
+	buf    *buffer.Buffer
+	fields []zapcore.Field
+}
+
+func newLogfmtEncoder() zapcore.Encoder {
+	return &logfmtEncoder{buf: logfmtPool.Get()}
+}
+
+func (e *logfmtEncoder) Clone() zapcore.Encoder {
+	clone := &logfmtEncoder{buf: logfmtPool.Get(), fields: make([]zapcore.Field, len(e.fields))}
+	copy(clone.fields, e.fields)
+	return clone
+}
+
+func (e *logfmtEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+	buf := logfmtPool.Get()
+
+	// level
+	buf.AppendString("level=")
+	buf.AppendString(entry.Level.String())
+
+	// timestamp
+	buf.AppendString(" ts=")
+	buf.AppendString(entry.Time.Format(time.RFC3339))
+
+	// message
+	buf.AppendString(" msg=")
+	buf.AppendString(quoteLogfmt(entry.Message))
+
+	// caller
+	if entry.Caller.Defined {
+		buf.AppendString(" caller=")
+		buf.AppendString(entry.Caller.TrimmedPath())
+	}
+
+	// fields from With() + fields from this entry
+	allFields := append(e.fields, fields...)
+	enc := zapcore.NewMapObjectEncoder()
+	for _, f := range allFields {
+		f.AddTo(enc)
+	}
+	for k, v := range enc.Fields {
+		buf.AppendString(" ")
+		buf.AppendString(k)
+		buf.AppendString("=")
+		buf.AppendString(quoteLogfmt(fmt.Sprint(v)))
+	}
+
+	buf.AppendString("\n")
+	return buf, nil
+}
+
+func quoteLogfmt(s string) string {
+	if s == "" || strings.ContainsAny(s, " \t\n\"=") {
+		return fmt.Sprintf("%q", s)
+	}
+	return s
+}
+
+// Required interface methods — delegate to buffer for simple types.
+func (e *logfmtEncoder) AddArray(key string, arr zapcore.ArrayMarshaler) error   { return nil }
+func (e *logfmtEncoder) AddObject(key string, obj zapcore.ObjectMarshaler) error { return nil }
+func (e *logfmtEncoder) AddBinary(key string, val []byte)                        {}
+func (e *logfmtEncoder) AddByteString(key string, val []byte)                    {}
+func (e *logfmtEncoder) AddBool(key string, val bool) {
+	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.BoolType, Integer: boolToInt(val)})
+}
+func (e *logfmtEncoder) AddComplex128(key string, val complex128) {}
+func (e *logfmtEncoder) AddComplex64(key string, val complex64)   {}
+func (e *logfmtEncoder) AddDuration(key string, val time.Duration) {
+	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.StringType, String: val.String()})
+}
+func (e *logfmtEncoder) AddFloat64(key string, val float64) {
+	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.Float64Type})
+}
+func (e *logfmtEncoder) AddFloat32(key string, val float32) {}
+func (e *logfmtEncoder) AddInt(key string, val int)         { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddInt64(key string, val int64) {
+	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.Int64Type, Integer: val})
+}
+func (e *logfmtEncoder) AddInt32(key string, val int32)   { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddInt16(key string, val int16)   { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddInt8(key string, val int8)     { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddString(key, val string) {
+	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.StringType, String: val})
+}
+func (e *logfmtEncoder) AddTime(key string, val time.Time) {
+	e.AddString(key, val.Format(time.RFC3339))
+}
+func (e *logfmtEncoder) AddUint(key string, val uint)     { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddUint64(key string, val uint64) { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddUint32(key string, val uint32) { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddUint16(key string, val uint16) { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddUint8(key string, val uint8)   { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddUintptr(key string, val uintptr) {}
+func (e *logfmtEncoder) AddReflected(key string, val interface{}) error {
+	e.AddString(key, fmt.Sprint(val))
+	return nil
+}
+func (e *logfmtEncoder) OpenNamespace(key string) {}
+
+func boolToInt(b bool) int64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/pkg/log/logfmt.go
+++ b/pkg/log/logfmt.go
@@ -2,6 +2,8 @@ package log
 
 import (
 	"fmt"
+	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -48,16 +50,24 @@ func (e *logfmtEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Field)
 	}
 
 	// fields from With() + fields from this entry
-	allFields := append(e.fields, fields...)
+	allFields := make([]zapcore.Field, 0, len(e.fields)+len(fields))
+	allFields = append(allFields, e.fields...)
+	allFields = append(allFields, fields...)
 	enc := zapcore.NewMapObjectEncoder()
 	for _, f := range allFields {
 		f.AddTo(enc)
 	}
-	for k, v := range enc.Fields {
+	// Sort keys for deterministic output
+	keys := make([]string, 0, len(enc.Fields))
+	for k := range enc.Fields {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
 		buf.AppendString(" ")
 		buf.AppendString(k)
 		buf.AppendString("=")
-		buf.AppendString(quoteLogfmt(fmt.Sprint(v)))
+		buf.AppendString(quoteLogfmt(fmt.Sprint(enc.Fields[k])))
 	}
 
 	buf.AppendString("\n")
@@ -85,7 +95,7 @@ func (e *logfmtEncoder) AddDuration(key string, val time.Duration) {
 	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.StringType, String: val.String()})
 }
 func (e *logfmtEncoder) AddFloat64(key string, val float64) {
-	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.Float64Type})
+	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.Float64Type, Integer: int64(math.Float64bits(val))})
 }
 func (e *logfmtEncoder) AddFloat32(key string, val float32) {}
 func (e *logfmtEncoder) AddInt(key string, val int)         { e.AddInt64(key, int64(val)) }
@@ -101,8 +111,8 @@ func (e *logfmtEncoder) AddString(key, val string) {
 func (e *logfmtEncoder) AddTime(key string, val time.Time) {
 	e.AddString(key, val.Format(time.RFC3339))
 }
-func (e *logfmtEncoder) AddUint(key string, val uint)     { e.AddInt64(key, int64(val)) }
-func (e *logfmtEncoder) AddUint64(key string, val uint64) { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddUint(key string, val uint)   { e.AddString(key, fmt.Sprintf("%d", val)) }
+func (e *logfmtEncoder) AddUint64(key string, val uint64) { e.AddString(key, fmt.Sprintf("%d", val)) }
 func (e *logfmtEncoder) AddUint32(key string, val uint32) { e.AddInt64(key, int64(val)) }
 func (e *logfmtEncoder) AddUint16(key string, val uint16) { e.AddInt64(key, int64(val)) }
 func (e *logfmtEncoder) AddUint8(key string, val uint8)   { e.AddInt64(key, int64(val)) }

--- a/pkg/log/logfmt.go
+++ b/pkg/log/logfmt.go
@@ -2,11 +2,11 @@ package log
 
 import (
 	"fmt"
-	"math"
 	"sort"
 	"strings"
 	"time"
 
+	"go.uber.org/zap"
 	"go.uber.org/zap/buffer"
 	"go.uber.org/zap/zapcore"
 )
@@ -23,46 +23,50 @@ func newLogfmtEncoder() zapcore.Encoder {
 }
 
 func (e *logfmtEncoder) Clone() zapcore.Encoder {
-	clone := &logfmtEncoder{buf: logfmtPool.Get(), fields: make([]zapcore.Field, len(e.fields))}
+	clone := &logfmtEncoder{
+		buf:    logfmtPool.Get(),
+		fields: make([]zapcore.Field, len(e.fields)),
+	}
 	copy(clone.fields, e.fields)
 	return clone
 }
 
-func (e *logfmtEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+func (e *logfmtEncoder) EncodeEntry(
+	entry zapcore.Entry,
+	fields []zapcore.Field,
+) (*buffer.Buffer, error) {
 	buf := logfmtPool.Get()
 
-	// level
 	buf.AppendString("level=")
 	buf.AppendString(entry.Level.String())
 
-	// timestamp
 	buf.AppendString(" ts=")
 	buf.AppendString(entry.Time.Format(time.RFC3339))
 
-	// message
 	buf.AppendString(" msg=")
 	buf.AppendString(quoteLogfmt(entry.Message))
 
-	// caller
 	if entry.Caller.Defined {
 		buf.AppendString(" caller=")
 		buf.AppendString(entry.Caller.TrimmedPath())
 	}
 
-	// fields from With() + fields from this entry
+	// Merge With() fields and entry fields into a fresh slice.
 	allFields := make([]zapcore.Field, 0, len(e.fields)+len(fields))
 	allFields = append(allFields, e.fields...)
 	allFields = append(allFields, fields...)
+
 	enc := zapcore.NewMapObjectEncoder()
 	for _, f := range allFields {
 		f.AddTo(enc)
 	}
-	// Sort keys for deterministic output
+
 	keys := make([]string, 0, len(enc.Fields))
 	for k := range enc.Fields {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
+
 	for _, k := range keys {
 		buf.AppendString(" ")
 		buf.AppendString(k)
@@ -86,41 +90,68 @@ func (e *logfmtEncoder) AddArray(key string, arr zapcore.ArrayMarshaler) error  
 func (e *logfmtEncoder) AddObject(key string, obj zapcore.ObjectMarshaler) error { return nil }
 func (e *logfmtEncoder) AddBinary(key string, val []byte)                        {}
 func (e *logfmtEncoder) AddByteString(key string, val []byte)                    {}
+
 func (e *logfmtEncoder) AddBool(key string, val bool) {
-	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.BoolType, Integer: boolToInt(val)})
+	e.fields = append(e.fields, zapcore.Field{
+		Key: key, Type: zapcore.BoolType, Integer: boolToInt(val),
+	})
 }
+
 func (e *logfmtEncoder) AddComplex128(key string, val complex128) {}
 func (e *logfmtEncoder) AddComplex64(key string, val complex64)   {}
+
 func (e *logfmtEncoder) AddDuration(key string, val time.Duration) {
-	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.StringType, String: val.String()})
+	e.fields = append(e.fields, zapcore.Field{
+		Key: key, Type: zapcore.StringType, String: val.String(),
+	})
 }
+
 func (e *logfmtEncoder) AddFloat64(key string, val float64) {
-	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.Float64Type, Integer: int64(math.Float64bits(val))})
+	e.fields = append(e.fields, zap.Float64(key, val))
 }
+
 func (e *logfmtEncoder) AddFloat32(key string, val float32) {}
-func (e *logfmtEncoder) AddInt(key string, val int)         { e.AddInt64(key, int64(val)) }
+
+func (e *logfmtEncoder) AddInt(key string, val int) { e.AddInt64(key, int64(val)) }
+
 func (e *logfmtEncoder) AddInt64(key string, val int64) {
-	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.Int64Type, Integer: val})
+	e.fields = append(e.fields, zapcore.Field{
+		Key: key, Type: zapcore.Int64Type, Integer: val,
+	})
 }
-func (e *logfmtEncoder) AddInt32(key string, val int32)   { e.AddInt64(key, int64(val)) }
-func (e *logfmtEncoder) AddInt16(key string, val int16)   { e.AddInt64(key, int64(val)) }
-func (e *logfmtEncoder) AddInt8(key string, val int8)     { e.AddInt64(key, int64(val)) }
+
+func (e *logfmtEncoder) AddInt32(key string, val int32) { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddInt16(key string, val int16) { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddInt8(key string, val int8)   { e.AddInt64(key, int64(val)) }
+
 func (e *logfmtEncoder) AddString(key, val string) {
-	e.fields = append(e.fields, zapcore.Field{Key: key, Type: zapcore.StringType, String: val})
+	e.fields = append(e.fields, zapcore.Field{
+		Key: key, Type: zapcore.StringType, String: val,
+	})
 }
+
 func (e *logfmtEncoder) AddTime(key string, val time.Time) {
 	e.AddString(key, val.Format(time.RFC3339))
 }
-func (e *logfmtEncoder) AddUint(key string, val uint)   { e.AddString(key, fmt.Sprintf("%d", val)) }
-func (e *logfmtEncoder) AddUint64(key string, val uint64) { e.AddString(key, fmt.Sprintf("%d", val)) }
+
+func (e *logfmtEncoder) AddUint(key string, val uint) {
+	e.AddString(key, fmt.Sprintf("%d", val))
+}
+
+func (e *logfmtEncoder) AddUint64(key string, val uint64) {
+	e.AddString(key, fmt.Sprintf("%d", val))
+}
+
 func (e *logfmtEncoder) AddUint32(key string, val uint32) { e.AddInt64(key, int64(val)) }
 func (e *logfmtEncoder) AddUint16(key string, val uint16) { e.AddInt64(key, int64(val)) }
 func (e *logfmtEncoder) AddUint8(key string, val uint8)   { e.AddInt64(key, int64(val)) }
 func (e *logfmtEncoder) AddUintptr(key string, val uintptr) {}
-func (e *logfmtEncoder) AddReflected(key string, val interface{}) error {
+
+func (e *logfmtEncoder) AddReflected(key string, val any) error {
 	e.AddString(key, fmt.Sprint(val))
 	return nil
 }
+
 func (e *logfmtEncoder) OpenNamespace(key string) {}
 
 func boolToInt(b bool) int64 {

--- a/pkg/log/logfmt.go
+++ b/pkg/log/logfmt.go
@@ -142,9 +142,9 @@ func (e *logfmtEncoder) AddUint64(key string, val uint64) {
 	e.AddString(key, fmt.Sprintf("%d", val))
 }
 
-func (e *logfmtEncoder) AddUint32(key string, val uint32) { e.AddInt64(key, int64(val)) }
-func (e *logfmtEncoder) AddUint16(key string, val uint16) { e.AddInt64(key, int64(val)) }
-func (e *logfmtEncoder) AddUint8(key string, val uint8)   { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddUint32(key string, val uint32)   { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddUint16(key string, val uint16)   { e.AddInt64(key, int64(val)) }
+func (e *logfmtEncoder) AddUint8(key string, val uint8)     { e.AddInt64(key, int64(val)) }
 func (e *logfmtEncoder) AddUintptr(key string, val uintptr) {}
 
 func (e *logfmtEncoder) AddReflected(key string, val any) error {

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -12,9 +12,9 @@ import (
 var sugar *zap.SugaredLogger
 
 func init() {
-	// Default logger before Init() is called — error level, text to stderr.
-	logger, _ := zap.NewProduction()
-	sugar = logger.Sugar()
+	// Default: silent until Init() is called. This avoids double-logging
+	// during the migration period when the old logger is still active.
+	sugar = zap.NewNop().Sugar()
 }
 
 // Config holds logger configuration parsed from CLI flags.
@@ -52,7 +52,7 @@ func resolveEncoder(format string) zapcore.Encoder {
 		return newLogfmtEncoder()
 	default:
 		// "text" — use console encoder, with color if stderr is a terminal
-		if term.IsTerminal(int(os.Stderr.Fd())) {
+		if term.IsTerminal(int(os.Stderr.Fd())) { //nolint:gosec // fd fits in int
 			return zapcore.NewConsoleEncoder(colorEncoderConfig())
 		}
 		return zapcore.NewConsoleEncoder(plainEncoderConfig())
@@ -104,7 +104,7 @@ func Warn(args ...any)  { sugar.Warn(args...) }
 func Error(args ...any) { sugar.Error(args...) }
 func Fatal(args ...any) { sugar.Fatal(args...) }
 
-// Structured logging
+// Structured logging.
 func Debugw(msg string, keysAndValues ...any) { sugar.Debugw(msg, keysAndValues...) }
 func Infow(msg string, keysAndValues ...any)  { sugar.Infow(msg, keysAndValues...) }
 func Warnw(msg string, keysAndValues ...any)  { sugar.Warnw(msg, keysAndValues...) }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -1,0 +1,106 @@
+package log
+
+import (
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"golang.org/x/term"
+)
+
+// sugar is the package-level sugared logger. All package functions delegate to it.
+var sugar *zap.SugaredLogger
+
+func init() {
+	// Default logger before Init() is called — error level, text to stderr.
+	logger, _ := zap.NewProduction()
+	sugar = logger.Sugar()
+}
+
+// Config holds logger configuration parsed from CLI flags.
+type Config struct {
+	Verbosity int    // 0=error, 1=info+warn, 2=debug, 3=trace
+	Quiet     bool   // fatal only
+	Debug     bool   // backwards compat, equivalent to Verbosity=2
+	Format    string // "text", "json", "logfmt"
+}
+
+// Init configures the global logger. Called once in root command PersistentPreRunE.
+func Init(cfg Config) {
+	level := resolveLevel(cfg)
+	encoder := resolveEncoder(cfg.Format)
+	core := zapcore.NewCore(encoder, zapcore.Lock(os.Stderr), level)
+	logger := zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.FatalLevel))
+	sugar = logger.Sugar()
+}
+
+func resolveLevel(cfg Config) zapcore.Level {
+	if cfg.Quiet {
+		return zapcore.FatalLevel
+	}
+	if cfg.Debug {
+		return zapcore.DebugLevel
+	}
+	return VerbosityToLevel(cfg.Verbosity)
+}
+
+func resolveEncoder(format string) zapcore.Encoder {
+	switch format {
+	case "json":
+		return zapcore.NewJSONEncoder(jsonEncoderConfig())
+	case "logfmt":
+		return newLogfmtEncoder()
+	default:
+		// "text" — use console encoder, with color if stderr is a terminal
+		if term.IsTerminal(int(os.Stderr.Fd())) {
+			return zapcore.NewConsoleEncoder(colorEncoderConfig())
+		}
+		return zapcore.NewConsoleEncoder(plainEncoderConfig())
+	}
+}
+
+func jsonEncoderConfig() zapcore.EncoderConfig {
+	cfg := zap.NewProductionEncoderConfig()
+	cfg.TimeKey = "ts"
+	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	return cfg
+}
+
+func colorEncoderConfig() zapcore.EncoderConfig {
+	cfg := zap.NewDevelopmentEncoderConfig()
+	cfg.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	return cfg
+}
+
+func plainEncoderConfig() zapcore.EncoderConfig {
+	cfg := zap.NewDevelopmentEncoderConfig()
+	cfg.EncodeLevel = zapcore.CapitalLevelEncoder
+	cfg.EncodeTime = zapcore.ISO8601TimeEncoder
+	return cfg
+}
+
+// Underlying returns the raw *zap.Logger for advanced use cases.
+func Underlying() *zap.Logger {
+	return sugar.Desugar()
+}
+
+// --- Package-level logging functions ---
+
+func Debugf(format string, args ...any) { sugar.Debugf(format, args...) }
+func Infof(format string, args ...any)  { sugar.Infof(format, args...) }
+func Warnf(format string, args ...any)  { sugar.Warnf(format, args...) }
+func Errorf(format string, args ...any) { sugar.Errorf(format, args...) }
+func Fatalf(format string, args ...any) { sugar.Fatalf(format, args...) }
+
+func Debug(args ...any) { sugar.Debug(args...) }
+func Info(args ...any)  { sugar.Info(args...) }
+func Warn(args ...any)  { sugar.Warn(args...) }
+func Error(args ...any) { sugar.Error(args...) }
+func Fatal(args ...any) { sugar.Fatal(args...) }
+
+// Structured logging
+func Debugw(msg string, keysAndValues ...any) { sugar.Debugw(msg, keysAndValues...) }
+func Infow(msg string, keysAndValues ...any)  { sugar.Infow(msg, keysAndValues...) }
+func Warnw(msg string, keysAndValues ...any)  { sugar.Warnw(msg, keysAndValues...) }
+func Errorw(msg string, keysAndValues ...any) { sugar.Errorw(msg, keysAndValues...) }

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -85,6 +85,11 @@ func Underlying() *zap.Logger {
 	return sugar.Desugar()
 }
 
+// Sync flushes any buffered log entries. Call before process exit.
+func Sync() error {
+	return sugar.Desugar().Sync()
+}
+
 // --- Package-level logging functions ---
 
 func Debugf(format string, args ...any) { sugar.Debugf(format, args...) }

--- a/pkg/log/logr.go
+++ b/pkg/log/logr.go
@@ -1,0 +1,11 @@
+package log
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+)
+
+// LogrSink returns a logr.LogSink for Kubernetes client-go compatibility.
+func LogrSink() logr.LogSink {
+	return zapr.NewLogger(Underlying()).GetSink()
+}

--- a/pkg/log/testing.go
+++ b/pkg/log/testing.go
@@ -1,0 +1,15 @@
+package log
+
+import (
+	"testing"
+
+	"go.uber.org/zap/zaptest"
+)
+
+// InitTest replaces the package-level logger with a test logger.
+// Log output is captured by t.Log() and only shown on test failure.
+func InitTest(t testing.TB) {
+	t.Helper()
+	logger := zaptest.NewLogger(t)
+	sugar = logger.Sugar()
+}

--- a/pkg/log/testing.go
+++ b/pkg/log/testing.go
@@ -10,6 +10,8 @@ import (
 // Log output is captured by t.Log() and only shown on test failure.
 func InitTest(t testing.TB) {
 	t.Helper()
+	prev := sugar
 	logger := zaptest.NewLogger(t)
 	sugar = logger.Sugar()
+	t.Cleanup(func() { sugar = prev })
 }

--- a/pkg/log/writer.go
+++ b/pkg/log/writer.go
@@ -1,0 +1,51 @@
+package log
+
+import (
+	"io"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// Writer returns an io.WriteCloser that writes each line as a log entry at the given level.
+// Level uses the package constants: LevelInfo, LevelDebug, etc.
+func Writer(level int) io.WriteCloser {
+	zapLevel := verbosityConstToZapLevel(level)
+	w, closer := zap.Open("stderr")
+	_ = closer // stderr doesn't need closing
+	return &levelWriter{
+		sink:  w,
+		level: zapLevel,
+		core:  sugar.Desugar().Core(),
+	}
+}
+
+func verbosityConstToZapLevel(level int) zapcore.Level {
+	switch level {
+	case LevelDebug:
+		return zapcore.DebugLevel
+	case LevelInfo, LevelWarn:
+		return zapcore.InfoLevel
+	case LevelError:
+		return zapcore.ErrorLevel
+	default:
+		return zapcore.InfoLevel
+	}
+}
+
+type levelWriter struct {
+	sink  zapcore.WriteSyncer
+	level zapcore.Level
+	core  zapcore.Core
+}
+
+func (w *levelWriter) Write(p []byte) (int, error) {
+	if !w.core.Enabled(w.level) {
+		return len(p), nil // discard if below current level
+	}
+	return w.sink.Write(p)
+}
+
+func (w *levelWriter) Close() error {
+	return nil
+}

--- a/pkg/log/writer.go
+++ b/pkg/log/writer.go
@@ -11,7 +11,7 @@ import (
 // Level uses the package constants: LevelInfo, LevelDebug, etc.
 func Writer(level int) io.WriteCloser {
 	zapLevel := verbosityConstToZapLevel(level)
-	w, closer := zap.Open("stderr")
+	w, closer, _ := zap.Open("stderr")
 	_ = closer // stderr doesn't need closing
 	return &levelWriter{
 		sink:  w,
@@ -24,7 +24,7 @@ func verbosityConstToZapLevel(level int) zapcore.Level {
 	switch level {
 	case LevelDebug:
 		return zapcore.DebugLevel
-	case LevelInfo, LevelWarn:
+	case LevelInfo: // LevelWarn has the same value
 		return zapcore.InfoLevel
 	case LevelError:
 		return zapcore.ErrorLevel


### PR DESCRIPTION
## Summary

- Create new `pkg/log` package wrapping `go.uber.org/zap` with package-level functions
- Add `-v`/`-vv`/`-vvv` verbosity flags and `-q`/`--quiet` flag
- Support three output formats: `text` (default, TTY color detection), `json`, `logfmt`
- Centralize logger initialization in `cmd/root.go` PersistentPreRunE
- Remove duplicate log init from `cmd/pro/pro.go`
- All log output goes to stderr (CLI best practice)
- Add `logr.LogSink` adapter for Kubernetes client-go compatibility
- Add `InitTest(t)` helper for test isolation via `zaptest`
- Add `Writer(level)` adapter for piping subprocess output through log levels

Part 1 of logging overhaul. See `docs/superpowers/specs/2026-04-20-logging-overhaul-design.md`.

**Note:** `cmd/agent/agent.go` has a known compile error (`globalFlags.Silent` removed) — will be fixed in PR 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Introduced `-v/--verbose` flag for incremental verbosity control (stackable: `-vv` for debug level).
* Added `-q/--quiet` flag to suppress all log output except fatal errors.
* Added support for "logfmt" log output format alongside existing JSON and text formats.

**Refactor**
* Replaced `--silent` flag with improved verbosity and quiet controls.
* Updated default log output format from "plain" to "text" with automatic colored output when appropriate.
* Modernized internal logging infrastructure for improved reliability and flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->