### PR TITLE
refactor(log): migrate cmd/agent/ to pkg/log

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -72,6 +72,6 @@ func AgentPersistentPreRunE(
 	}
 
 	// apply environment
-	envfile.Apply(log.Default.ErrorStreamOnly())
+	envfile.Apply()
 	return nil
 }

--- a/cmd/agent/container/credentials_server.go
+++ b/cmd/agent/container/credentials_server.go
@@ -16,9 +16,10 @@ import (
 	"github.com/devsy-org/devsy/pkg/dockercredentials"
 	"github.com/devsy-org/devsy/pkg/gitcredentials"
 	"github.com/devsy-org/devsy/pkg/gitsshsigning"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/netstat"
 	portpkg "github.com/devsy-org/devsy/pkg/port"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -84,13 +85,13 @@ func (cmd *CredentialsServerCmd) Run(ctx context.Context, port int) error {
 	}
 
 	// create debug logger
-	log := tunnelserver.NewTunnelLogger(ctx, tunnelClient, cmd.Debug)
+	logger := tunnelserver.NewTunnelLogger(ctx, tunnelClient, cmd.Debug)
 
 	// forward ports
 	if cmd.ForwardPorts {
 		go func() {
 			log.Debugf("Start watching & forwarding open ports")
-			err = forwardPorts(ctx, tunnelClient, log)
+			err = forwardPorts(ctx, tunnelClient, logger)
 			if err != nil {
 				log.Errorf("error forwarding ports: %v", err)
 			}
@@ -105,7 +106,7 @@ func (cmd *CredentialsServerCmd) Run(ctx context.Context, port int) error {
 
 	// configure docker credential helper
 	if cmd.ConfigureDockerHelper {
-		err = dockercredentials.ConfigureCredentialsContainer(cmd.User, port, log)
+		err = dockercredentials.ConfigureCredentialsContainer(cmd.User, port, logger)
 		if err != nil {
 			return err
 		}
@@ -135,7 +136,7 @@ func (cmd *CredentialsServerCmd) Run(ctx context.Context, port int) error {
 		}(cmd.User)
 	}
 
-	// configure git ssh signature helper — non-fatal so that a signing
+	// configure git ssh signature helper -- non-fatal so that a signing
 	// setup failure does not take down the entire credentials server
 	// (git/docker credential forwarding, port forwarding, etc.)
 	if cmd.GitUserSigningKey != "" {
@@ -143,7 +144,7 @@ func (cmd *CredentialsServerCmd) Run(ctx context.Context, port int) error {
 		if err != nil {
 			log.Errorf("Failed to decode git SSH signing key, signing will be unavailable: %v", err)
 		} else {
-			err = gitsshsigning.ConfigureHelper(cmd.User, string(decodedKey), log)
+			err = gitsshsigning.ConfigureHelper(cmd.User, string(decodedKey), logger)
 			if err != nil {
 				log.Errorf(
 					"Failed to configure git SSH signature helper, signing will be unavailable: %v",
@@ -157,7 +158,7 @@ func (cmd *CredentialsServerCmd) Run(ctx context.Context, port int) error {
 		}
 	}
 
-	return credentials.RunCredentialsServer(ctx, port, tunnelClient, log)
+	return credentials.RunCredentialsServer(ctx, port, tunnelClient, logger)
 }
 
 func configureGitUserLocally(
@@ -203,8 +204,8 @@ func configureGitUserLocally(
 	return nil
 }
 
-func forwardPorts(ctx context.Context, client tunnel.TunnelClient, log log.Logger) error {
-	return netstat.NewWatcher(&forwarder{ctx: ctx, client: client}, log).Run(ctx)
+func forwardPorts(ctx context.Context, client tunnel.TunnelClient, logger oldlog.Logger) error {
+	return netstat.NewWatcher(&forwarder{ctx: ctx, client: client}, logger).Run(ctx)
 }
 
 type forwarder struct {

--- a/cmd/agent/container/daemon.go
+++ b/cmd/agent/container/daemon.go
@@ -16,9 +16,10 @@ import (
 	"github.com/devsy-org/devsy/pkg/agent"
 	config2 "github.com/devsy-org/devsy/pkg/config"
 	agentd "github.com/devsy-org/devsy/pkg/daemon/agent"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/ts"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
@@ -31,14 +32,12 @@ const (
 
 type DaemonCmd struct {
 	Config *agentd.DaemonConfig
-	Log    log.Logger
 }
 
 // NewDaemonCmd creates the merged daemon command.
 func NewDaemonCmd() *cobra.Command {
 	cmd := &DaemonCmd{
 		Config: &agentd.DaemonConfig{},
-		Log:    log.NewStreamLogger(os.Stdout, os.Stderr, logrus.InfoLevel),
 	}
 	daemonCmd := &cobra.Command{
 		Use:   "daemon",
@@ -125,7 +124,7 @@ func (cmd *DaemonCmd) Run(c *cobra.Command, args []string) error {
 
 	err := g.Wait()
 	if err != nil {
-		cmd.Log.Errorf("daemon error: %v", err)
+		log.Errorf("daemon error: %v", err)
 		os.Exit(1)
 	}
 	os.Exit(0)
@@ -266,6 +265,6 @@ func runSshServer(ctx context.Context, cmd *DaemonCmd) error {
 }
 
 // initLogging initializes logging and returns a combined logger.
-func initLogging() log.Logger {
-	return log.NewStdoutLogger(nil, os.Stdout, os.Stderr, logrus.InfoLevel)
+func initLogging() oldlog.Logger {
+	return oldlog.NewStdoutLogger(nil, os.Stdout, os.Stderr, logrus.InfoLevel)
 }

--- a/cmd/agent/container/openvscode_async.go
+++ b/cmd/agent/container/openvscode_async.go
@@ -7,7 +7,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/compress"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/ide/openvscode"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +35,7 @@ func NewOpenVSCodeAsyncCmd() *cobra.Command {
 
 // Run runs the command logic.
 func (cmd *OpenVSCodeAsyncCmd) Run(_ *cobra.Command, _ []string) error {
-	log.Default.Debugf("Start setting up container...")
+	log.Debugf("Start setting up container...")
 	decompressed, err := compress.Decompress(cmd.SetupInfo)
 	if err != nil {
 		return err
@@ -47,7 +48,7 @@ func (cmd *OpenVSCodeAsyncCmd) Run(_ *cobra.Command, _ []string) error {
 	}
 
 	// install IDE
-	err = setupOpenVSCodeExtensions(setupInfo, log.Default)
+	err = setupOpenVSCodeExtensions(setupInfo, oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -55,9 +56,9 @@ func (cmd *OpenVSCodeAsyncCmd) Run(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func setupOpenVSCodeExtensions(setupInfo *config.Result, log log.Logger) error {
+func setupOpenVSCodeExtensions(setupInfo *config.Result, logger oldlog.Logger) error {
 	vsCodeConfiguration := config.GetVSCodeConfiguration(setupInfo.MergedConfig)
 	user := config.GetRemoteUser(setupInfo)
-	return openvscode.NewOpenVSCodeServer(vsCodeConfiguration.Extensions, "", user, "", "", nil, log).
+	return openvscode.NewOpenVSCodeServer(vsCodeConfiguration.Extensions, "", user, "", "", nil, logger).
 		InstallExtensions()
 }

--- a/cmd/agent/container/post_attach.go
+++ b/cmd/agent/container/post_attach.go
@@ -10,7 +10,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/compress"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/setup"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +41,7 @@ func NewPostAttachCmd(flags *flags.GlobalFlags) *cobra.Command {
 
 // Run runs the postAttachCommand lifecycle hooks.
 func (cmd *PostAttachCmd) Run(ctx context.Context) error {
-	logger := log.Default
+	logger := oldlog.Default
 
 	decompressed, err := compress.Decompress(cmd.SetupInfo)
 	if err != nil {
@@ -52,9 +53,9 @@ func (cmd *PostAttachCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	logger.Debugf("running postAttachCommand hooks")
+	log.Debugf("running postAttachCommand hooks")
 	if err := setup.RunPostAttachHooks(ctx, setupInfo, logger); err != nil {
-		logger.Errorf("postAttachCommand failed: %v", err)
+		log.Errorf("postAttachCommand failed: %v", err)
 	}
 
 	return nil

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -37,9 +37,10 @@ import (
 	"github.com/devsy-org/devsy/pkg/ide/openvscode"
 	"github.com/devsy-org/devsy/pkg/ide/rstudio"
 	"github.com/devsy-org/devsy/pkg/ide/vscode"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/ts"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -94,7 +95,7 @@ type setupContext struct {
 	workspaceInfo *provider2.ContainerWorkspaceInfo
 	setupInfo     *config.Result
 	tunnelClient  tunnel.TunnelClient
-	logger        log.Logger
+	logger        oldlog.Logger
 }
 
 // Run runs the command logic.
@@ -104,7 +105,7 @@ func (cmd *SetupContainerCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	workspaceInfo, setupInfo, err := cmd.parseWorkspaceAndSetupInfo(logger)
+	workspaceInfo, setupInfo, err := cmd.parseWorkspaceAndSetupInfo()
 	if err != nil {
 		return err
 	}
@@ -199,7 +200,7 @@ func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
 		return err
 	}
 
-	if err := cmd.startContainerDaemon(sctx.workspaceInfo, sctx.logger); err != nil {
+	if err := cmd.startContainerDaemon(sctx.workspaceInfo); err != nil {
 		return err
 	}
 
@@ -208,7 +209,7 @@ func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
 	// tunnel which kills this process, so postAttach must already be running
 	// independently.
 	if err := cmd.startPostAttachHooks(sctx); err != nil {
-		sctx.logger.Errorf("failed to start postAttachCommand: %v", err)
+		log.Errorf("failed to start postAttachCommand: %v", err)
 	}
 
 	return cmd.sendSetupResult(sctx.ctx, sctx.setupInfo, sctx.tunnelClient)
@@ -216,14 +217,14 @@ func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
 
 func (cmd *SetupContainerCmd) initializeTunnelClient(
 	ctx context.Context,
-) (tunnel.TunnelClient, log.Logger, error) {
+) (tunnel.TunnelClient, oldlog.Logger, error) {
 	tunnelClient, err := tunnelserver.NewTunnelClient(os.Stdin, os.Stdout, true, 0)
 	if err != nil {
 		return nil, nil, fmt.Errorf("initializing tunnel client: %w", err)
 	}
 
 	logger := tunnelserver.NewTunnelLogger(ctx, tunnelClient, cmd.Debug)
-	logger.Debugf("created logger")
+	log.Debugf("created logger")
 
 	if _, err := tunnelClient.Ping(ctx, &tunnel.Empty{}); err != nil {
 		return nil, nil, fmt.Errorf("ping client: %w", err)
@@ -232,10 +233,8 @@ func (cmd *SetupContainerCmd) initializeTunnelClient(
 	return tunnelClient, logger, nil
 }
 
-func (cmd *SetupContainerCmd) parseWorkspaceAndSetupInfo(
-	logger log.Logger,
-) (*provider2.ContainerWorkspaceInfo, *config.Result, error) {
-	logger.Debugf("begin setting up container")
+func (cmd *SetupContainerCmd) parseWorkspaceAndSetupInfo() (*provider2.ContainerWorkspaceInfo, *config.Result, error) {
+	log.Debugf("begin setting up container")
 	workspaceInfo, _, err := agent.DecodeContainerWorkspaceInfo(cmd.ContainerWorkspaceInfo)
 	if err != nil {
 		return nil, nil, err
@@ -260,12 +259,12 @@ func (cmd *SetupContainerCmd) syncMounts(sctx *setupContext) error {
 	}
 
 	mounts := config.GetMounts(sctx.setupInfo)
-	sctx.logger.Debugf("syncing mounts: %v", mounts)
+	log.Debugf("syncing mounts: %v", mounts)
 	for _, m := range mounts {
 		if !sctx.workspaceInfo.CLIOptions.Reset {
 			files, err := os.ReadDir(m.Target)
 			if err == nil && len(files) > 0 {
-				sctx.logger.Debugf("skip stream mount %s because it is not empty", m.Target)
+				log.Debugf("skip stream mount %s because it is not empty", m.Target)
 				continue
 			}
 		}
@@ -287,14 +286,14 @@ func (cmd *SetupContainerCmd) syncMounts(sctx *setupContext) error {
 func (cmd *SetupContainerCmd) setupGitCredentials(
 	ctx context.Context,
 	tunnelClient tunnel.TunnelClient,
-	logger log.Logger,
+	logger oldlog.Logger,
 ) func() {
 	if !cmd.InjectGitCredentials {
 		return nil
 	}
 
 	if !command.Exists("git") {
-		logger.Debugf("git not found, skipping git credentials configuration")
+		log.Debugf("git not found, skipping git credentials configuration")
 		return nil
 	}
 
@@ -302,7 +301,7 @@ func (cmd *SetupContainerCmd) setupGitCredentials(
 	cleanupFunc, err := configureSystemGitCredentials(cancelCtx, tunnelClient, logger)
 	if err != nil {
 		cancel()
-		logger.Errorf("error configuring git credentials: %v", err)
+		log.Errorf("error configuring git credentials: %v", err)
 		return nil
 	}
 
@@ -316,7 +315,7 @@ func (cmd *SetupContainerCmd) cloneRepositoryIfNeeded(
 	ctx context.Context,
 	workspaceInfo *provider2.ContainerWorkspaceInfo,
 	setupInfo *config.Result,
-	logger log.Logger,
+	logger oldlog.Logger,
 ) error {
 	b, err := workspaceInfo.PullFromInsideContainer.Bool()
 	if err != nil {
@@ -328,7 +327,7 @@ func (cmd *SetupContainerCmd) cloneRepositoryIfNeeded(
 
 	gitPath := filepath.Join(setupInfo.SubstitutionContext.ContainerWorkspaceFolder, ".git")
 	if _, err := os.Stat(gitPath); err == nil && !workspaceInfo.CLIOptions.Recreate {
-		logger.Debugf(
+		log.Debugf(
 			"workspace repository already checked out %s, skipping clone",
 			setupInfo.SubstitutionContext.ContainerWorkspaceFolder,
 		)
@@ -348,7 +347,6 @@ func (cmd *SetupContainerCmd) cloneRepositoryIfNeeded(
 
 func (cmd *SetupContainerCmd) startContainerDaemon(
 	workspaceInfo *provider2.ContainerWorkspaceInfo,
-	logger log.Logger,
 ) error {
 	if workspaceInfo.CLIOptions.Platform.Enabled ||
 		workspaceInfo.CLIOptions.DisableDaemon ||
@@ -357,7 +355,7 @@ func (cmd *SetupContainerCmd) startContainerDaemon(
 	}
 
 	return command.StartBackgroundOnce(config2.BinaryName+".daemon", func() (*exec.Cmd, error) {
-		logger.Debugf(
+		log.Debugf(
 			"start %s container daemon with inactivity timeout %s",
 			config2.BinaryName,
 			workspaceInfo.ContainerTimeout,
@@ -385,7 +383,7 @@ func (cmd *SetupContainerCmd) startPostAttachHooks(sctx *setupContext) error {
 	}
 
 	return command.StartBackgroundOnce("devsy.post-attach", func() (*exec.Cmd, error) {
-		sctx.logger.Debugf("starting postAttachCommand as background process")
+		log.Debugf("starting postAttachCommand as background process")
 		binaryPath, err := os.Executable()
 		if err != nil {
 			return nil, err
@@ -447,71 +445,71 @@ func fillContainerEnv(setupInfo *config.Result) error {
 func (cmd *SetupContainerCmd) installIDE(
 	setupInfo *config.Result,
 	ide *provider2.WorkspaceIDEConfig,
-	log log.Logger,
+	logger oldlog.Logger,
 ) error {
 	switch ide.Name {
 	case string(config2.IDENone):
 		return nil
 	case string(config2.IDEVSCode):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorStable, log)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorStable, logger)
 	case string(config2.IDEVSCodeInsiders):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorInsiders, log)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorInsiders, logger)
 	case string(config2.IDECursor):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorCursor, log)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorCursor, logger)
 	case string(config2.IDEPositron):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorPositron, log)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorPositron, logger)
 	case string(config2.IDECodium):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorCodium, log)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorCodium, logger)
 	case string(config2.IDEWindsurf):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorWindsurf, log)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorWindsurf, logger)
 	case string(config2.IDEAntigravity):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorAntigravity, log)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorAntigravity, logger)
 	case string(config2.IDEBob):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorBob, log)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorBob, logger)
 	case string(config2.IDEOpenVSCode):
-		return cmd.setupOpenVSCode(setupInfo, ide.Options, log)
+		return cmd.setupOpenVSCode(setupInfo, ide.Options, logger)
 	case string(config2.IDEGoland):
-		return jetbrains.NewGolandServer(config.GetRemoteUser(setupInfo), ide.Options, log).
+		return jetbrains.NewGolandServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install(setupInfo)
 	case string(config2.IDERustRover):
-		return jetbrains.NewRustRoverServer(config.GetRemoteUser(setupInfo), ide.Options, log).
+		return jetbrains.NewRustRoverServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install(setupInfo)
 	case string(config2.IDEPyCharm):
-		return jetbrains.NewPyCharmServer(config.GetRemoteUser(setupInfo), ide.Options, log).
+		return jetbrains.NewPyCharmServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install(setupInfo)
 	case string(config2.IDEPhpStorm):
-		return jetbrains.NewPhpStorm(config.GetRemoteUser(setupInfo), ide.Options, log).
+		return jetbrains.NewPhpStorm(config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install(setupInfo)
 	case string(config2.IDEIntellij):
-		return jetbrains.NewIntellij(config.GetRemoteUser(setupInfo), ide.Options, log).
+		return jetbrains.NewIntellij(config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install(setupInfo)
 	case string(config2.IDECLion):
-		return jetbrains.NewCLionServer(config.GetRemoteUser(setupInfo), ide.Options, log).
+		return jetbrains.NewCLionServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install(setupInfo)
 	case string(config2.IDERider):
-		return jetbrains.NewRiderServer(config.GetRemoteUser(setupInfo), ide.Options, log).
+		return jetbrains.NewRiderServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install(setupInfo)
 	case string(config2.IDERubyMine):
-		return jetbrains.NewRubyMineServer(config.GetRemoteUser(setupInfo), ide.Options, log).
+		return jetbrains.NewRubyMineServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install(setupInfo)
 	case string(config2.IDEWebStorm):
-		return jetbrains.NewWebStormServer(config.GetRemoteUser(setupInfo), ide.Options, log).
+		return jetbrains.NewWebStormServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install(setupInfo)
 	case string(config2.IDEDataSpell):
-		return jetbrains.NewDataSpellServer(config.GetRemoteUser(setupInfo), ide.Options, log).
+		return jetbrains.NewDataSpellServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install(setupInfo)
 	case string(config2.IDEFleet):
-		return fleet.NewFleetServer(config.GetRemoteUser(setupInfo), ide.Options, log).
+		return fleet.NewFleetServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install(setupInfo.SubstitutionContext.ContainerWorkspaceFolder)
 	case string(config2.IDEJupyterNotebook):
 		return jupyter.NewJupyterNotebookServer(
 			setupInfo.SubstitutionContext.ContainerWorkspaceFolder,
-			config.GetRemoteUser(setupInfo), ide.Options, log).
+			config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install()
 	case string(config2.IDERStudio):
 		return rstudio.NewRStudioServer(
 			setupInfo.SubstitutionContext.ContainerWorkspaceFolder,
-			config.GetRemoteUser(setupInfo), ide.Options, log).
+			config.GetRemoteUser(setupInfo), ide.Options, logger).
 			Install()
 	}
 
@@ -522,7 +520,7 @@ func (cmd *SetupContainerCmd) setupVSCode(
 	setupInfo *config.Result,
 	ideOptions map[string]config2.OptionValue,
 	flavor vscode.Flavor,
-	log log.Logger,
+	logger oldlog.Logger,
 ) error {
 	log.Debugf("setup %s", flavor.DisplayName())
 	vsCodeConfiguration := config.GetVSCodeConfiguration(setupInfo.MergedConfig)
@@ -544,7 +542,7 @@ func (cmd *SetupContainerCmd) setupVSCode(
 		UserName:   user,
 		Values:     ideOptions,
 		Flavor:     flavor,
-		Log:        log,
+		Log:        logger,
 	}).Install()
 	if err != nil {
 		return err
@@ -585,7 +583,7 @@ func (cmd *SetupContainerCmd) setupVSCode(
 func (cmd *SetupContainerCmd) setupOpenVSCode(
 	setupInfo *config.Result,
 	ideOptions map[string]config2.OptionValue,
-	log log.Logger,
+	logger oldlog.Logger,
 ) error {
 	log.Debugf("setup openvscode")
 	vsCodeConfiguration := config.GetVSCodeConfiguration(setupInfo.MergedConfig)
@@ -607,7 +605,7 @@ func (cmd *SetupContainerCmd) setupOpenVSCode(
 		"0.0.0.0",
 		strconv.Itoa(openvscode.DefaultVSCodePort),
 		ideOptions,
-		log,
+		logger,
 	)
 
 	// install open vscode
@@ -649,13 +647,13 @@ func (cmd *SetupContainerCmd) setupOpenVSCode(
 func configureSystemGitCredentials(
 	ctx context.Context,
 	client tunnel.TunnelClient,
-	log log.Logger,
+	logger oldlog.Logger,
 ) (func(), error) {
 	if !command.Exists("git") {
 		return nil, errors.New("git not found")
 	}
 
-	serverPort, err := credentials.StartCredentialsServer(ctx, client, log)
+	serverPort, err := credentials.StartCredentialsServer(ctx, client, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -692,7 +690,7 @@ func streamMount(
 	workspaceInfo *provider2.ContainerWorkspaceInfo,
 	m *config.Mount,
 	tunnelClient tunnel.TunnelClient,
-	logger log.Logger,
+	logger oldlog.Logger,
 ) error {
 	// if we have a platform workspace socket we connect directly to it
 	if workspaceInfo.CLIOptions.Platform.Enabled {
@@ -706,7 +704,7 @@ func streamMount(
 		}
 
 		// build the url
-		logger.Infof("Download %s into DevContainer %s", m.Source, m.Target)
+		log.Infof("Download %s into DevContainer %s", m.Source, m.Target)
 		url := fmt.Sprintf(
 			"https://%s/kubernetes/management/apis/management.devsy.sh/v1/namespaces/%s/devsyworkspaceinstances/%s/download?path=%s",
 			ts.RemoveProtocol(workspaceInfo.CLIOptions.Platform.PlatformHost),
@@ -743,7 +741,6 @@ func streamMount(
 		// create progress reader
 		progressReader := &progressReader{
 			Reader: resp.Body,
-			Log:    logger,
 		}
 
 		// target folder
@@ -756,7 +753,7 @@ func streamMount(
 	}
 
 	// stream mount
-	logger.Infof("Copy %s into DevContainer %s", m.Source, m.Target)
+	log.Infof("Copy %s into DevContainer %s", m.Source, m.Target)
 	stream, err := tunnelClient.StreamMount(ctx, &tunnel.StreamMountRequest{Mount: m.String()})
 	if err != nil {
 		return fmt.Errorf("init stream mount %s: %w", m.String(), err)
@@ -773,7 +770,6 @@ func streamMount(
 
 type progressReader struct {
 	Reader io.Reader
-	Log    log.Logger
 
 	lastMessage time.Time
 	bytesRead   int64
@@ -783,7 +779,7 @@ func (p *progressReader) Read(b []byte) (n int, err error) {
 	n, err = p.Reader.Read(b)
 	p.bytesRead += int64(n)
 	if time.Since(p.lastMessage) > time.Second*4 {
-		p.Log.Infof("downloaded %.2f MB", float64(p.bytesRead)/1024/1024)
+		log.Infof("downloaded %.2f MB", float64(p.bytesRead)/1024/1024)
 		p.lastMessage = time.Now()
 	}
 

--- a/cmd/agent/container/setup_loft_platform_access.go
+++ b/cmd/agent/container/setup_loft_platform_access.go
@@ -6,7 +6,8 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/credentials"
 	devsyconfig "github.com/devsy-org/devsy/pkg/loftconfig"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +50,7 @@ func NewSetupLoftPlatformAccessCmd(flags *flags.GlobalFlags) *cobra.Command {
 // Run executes main command logic.
 // It fetches Devsy Platform credentials from credentials server and sets it up inside the workspace.
 func (c *SetupLoftPlatformAccessCmd) Run(_ *cobra.Command, args []string) error {
-	logger := log.Default.ErrorStreamOnly()
+	logger := oldlog.Default.ErrorStreamOnly()
 
 	port, err := credentials.GetPort()
 	if err != nil {
@@ -66,20 +67,20 @@ func (c *SetupLoftPlatformAccessCmd) Run(_ *cobra.Command, args []string) error 
 	}
 
 	if loftConfig == nil {
-		logger.Debug("Got empty devsy config response, Devsy Platform access won't be set up.")
+		log.Debug("Got empty devsy config response, Devsy Platform access won't be set up.")
 		return nil
 	}
 
 	err = devsyconfig.AuthDevsyCliToPlatform(loftConfig, logger)
 	if err != nil {
 		// log error but don't return to allow other CLIs to install as well
-		logger.Warnf("unable to authenticate devsy cli: %w", err)
+		log.Warnf("unable to authenticate devsy cli: %v", err)
 	}
 
 	err = devsyconfig.AuthVClusterCliToPlatform(loftConfig, logger)
 	if err != nil {
 		// log error but don't return to allow other CLIs to install as well
-		logger.Warnf("unable to authenticate vcluster cli: %w", err)
+		log.Warnf("unable to authenticate vcluster cli: %v", err)
 	}
 
 	return nil

--- a/cmd/agent/container/ssh_server.go
+++ b/cmd/agent/container/ssh_server.go
@@ -8,9 +8,10 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	helperssh "github.com/devsy-org/devsy/pkg/ssh/server"
 	"github.com/devsy-org/devsy/pkg/ssh/server/port"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -62,19 +63,19 @@ func (cmd *SSHServerCmd) Run(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("address %s already in use: %w", cmd.Address, err)
 		}
 
-		log.Default.ErrorStreamOnly().Info("address %s already in use", cmd.Address)
+		log.Infof("address %s already in use", cmd.Address)
 		return nil
 	}
 
 	return server.ListenAndServe()
 }
 
-func getFileLogger(remoteUser string, debug bool) log.Logger {
+func getFileLogger(remoteUser string, debug bool) oldlog.Logger {
 	logLevel := logrus.InfoLevel
 	if debug {
 		logLevel = logrus.DebugLevel
 	}
-	fallback := log.NewDiscardLogger(logLevel)
+	fallback := oldlog.NewDiscardLogger(logLevel)
 
 	targetFolder := filepath.Join(os.TempDir(), config.ConfigDirName)
 	if remoteUser != "" {
@@ -85,5 +86,5 @@ func getFileLogger(remoteUser string, debug bool) log.Logger {
 		return fallback
 	}
 
-	return log.NewFileLogger(filepath.Join(targetFolder, "ssh.log"), logLevel)
+	return oldlog.NewFileLogger(filepath.Join(targetFolder, "ssh.log"), logLevel)
 }

--- a/cmd/agent/container/vscode_async.go
+++ b/cmd/agent/container/vscode_async.go
@@ -7,7 +7,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/compress"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/ide/vscode"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +49,7 @@ func (cmd *VSCodeAsyncCmd) Run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	err = setupVSCodeExtensions(setupInfo, vscode.Flavor(cmd.Flavor), log.Default)
+	err = setupVSCodeExtensions(setupInfo, vscode.Flavor(cmd.Flavor), oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -57,13 +57,17 @@ func (cmd *VSCodeAsyncCmd) Run(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func setupVSCodeExtensions(setupInfo *config.Result, flavor vscode.Flavor, log log.Logger) error {
+func setupVSCodeExtensions(
+	setupInfo *config.Result,
+	flavor vscode.Flavor,
+	logger oldlog.Logger,
+) error {
 	vsCodeConfiguration := config.GetVSCodeConfiguration(setupInfo.MergedConfig)
 	user := config.GetRemoteUser(setupInfo)
 	return vscode.NewVSCodeServer(vscode.ServerOptions{
 		Extensions: vsCodeConfiguration.Extensions,
 		UserName:   user,
 		Flavor:     flavor,
-		Log:        log,
+		Log:        logger,
 	}).InstallExtensions()
 }

--- a/cmd/agent/container_tunnel.go
+++ b/cmd/agent/container_tunnel.go
@@ -15,8 +15,9 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/encoding"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +39,7 @@ func NewContainerTunnelCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Short: "Starts a new container ssh tunnel",
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
-			return cmd.Run(cobraCmd.Context(), log.Default.ErrorStreamOnly())
+			return cmd.Run(cobraCmd.Context())
 		},
 	}
 
@@ -51,9 +52,11 @@ func NewContainerTunnelCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 // Run runs the command logic.
-func (cmd *ContainerTunnelCmd) Run(ctx context.Context, log log.Logger) error {
+func (cmd *ContainerTunnelCmd) Run(ctx context.Context) error {
+	logger := oldlog.Default.ErrorStreamOnly()
+
 	// write workspace info
-	shouldExit, workspaceInfo, err := agent.WriteWorkspaceInfo(cmd.WorkspaceInfo, log)
+	shouldExit, workspaceInfo, err := agent.WriteWorkspaceInfo(cmd.WorkspaceInfo, logger)
 	if err != nil {
 		return err
 	} else if shouldExit {
@@ -61,19 +64,19 @@ func (cmd *ContainerTunnelCmd) Run(ctx context.Context, log log.Logger) error {
 	}
 
 	// make sure content folder exists
-	_, err = workspace.InitContentFolder(workspaceInfo, log)
+	_, err = workspace.InitContentFolder(workspaceInfo, logger)
 	if err != nil {
 		return err
 	}
 
 	// create runner
-	runner, err := workspace.CreateRunner(workspaceInfo, log)
+	runner, err := workspace.CreateRunner(workspaceInfo, logger)
 	if err != nil {
 		return err
 	}
 
 	// wait until devcontainer is started
-	err = startDevContainer(ctx, workspaceInfo, runner, log)
+	err = startDevContainer(ctx, workspaceInfo, runner, logger)
 	if err != nil {
 		return err
 	}
@@ -96,7 +99,7 @@ func (cmd *ContainerTunnelCmd) Run(ctx context.Context, log log.Logger) error {
 		os.Stdin,
 		os.Stdout,
 		os.Stderr,
-		log,
+		logger,
 		workspaceInfo.InjectTimeout,
 	)
 	if err != nil {
@@ -110,7 +113,7 @@ func startDevContainer(
 	ctx context.Context,
 	workspaceConfig *provider2.AgentWorkspaceInfo,
 	runner devcontainer.Runner,
-	log log.Logger,
+	logger oldlog.Logger,
 ) error {
 	containerDetails, err := runner.Find(ctx)
 	if err != nil {
@@ -120,7 +123,7 @@ func startDevContainer(
 	// start container if necessary
 	if containerDetails == nil || containerDetails.State.Status != "running" {
 		// start container
-		_, err = StartContainer(ctx, runner, log, workspaceConfig)
+		_, err = StartContainer(ctx, runner, logger, workspaceConfig)
 		if err != nil {
 			return err
 		}
@@ -130,7 +133,7 @@ func startDevContainer(
 		err = runner.Command(ctx, "root", "cat "+pkgconfig.DevContainerResultPath, nil, buf, buf)
 		if err != nil {
 			// start container
-			_, err = StartContainer(ctx, runner, log, workspaceConfig)
+			_, err = StartContainer(ctx, runner, logger, workspaceConfig)
 			if err != nil {
 				return err
 			}
@@ -143,7 +146,7 @@ func startDevContainer(
 func StartContainer(
 	ctx context.Context,
 	runner devcontainer.Runner,
-	log log.Logger,
+	logger oldlog.Logger,
 	workspaceConfig *provider2.AgentWorkspaceInfo,
 ) (*config.Result, error) {
 	log.Debugf("starting Devsy container")

--- a/cmd/agent/daemon.go
+++ b/cmd/agent/daemon.go
@@ -12,9 +12,9 @@ import (
 	"github.com/devsy-org/devsy/pkg/agent"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/driver/custom"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -49,18 +49,17 @@ func (cmd *DaemonCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	logger := log.NewFileLogger(filepath.Join(logFolder, "agent-daemon.log"), logrus.InfoLevel)
-	logger.Infof("starting Devsy daemon patrol at %s", logFolder)
+	log.Infof("starting Devsy daemon patrol at %s", logFolder)
 
 	// start patrolling
-	cmd.patrol(ctx, logger)
+	cmd.patrol(ctx)
 
 	return nil
 }
 
-func (cmd *DaemonCmd) patrol(ctx context.Context, log log.Logger) {
+func (cmd *DaemonCmd) patrol(ctx context.Context) {
 	// make sure we don't immediately resleep on startup
-	cmd.initialTouch(log)
+	cmd.initialTouch()
 
 	// parse the daemon interval
 	interval := time.Second * 60
@@ -79,12 +78,12 @@ func (cmd *DaemonCmd) patrol(ctx context.Context, log log.Logger) {
 			timer.Stop()
 			return
 		case <-timer.C:
-			cmd.doOnce(ctx, log)
+			cmd.doOnce(ctx)
 		}
 	}
 }
 
-func (cmd *DaemonCmd) doOnce(ctx context.Context, log log.Logger) {
+func (cmd *DaemonCmd) doOnce(ctx context.Context) {
 	var latestActivity *time.Time
 	var workspace *provider2.AgentWorkspaceInfo
 
@@ -103,7 +102,7 @@ func (cmd *DaemonCmd) doOnce(ctx context.Context, log log.Logger) {
 	}
 
 	// check when the last touch was
-	latestActivity, workspace = findLatestActivity(matches, log)
+	latestActivity, workspace = findLatestActivity(matches)
 
 	// should we run shutdown command?
 	if latestActivity == nil {
@@ -120,14 +119,13 @@ func (cmd *DaemonCmd) doOnce(ctx context.Context, log log.Logger) {
 		return
 	}
 
-	cmd.checkAndShutdown(ctx, latestActivity, workspace, log)
+	cmd.checkAndShutdown(ctx, latestActivity, workspace)
 }
 
 func (cmd *DaemonCmd) checkAndShutdown(
 	ctx context.Context,
 	latestActivity *time.Time,
 	workspace *provider2.AgentWorkspaceInfo,
-	log log.Logger,
 ) {
 	// check timeout
 	timeout := agent.DefaultInactivityTimeout
@@ -150,16 +148,15 @@ func (cmd *DaemonCmd) checkAndShutdown(
 	}
 
 	// run shutdown command
-	cmd.runShutdownCommand(ctx, workspace, log)
+	cmd.runShutdownCommand(ctx, workspace)
 }
 
 func (cmd *DaemonCmd) runShutdownCommand(
 	ctx context.Context,
 	workspace *provider2.AgentWorkspaceInfo,
-	log log.Logger,
 ) {
 	// get environ
-	environ, err := custom.ToEnvironWithBinaries(workspace, log)
+	environ, err := custom.ToEnvironWithBinaries(workspace, oldlog.Default)
 	if err != nil {
 		log.Errorf("%v", err)
 		return
@@ -192,7 +189,7 @@ func (cmd *DaemonCmd) runShutdownCommand(
 	log.Infof("ran command: %s", buf.String())
 }
 
-func (cmd *DaemonCmd) initialTouch(log log.Logger) {
+func (cmd *DaemonCmd) initialTouch() {
 	// get base folder
 	baseFolder, err := agent.FindAgentHomeFolder(cmd.AgentDir)
 	if err != nil {
@@ -219,12 +216,11 @@ func (cmd *DaemonCmd) initialTouch(log log.Logger) {
 
 func findLatestActivity(
 	matches []string,
-	log log.Logger,
 ) (*time.Time, *provider2.AgentWorkspaceInfo) {
 	var latestActivity *time.Time
 	var workspace *provider2.AgentWorkspaceInfo
 	for _, match := range matches {
-		activity, activityWorkspace, err := getActivity(match, log)
+		activity, activityWorkspace, err := getActivity(match)
 		if err != nil {
 			log.Errorf("error checking for inactivity: %v", err)
 			continue
@@ -242,7 +238,6 @@ func findLatestActivity(
 
 func getActivity(
 	workspaceConfig string,
-	log log.Logger,
 ) (*time.Time, *provider2.AgentWorkspaceInfo, error) {
 	workspace, err := agent.ParseAgentWorkspaceInfo(workspaceConfig)
 	if err != nil {

--- a/cmd/agent/docker_credentials.go
+++ b/cmd/agent/docker_credentials.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/dockercredentials"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/docker/docker-credential-helpers/credentials"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +27,7 @@ func NewDockerCredentialsCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Use:   "docker-credentials",
 		Short: "Retrieves docker-credentials from the local machine",
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.Run(cobraCmd.Context(), args, log.Default.ErrorStreamOnly())
+			return cmd.Run(cobraCmd.Context(), args)
 		},
 	}
 	dockerCredentialsCmd.Flags().
@@ -36,7 +36,7 @@ func NewDockerCredentialsCmd(flags *flags.GlobalFlags) *cobra.Command {
 	return dockerCredentialsCmd
 }
 
-func (cmd *DockerCredentialsCmd) Run(ctx context.Context, args []string, log log.Logger) error {
+func (cmd *DockerCredentialsCmd) Run(ctx context.Context, args []string) error {
 	if len(args) == 0 {
 		return nil
 	}

--- a/cmd/agent/git_credentials.go
+++ b/cmd/agent/git_credentials.go
@@ -17,7 +17,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/gitcredentials"
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
 	"github.com/devsy-org/devsy/pkg/ts"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -37,14 +36,14 @@ func NewGitCredentialsCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Use:   "git-credentials",
 		Short: "Retrieves git-credentials from the local machine",
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			return cmd.Run(cobraCmd.Context(), args, log.Default.ErrorStreamOnly())
+			return cmd.Run(cobraCmd.Context(), args)
 		},
 	}
 	gitCredentialsCmd.Flags().IntVar(&cmd.Port, "port", 0, "If specified, will use the given port")
 	return gitCredentialsCmd
 }
 
-func (cmd *GitCredentialsCmd) Run(ctx context.Context, args []string, log log.Logger) error {
+func (cmd *GitCredentialsCmd) Run(ctx context.Context, args []string) error {
 	if len(args) == 0 {
 		return nil
 	} else if args[0] != "get" {

--- a/cmd/agent/git_ssh_signature.go
+++ b/cmd/agent/git_ssh_signature.go
@@ -8,7 +8,8 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/gitsshsigning"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -30,14 +31,12 @@ func NewGitSSHSignatureCmd(flags *flags.GlobalFlags) *cobra.Command {
 		// mode) that cobra cannot distinguish from flags that take a value.
 		DisableFlagParsing: true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			logger := log.GetInstance()
-
 			parsed := parseSSHKeygenArgs(args)
 
 			// For non-sign operations (verify, find-principals, check-novalidate),
 			// delegate command to system ssh-keygen since op does not require the tunnel.
 			if parsed.command != "sign" {
-				return delegateToSSHKeygen(args, logger)
+				return delegateToSSHKeygen(args)
 			}
 
 			if parsed.certPath == "" {
@@ -51,7 +50,7 @@ func NewGitSSHSignatureCmd(flags *flags.GlobalFlags) *cobra.Command {
 			}
 
 			return gitsshsigning.HandleGitSSHProgramCall(
-				parsed.certPath, parsed.namespace, parsed.bufferFile, logger)
+				parsed.certPath, parsed.namespace, parsed.bufferFile, oldlog.Default)
 		},
 	}
 }
@@ -123,13 +122,13 @@ func consumeFlag(result *sshKeygenArgs, args []string, i int) int {
 }
 
 // delegateToSSHKeygen forwards args to the system ssh-keygen binary.
-func delegateToSSHKeygen(args []string, logger log.Logger) error {
+func delegateToSSHKeygen(args []string) error {
 	sshKeygen, err := exec.LookPath("ssh-keygen")
 	if err != nil {
 		return fmt.Errorf("find ssh-keygen: %w", err)
 	}
 
-	logger.Debugf("delegating to ssh-keygen: %s %v", sshKeygen, args)
+	log.Debugf("delegating to ssh-keygen: %s %v", sshKeygen, args)
 
 	c := exec.Command(sshKeygen, args...) // #nosec G204,G304,G702
 	c.Stdin = os.Stdin

--- a/cmd/agent/git_ssh_signature_helper.go
+++ b/cmd/agent/git_ssh_signature_helper.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/gitsshsigning"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -47,8 +47,7 @@ func NewGitSSHSignatureHelperCmd(flags *flags.GlobalFlags) *cobra.Command {
 			}
 			cmd.CertPath = args[0]
 
-			log := log.GetInstance()
-			err = gitsshsigning.ConfigureHelper(usr.Username, cmd.CertPath, log)
+			err = gitsshsigning.ConfigureHelper(usr.Username, cmd.CertPath, oldlog.Default)
 			if err != nil {
 				return err
 			}

--- a/cmd/agent/workspace/build.go
+++ b/cmd/agent/workspace/build.go
@@ -7,8 +7,9 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -42,10 +43,10 @@ func (cmd *BuildCmd) Run(ctx context.Context) error {
 	// write workspace info
 	shouldExit, workspaceInfo, err := agent.WriteWorkspaceInfoAndDeleteOld(
 		cmd.WorkspaceInfo,
-		func(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) error {
-			return deleteWorkspace(ctx, workspaceInfo, log)
+		func(workspaceInfo *provider2.AgentWorkspaceInfo, l oldlog.Logger) error {
+			return deleteWorkspace(ctx, workspaceInfo, l)
 		},
-		log.Default.ErrorStreamOnly(),
+		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return err
@@ -96,14 +97,14 @@ func (cmd *BuildCmd) Run(ctx context.Context) error {
 			ExportCache:   true,
 		})
 		if err != nil {
-			logger.Errorf("Error building image: %v", err)
+			log.Errorf("Error building image: %v", err)
 			return fmt.Errorf("build: %w", err)
 		}
 
 		if workspaceInfo.CLIOptions.SkipPush {
-			logger.Donef("done building image %s", imageName)
+			log.Infof("done building image %s", imageName)
 		} else {
-			logger.Donef("done building and pushing image %s", imageName)
+			log.Infof("done building and pushing image %s", imageName)
 		}
 	}
 
@@ -113,9 +114,9 @@ func (cmd *BuildCmd) Run(ctx context.Context) error {
 func deleteWorkspace(
 	ctx context.Context,
 	workspaceInfo *provider2.AgentWorkspaceInfo,
-	log log.Logger,
+	logger oldlog.Logger,
 ) error {
-	err := removeContainer(ctx, workspaceInfo, log)
+	err := removeContainer(ctx, workspaceInfo, logger)
 	if err != nil {
 		log.Errorf("Removing container: %v", err)
 	}

--- a/cmd/agent/workspace/delete.go
+++ b/cmd/agent/workspace/delete.go
@@ -8,8 +8,9 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
 	agentdaemon "github.com/devsy-org/devsy/pkg/daemon/agent"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -47,10 +48,12 @@ func NewDeleteCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 func (cmd *DeleteCmd) Run(ctx context.Context) error {
+	logger := oldlog.Default.ErrorStreamOnly()
+
 	// get workspace
 	shouldExit, workspaceInfo, err := agent.WorkspaceInfo(
 		cmd.WorkspaceInfo,
-		log.Default.ErrorStreamOnly(),
+		logger,
 	)
 	if err != nil {
 		return fmt.Errorf("error parsing workspace info: %w", err)
@@ -60,7 +63,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context) error {
 
 	// remove daemon
 	if cmd.Daemon {
-		err = removeDaemon(workspaceInfo, log.Default)
+		err = removeDaemon(workspaceInfo)
 		if err != nil {
 			return fmt.Errorf("remove daemon: %w", err)
 		}
@@ -68,7 +71,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context) error {
 
 	// cleanup docker container
 	if cmd.Container {
-		err = removeContainer(ctx, workspaceInfo, log.Default)
+		err = removeContainer(ctx, workspaceInfo, logger)
 		if err != nil {
 			return fmt.Errorf("remove container: %w", err)
 		}
@@ -82,10 +85,10 @@ func (cmd *DeleteCmd) Run(ctx context.Context) error {
 func removeContainer(
 	ctx context.Context,
 	workspaceInfo *provider2.AgentWorkspaceInfo,
-	log log.Logger,
+	logger oldlog.Logger,
 ) error {
 	log.Debugf("removing Devsy container from server: workspaceId=%s", workspaceInfo.Workspace.ID)
-	runner, err := CreateRunner(workspaceInfo, log)
+	runner, err := CreateRunner(workspaceInfo, logger)
 	if err != nil {
 		return err
 	}
@@ -103,7 +106,7 @@ func removeContainer(
 	return nil
 }
 
-func removeDaemon(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) error {
+func removeDaemon(workspaceInfo *provider2.AgentWorkspaceInfo) error {
 	if len(workspaceInfo.Agent.Exec.Shutdown) == 0 {
 		return nil
 	}

--- a/cmd/agent/workspace/install_dotfiles.go
+++ b/cmd/agent/workspace/install_dotfiles.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/git"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	"github.com/devsy-org/devsy/pkg/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -50,12 +50,12 @@ func NewInstallDotfilesCmd(flags *flags.GlobalFlags) *cobra.Command {
 
 // Run runs the command logic.
 func (cmd *InstallDotfilesCmd) Run(ctx context.Context) error {
-	logger := log.Default.ErrorStreamOnly()
+	logger := oldlog.Default.ErrorStreamOnly()
 	targetDir := filepath.Join(os.Getenv("HOME"), "dotfiles")
 
 	_, err := os.Stat(targetDir)
 	if err != nil {
-		logger.Infof("Cloning dotfiles %s", cmd.Repository)
+		log.Infof("Cloning dotfiles %s", cmd.Repository)
 
 		gitInfo := git.NormalizeRepositoryGitInfo(cmd.Repository)
 		if err := git.CloneRepository(
@@ -69,10 +69,10 @@ func (cmd *InstallDotfilesCmd) Run(ctx context.Context) error {
 			return err
 		}
 	} else {
-		logger.Info("dotfiles already set up, skipping cloning")
+		log.Info("dotfiles already set up, skipping cloning")
 	}
 
-	logger.Debugf("Entering dotfiles directory")
+	log.Debugf("Entering dotfiles directory")
 
 	err = os.Chdir(targetDir)
 	if err != nil {
@@ -80,7 +80,7 @@ func (cmd *InstallDotfilesCmd) Run(ctx context.Context) error {
 	}
 
 	if cmd.InstallScript != "" {
-		logger.Infof("Executing install script %s", cmd.InstallScript)
+		log.Infof("Executing install script %s", cmd.InstallScript)
 		command := "./" + strings.TrimPrefix(cmd.InstallScript, "./")
 
 		err := ensureExecutable(ctx, command)
@@ -92,16 +92,16 @@ func (cmd *InstallDotfilesCmd) Run(ctx context.Context) error {
 			ctx,
 			command,
 		) // #nosec G204 -- user-provided dotfile install script
-		writer := logger.Writer(logrus.InfoLevel, false)
+		writer := log.Writer(log.LevelInfo)
 		scriptCmd.Stdout = writer
 		scriptCmd.Stderr = writer
 
 		return scriptCmd.Run()
 	}
 
-	logger.Debugf("Install script not specified, trying known locations")
+	log.Debugf("Install script not specified, trying known locations")
 
-	return setupDotfiles(ctx, logger)
+	return setupDotfiles(ctx)
 }
 
 var installScriptPaths = []string{
@@ -115,7 +115,7 @@ var installScriptPaths = []string{
 	"./setup/setup",
 }
 
-func setupDotfiles(ctx context.Context, logger log.Logger) error {
+func setupDotfiles(ctx context.Context) error {
 	scripts := slices.Clone(installScriptPaths)
 	scripts = slices.DeleteFunc(scripts, func(path string) bool {
 		if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -126,10 +126,10 @@ func setupDotfiles(ctx context.Context, logger log.Logger) error {
 	})
 
 	for _, installScriptPath := range scripts {
-		writer := logger.Writer(logrus.InfoLevel, false)
+		writer := log.Writer(log.LevelInfo)
 		err := ensureExecutable(ctx, installScriptPath)
 		if err != nil {
-			logger.Debugf(
+			log.Debugf(
 				"install script not found: scriptPath=%s, error=%v",
 				installScriptPath,
 				err,
@@ -140,7 +140,7 @@ func setupDotfiles(ctx context.Context, logger log.Logger) error {
 			continue
 		}
 
-		logger.Debugf("executing dotfile install script: scriptPath=%s", installScriptPath)
+		log.Debugf("executing dotfile install script: scriptPath=%s", installScriptPath)
 		scriptCmd := exec.CommandContext(
 			ctx,
 			installScriptPath,
@@ -148,7 +148,7 @@ func setupDotfiles(ctx context.Context, logger log.Logger) error {
 		scriptCmd.Stdout = writer
 		scriptCmd.Stderr = writer
 		if err := scriptCmd.Run(); err != nil {
-			logger.Debugf("script execution failed: error=%v", err)
+			log.Debugf("script execution failed: error=%v", err)
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
@@ -156,16 +156,16 @@ func setupDotfiles(ctx context.Context, logger log.Logger) error {
 		}
 
 		// exit after first successful script
-		logger.Debug("install script executed")
+		log.Debug("install script executed")
 		return nil
 	}
 
-	logger.Info("Finished script locations, trying to link the files")
+	log.Info("Finished script locations, trying to link the files")
 
-	return linkDotfiles(ctx, logger)
+	return linkDotfiles(ctx)
 }
 
-func linkDotfiles(ctx context.Context, logger log.Logger) error {
+func linkDotfiles(ctx context.Context) error {
 	files, err := os.ReadDir(".")
 	if err != nil {
 		return err
@@ -185,7 +185,6 @@ func linkDotfiles(ctx context.Context, logger log.Logger) error {
 			continue
 		}
 		if err := linkDotfile(
-			logger,
 			filepath.Join(pwd, file.Name()),
 			filepath.Join(home, file.Name()),
 		); err != nil {
@@ -196,11 +195,11 @@ func linkDotfiles(ctx context.Context, logger log.Logger) error {
 	return nil
 }
 
-func linkDotfile(logger log.Logger, src, dest string) error {
-	logger.Debugf("linking %s in home", filepath.Base(dest))
+func linkDotfile(src, dest string) error {
+	log.Debugf("linking %s in home", filepath.Base(dest))
 	if _, err := os.Lstat(dest); err == nil { // #nosec G703
 		if removeErr := os.Remove(dest); removeErr != nil { // #nosec G703
-			logger.Debugf("failed to remove %s: %v", dest, removeErr)
+			log.Debugf("failed to remove %s: %v", dest, removeErr)
 		}
 	}
 	return os.Symlink(src, dest)

--- a/cmd/agent/workspace/logs.go
+++ b/cmd/agent/workspace/logs.go
@@ -8,7 +8,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
 	"github.com/devsy-org/devsy/pkg/devcontainer"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -39,19 +39,20 @@ func NewLogsCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 func (cmd *LogsCmd) Run(ctx context.Context) error {
+	logger := oldlog.Default.ErrorStreamOnly()
+
 	// get workspace info
 	shouldExit, workspaceInfo, err := agent.ReadAgentWorkspaceInfo(
 		cmd.AgentDir,
 		cmd.Context,
 		cmd.ID,
-		log.Default.ErrorStreamOnly(),
+		logger,
 	)
 	if err != nil {
 		return err
 	} else if shouldExit {
 		return nil
 	}
-	logger := log.Default.ErrorStreamOnly()
 
 	// create new runner
 	runner, err := devcontainer.NewRunner(

--- a/cmd/agent/workspace/logs_daemon.go
+++ b/cmd/agent/workspace/logs_daemon.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -44,7 +44,7 @@ func (cmd *LogsDaemonCmd) Run(ctx context.Context) error {
 		cmd.AgentDir,
 		cmd.Context,
 		cmd.ID,
-		log.Default.ErrorStreamOnly(),
+		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return err

--- a/cmd/agent/workspace/setup_gpg.go
+++ b/cmd/agent/workspace/setup_gpg.go
@@ -9,7 +9,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/credentials"
 	"github.com/devsy-org/devsy/pkg/gitcredentials"
 	"github.com/devsy-org/devsy/pkg/gpg"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +33,7 @@ func NewSetupGPGCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Short: "setups gpg-agent forwarding in the container",
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
-			return cmd.Run(cobraCmd.Context(), log.Default.ErrorStreamOnly())
+			return cmd.Run(cobraCmd.Context())
 		},
 	}
 	setupGPGCmd.Flags().
@@ -53,11 +54,13 @@ func NewSetupGPGCmd(flags *flags.GlobalFlags) *cobra.Command {
 // - ensuring the gpg-agent is stopped in the container
 // - starting a reverse-tunnel of the local unix socket to remote
 // - ensuring paths and permissions are correctly set in the remote.
-func (cmd *SetupGPGCmd) Run(ctx context.Context, log log.Logger) error {
+//
+//nolint:cyclop,funlen // pre-existing complexity
+func (cmd *SetupGPGCmd) Run(ctx context.Context) error {
 	log.Debugf("Initializing gpg-agent forwarding")
 
 	log.Debugf("Fetching public key")
-	rawPublicKeys, err := getPublicKeys(log)
+	rawPublicKeys, err := getPublicKeys()
 	if err != nil {
 		log.Errorf("Fetch public key: %v", err)
 		return err
@@ -143,13 +146,13 @@ func (cmd *SetupGPGCmd) Run(ctx context.Context, log log.Logger) error {
 	return nil
 }
 
-func getPublicKeys(log log.Logger) (string, error) {
+func getPublicKeys() (string, error) {
 	port, err := credentials.GetPort()
 	if err != nil {
 		return "", fmt.Errorf("get port: %w", err)
 	}
 
-	out, err := credentials.PostWithRetry(port, "gpg-public-keys", nil, log)
+	out, err := credentials.PostWithRetry(port, "gpg-public-keys", nil, oldlog.Default)
 	if err != nil {
 		return "", fmt.Errorf("get public gpg keys: %w", err)
 	}

--- a/cmd/agent/workspace/status.go
+++ b/cmd/agent/workspace/status.go
@@ -8,7 +8,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
 	"github.com/devsy-org/devsy/pkg/client"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +29,7 @@ func NewStatusCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Short: "Print the status of a remote container",
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
-			return cmd.Run(cobraCmd.Context(), log.Default.ErrorStreamOnly())
+			return cmd.Run(cobraCmd.Context())
 		},
 	}
 	statusCmd.Flags().StringVar(&cmd.WorkspaceInfo, "workspace-info", "", "The workspace info")
@@ -37,9 +37,11 @@ func NewStatusCmd(flags *flags.GlobalFlags) *cobra.Command {
 	return statusCmd
 }
 
-func (cmd *StatusCmd) Run(ctx context.Context, log log.Logger) error {
+func (cmd *StatusCmd) Run(ctx context.Context) error {
+	logger := oldlog.Default.ErrorStreamOnly()
+
 	// get workspace
-	shouldExit, workspaceInfo, err := agent.WorkspaceInfo(cmd.WorkspaceInfo, log)
+	shouldExit, workspaceInfo, err := agent.WorkspaceInfo(cmd.WorkspaceInfo, logger)
 	if err != nil {
 		return err
 	} else if shouldExit {
@@ -47,7 +49,7 @@ func (cmd *StatusCmd) Run(ctx context.Context, log log.Logger) error {
 	}
 
 	// create runner
-	runner, err := CreateRunner(workspaceInfo, log)
+	runner, err := CreateRunner(workspaceInfo, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/workspace/stop.go
+++ b/cmd/agent/workspace/stop.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -37,10 +38,12 @@ func NewStopCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 func (cmd *StopCmd) Run(ctx context.Context) error {
+	logger := oldlog.Default.ErrorStreamOnly()
+
 	// get workspace
 	shouldExit, workspaceInfo, err := agent.WriteWorkspaceInfo(
 		cmd.WorkspaceInfo,
-		log.Default.ErrorStreamOnly(),
+		logger,
 	)
 	if err != nil {
 		return fmt.Errorf("error parsing workspace info: %w", err)
@@ -49,7 +52,7 @@ func (cmd *StopCmd) Run(ctx context.Context) error {
 	}
 
 	// stop docker container
-	err = stopContainer(ctx, workspaceInfo, log.Default)
+	err = stopContainer(ctx, workspaceInfo, logger)
 	if err != nil {
 		return fmt.Errorf("stop container: %w", err)
 	}
@@ -60,10 +63,10 @@ func (cmd *StopCmd) Run(ctx context.Context) error {
 func stopContainer(
 	ctx context.Context,
 	workspaceInfo *provider2.AgentWorkspaceInfo,
-	log log.Logger,
+	logger oldlog.Logger,
 ) error {
 	log.Debugf("stopping Devsy container")
-	runner, err := CreateRunner(workspaceInfo, log)
+	runner, err := CreateRunner(workspaceInfo, logger)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -25,10 +25,10 @@ import (
 	"github.com/devsy-org/devsy/pkg/dockercredentials"
 	"github.com/devsy-org/devsy/pkg/dockerinstall"
 	"github.com/devsy-org/devsy/pkg/extract"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/util"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -95,10 +95,10 @@ func (cmd *UpCmd) Run(ctx context.Context) error {
 func (cmd *UpCmd) loadWorkspaceInfo(ctx context.Context) (*provider.AgentWorkspaceInfo, error) {
 	shouldExit, workspaceInfo, err := agent.WriteWorkspaceInfoAndDeleteOld(
 		cmd.WorkspaceInfo,
-		func(workspaceInfo *provider.AgentWorkspaceInfo, log log.Logger) error {
-			return deleteWorkspace(ctx, workspaceInfo, log)
+		func(workspaceInfo *provider.AgentWorkspaceInfo, l oldlog.Logger) error {
+			return deleteWorkspace(ctx, workspaceInfo, l)
 		},
-		log.Default.ErrorStreamOnly(),
+		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing workspace info: %w", err)
@@ -120,10 +120,10 @@ func (cmd *UpCmd) shouldInstallDaemon(workspaceInfo *provider.AgentWorkspaceInfo
 func (cmd *UpCmd) handleInitError(
 	err error,
 	workspaceInfo *provider.AgentWorkspaceInfo,
-	logger log.Logger,
+	logger oldlog.Logger,
 ) error {
 	if logger == nil {
-		logger = log.Discard
+		logger = oldlog.Discard
 	}
 	deleteErr := clientimplementation.DeleteWorkspaceFolder(
 		clientimplementation.DeleteWorkspaceFolderParams{
@@ -150,7 +150,7 @@ func (cmd *UpCmd) up(
 	ctx context.Context,
 	workspaceInfo *provider.AgentWorkspaceInfo,
 	tunnelClient tunnel.TunnelClient,
-	logger log.Logger,
+	logger oldlog.Logger,
 ) error {
 	result, err := cmd.devsyUp(ctx, workspaceInfo, logger)
 	if err != nil {
@@ -181,9 +181,9 @@ func (cmd *UpCmd) sendResult(
 func (cmd *UpCmd) devsyUp(
 	ctx context.Context,
 	workspaceInfo *provider.AgentWorkspaceInfo,
-	log log.Logger,
+	logger oldlog.Logger,
 ) (*config2.Result, error) {
-	runner, err := CreateRunner(workspaceInfo, log)
+	runner, err := CreateRunner(workspaceInfo, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -196,18 +196,21 @@ func (cmd *UpCmd) devsyUp(
 
 func CreateRunner(
 	workspaceInfo *provider.AgentWorkspaceInfo,
-	log log.Logger,
+	logger oldlog.Logger,
 ) (devcontainer.Runner, error) {
 	return devcontainer.NewRunner(
 		agent.ContainerDevsyHelperLocation,
 		agent.DefaultAgentDownloadURL(),
 		workspaceInfo,
-		log,
+		logger,
 	)
 }
 
-func InitContentFolder(workspaceInfo *provider.AgentWorkspaceInfo, log log.Logger) (bool, error) {
-	exists, err := contentFolderExists(workspaceInfo.ContentFolder, log)
+func InitContentFolder(
+	workspaceInfo *provider.AgentWorkspaceInfo,
+	logger oldlog.Logger,
+) (bool, error) {
+	exists, err := contentFolderExists(workspaceInfo.ContentFolder)
 	if err != nil {
 		return false, err
 	}
@@ -215,11 +218,11 @@ func InitContentFolder(workspaceInfo *provider.AgentWorkspaceInfo, log log.Logge
 		return true, nil
 	}
 
-	if err := createContentFolder(workspaceInfo.ContentFolder, log); err != nil {
+	if err := createContentFolder(workspaceInfo.ContentFolder); err != nil {
 		return false, err
 	}
 
-	if err := downloadWorkspaceBinaries(workspaceInfo, log); err != nil {
+	if err := downloadWorkspaceBinaries(workspaceInfo, logger); err != nil {
 		_ = os.RemoveAll(workspaceInfo.ContentFolder)
 		return false, err
 	}
@@ -234,7 +237,7 @@ func InitContentFolder(workspaceInfo *provider.AgentWorkspaceInfo, log log.Logge
 	return false, nil
 }
 
-func contentFolderExists(path string, log log.Logger) (bool, error) {
+func contentFolderExists(path string) (bool, error) {
 	_, err := os.Stat(path)
 	if err == nil {
 		log.Debugf("workspace folder already exists: path=%s", path)
@@ -246,7 +249,7 @@ func contentFolderExists(path string, log log.Logger) (bool, error) {
 	return false, err
 }
 
-func createContentFolder(path string, log log.Logger) error {
+func createContentFolder(path string) error {
 	log.Debugf("create content folder: path=%s", path)
 	if err := os.MkdirAll(path, 0o750); err != nil {
 		return fmt.Errorf("make workspace folder: %w", err)
@@ -254,7 +257,10 @@ func createContentFolder(path string, log log.Logger) error {
 	return nil
 }
 
-func downloadWorkspaceBinaries(workspaceInfo *provider.AgentWorkspaceInfo, log log.Logger) error {
+func downloadWorkspaceBinaries(
+	workspaceInfo *provider.AgentWorkspaceInfo,
+	logger oldlog.Logger,
+) error {
 	binariesDir, err := agent.GetAgentBinariesDir(
 		workspaceInfo.Agent.DataPath,
 		workspaceInfo.Workspace.Context,
@@ -268,7 +274,7 @@ func downloadWorkspaceBinaries(workspaceInfo *provider.AgentWorkspaceInfo, log l
 		)
 	}
 
-	_, err = provider.DownloadBinaries(workspaceInfo.Agent.Binaries, binariesDir, log)
+	_, err = provider.DownloadBinaries(workspaceInfo.Agent.Binaries, binariesDir, logger)
 	if err != nil {
 		return fmt.Errorf(
 			"error downloading workspace %s binaries: %w",
@@ -286,7 +292,7 @@ type workspaceInitializer struct {
 	debug                bool
 	shouldInstallDaemon  bool
 	tunnelClient         tunnel.TunnelClient
-	logger               log.Logger
+	logger               oldlog.Logger
 	dockerCredentialsDir string
 	gitCredentialsHelper string
 }
@@ -298,7 +304,8 @@ type initWorkspaceParams struct {
 	shouldInstallDaemon bool
 }
 
-func initWorkspace(params initWorkspaceParams) (tunnel.TunnelClient, log.Logger, string, error) {
+//nolint:revive // pre-existing 4 return values
+func initWorkspace(params initWorkspaceParams) (tunnel.TunnelClient, oldlog.Logger, string, error) {
 	init := &workspaceInitializer{
 		ctx:                 params.ctx,
 		workspaceInfo:       params.workspaceInfo,
@@ -319,7 +326,7 @@ func (w *workspaceInitializer) initialize() error {
 	}
 
 	if err := w.setupCredentials(); err != nil {
-		w.logger.Warnf("failed to set up docker/git credentials (continuing without them): %v", err)
+		log.Warnf("failed to set up docker/git credentials (continuing without them): %v", err)
 	}
 
 	dockerErrChan := w.installDockerAsync()
@@ -341,18 +348,18 @@ func (w *workspaceInitializer) initialize() error {
 func (w *workspaceInitializer) setupDaemonIfNeeded() {
 	if w.shouldInstallDaemon {
 		if err := installDaemon(w.workspaceInfo, w.logger); err != nil {
-			w.logger.Errorf("install Devsy daemon: %v", err)
+			log.Errorf("install Devsy daemon: %v", err)
 		}
 	}
 }
 
 func (w *workspaceInitializer) tryConfigureDockerDaemon() {
 	if !w.shouldConfigureDockerDaemon() {
-		w.logger.Debug("skipping configuring docker daemon")
+		log.Debug("skipping configuring docker daemon")
 		return
 	}
-	if err := configureDockerDaemon(w.ctx, w.logger); err != nil {
-		w.logger.Warn(
+	if err := configureDockerDaemon(w.ctx); err != nil {
+		log.Warn(
 			"could not find docker daemon config file, if using the registry cache, " +
 				"please ensure the daemon is configured with containerd-snapshotter=true, " +
 				"more info at https://docs.docker.com/engine/storage/containerd/",
@@ -367,7 +374,7 @@ func (w *workspaceInitializer) initializeTunnel() error {
 	}
 	w.tunnelClient = client
 	w.logger = tunnelserver.NewTunnelLogger(w.ctx, w.tunnelClient, w.debug)
-	w.logger.Debugf("created logger")
+	log.Debugf("created logger")
 
 	if _, err := w.tunnelClient.Ping(w.ctx, &tunnel.Empty{}); err != nil {
 		return fmt.Errorf("ping client: %w", err)
@@ -398,7 +405,7 @@ func (w *workspaceInitializer) installDockerAsync() <-chan dockerInstallResult {
 
 	go func() {
 		if !w.workspaceInfo.Agent.IsDockerDriver() {
-			w.logger.Debug("not a docker driver, skipping docker installation")
+			log.Debug("not a docker driver, skipping docker installation")
 			resultChan <- dockerInstallResult{}
 			return
 		}
@@ -414,7 +421,7 @@ func (w *workspaceInitializer) ensureDockerInstalled() (string, error) {
 	dockerCmd := w.getDockerCommand()
 
 	if command.Exists(dockerCmd) {
-		w.logger.Debug("docker command exists, skipping installation")
+		log.Debug("docker command exists, skipping installation")
 		return "", nil
 	}
 
@@ -427,20 +434,20 @@ func (w *workspaceInitializer) ensureDockerInstalled() (string, error) {
 	}
 
 	if w.isDockerInstallDisabled() {
-		w.logger.Debug(
+		log.Debug(
 			"docker not found but installation was disabled, installing anyway as it is required",
 		)
 	}
 
-	w.logger.Debug("attempting to install docker")
-	dockerPath, err := installDocker(w.logger)
-	w.logger.Debugf("docker installation path=%q, err=%v", dockerPath, err)
+	log.Debug("attempting to install docker")
+	dockerPath, err := installDocker()
+	log.Debugf("docker installation path=%q, err=%v", dockerPath, err)
 	return dockerPath, err
 }
 
 func (w *workspaceInitializer) getDockerCommand() string {
 	if w.workspaceInfo.Agent.Docker.Path != "" {
-		w.logger.Debugf("using custom docker path %s", w.workspaceInfo.Agent.Docker.Path)
+		log.Debugf("using custom docker path %s", w.workspaceInfo.Agent.Docker.Path)
 		return w.workspaceInfo.Agent.Docker.Path
 	}
 	return "docker"
@@ -468,7 +475,7 @@ func (w *workspaceInitializer) waitForDocker(resultChan <-chan dockerInstallResu
 
 	if result.path != "" && w.workspaceInfo.Agent.Docker.Path == "" {
 		w.workspaceInfo.Agent.Docker.Path = result.path
-		w.logger.Debugf("set docker path to %s", result.path)
+		log.Debugf("set docker path to %s", result.path)
 	}
 
 	if result.err != nil {
@@ -485,7 +492,7 @@ func (w *workspaceInitializer) shouldConfigureDockerDaemon() bool {
 
 	local, err := w.workspaceInfo.Agent.Local.Bool()
 	if err != nil {
-		w.logger.Debugf("failed to parse Local option: %v", err)
+		log.Debugf("failed to parse Local option: %v", err)
 		return false
 	}
 	return !local
@@ -496,7 +503,7 @@ type prepareWorkspaceParams struct {
 	workspaceInfo *provider.AgentWorkspaceInfo
 	client        tunnel.TunnelClient
 	gitHelper     string
-	log           log.Logger
+	log           oldlog.Logger
 }
 
 // prepareWorkspace initializes the workspace content folder and downloads/prepares the workspace source.
@@ -553,7 +560,7 @@ type prepareGitWorkspaceParams struct {
 	workspaceInfo *provider.AgentWorkspaceInfo
 	gitHelper     string
 	exists        bool
-	log           log.Logger
+	log           oldlog.Logger
 }
 
 func prepareGitWorkspace(params prepareGitWorkspaceParams) error {
@@ -596,7 +603,7 @@ func prepareLocalWorkspace(
 	ctx context.Context,
 	workspaceInfo *provider.AgentWorkspaceInfo,
 	client tunnel.TunnelClient,
-	log log.Logger,
+	logger oldlog.Logger,
 ) error {
 	if workspaceInfo.ContentFolder == workspaceInfo.Workspace.Source.LocalFolder {
 		log.Debugf(
@@ -607,7 +614,7 @@ func prepareLocalWorkspace(
 	}
 
 	log.Debugf("download local folder %s", workspaceInfo.ContentFolder)
-	return downloadLocalFolder(ctx, workspaceInfo.ContentFolder, client, log)
+	return downloadLocalFolder(ctx, workspaceInfo.ContentFolder, client, logger)
 }
 
 func ensureLastDevContainerJson(workspaceInfo *provider.AgentWorkspaceInfo) error {
@@ -642,7 +649,7 @@ type credentialsConfig struct {
 	ctx           context.Context
 	workspaceInfo *provider.AgentWorkspaceInfo
 	client        tunnel.TunnelClient
-	log           log.Logger
+	log           oldlog.Logger
 }
 
 func configureCredentials(cfg credentialsConfig) (string, string, error) {
@@ -690,7 +697,7 @@ func configureCredentials(cfg credentialsConfig) (string, string, error) {
 	return dockerCredentials, gitCredentials, nil
 }
 
-func installDaemon(workspaceInfo *provider.AgentWorkspaceInfo, log log.Logger) error {
+func installDaemon(workspaceInfo *provider.AgentWorkspaceInfo, logger oldlog.Logger) error {
 	if len(workspaceInfo.Agent.Exec.Shutdown) == 0 {
 		return nil
 	}
@@ -699,7 +706,7 @@ func installDaemon(workspaceInfo *provider.AgentWorkspaceInfo, log log.Logger) e
 	return agentdaemon.InstallDaemon(
 		workspaceInfo.Agent.DataPath,
 		workspaceInfo.CLIOptions.DaemonInterval,
-		log,
+		logger,
 	)
 }
 
@@ -707,7 +714,7 @@ func downloadLocalFolder(
 	ctx context.Context,
 	workspaceDir string,
 	client tunnel.TunnelClient,
-	log log.Logger,
+	logger oldlog.Logger,
 ) error {
 	log.Infof("Upload folder to server")
 	stream, err := client.StreamWorkspace(ctx, &tunnel.Empty{})
@@ -715,7 +722,7 @@ func downloadLocalFolder(
 		return fmt.Errorf("read workspace: %w", err)
 	}
 
-	return extract.Extract(tunnelserver.NewStreamReader(stream, log), workspaceDir)
+	return extract.Extract(tunnelserver.NewStreamReader(stream, logger), workspaceDir)
 }
 
 func prepareImage(workspaceDir, image string) error {
@@ -731,14 +738,14 @@ func prepareImage(workspaceDir, image string) error {
 
 // installDocker installs Docker and returns the path to the docker binary.
 // This function assumes docker does not already exist - the caller should check first.
-func installDocker(log log.Logger) (dockerPath string, err error) {
-	writer := log.Writer(logrus.InfoLevel, false)
+func installDocker() (dockerPath string, err error) {
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 	log.Debug("installing Docker")
 	return dockerinstall.Install(writer, writer)
 }
 
-func configureDockerDaemon(ctx context.Context, log log.Logger) error {
+func configureDockerDaemon(ctx context.Context) error {
 	log.Info("configuring docker daemon")
 
 	if err := mergeDockerDaemonConfig(); err != nil {

--- a/cmd/agent/workspace/update_config.go
+++ b/cmd/agent/workspace/update_config.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +37,7 @@ func NewUpdateConfigCmd(flags *flags.GlobalFlags) *cobra.Command {
 
 func (cmd *UpdateConfigCmd) Run(ctx context.Context) error {
 	// write workspace info
-	shouldExit, _, err := agent.WriteWorkspaceInfo(cmd.WorkspaceInfo, log.Default)
+	shouldExit, _, err := agent.WriteWorkspaceInfo(cmd.WorkspaceInfo, oldlog.Default)
 	if err != nil {
 		return err
 	} else if shouldExit {

--- a/pkg/agent/dockerless.go
+++ b/pkg/agent/dockerless.go
@@ -294,6 +294,6 @@ func applyContainerEnv(imageConfigPath string, log log.Logger) error {
 		return fmt.Errorf("parse container config: %w", err)
 	}
 
-	envfile.MergeAndApply(config.ListToObject(configFile.Config.Env), log)
+	envfile.MergeAndApply(config.ListToObject(configFile.Config.Env))
 	return nil
 }

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -270,7 +270,7 @@ func patchEtcEnvironmentFlags(workspaceEnv []string, log log.Logger) error {
 	}
 
 	// update env
-	envfile.MergeAndApply(config.ListToObject(workspaceEnv), log)
+	envfile.MergeAndApply(config.ListToObject(workspaceEnv))
 	return nil
 }
 
@@ -295,7 +295,7 @@ func patchEtcEnvironment(mergedConfig *config.MergedDevContainerConfig, log log.
 	}
 
 	// update env
-	envfile.MergeAndApply(mergedConfig.RemoteEnv, log)
+	envfile.MergeAndApply(mergedConfig.RemoteEnv)
 	return nil
 }
 

--- a/pkg/envfile/envfile.go
+++ b/pkg/envfile/envfile.go
@@ -5,7 +5,7 @@ import (
 	"maps"
 	"os"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 var location = "/etc/envfile.json"
@@ -15,7 +15,7 @@ type EnvFile struct {
 	Env map[string]string `json:"env,omitempty"`
 }
 
-func Apply(log log.Logger) {
+func Apply() {
 	out, err := os.ReadFile(location)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -37,7 +37,8 @@ func Apply(log log.Logger) {
 	}
 }
 
-func MergeAndApply(env map[string]string, log log.Logger) {
+//nolint:cyclop // pre-existing complexity
+func MergeAndApply(env map[string]string) {
 	if len(env) == 0 {
 		return
 	}


### PR DESCRIPTION
## Summary

- Remove duplicate log initialization from `cmd/agent/agent.go`
- Migrate all `cmd/agent/` files (25 files) to use `pkg/log` package-level functions
- Remove Logger struct fields and parameter threading
- Update `pkg/envfile` to use `pkg/log` directly (removed logger parameter)
- Replace `Donef()` → `log.Infof()`, `.Writer(logrus.Level)` → `log.Writer(log.LevelX)`

Part 2 of logging overhaul.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized logging infrastructure across agent and workspace commands.
  * Simplified function signatures by removing explicit logger parameter passing.
  * Updated environment file processing to use unified logging approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->