### PR TITLE
refactor(log): migrate remaining cmd/ to pkg/log

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -10,9 +10,10 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/image"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -78,7 +79,7 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 			}
 
 			// create a temporary workspace
-			exists := workspace2.Exists(ctx, devsyConfig, args, "", cmd.Owner, log.Default)
+			exists := workspace2.Exists(ctx, devsyConfig, args, "", cmd.Owner, oldlog.Default)
 			sshConfigFile, err := os.CreateTemp("", config.BinaryName+"ssh.config")
 			if err != nil {
 				return err
@@ -107,7 +108,7 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 					ChangeLastUsed:       false,
 					Owner:                cmd.Owner,
 				},
-				log.Default,
+				oldlog.Default,
 			)
 			if err != nil {
 				return err
@@ -118,7 +119,7 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 				defer func() {
 					err = baseWorkspaceClient.Delete(ctx, client.DeleteOptions{Force: true})
 					if err != nil {
-						log.Default.Errorf("Error deleting workspace: %v", err)
+						log.Errorf("Error deleting workspace: %v", err)
 					}
 				}()
 			}
@@ -179,13 +180,13 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 func (cmd *BuildCmd) Run(ctx context.Context, client client.WorkspaceClient) error {
-	return cmd.build(ctx, client, log.Default)
+	return cmd.build(ctx, client, oldlog.Default)
 }
 
 func (cmd *BuildCmd) build(
 	ctx context.Context,
 	workspaceClient client.WorkspaceClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	err := workspaceClient.Lock(ctx)
 	if err != nil {

--- a/cmd/completion/suggestions.go
+++ b/cmd/completion/suggestions.go
@@ -7,7 +7,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +22,6 @@ func RegisterFlagCompletionFuns(rootCmd *cobra.Command, globalFlags *flags.Globa
 				args,
 				toComplete,
 				globalFlags.Owner,
-				log.Default,
 			)
 		},
 	); err != nil {
@@ -39,7 +38,6 @@ func RegisterFlagCompletionFuns(rootCmd *cobra.Command, globalFlags *flags.Globa
 				args,
 				toComplete,
 				globalFlags.Owner,
-				log.Default,
 			)
 		},
 	); err != nil {
@@ -55,14 +53,13 @@ func GetWorkspaceSuggestions(
 	args []string,
 	toComplete string,
 	owner platform.OwnerFilter,
-	logger log.Logger,
 ) ([]string, cobra.ShellCompDirective) {
 	devsyConfig, err := config.LoadConfig(context, provider)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	workspaces, err := workspace.List(rootCmd.Context(), devsyConfig, false, owner, logger)
+	workspaces, err := workspace.List(rootCmd.Context(), devsyConfig, false, owner, oldlog.Default)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -82,14 +79,13 @@ func GetProviderSuggestions(
 	args []string,
 	toComplete string,
 	owner platform.OwnerFilter,
-	logger log.Logger,
 ) ([]string, cobra.ShellCompDirective) {
 	devsyConfig, err := config.LoadConfig(context, provider)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	providers, err := workspace.LoadAllProviders(devsyConfig, log.Default.ErrorStreamOnly())
+	providers, err := workspace.LoadAllProviders(devsyConfig, oldlog.Default.ErrorStreamOnly())
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -109,7 +105,6 @@ func GetContextSuggestions(
 	args []string,
 	toComplete string,
 	owner platform.OwnerFilter,
-	logger log.Logger,
 ) ([]string, cobra.ShellCompDirective) {
 	devsyConfig, err := config.LoadConfig(context, provider)
 	if err != nil {

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -9,8 +9,9 @@ import (
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -43,7 +44,6 @@ If the workspace is not found, you can use the --ignore-not-found flag to treat 
 				args,
 				toComplete,
 				cmd.Owner,
-				log.Default,
 			)
 		},
 	}
@@ -98,7 +98,7 @@ func (cmd *DeleteCmd) deleteSingle(
 		return err
 	}
 
-	log.Default.Donef("deleted workspace %s", name)
+	log.Infof("deleted workspace %s", name)
 
 	return nil
 }
@@ -117,7 +117,7 @@ func (cmd *DeleteCmd) deleteMultiple(
 			continue
 		}
 
-		log.Default.Donef("deleted workspace %s", name)
+		log.Infof("deleted workspace %s", name)
 	}
 
 	if len(errs) > 0 {
@@ -143,6 +143,6 @@ func (cmd *DeleteCmd) deleteWorkspace(
 		Force:          cmd.Force,
 		ClientDelete:   cmd.DeleteOptions,
 		Owner:          cmd.Owner,
-		Log:            log.Default,
+		Log:            oldlog.Default,
 	})
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -10,7 +10,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -47,7 +47,6 @@ func NewExportCmd(flags *flags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				log.Default,
 			)
 		},
 	}
@@ -58,12 +57,11 @@ func NewExportCmd(flags *flags.GlobalFlags) *cobra.Command {
 // Run runs the command logic.
 func (cmd *ExportCmd) Run(ctx context.Context, devsyConfig *config.Config, args []string) error {
 	// try to load workspace
-	logger := log.Default.ErrorStreamOnly()
 	client, err := workspace2.Get(ctx, workspace2.GetOptions{
 		DevsyConfig: devsyConfig,
 		Args:        args,
 		Owner:       cmd.Owner,
-		Log:         logger,
+		Log:         oldlog.Default,
 	})
 	if err != nil {
 		return err

--- a/cmd/helper/check_provider_update.go
+++ b/cmd/helper/check_provider_update.go
@@ -13,7 +13,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +21,6 @@ var errProviderNotFound = errors.New("provider not found")
 
 type CheckProviderUpdateCmd struct {
 	*flags.GlobalFlags
-	log log.Logger
 }
 
 type providerVersionCheck struct {
@@ -33,7 +32,6 @@ type providerVersionCheck struct {
 func NewCheckProviderUpdateCmd(flags *flags.GlobalFlags) *cobra.Command {
 	cmd := &CheckProviderUpdateCmd{
 		GlobalFlags: flags,
-		log:         log.Default,
 	}
 	shellCmd := &cobra.Command{
 		Use:   "check-provider-update",
@@ -60,13 +58,17 @@ func (cmd *CheckProviderUpdateCmd) Run(
 	}
 	providerName := args[0]
 
-	providerSourceRaw, err := workspace.ResolveProviderSource(devsyConfig, providerName, cmd.log)
+	providerSourceRaw, err := workspace.ResolveProviderSource(
+		devsyConfig,
+		providerName,
+		oldlog.Default,
+	)
 	if err != nil {
 		return fmt.Errorf("provider %s doesn't exist", providerName)
 	}
 
 	// retrieve current config for provider
-	allProviders, err := workspace.LoadAllProviders(devsyConfig, cmd.log)
+	allProviders, err := workspace.LoadAllProviders(devsyConfig, oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -75,7 +77,7 @@ func (cmd *CheckProviderUpdateCmd) Run(
 		return errProviderNotFound
 	}
 
-	latestProviderConfig, err := loadLatestProvider(providerSourceRaw, cmd.log)
+	latestProviderConfig, err := loadLatestProvider(providerSourceRaw)
 	if err != nil {
 		return err
 	}
@@ -109,9 +111,8 @@ func (cmd *CheckProviderUpdateCmd) Run(
 
 func loadLatestProvider(
 	providerSourceRaw string,
-	log log.Logger,
 ) (*provider.ProviderConfig, error) {
-	providerRaw, _, err := workspace.ResolveProvider(providerSourceRaw, log)
+	providerRaw, _, err := workspace.ResolveProvider(providerSourceRaw, oldlog.Default)
 	if err != nil {
 		return nil, fmt.Errorf("resolve provider: %w", err)
 	}

--- a/cmd/helper/docker_credentials.go
+++ b/cmd/helper/docker_credentials.go
@@ -7,7 +7,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/credentials"
 	"github.com/devsy-org/devsy/pkg/dockercredentials"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -42,5 +42,5 @@ func (c *DockerCredentialsHelperCmd) Run(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("get port: %w", err)
 	}
 
-	return dockercredentials.ConfigureCredentialsContainer(u.Name, port, log.Default)
+	return dockercredentials.ConfigureCredentialsContainer(u.Name, port, oldlog.Default)
 }

--- a/cmd/helper/get_provider_name.go
+++ b/cmd/helper/get_provider_name.go
@@ -8,7 +8,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +37,7 @@ func (cmd *GetProviderNameCmd) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("provider is missing")
 	}
 
-	providerRaw, _, err := workspace.ResolveProvider(args[0], log.Default.ErrorStreamOnly())
+	providerRaw, _, err := workspace.ResolveProvider(args[0], oldlog.Default.ErrorStreamOnly())
 	if err != nil {
 		return fmt.Errorf("resolve provider: %w", err)
 	}

--- a/cmd/helper/get_workspace_config.go
+++ b/cmd/helper/get_workspace_config.go
@@ -10,7 +10,8 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -43,7 +44,7 @@ func NewGetWorkspaceConfigCommand(flags *flags.GlobalFlags) *cobra.Command {
 			}
 
 			if cmd.maxDepth < 0 {
-				log.Default.Debugf("--max-depth was %d, setting to 0", cmd.maxDepth)
+				log.Debugf("--max-depth was %d, setting to 0", cmd.maxDepth)
 				cmd.maxDepth = 0
 			}
 
@@ -69,13 +70,13 @@ func (cmd *GetWorkspaceConfigCommand) Run(
 	}
 	rawSource := args[0]
 
-	level := log.Default.GetLevel()
+	level := oldlog.Default.GetLevel()
 	if cmd.Debug {
 		level = logrus.DebugLevel
 	}
-	var logger log.Logger = log.NewStdoutLogger(os.Stdin, os.Stdout, os.Stderr, level)
+	var logger oldlog.Logger = oldlog.NewStdoutLogger(os.Stdin, os.Stdout, os.Stderr, level)
 	if os.Getenv(config.EnvUI) == config.BoolTrue {
-		logger = log.Discard
+		logger = oldlog.Discard
 	}
 	logger.Debugf("Resolving devcontainer config for source: %s", rawSource)
 

--- a/cmd/helper/ssh_server.go
+++ b/cmd/helper/ssh_server.go
@@ -12,7 +12,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/ssh/server/port"
 	"github.com/devsy-org/devsy/pkg/stdio"
 	"github.com/devsy-org/devsy/pkg/token"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/ssh"
 	"github.com/spf13/cobra"
 )
@@ -104,7 +104,7 @@ func (cmd *SSHServerCmd) Run(_ *cobra.Command, _ []string) error {
 		keys,
 		cmd.Workdir,
 		cmd.ReuseSSHAuthSock,
-		log.Default.ErrorStreamOnly(),
+		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return err
@@ -152,7 +152,7 @@ func (cmd *SSHServerCmd) Run(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("address %s already in use: %w", cmd.Address, err)
 		}
 
-		log.Default.ErrorStreamOnly().Infof("address %s already in use", cmd.Address)
+		oldlog.Default.ErrorStreamOnly().Infof("address %s already in use", cmd.Address)
 		return nil
 	}
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -13,7 +13,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/extract"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +48,7 @@ func NewImportCmd(flags *flags.GlobalFlags) *cobra.Command {
 				return err
 			}
 
-			return cmd.Run(cobraCmd.Context(), devsyConfig, log.Default)
+			return cmd.Run(cobraCmd.Context(), devsyConfig, oldlog.Default)
 		},
 	}
 
@@ -64,8 +64,12 @@ func NewImportCmd(flags *flags.GlobalFlags) *cobra.Command {
 	return importCmd
 }
 
-// Run runs the command logic.
-func (cmd *ImportCmd) Run(ctx context.Context, devsyConfig *config.Config, log log.Logger) error {
+//nolint:cyclop // pre-existing complexity
+func (cmd *ImportCmd) Run(
+	ctx context.Context,
+	devsyConfig *config.Config,
+	log oldlog.Logger,
+) error {
 	exportConfig := &provider.ExportConfig{}
 	err := json.Unmarshal([]byte(cmd.Data), exportConfig)
 	if err != nil {
@@ -117,7 +121,7 @@ func (cmd *ImportCmd) Run(ctx context.Context, devsyConfig *config.Config, log l
 func (cmd *ImportCmd) importWorkspace(
 	devsyConfig *config.Config,
 	exportConfig *provider.ExportConfig,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	workspaceDir, err := provider.GetWorkspaceDir(devsyConfig.DefaultContext, cmd.WorkspaceID)
 	if err != nil {
@@ -166,7 +170,7 @@ func (cmd *ImportCmd) importWorkspace(
 func (cmd *ImportCmd) importMachine(
 	devsyConfig *config.Config,
 	exportConfig *provider.ExportConfig,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	if exportConfig.Machine == nil {
 		return nil
@@ -221,7 +225,7 @@ func (cmd *ImportCmd) importMachine(
 func (cmd *ImportCmd) importProvider(
 	devsyConfig *config.Config,
 	exportConfig *provider.ExportConfig,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	// if provider already exists we skip
 	if cmd.ProviderReuse && provider.ProviderExists(devsyConfig.DefaultContext, cmd.ProviderID) {
@@ -284,7 +288,7 @@ func (cmd *ImportCmd) checkForConflictingIDs(
 	ctx context.Context,
 	exportConfig *provider.ExportConfig,
 	devsyConfig *config.Config,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	workspaces, err := workspace.List(ctx, devsyConfig, false, cmd.Owner, log)
 	if err != nil {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,7 +11,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/table"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -51,7 +51,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	workspaces, err := workspace.List(ctx, devsyConfig, cmd.SkipPro, cmd.Owner, log.Default)
+	workspaces, err := workspace.List(ctx, devsyConfig, cmd.SkipPro, cmd.Owner, oldlog.Default)
 	if err != nil {
 		return err
 	}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/ssh"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -44,7 +44,6 @@ func NewLogsCmd(flags *flags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				log.Default,
 			)
 		},
 	}
@@ -63,7 +62,7 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 		DevsyConfig: devsyConfig,
 		Args:        args,
 		Owner:       cmd.Owner,
-		Log:         log.Default,
+		Log:         oldlog.Default,
 	})
 	if err != nil {
 		return err
@@ -73,7 +72,7 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 	if !ok {
 		return fmt.Errorf("this command is not supported for proxy providers")
 	}
-	log := log.Default
+	log := oldlog.Default
 
 	// create readers
 	stdoutReader, stdoutWriter, err := os.Pipe()
@@ -98,7 +97,7 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 	// start ssh server in background
 	errChan := make(chan error, 1)
 	go func() {
-		stderr := log.ErrorStreamOnly().Writer(logrus.DebugLevel, false)
+		stderr := log.Writer(logrus.DebugLevel, false)
 		defer func() { _ = stderr.Close() }()
 
 		errChan <- agent.InjectAgent(&agent.InjectOptions{

--- a/cmd/logs_daemon.go
+++ b/cmd/logs_daemon.go
@@ -10,7 +10,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +46,7 @@ func (cmd *LogsDaemonCmd) Run(ctx context.Context, args []string) error {
 		DevsyConfig: devsyConfig,
 		Args:        args,
 		Owner:       cmd.Owner,
-		Log:         log.Default,
+		Log:         oldlog.Default,
 	})
 	if err != nil {
 		return err

--- a/cmd/machine/create.go
+++ b/cmd/machine/create.go
@@ -6,7 +6,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +45,7 @@ func (cmd *CreateCmd) Run(ctx context.Context, args []string) error {
 		devsyConfig,
 		args,
 		cmd.ProviderOptions,
-		log.Default,
+		oldlog.Default,
 	)
 	if err != nil {
 		return err

--- a/cmd/machine/delete.go
+++ b/cmd/machine/delete.go
@@ -9,7 +9,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +48,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, log.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -59,7 +59,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 		devsyConfig,
 		false,
 		platform.SelfOwnerFilter,
-		log.Default,
+		oldlog.Default,
 	)
 	if err != nil {
 		return err

--- a/cmd/machine/describe.go
+++ b/cmd/machine/describe.go
@@ -8,7 +8,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +40,7 @@ func (cmd *DescribeCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, log.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
 	if err != nil {
 		return err
 	}

--- a/cmd/machine/inspect.go
+++ b/cmd/machine/inspect.go
@@ -9,7 +9,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +38,7 @@ func (cmd *InspectCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, log.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
 	if err != nil {
 		return err
 	}

--- a/cmd/machine/ssh.go
+++ b/cmd/machine/ssh.go
@@ -18,7 +18,7 @@ import (
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
 	devsshagent "github.com/devsy-org/devsy/pkg/ssh/agent"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
@@ -120,12 +120,12 @@ func (cmd *SSHCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, log.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
 	if err != nil {
 		return err
 	}
 
-	writer := log.Default.ErrorStreamOnly().Writer(logrus.InfoLevel, false)
+	writer := oldlog.Default.ErrorStreamOnly().Writer(logrus.InfoLevel, false)
 	defer func() { _ = writer.Close() }()
 
 	// Get the timeout from the context options
@@ -161,7 +161,7 @@ func (cmd *SSHCmd) Run(ctx context.Context, args []string) error {
 				Stdin:           stdin,
 				Stdout:          stdout,
 				Stderr:          stderr,
-				Log:             log.Default.ErrorStreamOnly(),
+				Log:             oldlog.Default.ErrorStreamOnly(),
 				Timeout:         timeout,
 			})
 		},

--- a/cmd/machine/start.go
+++ b/cmd/machine/start.go
@@ -6,7 +6,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +38,7 @@ func (cmd *StartCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, log.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
 	if err != nil {
 		return err
 	}

--- a/cmd/machine/status.go
+++ b/cmd/machine/status.go
@@ -8,8 +8,9 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -44,7 +45,7 @@ func (cmd *StatusCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, log.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -59,23 +60,23 @@ func (cmd *StatusCmd) Run(ctx context.Context, args []string) error {
 	case "plain":
 		switch machineStatus {
 		case client.StatusStopped:
-			log.Default.Infof(
+			log.Infof(
 				"Machine '%s' is '%s', you can start it via 'devsy machine start %s'",
 				machineClient.Machine(),
 				machineStatus,
 				machineClient.Machine(),
 			)
 		case client.StatusBusy:
-			log.Default.Infof(
+			log.Infof(
 				"Machine '%s' is '%s', which means its currently unaccessible. "+
 					"This is usually resolved by waiting a couple of minutes",
 				machineClient.Machine(),
 				machineStatus,
 			)
 		case client.StatusNotFound:
-			log.Default.Infof("Machine '%s' is '%s'", machineClient.Machine(), machineStatus)
+			log.Infof("Machine '%s' is '%s'", machineClient.Machine(), machineStatus)
 		default:
-			log.Default.Infof("Machine '%s' is '%s'", machineClient.Machine(), machineStatus)
+			log.Infof("Machine '%s' is '%s'", machineClient.Machine(), machineStatus)
 		}
 	case "json":
 		out, err := json.Marshal(struct {

--- a/cmd/machine/stop.go
+++ b/cmd/machine/stop.go
@@ -7,7 +7,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +39,7 @@ func (cmd *StopCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, log.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
 	if err != nil {
 		return err
 	}

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -10,7 +10,7 @@ import (
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -36,7 +36,6 @@ func NewPingCmd(flags *flags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				log.Default,
 			)
 		},
 		Hidden: true,
@@ -56,7 +55,7 @@ func (cmd *PingCmd) Run(ctx context.Context, args []string) error {
 		Args:           args,
 		ChangeLastUsed: true,
 		Owner:          cmd.Owner,
-		Log:            log.Default.ErrorStreamOnly(),
+		Log:            oldlog.Default.ErrorStreamOnly(),
 	})
 	if err != nil {
 		return err

--- a/cmd/pro/add/cluster.go
+++ b/cmd/pro/add/cluster.go
@@ -13,10 +13,11 @@ import (
 	storagev1 "github.com/devsy-org/api/pkg/apis/storage/v1"
 	proflags "github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/log/survey"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -28,7 +29,6 @@ import (
 )
 
 type ClusterCmd struct {
-	Log log.Logger
 	*proflags.GlobalFlags
 
 	Namespace        string
@@ -48,7 +48,6 @@ type ClusterCmd struct {
 func NewClusterCmd(globalFlags *proflags.GlobalFlags) *cobra.Command {
 	cmd := &ClusterCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 
 	c := &cobra.Command{
@@ -91,7 +90,7 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	cmd.Host, err = ensureHost(devsyConfig, cmd.Host, cmd.Log)
+	cmd.Host, err = ensureHost(devsyConfig, cmd.Host)
 	if err != nil {
 		return err
 	}
@@ -99,7 +98,7 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 	// Get clusterName from command argument
 	clusterName := args[0]
 
-	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host, cmd.Log)
+	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host, oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -267,12 +266,12 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 	go func() {
 		helmCmd := exec.CommandContext(ctx, "helm", helmArgs...)
 
-		helmCmd.Stdout = cmd.Log.Writer(logrus.DebugLevel, true)
-		helmCmd.Stderr = cmd.Log.Writer(logrus.DebugLevel, true)
+		helmCmd.Stdout = oldlog.Default.Writer(logrus.DebugLevel, true)
+		helmCmd.Stderr = oldlog.Default.Writer(logrus.DebugLevel, true)
 		helmCmd.Stdin = os.Stdin
 
-		cmd.Log.Info("Installing agent...")
-		cmd.Log.Debugf("Running helm command: %v", helmCmd.Args)
+		log.Info("Installing agent...")
+		log.Debugf("Running helm command: %v", helmCmd.Args)
 
 		err = helmCmd.Run()
 		if err != nil {
@@ -282,13 +281,13 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 		close(errChan)
 	}()
 
-	_, err = platform.WaitForPodReady(ctx, clientset, namespace, cmd.Log)
+	_, err = platform.WaitForPodReady(ctx, clientset, namespace, oldlog.Default)
 	if err = errors.Join(err, <-errChan); err != nil {
 		return fmt.Errorf("wait for pod: %w", err)
 	}
 
 	if cmd.Wait {
-		cmd.Log.Info("Waiting for the cluster to be initialized...")
+		log.Info("Waiting for the cluster to be initialized...")
 		waitErr := wait.PollUntilContextTimeout(
 			ctx,
 			time.Second,
@@ -312,17 +311,17 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 		}
 	}
 
-	cmd.Log.Donef("added cluster: cluster=%s", clusterName)
+	log.Infof("added cluster: cluster=%s", clusterName)
 
 	return nil
 }
 
-func ensureHost(devsyConfig *config.Config, host string, log log.Logger) (string, error) {
+func ensureHost(devsyConfig *config.Config, host string) (string, error) {
 	if host != "" {
 		return host, nil
 	}
 
-	proInstances, err := workspace.ListProInstances(devsyConfig, log)
+	proInstances, err := workspace.ListProInstances(devsyConfig, oldlog.Default)
 	if err != nil {
 		return "", fmt.Errorf("list pro instances: %w", err)
 	}
@@ -330,7 +329,7 @@ func ensureHost(devsyConfig *config.Config, host string, log log.Logger) (string
 	for _, pro := range proInstances {
 		options = append(options, pro.Host)
 	}
-	h, err := log.Question(&survey.QuestionOptions{
+	h, err := oldlog.Default.Question(&survey.QuestionOptions{
 		Question:     "Select Pro instance to connect your cluster to",
 		Options:      options,
 		DefaultValue: options[0],

--- a/cmd/pro/check_health.go
+++ b/cmd/pro/check_health.go
@@ -10,7 +10,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +18,6 @@ import (
 // CheckHealthCmd holds the cmd flags.
 type CheckHealthCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Host string
 }
@@ -27,7 +26,6 @@ type CheckHealthCmd struct {
 func NewCheckHealthCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &CheckHealthCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "check-health",
@@ -39,7 +37,6 @@ func NewCheckHealthCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -72,8 +69,6 @@ func (cmd *CheckHealthCmd) Run(
 	provider *provider.ProviderConfig,
 ) error {
 	var buf bytes.Buffer
-	// ignore --debug because we tunnel json through stdio
-	cmd.Log.SetLevel(logrus.InfoLevel)
 
 	err := clientimplementation.RunCommandWithBinaries(clientimplementation.CommandOptions{
 		Ctx:     ctx,
@@ -83,8 +78,8 @@ func (cmd *CheckHealthCmd) Run(
 		Options: devsyConfig.ProviderOptions(provider.Name),
 		Config:  provider,
 		Stdout:  &buf,
-		Stderr:  cmd.Log.Writer(logrus.ErrorLevel, true),
-		Log:     cmd.Log,
+		Stderr:  oldlog.Default.Writer(logrus.ErrorLevel, true),
+		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("check health with provider \"%s\": %w", provider.Name, err)

--- a/cmd/pro/check_update.go
+++ b/cmd/pro/check_update.go
@@ -11,14 +11,12 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
 	versionpkg "github.com/devsy-org/devsy/pkg/version"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // CheckUpdateCmd holds the cmd flags.
 type CheckUpdateCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Host string
 }
@@ -27,7 +25,6 @@ type CheckUpdateCmd struct {
 func NewCheckUpdateCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &CheckUpdateCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "check-update",
@@ -39,7 +36,6 @@ func NewCheckUpdateCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err

--- a/cmd/pro/completion/suggestions.go
+++ b/cmd/pro/completion/suggestions.go
@@ -6,7 +6,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -16,14 +16,13 @@ func GetPlatformHostSuggestions(
 	args []string,
 	toComplete string,
 	owner platform.OwnerFilter,
-	logger log.Logger,
 ) ([]string, cobra.ShellCompDirective) {
 	devsyConfig, err := config.LoadConfig(context, provider)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	proInstances, err := workspace.ListProInstances(devsyConfig, logger)
+	proInstances, err := workspace.ListProInstances(devsyConfig, oldlog.Default)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/cmd/pro/create_workspace.go
+++ b/cmd/pro/create_workspace.go
@@ -10,7 +10,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +18,6 @@ import (
 // CreateWorkspaceCmd holds the cmd flags.
 type CreateWorkspaceCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Host     string
 	Instance string
@@ -28,7 +27,6 @@ type CreateWorkspaceCmd struct {
 func NewCreateWorkspaceCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &CreateWorkspaceCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "create-workspace",
@@ -40,7 +38,6 @@ func NewCreateWorkspaceCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -67,8 +64,6 @@ func (cmd *CreateWorkspaceCmd) Run(
 	opts[platform.WorkspaceInstanceEnv] = config.OptionValue{Value: cmd.Instance}
 
 	var buf bytes.Buffer
-	// ignore --debug because we tunnel json through stdio
-	cmd.Log.SetLevel(logrus.InfoLevel)
 
 	err := clientimplementation.RunCommandWithBinaries(clientimplementation.CommandOptions{
 		Ctx:     ctx,
@@ -78,8 +73,8 @@ func (cmd *CreateWorkspaceCmd) Run(
 		Options: opts,
 		Config:  provider,
 		Stdout:  &buf,
-		Stderr:  cmd.Log.ErrorStreamOnly().Writer(logrus.ErrorLevel, true),
-		Log:     cmd.Log,
+		Stderr:  oldlog.Default.ErrorStreamOnly().Writer(logrus.ErrorLevel, true),
+		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("create workspace: %w", err)

--- a/cmd/pro/daemon/daemon.go
+++ b/cmd/pro/daemon/daemon.go
@@ -8,7 +8,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -31,14 +31,13 @@ func NewCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 func findProProvider(
 	ctx context.Context,
 	context, provider, host string,
-	log log.Logger,
 ) (*config.Config, *providerpkg.ProviderConfig, error) {
 	devsyConfig, err := config.LoadConfig(context, provider)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	pCfg, err := workspace.ProviderFromHost(ctx, devsyConfig, host, log)
+	pCfg, err := workspace.ProviderFromHost(ctx, devsyConfig, host, oldlog.Default)
 	if err != nil {
 		return devsyConfig, nil, fmt.Errorf("load provider: %w", err)
 	}

--- a/cmd/pro/daemon/netcheck.go
+++ b/cmd/pro/daemon/netcheck.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	daemon "github.com/devsy-org/devsy/pkg/daemon/platform"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	"tailscale.com/client/local"
 )
@@ -21,14 +20,12 @@ type NetcheckCmd struct {
 	*proflags.GlobalFlags
 
 	Host string
-	Log  log.Logger
 }
 
 // NewNetcheckCmd creates a new command.
 func NewNetcheckCmd(flags *proflags.GlobalFlags) *cobra.Command {
 	cmd := &NetcheckCmd{
 		GlobalFlags: flags,
-		Log:         log.Default,
 	}
 	c := &cobra.Command{
 		Use:   "netcheck",
@@ -39,7 +36,6 @@ func NewNetcheckCmd(flags *proflags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -72,7 +68,6 @@ func NewNetcheckCmd(flags *proflags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				cmd.Log,
 			)
 		},
 	)

--- a/cmd/pro/daemon/start.go
+++ b/cmd/pro/daemon/start.go
@@ -14,9 +14,9 @@ import (
 	proflags "github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	daemon "github.com/devsy-org/devsy/pkg/daemon/platform"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -25,14 +25,12 @@ type StartCmd struct {
 	*proflags.GlobalFlags
 
 	Host string
-	Log  log.Logger
 }
 
 // NewStartCmd creates a new command.
 func NewStartCmd(flags *proflags.GlobalFlags) *cobra.Command {
 	cmd := &StartCmd{
 		GlobalFlags: flags,
-		Log:         log.Default,
 	}
 	c := &cobra.Command{
 		Use:   "start",
@@ -43,7 +41,6 @@ func NewStartCmd(flags *proflags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -65,7 +62,6 @@ func NewStartCmd(flags *proflags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				cmd.Log,
 			)
 		},
 	)
@@ -100,7 +96,7 @@ func (cmd *StartCmd) Run(
 	}
 
 	// Create a context with signal handling
-	ctx, cancel := withGracefulShutdown(ctx, cmd.Log)
+	ctx, cancel := withGracefulShutdown(ctx)
 	defer cancel()
 
 	d, err := daemon.Init(ctx, daemon.InitConfig{
@@ -124,7 +120,7 @@ func (cmd *StartCmd) Run(
 
 // withGracefulShutdown returns a context that is canceled when termination signals are received.
 // It implements a two-phase shutdown where a second signal forces immediate termination.
-func withGracefulShutdown(ctx context.Context, log log.Logger) (context.Context, func()) {
+func withGracefulShutdown(ctx context.Context) (context.Context, func()) {
 	ctx, cancel := context.WithCancel(ctx)
 	sigChan := make(chan os.Signal, 2)
 	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGQUIT)
@@ -134,6 +130,7 @@ func withGracefulShutdown(ctx context.Context, log log.Logger) (context.Context,
 			select {
 			case sig := <-sigChan:
 				log.Infof("Received signal %s, starting graceful shutdown...", sig)
+
 				cancel()
 			case <-ctx.Done():
 				return

--- a/cmd/pro/daemon/status.go
+++ b/cmd/pro/daemon/status.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	platformdaemon "github.com/devsy-org/devsy/pkg/daemon/platform"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -20,14 +19,12 @@ type StatusCmd struct {
 	*proflags.GlobalFlags
 
 	Host string
-	Log  log.Logger
 }
 
 // NewStatusCmd creates a new command.
 func NewStatusCmd(flags *proflags.GlobalFlags) *cobra.Command {
 	cmd := &StatusCmd{
 		GlobalFlags: flags,
-		Log:         log.Default,
 	}
 	c := &cobra.Command{
 		Use:   "status",
@@ -38,7 +35,6 @@ func NewStatusCmd(flags *proflags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -71,7 +67,6 @@ func NewStatusCmd(flags *proflags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				cmd.Log,
 			)
 		},
 	)

--- a/cmd/pro/delete.go
+++ b/cmd/pro/delete.go
@@ -12,10 +12,11 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	daemon "github.com/devsy-org/devsy/pkg/daemon/platform"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -83,10 +84,10 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 		workspaces, err := workspace.ListLocalWorkspaces(
 			devsyConfig.DefaultContext,
 			false,
-			log.Default,
+			oldlog.Default,
 		)
 		if err != nil {
-			log.Default.Warnf("Failed to list workspaces: %v", err)
+			log.Warnf("Failed to list workspaces: %v", err)
 		} else {
 			cleanupLocalWorkspaces(
 				ctx,
@@ -94,19 +95,19 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 				workspaces,
 				providerConfig.Name,
 				cmd.Owner,
-				log.Default,
+				oldlog.Default,
 			)
 		}
 
 		daemonClient := daemon.NewLocalClient(proInstanceConfig.Provider)
 		err = daemonClient.Shutdown(ctx)
 		if err != nil {
-			log.Default.Warnf("Failed to shut down daemon: %v", err)
+			log.Warnf("Failed to shut down daemon: %v", err)
 		}
-		log.Default.Debug("Waiting for daemon to shut down")
+		log.Debug("Waiting for daemon to shut down")
 		err = waitDaemonStopped(ctx, providerConfig.Name)
 		if err != nil {
-			log.Default.Warnf("Failed to wait for daemon to be stopped: %v", err)
+			log.Warnf("Failed to wait for daemon to be stopped: %v", err)
 		}
 	}
 
@@ -130,7 +131,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("delete pro instance dir: %w", err)
 	}
 
-	log.Default.Donef("deleted pro instance: proInstanceName=%s", proInstanceName)
+	log.Infof("deleted pro instance: proInstanceName=%s", proInstanceName)
 	return nil
 }
 
@@ -140,7 +141,7 @@ func cleanupLocalWorkspaces(
 	workspaces []*provider.Workspace,
 	providerName string,
 	owner platform.OwnerFilter,
-	log log.Logger,
+	log oldlog.Logger,
 ) {
 	usedWorkspaces := []*provider.Workspace{}
 

--- a/cmd/pro/import_workspace.go
+++ b/cmd/pro/import_workspace.go
@@ -10,6 +10,7 @@ import (
 	proflags "github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/cmd/pro/provider/list"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/options"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
@@ -18,7 +19,7 @@ import (
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/random"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -31,15 +32,12 @@ type ImportCmd struct {
 	WorkspaceProject string
 
 	Own bool
-	log log.Logger
 }
 
 // NewImportCmd creates a new command.
 func NewImportCmd(globalFlags *proflags.GlobalFlags) *cobra.Command {
-	logger := log.GetInstance()
 	cmd := &ImportCmd{
 		GlobalFlags: globalFlags,
-		log:         logger,
 	}
 
 	importCmd := &cobra.Command{
@@ -86,7 +84,7 @@ func (cmd *ImportCmd) Run(ctx context.Context, args []string) error {
 		if err != nil {
 			return fmt.Errorf("load workspace: %w", err)
 		} else if workspaceConfig.UID == cmd.WorkspaceUid {
-			cmd.log.Infof("Workspace %s already imported", cmd.WorkspaceId)
+			log.Infof("Workspace %s already imported", cmd.WorkspaceId)
 			return nil
 		}
 
@@ -95,7 +93,7 @@ func (cmd *ImportCmd) Run(ctx context.Context, args []string) error {
 			return fmt.Errorf("workspace %s already exists", cmd.WorkspaceId)
 		}
 
-		cmd.log.Infof(
+		log.Infof(
 			"workspace ID conflict, will import workspace with new ID: "+
 				"existingWorkspaceId=%s, existingWorkspaceUid=%s, newWorkspaceId=%s",
 			cmd.WorkspaceId,
@@ -105,12 +103,17 @@ func (cmd *ImportCmd) Run(ctx context.Context, args []string) error {
 		cmd.WorkspaceId = newWorkspaceId
 	}
 
-	provider, err := workspace.ProviderFromHost(ctx, devsyConfig, devsyProHost, cmd.log)
+	provider, err := workspace.ProviderFromHost(ctx, devsyConfig, devsyProHost, oldlog.Default)
 	if err != nil {
 		return fmt.Errorf("resolve provider: %w", err)
 	}
 
-	baseClient, err := platform.InitClientFromProvider(ctx, devsyConfig, provider.Name, cmd.log)
+	baseClient, err := platform.InitClientFromProvider(
+		ctx,
+		devsyConfig,
+		provider.Name,
+		oldlog.Default,
+	)
 	if err != nil {
 		return fmt.Errorf("base client: %w", err)
 	}
@@ -134,7 +137,7 @@ func (cmd *ImportCmd) Run(ctx context.Context, args []string) error {
 		if err != nil {
 			return fmt.Errorf("prepare workspace to import definition: %w", err)
 		}
-		cmd.log.Infof("imported workspace: workspaceId=%s", cmd.WorkspaceId)
+		log.Infof("imported workspace: workspaceId=%s", cmd.WorkspaceId)
 		return nil
 	}
 
@@ -144,7 +147,7 @@ func (cmd *ImportCmd) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("prepare workspace to import definition: %w", err)
 	}
 
-	cmd.log.Infof("imported workspace: workspaceId=%s", cmd.WorkspaceId)
+	log.Infof("imported workspace: workspaceId=%s", cmd.WorkspaceId)
 
 	return nil
 }
@@ -200,7 +203,7 @@ func (cmd *ImportCmd) writeWorkspaceDefinition(
 		false,
 		false,
 		nil,
-		cmd.log,
+		oldlog.Default,
 	)
 	if err != nil {
 		return fmt.Errorf("resolve options: %w", err)

--- a/cmd/pro/list.go
+++ b/cmd/pro/list.go
@@ -12,7 +12,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/table"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -53,7 +53,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	proInstances, err := workspace.ListProInstances(devsyConfig, log.Default)
+	proInstances, err := workspace.ListProInstances(devsyConfig, oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 			entry := &proTableEntry{
 				ProInstance:  proInstance,
 				Context:      devsyConfig.DefaultContext,
-				Capabilities: getCapabilities(devsyConfig, proInstance, log.Discard),
+				Capabilities: getCapabilities(devsyConfig, proInstance, oldlog.Discard),
 			}
 			if cmd.Login {
 				err = checkLogin(ctx, devsyConfig, proInstance)
@@ -153,7 +153,7 @@ func checkLogin(
 		"",
 		true,
 		false,
-		log.Default,
+		oldlog.Default,
 	); err != nil {
 		return fmt.Errorf("not logged into %s", proInstance.Host)
 	}
@@ -164,7 +164,7 @@ func checkLogin(
 func getCapabilities(
 	devsyConfig *config.Config,
 	proInstance *provider.ProInstance,
-	log log.Logger,
+	log oldlog.Logger,
 ) []Capability {
 	capabilities := []Capability{}
 	provider, err := workspace.FindProvider(devsyConfig, proInstance.Provider, log)

--- a/cmd/pro/list_clusters.go
+++ b/cmd/pro/list_clusters.go
@@ -10,15 +10,13 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // ListClustersCmd holds the cmd flags.
 type ListClustersCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Host    string
 	Project string
@@ -28,7 +26,6 @@ type ListClustersCmd struct {
 func NewListClustersCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &ListClustersCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "list-clusters",
@@ -40,7 +37,6 @@ func NewListClustersCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -66,9 +62,6 @@ func (cmd *ListClustersCmd) Run(
 	opts := devsyConfig.ProviderOptions(provider.Name)
 	opts[platform.ProjectEnv] = config.OptionValue{Value: cmd.Project}
 
-	// ignore --debug because we tunnel json through stdio
-	cmd.Log.SetLevel(logrus.InfoLevel)
-
 	var buf bytes.Buffer
 	err := clientimplementation.RunCommandWithBinaries(clientimplementation.CommandOptions{
 		Ctx:     ctx,
@@ -78,7 +71,7 @@ func (cmd *ListClustersCmd) Run(
 		Options: opts,
 		Config:  provider,
 		Stdout:  &buf,
-		Log:     cmd.Log,
+		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("list clusters with provider \"%s\": %w", provider.Name, err)

--- a/cmd/pro/list_projects.go
+++ b/cmd/pro/list_projects.go
@@ -9,15 +9,13 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // ListProjectsCmd holds the cmd flags.
 type ListProjectsCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Host string
 }
@@ -26,7 +24,6 @@ type ListProjectsCmd struct {
 func NewListProjectsCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &ListProjectsCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "list-projects",
@@ -38,7 +35,6 @@ func NewListProjectsCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -60,8 +56,6 @@ func (cmd *ListProjectsCmd) Run(
 	provider *provider.ProviderConfig,
 ) error {
 	var buf bytes.Buffer
-	// ignore --debug because we tunnel json through stdio
-	cmd.Log.SetLevel(logrus.InfoLevel)
 
 	err := clientimplementation.RunCommandWithBinaries(clientimplementation.CommandOptions{
 		Ctx:     ctx,
@@ -71,7 +65,7 @@ func (cmd *ListProjectsCmd) Run(
 		Options: devsyConfig.ProviderOptions(provider.Name),
 		Config:  provider,
 		Stdout:  &buf,
-		Log:     cmd.Log,
+		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("watch workspaces with provider \"%s\": %w", provider.Name, err)

--- a/cmd/pro/list_templates.go
+++ b/cmd/pro/list_templates.go
@@ -10,15 +10,13 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // ListTemplatesCmd holds the cmd flags.
 type ListTemplatesCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Host    string
 	Project string
@@ -28,7 +26,6 @@ type ListTemplatesCmd struct {
 func NewListTemplatesCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &ListTemplatesCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "list-templates",
@@ -40,7 +37,6 @@ func NewListTemplatesCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -66,8 +62,6 @@ func (cmd *ListTemplatesCmd) Run(
 	opts := devsyConfig.ProviderOptions(provider.Name)
 	opts[platform.ProjectEnv] = config.OptionValue{Value: cmd.Project}
 
-	// ignore --debug because we tunnel json through stdio
-	cmd.Log.SetLevel(logrus.InfoLevel)
 	var buf bytes.Buffer
 	err := clientimplementation.RunCommandWithBinaries(clientimplementation.CommandOptions{
 		Ctx:     ctx,
@@ -77,7 +71,7 @@ func (cmd *ListTemplatesCmd) Run(
 		Options: opts,
 		Config:  provider,
 		Stdout:  &buf,
-		Log:     cmd.Log,
+		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("list templates with provider \"%s\": %w", provider.Name, err)

--- a/cmd/pro/list_workspaces.go
+++ b/cmd/pro/list_workspaces.go
@@ -9,15 +9,13 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // ListWorkspacesCmd holds the cmd flags.
 type ListWorkspacesCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Host string
 }
@@ -26,7 +24,6 @@ type ListWorkspacesCmd struct {
 func NewListWorkspacesCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &ListWorkspacesCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "list-workspaces",
@@ -38,7 +35,6 @@ func NewListWorkspacesCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -60,8 +56,6 @@ func (cmd *ListWorkspacesCmd) Run(
 	provider *provider.ProviderConfig,
 ) error {
 	var buf bytes.Buffer
-	// ignore --debug because we tunnel json through stdio
-	cmd.Log.SetLevel(logrus.InfoLevel)
 
 	err := clientimplementation.RunCommandWithBinaries(clientimplementation.CommandOptions{
 		Ctx:     ctx,
@@ -71,7 +65,7 @@ func (cmd *ListWorkspacesCmd) Run(
 		Options: devsyConfig.ProviderOptions(provider.Name),
 		Config:  provider,
 		Stdout:  &buf,
-		Log:     cmd.Log,
+		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("list workspaces: %w", err)

--- a/cmd/pro/login.go
+++ b/cmd/pro/login.go
@@ -16,7 +16,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/types"
 	versionpkg "github.com/devsy-org/devsy/pkg/version"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -55,7 +55,7 @@ func NewLoginCmd(flags *proflags.GlobalFlags) *cobra.Command {
 				)
 			}
 
-			return cmd.Run(cobraCmd.Context(), args[0], log.Default)
+			return cmd.Run(cobraCmd.Context(), args[0], oldlog.Default)
 		},
 	}
 
@@ -80,8 +80,8 @@ func NewLoginCmd(flags *proflags.GlobalFlags) *cobra.Command {
 	return loginCmd
 }
 
-// Run runs the command logic.
-func (cmd *LoginCmd) Run(ctx context.Context, fullURL string, log log.Logger) error {
+//nolint:cyclop,funlen // pre-existing complexity
+func (cmd *LoginCmd) Run(ctx context.Context, fullURL string, log oldlog.Logger) error {
 	if strings.HasPrefix(fullURL, "http://") {
 		return fmt.Errorf("http is not supported for Devsy Pro, please use https:// instead")
 	} else if !strings.HasPrefix(fullURL, "https://") {
@@ -241,7 +241,7 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string, log log.Logger) er
 func (cmd *LoginCmd) addLoftProvider(
 	devsyConfig *config.Config,
 	url string,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	// find out loft version
 	err := cmd.resolveProviderSource(url)
@@ -300,7 +300,7 @@ func login(
 	providerName string,
 	accessKey string,
 	skipBrowserLogin, forceBrowser bool,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	configPath, err := platform.DevsyConfigPath(devsyConfig.DefaultContext, providerName)
 	if err != nil {

--- a/cmd/pro/pro.go
+++ b/cmd/pro/pro.go
@@ -13,7 +13,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -62,14 +62,13 @@ func NewProCmd(flags *flags.GlobalFlags) *cobra.Command {
 func findProProvider(
 	ctx context.Context,
 	context, provider, host string,
-	log log.Logger,
 ) (*config.Config, *providerpkg.ProviderConfig, error) {
 	devsyConfig, err := config.LoadConfig(context, provider)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	pCfg, err := workspace.ProviderFromHost(ctx, devsyConfig, host, log)
+	pCfg, err := workspace.ProviderFromHost(ctx, devsyConfig, host, oldlog.Default)
 	if err != nil {
 		return devsyConfig, nil, fmt.Errorf("load provider: %w", err)
 	}

--- a/cmd/pro/provider/create/workspace.go
+++ b/cmd/pro/provider/create/workspace.go
@@ -15,7 +15,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform/form"
 	"github.com/devsy-org/devsy/pkg/platform/project"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/log/terminal"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,15 +24,12 @@ import (
 // WorkspaceCmd holds the cmd flags.
 type WorkspaceCmd struct {
 	*flags.GlobalFlags
-
-	Log log.Logger
 }
 
 // NewWorkspaceCmd creates a new command.
 func NewWorkspaceCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &WorkspaceCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance().ErrorStreamOnly(),
 	}
 	c := &cobra.Command{
 		Use:    "workspace",
@@ -67,7 +64,7 @@ func (cmd *WorkspaceCmd) Run(
 			return fmt.Errorf("unmarshal workpace instance %s: %w", instanceEnv, err)
 		}
 
-		updatedInstance, err := createInstance(ctx, baseClient, instance, cmd.Log)
+		updatedInstance, err := createInstance(ctx, baseClient, instance)
 		if err != nil {
 			return err
 		}
@@ -119,13 +116,13 @@ func (cmd *WorkspaceCmd) Run(
 		workspaceUID,
 		workspaceSource,
 		workspacePicture,
-		cmd.Log,
+		oldlog.Default,
 	)
 	if err != nil {
 		return err
 	}
 
-	_, err = createInstance(ctx, baseClient, instance, cmd.Log)
+	_, err = createInstance(ctx, baseClient, instance)
 	if err != nil {
 		return err
 	}
@@ -154,7 +151,6 @@ func createInstance(
 	ctx context.Context,
 	client client.Client,
 	instance *managementv1.DevsyWorkspaceInstance,
-	log log.Logger,
 ) (*managementv1.DevsyWorkspaceInstance, error) {
 	managementClient, err := client.Management()
 	if err != nil {
@@ -168,5 +164,5 @@ func createInstance(
 		return nil, fmt.Errorf("create workspace instance: %w", err)
 	}
 
-	return platform.WaitForInstance(ctx, client, updatedInstance, log)
+	return platform.WaitForInstance(ctx, client, updatedInstance, oldlog.Default)
 }

--- a/cmd/pro/provider/delete.go
+++ b/cmd/pro/provider/delete.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -17,15 +16,12 @@ import (
 // DeleteCmd holds the cmd flags.
 type DeleteCmd struct {
 	*flags.GlobalFlags
-
-	Log log.Logger
 }
 
 // NewDeleteCmd creates a new command.
 func NewDeleteCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &DeleteCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Hidden: true,

--- a/cmd/pro/provider/get/self.go
+++ b/cmd/pro/provider/get/self.go
@@ -9,22 +9,18 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/platform/client"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // SelfCmd holds the cmd flags.
 type SelfCmd struct {
 	*flags.GlobalFlags
-
-	Log log.Logger
 }
 
 // NewSelfCmd creates a new command.
 func NewSelfCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &SelfCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:   "self",

--- a/cmd/pro/provider/get/version.go
+++ b/cmd/pro/provider/get/version.go
@@ -12,15 +12,12 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // VersionCmd holds the cmd flags.
 type VersionCmd struct {
 	*flags.GlobalFlags
-
-	Log log.Logger
 }
 
 type VersionInfo struct {
@@ -38,7 +35,6 @@ type VersionInfo struct {
 func NewVersionCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &VersionCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:   "version",

--- a/cmd/pro/provider/get/workspace.go
+++ b/cmd/pro/provider/get/workspace.go
@@ -8,22 +8,18 @@ import (
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // WorkspaceCmd holds the cmd flags.
 type WorkspaceCmd struct {
 	*flags.GlobalFlags
-
-	log log.Logger
 }
 
 // NewWorkspaceCmd creates a new command.
 func NewWorkspaceCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &WorkspaceCmd{
 		GlobalFlags: globalFlags,
-		log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:   "workspace",

--- a/cmd/pro/provider/health.go
+++ b/cmd/pro/provider/health.go
@@ -12,22 +12,18 @@ import (
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
 	"github.com/devsy-org/devsy/pkg/platform/client"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // HealthCmd holds the cmd flags.
 type HealthCmd struct {
 	*flags.GlobalFlags
-
-	Log log.Logger
 }
 
 // NewHealthCmd creates a new command.
 func NewHealthCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &HealthCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "health",

--- a/cmd/pro/provider/list/clusters.go
+++ b/cmd/pro/provider/list/clusters.go
@@ -10,7 +10,6 @@ import (
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -18,15 +17,12 @@ import (
 // ClustersCmd holds the cmd flags.
 type ClustersCmd struct {
 	*flags.GlobalFlags
-
-	log log.Logger
 }
 
 // NewClustersCmd creates a new command.
 func NewClustersCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &ClustersCmd{
 		GlobalFlags: globalFlags,
-		log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:   "clusters",

--- a/cmd/pro/provider/list/projects.go
+++ b/cmd/pro/provider/list/projects.go
@@ -8,7 +8,6 @@ import (
 	managementv1 "github.com/devsy-org/api/pkg/apis/management/v1"
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/platform/client"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -16,15 +15,12 @@ import (
 // ProjectsCmd holds the cmd flags.
 type ProjectsCmd struct {
 	*flags.GlobalFlags
-
-	log log.Logger
 }
 
 // NewProjectsCmd creates a new command.
 func NewProjectsCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &ProjectsCmd{
 		GlobalFlags: globalFlags,
-		log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:   "projects",

--- a/cmd/pro/provider/list/templates.go
+++ b/cmd/pro/provider/list/templates.go
@@ -16,7 +16,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/kube"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -24,15 +23,12 @@ import (
 // TemplatesCmd holds the cmd flags.
 type TemplatesCmd struct {
 	*flags.GlobalFlags
-
-	log log.Logger
 }
 
 // NewTemplatesCmd creates a new command.
 func NewTemplatesCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &TemplatesCmd{
 		GlobalFlags: globalFlags,
-		log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:   "templates",

--- a/cmd/pro/provider/list/workspaces.go
+++ b/cmd/pro/provider/list/workspaces.go
@@ -9,11 +9,11 @@ import (
 	managementv1 "github.com/devsy-org/api/pkg/apis/management/v1"
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/labels"
 	"github.com/devsy-org/devsy/pkg/platform/project"
-	"github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -21,15 +21,12 @@ import (
 // WorkspacesCmd holds the cmd flags.
 type WorkspacesCmd struct {
 	*flags.GlobalFlags
-
-	log log.Logger
 }
 
 // NewWorkspacesCmd creates a new command.
 func NewWorkspacesCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &WorkspacesCmd{
 		GlobalFlags: globalFlags,
-		log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:   "workspaces",
@@ -75,7 +72,7 @@ func (cmd *WorkspacesCmd) Run(ctx context.Context) error {
 			DevsyWorkspaceInstances(ns).
 			List(ctx, metav1.ListOptions{})
 		if err != nil {
-			cmd.log.Info("list workspaces in project \"%s\": %w", p.GetName(), err)
+			log.Infof("list workspaces in project %q: %v", p.GetName(), err)
 			continue
 		}
 

--- a/cmd/pro/provider/provider.go
+++ b/cmd/pro/provider/provider.go
@@ -13,7 +13,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -30,7 +30,7 @@ func NewProProviderCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				globalFlags.Config = os.Getenv(platform.ConfigEnv)
 			}
 
-			log.Default.SetFormat(log.JSONFormat)
+			oldlog.Default.SetFormat(oldlog.JSONFormat)
 
 			if os.Getenv(config.EnvDebug) == config.BoolTrue {
 				globalFlags.Debug = true

--- a/cmd/pro/provider/rebuild.go
+++ b/cmd/pro/provider/rebuild.go
@@ -11,7 +11,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/remotecommand"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +20,6 @@ const AllWorkspaces = "all"
 // RebuildCmd holds the cmd flags.
 type RebuildCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Project string
 }
@@ -29,14 +28,11 @@ type RebuildCmd struct {
 func NewRebuildCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &RebuildCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:   "rebuild",
 		Short: "Rebuild a workspace",
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			log.Default.SetFormat(log.TextFormat)
-
 			return cmd.Run(cobraCmd.Context(), args)
 		},
 	}
@@ -72,7 +68,7 @@ func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 	values := url.Values{"options": []string{string(rawOpts)}, "cliMode": []string{"true"}}
-	conn, err := platform.DialInstance(baseClient, workspace, "up", values, cmd.Log)
+	conn, err := platform.DialInstance(baseClient, workspace, "up", values, oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -83,7 +79,7 @@ func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 		os.Stdin,
 		os.Stdout,
 		os.Stderr,
-		cmd.Log.ErrorStreamOnly(),
+		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return fmt.Errorf("error executing: %w", err)

--- a/cmd/pro/provider/ssh.go
+++ b/cmd/pro/provider/ssh.go
@@ -11,22 +11,19 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/remotecommand"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // SshCmd holds the cmd flags.
 type SshCmd struct {
 	*flags.GlobalFlags
-
-	Log log.Logger
 }
 
 // NewSshCmd creates a new command.
 func NewSshCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &SshCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Hidden: true,
@@ -69,13 +66,20 @@ func (cmd *SshCmd) Run(
 		workspace,
 		"ssh",
 		platform.OptionsFromEnv(config.EnvFlagsSSH),
-		cmd.Log,
+		oldlog.Default,
 	)
 	if err != nil {
 		return err
 	}
 
-	_, err = remotecommand.ExecuteConn(ctx, conn, stdin, stdout, stderr, cmd.Log.ErrorStreamOnly())
+	_, err = remotecommand.ExecuteConn(
+		ctx,
+		conn,
+		stdin,
+		stdout,
+		stderr,
+		oldlog.Default.ErrorStreamOnly(),
+	)
 	if err != nil {
 		return fmt.Errorf("error executing: %w", err)
 	}

--- a/cmd/pro/provider/status.go
+++ b/cmd/pro/provider/status.go
@@ -13,22 +13,19 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/remotecommand"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // StatusCmd holds the cmd flags.
 type StatusCmd struct {
 	*flags.GlobalFlags
-
-	Log log.Logger
 }
 
 // NewStatusCmd creates a new command.
 func NewStatusCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &StatusCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Hidden: true,
@@ -82,13 +79,20 @@ func (cmd *StatusCmd) Run(
 		workspace,
 		"getstatus",
 		platform.OptionsFromEnv(config.EnvFlagsStatus),
-		cmd.Log,
+		oldlog.Default,
 	)
 	if err != nil {
 		return err
 	}
 
-	_, err = remotecommand.ExecuteConn(ctx, conn, stdin, stdout, stderr, cmd.Log.ErrorStreamOnly())
+	_, err = remotecommand.ExecuteConn(
+		ctx,
+		conn,
+		stdin,
+		stdout,
+		stderr,
+		oldlog.Default.ErrorStreamOnly(),
+	)
 	if err != nil {
 		return fmt.Errorf("error executing: %w", err)
 	}

--- a/cmd/pro/provider/stop.go
+++ b/cmd/pro/provider/stop.go
@@ -11,22 +11,19 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/remotecommand"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // StopCmd holds the cmd flags.
 type StopCmd struct {
 	*flags.GlobalFlags
-
-	Log log.Logger
 }
 
 // NewStopCmd creates a new command.
 func NewStopCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &StopCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Hidden: true,
@@ -69,13 +66,20 @@ func (cmd *StopCmd) Run(
 		workspace,
 		"stop",
 		platform.OptionsFromEnv(storagev1.DevsyFlagsStop),
-		cmd.Log,
+		oldlog.Default,
 	)
 	if err != nil {
 		return err
 	}
 
-	_, err = remotecommand.ExecuteConn(ctx, conn, stdin, stdout, stderr, cmd.Log.ErrorStreamOnly())
+	_, err = remotecommand.ExecuteConn(
+		ctx,
+		conn,
+		stdin,
+		stdout,
+		stderr,
+		oldlog.Default.ErrorStreamOnly(),
+	)
 	if err != nil {
 		return fmt.Errorf("error executing: %w", err)
 	}

--- a/cmd/pro/provider/up.go
+++ b/cmd/pro/provider/up.go
@@ -11,11 +11,11 @@ import (
 	storagev1 "github.com/devsy-org/api/pkg/apis/storage/v1"
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/remotecommand"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -24,7 +24,6 @@ import (
 type UpCmd struct {
 	*flags.GlobalFlags
 
-	Log     log.Logger
 	streams streams
 }
 
@@ -36,15 +35,8 @@ type streams struct {
 
 // NewUpCmd creates a new command.
 func NewUpCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
-	logLevel := logrus.InfoLevel
-	if os.Getenv(config.EnvDebug) == config.BoolTrue || globalFlags.Debug {
-		logLevel = logrus.DebugLevel
-	}
-
 	cmd := &UpCmd{
 		GlobalFlags: globalFlags,
-		Log: log.NewStreamLoggerWithFormat( /* we don't use stdout */ nil,
-			os.Stderr, logLevel, log.JSONFormat).ErrorStreamOnly(),
 		streams: streams{
 			Stdin:  os.Stdin,
 			Stdout: os.Stdout,
@@ -89,18 +81,24 @@ func (cmd *UpCmd) Run(ctx context.Context) error {
 
 	// Log current workspace information. This is both useful to the user to understand the workspace configuration
 	// and to us when we receive troubleshooting logs
-	printInstanceInfo(instance, cmd.Log)
+	printInstanceInfo(instance)
 
 	if instance.Spec.TemplateRef != nil && templateUpdateRequired(instance) {
-		cmd.Log.Info("Template update required")
+		log.Info("Template update required")
 		oldInstance := instance.DeepCopy()
 		instance.Spec.TemplateRef.SyncOnce = true
 
-		instance, err = platform.UpdateInstance(ctx, baseClient, oldInstance, instance, cmd.Log)
+		instance, err = platform.UpdateInstance(
+			ctx,
+			baseClient,
+			oldInstance,
+			instance,
+			oldlog.Default,
+		)
 		if err != nil {
 			return fmt.Errorf("update instance: %w", err)
 		}
-		cmd.Log.Info("updated template")
+		log.Info("updated template")
 	}
 
 	return cmd.up(ctx, instance, baseClient)
@@ -116,7 +114,7 @@ func (cmd *UpCmd) up(
 		options.Add("debug", config.BoolTrue)
 	}
 
-	conn, err := platform.DialInstance(client, workspace, "up", options, cmd.Log)
+	conn, err := platform.DialInstance(client, workspace, "up", options, oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -127,7 +125,7 @@ func (cmd *UpCmd) up(
 		cmd.streams.Stdin,
 		cmd.streams.Stdout,
 		cmd.streams.Stderr,
-		cmd.Log,
+		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return fmt.Errorf("error executing: %w", err)
@@ -154,7 +152,7 @@ func templateUpdateRequired(instance *managementv1.DevsyWorkspaceInstance) bool 
 	return !templateResolved || templateChangesAvailable
 }
 
-func printInstanceInfo(instance *managementv1.DevsyWorkspaceInstance, log log.Logger) {
+func printInstanceInfo(instance *managementv1.DevsyWorkspaceInstance) {
 	workspaceConfig, _ := json.Marshal(struct {
 		// Cluster    storagev1.WorkspaceTargetNamespace
 		Template   *storagev1.TemplateRef
@@ -165,5 +163,5 @@ func printInstanceInfo(instance *managementv1.DevsyWorkspaceInstance, log log.Lo
 		Template:   instance.Spec.TemplateRef,
 		Parameters: instance.Spec.Parameters,
 	})
-	log.Debug("Starting pro workspace with configuration", string(workspaceConfig))
+	log.Debugf("Starting pro workspace with configuration %s", string(workspaceConfig))
 }

--- a/cmd/pro/provider/update/workspace.go
+++ b/cmd/pro/provider/update/workspace.go
@@ -13,7 +13,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/form"
 	"github.com/devsy-org/devsy/pkg/platform/project"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/log/terminal"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,15 +22,12 @@ import (
 // WorkspaceCmd holds the cmd flags.
 type WorkspaceCmd struct {
 	*flags.GlobalFlags
-
-	Log log.Logger
 }
 
 // NewWorkspaceCmd creates a new command.
 func NewWorkspaceCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &WorkspaceCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance().ErrorStreamOnly(),
 	}
 	c := &cobra.Command{
 		Use:    "workspace",
@@ -80,7 +77,7 @@ func (cmd *WorkspaceCmd) Run(
 			)
 		}
 
-		updatedInstance, err := updateInstance(ctx, baseClient, oldInstance, newInstance, cmd.Log)
+		updatedInstance, err := updateInstance(ctx, baseClient, oldInstance, newInstance)
 		if err != nil {
 			return err
 		}
@@ -123,12 +120,12 @@ func (cmd *WorkspaceCmd) Run(
 		)
 	}
 
-	newInstance, err := form.UpdateInstance(ctx, baseClient, oldInstance, cmd.Log)
+	newInstance, err := form.UpdateInstance(ctx, baseClient, oldInstance, oldlog.Default)
 	if err != nil {
 		return err
 	}
 
-	_, err = updateInstance(ctx, baseClient, oldInstance, newInstance, cmd.Log)
+	_, err = updateInstance(ctx, baseClient, oldInstance, newInstance)
 	if err != nil {
 		return err
 	}
@@ -141,12 +138,11 @@ func updateInstance(
 	client client.Client,
 	oldInstance *managementv1.DevsyWorkspaceInstance,
 	newInstance *managementv1.DevsyWorkspaceInstance,
-	log log.Logger,
 ) (*managementv1.DevsyWorkspaceInstance, error) {
 	// This ensures the template is kept up to date with configuration changes
 	if newInstance.Spec.TemplateRef != nil {
 		newInstance.Spec.TemplateRef.SyncOnce = true
 	}
 
-	return platform.UpdateInstance(ctx, client, oldInstance, newInstance, log)
+	return platform.UpdateInstance(ctx, client, oldInstance, newInstance, oldlog.Default)
 }

--- a/cmd/pro/provider/watch/workspaces.go
+++ b/cmd/pro/provider/watch/workspaces.go
@@ -21,7 +21,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform/project"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -30,15 +30,12 @@ import (
 // WorkspacesCmd holds the cmd flags.
 type WorkspacesCmd struct {
 	*flags.GlobalFlags
-
-	Log log.Logger
 }
 
 // NewWorkspacesCmd creates a new command.
 func NewWorkspacesCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &WorkspacesCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.Default.ErrorStreamOnly(),
 	}
 	c := &cobra.Command{
 		Use:    "workspaces",
@@ -105,7 +102,7 @@ func (cmd *WorkspacesCmd) Run(
 
 	self := baseClient.Self()
 	filterByOwner := os.Getenv(config.EnvLoftFilterByOwner) == config.BoolTrue
-	instanceStore := newStore(workspaceInformer, self, cmd.Context, filterByOwner, cmd.Log)
+	instanceStore := newStore(workspaceInformer, self, cmd.Context, filterByOwner)
 
 	_, err = workspaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
@@ -172,8 +169,6 @@ type instanceStore struct {
 
 	m         sync.Mutex
 	instances map[string]*ProWorkspaceInstance
-
-	log log.Logger
 }
 
 func newStore(
@@ -181,7 +176,6 @@ func newStore(
 	self *managementv1.Self,
 	context string,
 	filterByOwner bool,
-	log log.Logger,
 ) *instanceStore {
 	return &instanceStore{
 		informer:      informer,
@@ -189,7 +183,6 @@ func newStore(
 		context:       context,
 		filterByOwner: filterByOwner,
 		instances:     map[string]*ProWorkspaceInstance{},
-		log:           log,
 	}
 }
 
@@ -257,7 +250,11 @@ func (s *instanceStore) List() []*ProWorkspaceInstance {
 	instanceList := []*ProWorkspaceInstance{}
 	// Check local imported workspaces
 	// Eventually this should be implemented by filtering based on ownership and access on the CRD, for now we're stuck with this approach...
-	localWorkspaces, err := workspace.ListLocalWorkspaces(s.context, false, s.log)
+	localWorkspaces, err := workspace.ListLocalWorkspaces(
+		s.context,
+		false,
+		oldlog.Default.ErrorStreamOnly(),
+	)
 	if err == nil {
 		for _, workspace := range localWorkspaces {
 			if workspace.Imported && workspace.Pro != nil {

--- a/cmd/pro/rebuild.go
+++ b/cmd/pro/rebuild.go
@@ -11,14 +11,13 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/remotecommand"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // RebuildCmd holds the cmd flags.
 type RebuildCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Project string
 	Host    string
@@ -28,14 +27,11 @@ type RebuildCmd struct {
 func NewRebuildCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &RebuildCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:   "rebuild",
 		Short: "Rebuild a workspace",
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			log.Default.SetFormat(log.TextFormat)
-
 			return cmd.Run(cobraCmd.Context(), args)
 		},
 	}
@@ -59,7 +55,7 @@ func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host, cmd.Log)
+	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host, oldlog.Default)
 	if err != nil {
 		return fmt.Errorf("resolve host \"%s\": %w", cmd.Host, err)
 	}
@@ -81,7 +77,7 @@ func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 	values := url.Values{"options": []string{string(rawOpts)}, "cliMode": []string{"true"}}
-	conn, err := platform.DialInstance(baseClient, workspace, "up", values, cmd.Log)
+	conn, err := platform.DialInstance(baseClient, workspace, "up", values, oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -92,7 +88,7 @@ func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 		os.Stdin,
 		os.Stdout,
 		os.Stderr,
-		cmd.Log.ErrorStreamOnly(),
+		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return fmt.Errorf("error executing: %w", err)

--- a/cmd/pro/reset/password.go
+++ b/cmd/pro/reset/password.go
@@ -8,9 +8,10 @@ import (
 
 	storagev1 "github.com/devsy-org/api/pkg/apis/storage/v1"
 	"github.com/devsy-org/devsy/cmd/pro/flags"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform/kube"
 	"github.com/devsy-org/devsy/pkg/random"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/log/survey"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -27,15 +28,12 @@ type PasswordCmd struct {
 	Password string
 	Create   bool
 	Force    bool
-
-	Log log.Logger
 }
 
 // NewPasswordCmd creates a new command.
 func NewPasswordCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &PasswordCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	description := `
 Resets the password of a user.
@@ -74,7 +72,7 @@ func (cmd *PasswordCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	cmd.Log.Infof("Resetting password of user %s", cmd.User)
+	log.Infof("Resetting password of user %s", cmd.User)
 	user, err := cmd.resolveUser(ctx, managementClient)
 	if err != nil {
 		return err
@@ -102,7 +100,7 @@ func (cmd *PasswordCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	cmd.Log.Done("reset user password")
+	log.Info("reset user password")
 	return nil
 }
 
@@ -225,7 +223,7 @@ func (cmd *PasswordCmd) resolvePassword() (string, error) {
 	}
 
 	for {
-		password, err := cmd.Log.Question(&survey.QuestionOptions{
+		password, err := oldlog.Default.Question(&survey.QuestionOptions{
 			Question:   "Please enter a new password",
 			IsPassword: true,
 		})
@@ -238,7 +236,7 @@ func (cmd *PasswordCmd) resolvePassword() (string, error) {
 			return password, nil
 		}
 
-		cmd.Log.Error("Please enter a password")
+		log.Error("Please enter a password")
 	}
 }
 

--- a/cmd/pro/self.go
+++ b/cmd/pro/self.go
@@ -9,15 +9,13 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // SelfCmd holds the cmd flags.
 type SelfCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Host string
 }
@@ -26,7 +24,6 @@ type SelfCmd struct {
 func NewSelfCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &SelfCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "self",
@@ -38,7 +35,6 @@ func NewSelfCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -60,8 +56,6 @@ func (cmd *SelfCmd) Run(
 	provider *provider.ProviderConfig,
 ) error {
 	var buf bytes.Buffer
-	// ignore --debug because we tunnel json through stdio
-	cmd.Log.SetLevel(logrus.InfoLevel)
 
 	err := clientimplementation.RunCommandWithBinaries(clientimplementation.CommandOptions{
 		Ctx:     ctx,
@@ -71,7 +65,7 @@ func (cmd *SelfCmd) Run(
 		Options: devsyConfig.ProviderOptions(provider.Name),
 		Config:  provider,
 		Stdout:  &buf,
-		Log:     cmd.Log,
+		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("get self: %w", err)

--- a/cmd/pro/sleep.go
+++ b/cmd/pro/sleep.go
@@ -10,9 +10,10 @@ import (
 	storagev1 "github.com/devsy-org/api/pkg/apis/storage/v1"
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/project"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -22,7 +23,6 @@ import (
 // SleepCmd holds the cmd flags.
 type SleepCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Project       string
 	Host          string
@@ -33,14 +33,11 @@ type SleepCmd struct {
 func NewSleepCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &SleepCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:   "sleep",
 		Short: "Put a workspace to sleep",
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			log.Default.SetFormat(log.TextFormat)
-
 			return cmd.Run(cobraCmd.Context(), args)
 		},
 	}
@@ -69,7 +66,7 @@ func (cmd *SleepCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host, cmd.Log)
+	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host, oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -117,7 +114,7 @@ func (cmd *SleepCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// wait for sleeping
-	cmd.Log.Info("Wait until workspace is sleeping...")
+	log.Info("Wait until workspace is sleeping...")
 	err = wait.PollUntilContextTimeout(
 		ctx,
 		time.Second,
@@ -139,6 +136,6 @@ func (cmd *SleepCmd) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("error waiting for workspace to start sleeping: %w", err)
 	}
 
-	cmd.Log.Donef("workspace is now sleeping: workspace=%s", workspaceInstance.Name)
+	log.Infof("workspace is now sleeping: workspace=%s", workspaceInstance.Name)
 	return nil
 }

--- a/cmd/pro/start.go
+++ b/cmd/pro/start.go
@@ -24,12 +24,13 @@ import (
 	loftclientset "github.com/devsy-org/api/pkg/clientset/versioned"
 	proflags "github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/machineid"
 	devsyopen "github.com/devsy-org/devsy/pkg/open"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/util"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/log/hash"
 	"github.com/devsy-org/log/scanner"
 	"github.com/devsy-org/log/survey"
@@ -63,7 +64,6 @@ type StartCmd struct {
 	proflags.GlobalFlags
 
 	KubeClient       kubernetes.Interface
-	Log              log.Logger
 	RestConfig       *rest.Config
 	Context          string
 	Values           string
@@ -95,7 +95,6 @@ func NewStartCmd(flags *proflags.GlobalFlags) *cobra.Command {
 		GlobalFlags: *flags,
 		Product:     config.ProReleaseName,
 		ChartName:   config.ProReleaseName,
-		Log:         log.Default,
 	}
 	startCmd := &cobra.Command{
 		Use:   "start",
@@ -157,11 +156,16 @@ func (cmd *StartCmd) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	cmd.Log.WriteString(logrus.InfoLevel, "\n")
-
 	// Uninstall already existing instance
 	if cmd.Reset {
-		err = uninstall(ctx, cmd.KubeClient, cmd.RestConfig, cmd.Context, cmd.Namespace, cmd.Log)
+		err = uninstall(
+			ctx,
+			cmd.KubeClient,
+			cmd.RestConfig,
+			cmd.Context,
+			cmd.Namespace,
+			oldlog.Default,
+		)
 		if err != nil {
 			return err
 		}
@@ -189,8 +193,8 @@ func (cmd *StartCmd) Run(ctx context.Context) error {
 	}
 
 	// Install Devsy
-	cmd.Log.Info("Welcome to Devsy Pro!")
-	cmd.Log.Info("This installer will help you to get started.")
+	log.Info("Welcome to Devsy Pro!")
+	log.Info("This installer will help you to get started.")
 
 	// make sure we are ready for installing
 	err = cmd.prepareInstall(ctx)
@@ -292,7 +296,7 @@ func (cmd *StartCmd) retryUpgradeAfterPurge(
 	chartName, chartRepo string,
 	extraArgs []string,
 ) error {
-	cmd.Log.Info("Trying to delete objects blocking current installation")
+	log.Info("Trying to delete objects blocking current installation")
 
 	manifests, err := getReleaseManifests(
 		ctx,
@@ -301,7 +305,6 @@ func (cmd *StartCmd) retryUpgradeAfterPurge(
 		cmd.Context,
 		cmd.Namespace,
 		extraArgs,
-		cmd.Log,
 	)
 	if err != nil {
 		return err
@@ -317,7 +320,7 @@ func (cmd *StartCmd) retryUpgradeAfterPurge(
 		cmd.Context,
 		cmd.Namespace,
 		extraArgs,
-		cmd.Log,
+		oldlog.Default,
 	)
 	if err != nil {
 		return errors.New(
@@ -348,7 +351,15 @@ func (cmd *StartCmd) upgrade(ctx context.Context) error {
 		chartRepo = cmd.ChartRepo
 	}
 
-	err = upgradeRelease(ctx, chartName, chartRepo, cmd.Context, cmd.Namespace, extraArgs, cmd.Log)
+	err = upgradeRelease(
+		ctx,
+		chartName,
+		chartRepo,
+		cmd.Context,
+		cmd.Namespace,
+		extraArgs,
+		oldlog.Default,
+	)
 	if err != nil {
 		if !cmd.Reset {
 			return errors.New(
@@ -398,8 +409,8 @@ func (cmd *StartCmd) success(ctx context.Context) error {
 		if !cmd.NoTunnel {
 			loftRouterDomain, err := cmd.pingLoftRouter(ctx, loftPod)
 			if err != nil {
-				cmd.Log.Errorf("Error retrieving loft router domain: %v", err)
-				cmd.Log.Info("Fallback to use port-forwarding")
+				log.Errorf("Error retrieving loft router domain: %v", err)
+				log.Info("Fallback to use port-forwarding")
 			} else if loftRouterDomain != "" {
 				return cmd.successLoftRouter(loftRouterDomain)
 			}
@@ -409,7 +420,7 @@ func (cmd *StartCmd) success(ctx context.Context) error {
 	}
 
 	// get login link
-	cmd.Log.Info("Checking Devsy status...")
+	log.Info("Checking Devsy status...")
 	host, err := getIngressHost(ctx, cmd.KubeClient, cmd.Namespace)
 	if err != nil {
 		return err
@@ -423,7 +434,7 @@ func (cmd *StartCmd) success(ctx context.Context) error {
 			NoOption  = "No, please re-run the DNS check"
 		)
 
-		answer, err := cmd.Log.Question(&survey.QuestionOptions{
+		answer, err := oldlog.Default.Question(&survey.QuestionOptions{
 			Question:     "Unable to reach Devsy at https://" + host + ". Do you want to start port-forwarding instead?",
 			DefaultValue: YesOption,
 			Options: []string{
@@ -452,8 +463,7 @@ func (cmd *StartCmd) successRemote(ctx context.Context, host string) error {
 			password = passwordChangedHint
 		}
 
-		cmd.Log.WriteString(logrus.InfoLevel, fmt.Sprintf(`
-
+		oldlog.Default.WriteString(logrus.InfoLevel, fmt.Sprintf(`
 
 ##########################   LOGIN   ############################
 
@@ -487,7 +497,7 @@ Thanks for using Devsy Pro!
 	}
 
 	// Print DNS Configuration
-	cmd.Log.WriteString(logrus.InfoLevel, `
+	oldlog.Default.WriteString(logrus.InfoLevel, `
 
 ###################################     DNS CONFIGURATION REQUIRED     ##################################
 
@@ -508,7 +518,7 @@ The command will wait until Devsy Pro is reachable under the host.
 
 `)
 
-	cmd.Log.Info(
+	log.Info(
 		"Waiting for you to configure DNS, so Devsy Pro can be reached on https://" + host,
 	)
 	err = wait.PollUntilContextTimeout(
@@ -524,7 +534,7 @@ The command will wait until Devsy Pro is reachable under the host.
 		return err
 	}
 
-	cmd.Log.Done("Devsy Pro is reachable at https://" + host)
+	log.Info("Devsy Pro is reachable at https://" + host)
 
 	printSuccess()
 	return nil
@@ -545,7 +555,7 @@ func (cmd *StartCmd) successLocal() error {
 		password = passwordChangedHint
 	}
 
-	cmd.Log.WriteString(logrus.InfoLevel, fmt.Sprintf(`
+	oldlog.Default.WriteString(logrus.InfoLevel, fmt.Sprintf(`
 
 ##########################   LOGIN   ############################
 
@@ -569,7 +579,7 @@ Thanks for using Devsy Pro!
 }
 
 func (cmd *StartCmd) startDocker(ctx context.Context) error {
-	cmd.Log.Infof("Starting Devsy Pro in Docker...")
+	log.Infof("Starting Devsy Pro in Docker...")
 	name := config.ProReleaseName
 
 	// prepare installation
@@ -586,7 +596,7 @@ func (cmd *StartCmd) startDocker(ctx context.Context) error {
 
 	// check if container is there
 	if containerID != "" && (cmd.Reset || cmd.Upgrade) {
-		cmd.Log.Info("Existing instance found.")
+		log.Info("Existing instance found.")
 		err = cmd.uninstallDocker(ctx, containerID)
 		if err != nil {
 			return err
@@ -597,18 +607,18 @@ func (cmd *StartCmd) startDocker(ctx context.Context) error {
 
 	// Use default password if none is set
 	if cmd.Password == "" {
-		cmd.Password = getMachineUID(cmd.Log)
+		cmd.Password = getMachineUID(oldlog.Default)
 	}
 
 	// check if is installed
 	if containerID != "" {
-		cmd.Log.Info("Existing instance found. Run with --upgrade to apply new configuration")
+		log.Info("Existing instance found. Run with --upgrade to apply new configuration")
 		return cmd.successDocker(ctx, containerID)
 	}
 
 	// Install Devsy
-	cmd.Log.Info("Welcome to Devsy Pro!")
-	cmd.Log.Info("This installer will help you get started.")
+	log.Info("Welcome to Devsy Pro!")
+	log.Info("This installer will help you get started.")
 
 	// make sure we are ready for installing
 	containerID, err = cmd.runInDocker(ctx, name)
@@ -637,7 +647,7 @@ func (cmd *StartCmd) successDocker(ctx context.Context, containerID string) erro
 	}
 
 	// wait for domain to become reachable
-	cmd.Log.Infof("Wait for Devsy Pro to become available at %s...", host)
+	log.Infof("Wait for Devsy Pro to become available at %s...", host)
 	err = wait.PollUntilContextTimeout(
 		ctx,
 		time.Second,
@@ -665,14 +675,13 @@ func (cmd *StartCmd) successDocker(ctx context.Context, containerID string) erro
 	}
 
 	// print success message
-	PrintSuccessMessageDockerInstall(host, cmd.Password, cmd.Log)
+	PrintSuccessMessageDockerInstall(host, cmd.Password, oldlog.Default)
 	return nil
 }
 
-func PrintSuccessMessageDockerInstall(host, password string, log log.Logger) {
+func PrintSuccessMessageDockerInstall(host, password string, log oldlog.Logger) {
 	url := "https://" + host
 	log.WriteString(logrus.InfoLevel, fmt.Sprintf(`
-
 
 ##########################   LOGIN   ############################
 
@@ -695,7 +704,7 @@ Thanks for using Devsy Pro!
 }
 
 func (cmd *StartCmd) waitForLoftDocker(ctx context.Context, containerID string) (string, error) {
-	cmd.Log.Info("Wait for Devsy Pro to become available...")
+	log.Info("Wait for Devsy Pro to become available...")
 
 	// check for local port
 	containerDetails, err := cmd.inspectContainer(ctx, containerID)
@@ -765,7 +774,7 @@ func (cmd *StartCmd) prepareDocker() error {
 }
 
 func (cmd *StartCmd) uninstallDocker(ctx context.Context, id string) error {
-	cmd.Log.Infof("Uninstalling...")
+	log.Infof("Uninstalling...")
 
 	// stop container
 	out, err := cmd.buildDockerCmd(ctx, "stop", id).Output()
@@ -814,7 +823,7 @@ func (cmd *StartCmd) runInDocker(ctx context.Context, name string) (string, erro
 		args = append(args, "ghcr.io/devsy-org/devsy-pro:latest")
 	}
 
-	cmd.Log.Infof("Start Devsy Pro via 'docker %s'", strings.Join(args, " "))
+	log.Infof("Start Devsy Pro via 'docker %s'", strings.Join(args, " "))
 	runCmd := cmd.buildDockerCmd(ctx, args...)
 	runCmd.Stdout = os.Stdout
 	runCmd.Stderr = os.Stderr
@@ -910,7 +919,14 @@ func (cmd *StartCmd) buildDockerCmd(ctx context.Context, args ...string) *exec.C
 
 func (cmd *StartCmd) prepareInstall(ctx context.Context) error {
 	// delete admin user & secret
-	return uninstall(ctx, cmd.KubeClient, cmd.RestConfig, cmd.Context, cmd.Namespace, log.Discard)
+	return uninstall(
+		ctx,
+		cmd.KubeClient,
+		cmd.RestConfig,
+		cmd.Context,
+		cmd.Namespace,
+		oldlog.Discard,
+	)
 }
 
 func (cmd *StartCmd) prepare(ctx context.Context) error {
@@ -982,7 +998,7 @@ func (cmd *StartCmd) resolveKubeConfig(
 	if cmd.Context != "" {
 		contextToLoad = cmd.Context
 	} else if loftConfig.LastInstallContext != "" && loftConfig.LastInstallContext != contextToLoad {
-		contextToLoad, err = cmd.Log.Question(&survey.QuestionOptions{
+		contextToLoad, err = oldlog.Default.Question(&survey.QuestionOptions{
 			Question:     "Seems like you try to use 'devsy pro start' with a different kubernetes context than before. Please choose which kubernetes context you want to use",
 			DefaultValue: contextToLoad,
 			Options:      []string{contextToLoad, loftConfig.LastInstallContext},
@@ -1049,7 +1065,7 @@ func (cmd *StartCmd) handleAlreadyExistingInstallation(ctx context.Context) erro
 
 	// Only ask if ingress should be enabled if --upgrade flag is not provided
 	if !cmd.Upgrade && term.IsTerminal(os.Stdin) {
-		cmd.Log.Info("Existing instance found.")
+		log.Info("Existing instance found.")
 
 		// Check if Devsy is installed in a local cluster
 		isLocal := isInstalledLocally(ctx, cmd.KubeClient, cmd.Namespace)
@@ -1067,7 +1083,7 @@ func (cmd *StartCmd) handleAlreadyExistingInstallation(ctx context.Context) erro
 					NoOption  = "No, my cluster is running not locally (GKE, EKS, Bare Metal, etc.)"
 				)
 
-				answer, err := cmd.Log.Question(&survey.QuestionOptions{
+				answer, err := oldlog.Default.Question(&survey.QuestionOptions{
 					Question:     "Seems like your cluster is running locally (docker desktop, minikube, kind etc.). Is that correct?",
 					DefaultValue: YesOption,
 					Options: []string{
@@ -1089,7 +1105,7 @@ func (cmd *StartCmd) handleAlreadyExistingInstallation(ctx context.Context) erro
 					NoOption  = "No"
 				)
 
-				answer, err := cmd.Log.Question(&survey.QuestionOptions{
+				answer, err := oldlog.Default.Question(&survey.QuestionOptions{
 					Question:     "Enabling ingress is usually only useful for remote clusters. Do you still want to deploy the ingress to your local cluster?",
 					DefaultValue: NoOption,
 					Options: []string{
@@ -1109,18 +1125,18 @@ func (cmd *StartCmd) handleAlreadyExistingInstallation(ctx context.Context) erro
 		if enableIngress {
 			// Ask for hostname if --host flag is not provided
 			if cmd.Host == "" {
-				host, err := enterHostNameQuestion(cmd.Log)
+				host, err := enterHostNameQuestion(oldlog.Default)
 				if err != nil {
 					return err
 				}
 
 				cmd.Host = host
 			} else {
-				cmd.Log.Info("Will enable an ingress with hostname: " + cmd.Host)
+				log.Info("Will enable an ingress with hostname: " + cmd.Host)
 			}
 
 			if term.IsTerminal(os.Stdin) {
-				err := ensureIngressController(ctx, cmd.KubeClient, cmd.Context, cmd.Log)
+				err := ensureIngressController(ctx, cmd.KubeClient, cmd.Context, oldlog.Default)
 				if err != nil {
 					return fmt.Errorf("install ingress controller: %w", err)
 				}
@@ -1141,9 +1157,9 @@ func (cmd *StartCmd) handleAlreadyExistingInstallation(ctx context.Context) erro
 
 func (cmd *StartCmd) waitForDeployment(ctx context.Context) (*corev1.Pod, error) {
 	// wait for loft pod to start
-	cmd.Log.Info("waiting for Devsy Pro pod to be running")
-	loftPod, err := platform.WaitForPodReady(ctx, cmd.KubeClient, cmd.Namespace, cmd.Log)
-	cmd.Log.Donef("release Pod started")
+	log.Info("waiting for Devsy Pro pod to be running")
+	loftPod, err := platform.WaitForPodReady(ctx, cmd.KubeClient, cmd.Namespace, oldlog.Default)
+	log.Infof("release Pod started")
 	if err != nil {
 		return nil, err
 	}
@@ -1154,7 +1170,6 @@ func (cmd *StartCmd) waitForDeployment(ctx context.Context) (*corev1.Pod, error)
 		cmd.KubeClient,
 		cmd.RestConfig,
 		cmd.Password,
-		cmd.Log,
 	)
 	if err != nil {
 		return nil, err
@@ -1193,7 +1208,7 @@ func (cmd *StartCmd) pingLoftRouter(ctx context.Context, loftPod *corev1.Pod) (s
 			},
 		},
 	}
-	cmd.Log.Infof("Waiting until Devsy Pro is reachable at https://%s", loftRouterDomain)
+	log.Infof("Waiting until Devsy Pro is reachable at https://%s", loftRouterDomain)
 	err = wait.PollUntilContextTimeout(
 		ctx,
 		time.Second*3,
@@ -1240,8 +1255,7 @@ func (cmd *StartCmd) successLoftRouter(url string) error {
 		password = passwordChangedHint
 	}
 
-	cmd.Log.WriteString(logrus.InfoLevel, fmt.Sprintf(`
-
+	oldlog.Default.WriteString(logrus.InfoLevel, fmt.Sprintf(`
 
 ##########################   LOGIN   ############################
 
@@ -1341,8 +1355,7 @@ func (cmd *StartCmd) loginViaCLI(url string) error {
 		return err
 	}
 
-	cmd.Log.WriteString(logrus.InfoLevel, "\n")
-	cmd.Log.Donef("logged in via CLI: url=%s", url)
+	log.Infof("logged in via CLI: url=%s", url)
 
 	return nil
 }
@@ -1360,7 +1373,7 @@ func (cmd *StartCmd) loginUI(url string) error {
 		return fmt.Errorf("couldn't open the login page in a browser: %w", err)
 	}
 
-	cmd.Log.Infof("If the browser does not open automatically, please navigate to %s", loginURL)
+	log.Infof("If the browser does not open automatically, please navigate to %s", loginURL)
 
 	return nil
 }
@@ -1384,7 +1397,7 @@ func uninstall(
 	kubeClient kubernetes.Interface,
 	restConfig *rest.Config,
 	kubeContext, namespace string,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	releaseName := config.ProReleaseName
 	deploy, err := kubeClient.AppsV1().
@@ -1549,7 +1562,7 @@ func isInstalledLocally(
 	return kerrors.IsNotFound(err)
 }
 
-func enterHostNameQuestion(log log.Logger) (string, error) {
+func enterHostNameQuestion(log oldlog.Logger) (string, error) {
 	return log.Question(&survey.QuestionOptions{
 		Question: fmt.Sprintf(
 			"Enter a hostname for your %s instance (e.g. loft.my-domain.tld): \n ",
@@ -1572,7 +1585,7 @@ func ensureIngressController(
 	ctx context.Context,
 	kubeClient kubernetes.Interface,
 	kubeContext string,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	// first create an ingress controller
 	const (
@@ -1697,7 +1710,6 @@ func ensureAdminPassword(
 	kubeClient kubernetes.Interface,
 	restConfig *rest.Config,
 	password string,
-	log log.Logger,
 ) (bool, error) {
 	loftClient, err := loftclientset.NewForConfig(restConfig)
 	if err != nil {
@@ -1865,7 +1877,7 @@ func upgradeRelease(
 	ctx context.Context,
 	chartName, chartRepo, kubeContext, namespace string,
 	extraArgs []string,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	// now we install loft
 	args := []string{
@@ -1913,7 +1925,6 @@ func getReleaseManifests(
 	ctx context.Context,
 	chartName, chartRepo, kubeContext, namespace string,
 	extraArgs []string,
-	_ log.Logger,
 ) (string, error) {
 	args := []string{
 		"template",
@@ -2036,7 +2047,7 @@ func (e *Error) Error() string {
 	return message + e.err.Error()
 }
 
-func getMachineUID(log log.Logger) string {
+func getMachineUID(log oldlog.Logger) string {
 	id, err := machineid.ID()
 	if err != nil {
 		id = "error"

--- a/cmd/pro/update_provider.go
+++ b/cmd/pro/update_provider.go
@@ -9,14 +9,13 @@ import (
 	providercmd "github.com/devsy-org/devsy/cmd/provider"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // UpdateProviderCmd holds the cmd flags.
 type UpdateProviderCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Host     string
 	Instance string
@@ -26,7 +25,6 @@ type UpdateProviderCmd struct {
 func NewUpdateProviderCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &UpdateProviderCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "update-provider [new-version]",
@@ -54,14 +52,18 @@ func (cmd *UpdateProviderCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	provider, err := workspace.ProviderFromHost(ctx, devsyConfig, cmd.Host, cmd.Log)
+	provider, err := workspace.ProviderFromHost(ctx, devsyConfig, cmd.Host, oldlog.Default)
 	if err != nil {
 		return fmt.Errorf("load provider: %w", err)
 	}
 	if provider.Source.Internal {
 		return nil
 	}
-	providerSource, err := workspace.ResolveProviderSource(devsyConfig, provider.Name, cmd.Log)
+	providerSource, err := workspace.ResolveProviderSource(
+		devsyConfig,
+		provider.Name,
+		oldlog.Default,
+	)
 	if err != nil {
 		return fmt.Errorf("resolve provider source %s: %w", provider.Name, err)
 	}
@@ -71,7 +73,7 @@ func (cmd *UpdateProviderCmd) Run(ctx context.Context, args []string) error {
 	}
 	providerSource = splitted[0] + "@" + newVersion
 
-	_, err = workspace.UpdateProvider(devsyConfig, provider.Name, providerSource, cmd.Log)
+	_, err = workspace.UpdateProvider(devsyConfig, provider.Name, providerSource, oldlog.Default)
 	if err != nil {
 		return fmt.Errorf("update provider %s: %w", provider.Name, err)
 	}
@@ -85,7 +87,7 @@ func (cmd *UpdateProviderCmd) Run(ctx context.Context, args []string) error {
 		SkipInit:       true,
 		SkipSubOptions: false,
 		SingleMachine:  nil,
-		Log:            log.Discard,
+		Log:            oldlog.Discard,
 	})
 	if err != nil {
 		return fmt.Errorf(

--- a/cmd/pro/update_workspace.go
+++ b/cmd/pro/update_workspace.go
@@ -10,7 +10,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -18,7 +18,6 @@ import (
 // UpdateWorkspaceCmd holds the cmd flags.
 type UpdateWorkspaceCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Host     string
 	Instance string
@@ -28,7 +27,6 @@ type UpdateWorkspaceCmd struct {
 func NewUpdateWorkspaceCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &UpdateWorkspaceCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "update-workspace",
@@ -40,7 +38,6 @@ func NewUpdateWorkspaceCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -67,8 +64,6 @@ func (cmd *UpdateWorkspaceCmd) Run(
 	opts[platform.WorkspaceInstanceEnv] = config.OptionValue{Value: cmd.Instance}
 
 	var buf bytes.Buffer
-	// ignore --debug because we tunnel json through stdio
-	cmd.Log.SetLevel(logrus.InfoLevel)
 
 	err := clientimplementation.RunCommandWithBinaries(clientimplementation.CommandOptions{
 		Ctx:     ctx,
@@ -78,8 +73,8 @@ func (cmd *UpdateWorkspaceCmd) Run(
 		Options: opts,
 		Config:  provider,
 		Stdout:  &buf,
-		Stderr:  cmd.Log.ErrorStreamOnly().Writer(logrus.ErrorLevel, true),
-		Log:     cmd.Log,
+		Stderr:  oldlog.Default.ErrorStreamOnly().Writer(logrus.ErrorLevel, true),
+		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("update workspace with provider \"%s\": %w", provider.Name, err)

--- a/cmd/pro/version.go
+++ b/cmd/pro/version.go
@@ -9,15 +9,13 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // VersionCmd holds the cmd flags.
 type VersionCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Host string
 }
@@ -26,7 +24,6 @@ type VersionCmd struct {
 func NewVersionCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &VersionCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "version",
@@ -38,7 +35,6 @@ func NewVersionCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -64,8 +60,6 @@ func (cmd *VersionCmd) Run(
 	opts[config.EnvProviderContext] = config.OptionValue{Value: cmd.Context}
 
 	var buf bytes.Buffer
-	// ignore --debug because we tunnel json through stdio
-	cmd.Log.SetLevel(logrus.InfoLevel)
 
 	err := clientimplementation.RunCommandWithBinaries(clientimplementation.CommandOptions{
 		Ctx:     ctx,
@@ -75,7 +69,7 @@ func (cmd *VersionCmd) Run(
 		Options: opts,
 		Config:  providerConfig,
 		Stdout:  &buf,
-		Log:     cmd.Log,
+		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("get version: %w", err)

--- a/cmd/pro/wakeup.go
+++ b/cmd/pro/wakeup.go
@@ -10,9 +10,10 @@ import (
 	storagev1 "github.com/devsy-org/api/pkg/apis/storage/v1"
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/project"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -22,7 +23,6 @@ import (
 // WakeupCmd holds the cmd flags.
 type WakeupCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Project string
 	Host    string
@@ -32,14 +32,11 @@ type WakeupCmd struct {
 func NewWakeupCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &WakeupCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:   "wakeup",
 		Short: "Wake a workspace up",
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			log.Default.SetFormat(log.TextFormat)
-
 			return cmd.Run(cobraCmd.Context(), args)
 		},
 	}
@@ -63,7 +60,7 @@ func (cmd *WakeupCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host, cmd.Log)
+	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host, oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -75,7 +72,7 @@ func (cmd *WakeupCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	if workspaceInstance.Status.Phase != storagev1.InstanceSleeping {
-		cmd.Log.Infof("Workspace %s is not sleeping", workspaceInstance.Name)
+		log.Infof("Workspace %s is not sleeping", workspaceInstance.Name)
 		return nil
 	}
 
@@ -116,7 +113,7 @@ func (cmd *WakeupCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// wait for sleeping
-	cmd.Log.Info("Wait until workspace wakes up...")
+	log.Info("Wait until workspace wakes up...")
 	err = wait.PollUntilContextTimeout(
 		ctx,
 		time.Second,
@@ -138,6 +135,6 @@ func (cmd *WakeupCmd) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("error waiting for workspace to wake up: %w", err)
 	}
 
-	cmd.Log.Donef("woke up workspace: workspaceName=%s", workspaceInstance.Name)
+	log.Infof("woke up workspace: workspaceName=%s", workspaceInstance.Name)
 	return nil
 }

--- a/cmd/pro/watch_workspaces.go
+++ b/cmd/pro/watch_workspaces.go
@@ -11,7 +11,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -19,7 +19,6 @@ import (
 // WatchWorkspacesCmd holds the cmd flags.
 type WatchWorkspacesCmd struct {
 	*flags.GlobalFlags
-	Log log.Logger
 
 	Host          string
 	Project       string
@@ -30,7 +29,6 @@ type WatchWorkspacesCmd struct {
 func NewWatchWorkspacesCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd := &WatchWorkspacesCmd{
 		GlobalFlags: globalFlags,
-		Log:         log.GetInstance(),
 	}
 	c := &cobra.Command{
 		Use:    "watch-workspaces",
@@ -42,7 +40,6 @@ func NewWatchWorkspacesCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				cmd.Context,
 				cmd.Provider,
 				cmd.Host,
-				cmd.Log,
 			)
 			if err != nil {
 				return err
@@ -84,9 +81,6 @@ func (cmd *WatchWorkspacesCmd) Run(
 		cancel()
 	}()
 
-	// ignore --debug because we tunnel json through stdio
-	cmd.Log.SetLevel(logrus.InfoLevel)
-
 	err := clientimplementation.RunCommandWithBinaries(clientimplementation.CommandOptions{
 		Ctx:     cancelCtx,
 		Name:    "watchWorkspaces",
@@ -95,8 +89,8 @@ func (cmd *WatchWorkspacesCmd) Run(
 		Options: opts,
 		Config:  providerConfig,
 		Stdout:  os.Stdout,
-		Stderr:  log.Default.ErrorStreamOnly().Writer(logrus.ErrorLevel, false),
-		Log:     cmd.Log,
+		Stderr:  oldlog.Default.ErrorStreamOnly().Writer(logrus.ErrorLevel, false),
+		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("watch workspaces with provider \"%s\": %w", providerConfig.Name, err)

--- a/cmd/provider/add.go
+++ b/cmd/provider/add.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -93,7 +94,7 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 			devsyConfig,
 			providerName,
 			cmd.FromExisting,
-			log.Default,
+			oldlog.Default,
 		)
 		if err != nil {
 			return err
@@ -110,7 +111,7 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 			return fmt.Errorf("please specify either a URL or path, " +
 				"e.g. devsy provider add https://path/to/my/provider.yaml")
 		}
-		c, err := workspace.AddProvider(devsyConfig, providerName, args[0], log.Default)
+		c, err := workspace.AddProvider(devsyConfig, providerName, args[0], oldlog.Default)
 		if err != nil {
 			return err
 		}
@@ -118,7 +119,7 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 		options = cmd.Options
 	}
 
-	log.Default.Donef("installed provider: providerName=%s", providerConfig.Name)
+	log.Infof("installed provider: providerName=%s", providerConfig.Name)
 	if cmd.Use {
 		configureErr := ConfigureProvider(ctx, ProviderOptionsConfig{
 			Provider:       providerConfig,
@@ -129,7 +130,7 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 			SkipInit:       false,
 			SkipSubOptions: false,
 			SingleMachine:  &cmd.SingleMachine,
-			Log:            log.Default,
+			Log:            oldlog.Default,
 		})
 		if configureErr != nil {
 			devsyConfig, err := config.LoadConfig(cmd.Context, "")
@@ -137,7 +138,7 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 				return err
 			}
 
-			err = DeleteProvider(ctx, devsyConfig, providerConfig.Name, true, true, log.Default)
+			err = DeleteProvider(ctx, devsyConfig, providerConfig.Name, true, true, oldlog.Default)
 			if err != nil {
 				return fmt.Errorf("delete provider: %w", err)
 			}
@@ -148,8 +149,8 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 		return nil
 	}
 
-	log.Default.Infof("To use the provider, please run the following command:")
-	log.Default.Infof("devsy provider use %s", providerConfig.Name)
+	log.Infof("To use the provider, please run the following command:")
+	log.Infof("devsy provider use %s", providerConfig.Name)
 	return nil
 }
 

--- a/cmd/provider/delete.go
+++ b/cmd/provider/delete.go
@@ -8,10 +8,11 @@ import (
 	"github.com/devsy-org/devsy/cmd/completion"
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	logpkg "github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -43,7 +44,6 @@ func NewDeleteCmd(flags *flags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				logpkg.Default,
 			)
 		},
 	}
@@ -70,12 +70,12 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// delete the provider
-	err = DeleteProvider(ctx, devsyConfig, provider, cmd.IgnoreNotFound, cmd.Force, logpkg.Default)
+	err = DeleteProvider(ctx, devsyConfig, provider, cmd.IgnoreNotFound, cmd.Force, oldlog.Default)
 	if err != nil {
 		return err
 	}
 
-	logpkg.Default.Donef("deleted provider: provider=%s", provider)
+	log.Infof("deleted provider: provider=%s", provider)
 	return nil
 }
 
@@ -84,12 +84,12 @@ func DeleteProvider(
 	devsyConfig *config.Config,
 	provider string,
 	ignoreNotFound, force bool,
-	log logpkg.Logger,
+	log oldlog.Logger,
 ) error {
 	// if force is not set, check if the provider is associated with a pro instance or workspace
 	if !force {
 		// check if this provider is associated with a pro instance
-		proInstances, err := workspace.ListProInstances(devsyConfig, logpkg.Default)
+		proInstances, err := workspace.ListProInstances(devsyConfig, oldlog.Default)
 		if err != nil {
 			return fmt.Errorf("list pro instances: %w", err)
 		}

--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -12,7 +12,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/table"
 	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -56,7 +56,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	providers, err := workspace.LoadAllProviders(devsyConfig, log.Default.ErrorStreamOnly())
+	providers, err := workspace.LoadAllProviders(devsyConfig, oldlog.Default.ErrorStreamOnly())
 	if err != nil {
 		return err
 	}

--- a/cmd/provider/options.go
+++ b/cmd/provider/options.go
@@ -11,10 +11,11 @@ import (
 	"github.com/devsy-org/devsy/cmd/completion"
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/table"
 	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +46,6 @@ func NewOptionsCmd(flags *flags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				log.Default,
 			)
 		},
 	}
@@ -80,8 +80,8 @@ func (cmd *OptionsCmd) Run(ctx context.Context, args []string) error {
 
 	if providerName != "" && cmd.Provider != "" {
 		if providerName != cmd.Provider {
-			log.Default.Infof("providerName=%+v", providerName)
-			log.Default.Infof("GlobalFlags.Provider=%+v", cmd.Provider)
+			log.Infof("providerName=%+v", providerName)
+			log.Infof("GlobalFlags.Provider=%+v", cmd.Provider)
 			return fmt.Errorf("ambiguous provider configuration detected")
 		}
 	}
@@ -89,7 +89,7 @@ func (cmd *OptionsCmd) Run(ctx context.Context, args []string) error {
 	providerWithOptions, err := workspace.FindProvider(
 		devsyConfig,
 		providerName,
-		log.Default.ErrorStreamOnly(),
+		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return err

--- a/cmd/provider/rename.go
+++ b/cmd/provider/rename.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	workspace "github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -88,7 +89,7 @@ func getWorkspacesForProvider(
 	workspaces, err := workspace.ListLocalWorkspaces(
 		devsyConfig.DefaultContext,
 		false,
-		log.Default,
+		oldlog.Default,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("listing workspaces: %w", err)
@@ -108,7 +109,7 @@ func getMachinesForProvider(
 	devsyConfig *config.Config,
 	providerName string,
 ) ([]*provider.Machine, error) {
-	machines, err := workspace.ListMachines(devsyConfig, log.Default)
+	machines, err := workspace.ListMachines(devsyConfig, oldlog.Default)
 	if err != nil {
 		return nil, fmt.Errorf("listing machines: %w", err)
 	}
@@ -184,7 +185,7 @@ type renameState struct {
 // restoreProviderState reverts all recorded mutations in reverse order: default provider,
 // workspaces, machines, and finally the provider directory move.
 func (r *renameState) restoreProviderState(ctx context.Context) error {
-	log.Default.Info("rolling back changes")
+	log.Info("rolling back changes")
 	var errs error
 
 	if r.defaultChanged {
@@ -210,7 +211,7 @@ func (r *renameState) restoreProviderState(ctx context.Context) error {
 // validateProviderRename verifies that the provider exists, is not a pro
 // provider, is not backing a pro instance, and has configuration state.
 func validateProviderRename(devsyConfig *config.Config, oldName string) error {
-	providerWithOptions, err := workspace.FindProvider(devsyConfig, oldName, log.Default)
+	providerWithOptions, err := workspace.FindProvider(devsyConfig, oldName, oldlog.Default)
 	if err != nil {
 		return fmt.Errorf("provider %s not found", oldName)
 	}
@@ -220,7 +221,7 @@ func validateProviderRename(devsyConfig *config.Config, oldName string) error {
 		return fmt.Errorf("cannot rename a pro provider; pro providers are managed by the platform")
 	}
 
-	proInstances, err := workspace.ListProInstances(devsyConfig, log.Default)
+	proInstances, err := workspace.ListProInstances(devsyConfig, oldlog.Default)
 	if err != nil {
 		return fmt.Errorf("listing pro instances: %w", err)
 	}
@@ -280,6 +281,6 @@ func renameProvider(
 		return errors.Join(err, rb.restoreProviderState(ctx))
 	}
 
-	log.Default.Donef("renamed provider %s to %s", oldName, newName)
+	log.Infof("renamed provider %s to %s", oldName, newName)
 	return nil
 }

--- a/cmd/provider/set_options.go
+++ b/cmd/provider/set_options.go
@@ -8,8 +8,9 @@ import (
 	"github.com/devsy-org/devsy/cmd/completion"
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -33,12 +34,7 @@ func NewSetOptionsCmd(f *flags.GlobalFlags) *cobra.Command {
 		Use:   "set-options [provider]",
 		Short: "Sets options for the given provider. Similar to 'devsy provider use', but does not switch the default provider.",
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
-			logger := log.Logger(log.Default)
-			if cmd.Dry {
-				logger = log.Default.ErrorStreamOnly()
-			}
-
-			return cmd.Run(cobraCmd.Context(), args, logger)
+			return cmd.Run(cobraCmd.Context(), args)
 		},
 		ValidArgsFunction: func(rootCmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return completion.GetProviderSuggestions(
@@ -48,7 +44,6 @@ func NewSetOptionsCmd(f *flags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				log.Default,
 			)
 		},
 	}
@@ -64,8 +59,8 @@ func NewSetOptionsCmd(f *flags.GlobalFlags) *cobra.Command {
 	return setOptionsCmd
 }
 
-// Run runs the command logic.
-func (cmd *SetOptionsCmd) Run(ctx context.Context, args []string, log log.Logger) error {
+//nolint:cyclop // pre-existing complexity
+func (cmd *SetOptionsCmd) Run(ctx context.Context, args []string) error {
 	devsyConfig, err := config.LoadConfig(cmd.Context, cmd.Provider)
 	if err != nil {
 		return err
@@ -84,7 +79,12 @@ func (cmd *SetOptionsCmd) Run(ctx context.Context, args []string, log log.Logger
 	}
 	log.Debugf("Options=%+v", cmd.Options)
 
-	providerWithOptions, err := workspace.FindProvider(devsyConfig, providerName, log)
+	var logger oldlog.Logger = oldlog.Default
+	if cmd.Dry {
+		logger = oldlog.Default.ErrorStreamOnly()
+	}
+
+	providerWithOptions, err := workspace.FindProvider(devsyConfig, providerName, logger)
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ func (cmd *SetOptionsCmd) Run(ctx context.Context, args []string, log log.Logger
 		SkipInit:       cmd.Dry,
 		SkipSubOptions: false,
 		SingleMachine:  &cmd.SingleMachine,
-		Log:            log,
+		Log:            logger,
 	})
 	if err != nil {
 		return err
@@ -119,6 +119,6 @@ func (cmd *SetOptionsCmd) Run(ctx context.Context, args []string, log log.Logger
 	}
 
 	// print success message
-	log.Donef("set options for provider: providerName=%s", providerWithOptions.Config.Name)
+	log.Infof("set options for provider: providerName=%s", providerWithOptions.Config.Name)
 	return nil
 }

--- a/cmd/provider/update.go
+++ b/cmd/provider/update.go
@@ -6,8 +6,9 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -60,13 +61,13 @@ func (cmd *UpdateCmd) Run(ctx context.Context, devsyConfig *config.Config, args 
 		devsyConfig,
 		args[0],
 		providerSource,
-		log.Default,
+		oldlog.Default,
 	)
 	if err != nil {
 		return err
 	}
 
-	log.Default.Donef("updated provider: providerName=%s", providerConfig.Name)
+	log.Infof("updated provider: providerName=%s", providerConfig.Name)
 	if cmd.Use {
 		err = ConfigureProvider(ctx, ProviderOptionsConfig{
 			Provider:       providerConfig,
@@ -77,10 +78,10 @@ func (cmd *UpdateCmd) Run(ctx context.Context, devsyConfig *config.Config, args 
 			SkipInit:       false,
 			SkipSubOptions: false,
 			SingleMachine:  nil,
-			Log:            log.Default,
+			Log:            oldlog.Default,
 		})
 		if err != nil {
-			log.Default.Errorf(
+			log.Errorf(
 				"Error configuring provider, please retry with 'devsy provider use %s --reconfigure'",
 				providerConfig.Name,
 			)
@@ -90,7 +91,7 @@ func (cmd *UpdateCmd) Run(ctx context.Context, devsyConfig *config.Config, args 
 		return nil
 	}
 
-	log.Default.Infof("To use the provider, please run the following command:")
-	log.Default.Infof("devsy provider use %s", providerConfig.Name)
+	log.Infof("To use the provider, please run the following command:")
+	log.Infof("devsy provider use %s", providerConfig.Name)
 	return nil
 }

--- a/cmd/provider/use.go
+++ b/cmd/provider/use.go
@@ -9,10 +9,11 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	options2 "github.com/devsy-org/devsy/pkg/options"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -52,7 +53,6 @@ func NewUseCmd(flags *flags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				log.Default,
 			)
 		},
 	}
@@ -81,7 +81,7 @@ func (cmd *UseCmd) Run(ctx context.Context, providerName string) error {
 		return err
 	}
 
-	providerWithOptions, err := workspace.FindProvider(devsyConfig, providerName, log.Default)
+	providerWithOptions, err := workspace.FindProvider(devsyConfig, providerName, oldlog.Default)
 	if err != nil {
 		return err
 	}
@@ -100,10 +100,10 @@ func (cmd *UseCmd) Run(ctx context.Context, providerName string) error {
 			SkipInit:       cmd.SkipInit,
 			SkipSubOptions: false,
 			SingleMachine:  &cmd.SingleMachine,
-			Log:            log.Default,
+			Log:            oldlog.Default,
 		})
 	} else {
-		log.Default.Infof(
+		log.Infof(
 			"To reconfigure provider %s, run with '--reconfigure' to reconfigure the provider",
 			providerWithOptions.Config.Name,
 		)
@@ -120,7 +120,7 @@ func (cmd *UseCmd) Run(ctx context.Context, providerName string) error {
 	}
 
 	// print success message
-	log.Default.Donef("switched default provider: providerName=%s", providerWithOptions.Config.Name)
+	log.Infof("switched default provider: providerName=%s", providerWithOptions.Config.Name)
 	return nil
 }
 
@@ -133,7 +133,7 @@ type ProviderOptionsConfig struct {
 	SkipInit       bool
 	SkipSubOptions bool
 	SingleMachine  *bool
-	Log            log.Logger
+	Log            oldlog.Logger
 }
 
 func ConfigureProvider(ctx context.Context, cfg ProviderOptionsConfig) error {
@@ -152,7 +152,7 @@ func ConfigureProvider(ctx context.Context, cfg ProviderOptionsConfig) error {
 		return fmt.Errorf("save config: %w", err)
 	}
 
-	cfg.Log.Donef("configured provider %s", cfg.Provider.Name)
+	log.Infof("configured provider %s", cfg.Provider.Name)
 	return nil
 }
 
@@ -234,7 +234,7 @@ func initProvider(
 		Config:  provider,
 		Stdout:  stdout,
 		Stderr:  stderr,
-		Log:     log.Default,
+		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("init: %w", err)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -26,7 +26,7 @@ import (
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
 	"github.com/devsy-org/devsy/pkg/tunnel"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
@@ -89,13 +89,13 @@ func NewSSHCmd(f *flags.GlobalFlags) *cobra.Command {
 				ChangeLastUsed: true,
 				Owner:          cmd.Owner,
 				LocalOnly:      localOnly,
-				Log:            log.Default.ErrorStreamOnly(),
+				Log:            oldlog.Default.ErrorStreamOnly(),
 			})
 			if err != nil {
 				return err
 			}
 
-			return cmd.Run(ctx, devsyConfig, client, log.Default.ErrorStreamOnly())
+			return cmd.Run(ctx, devsyConfig, client, oldlog.Default.ErrorStreamOnly())
 		},
 		ValidArgsFunction: func(rootCmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return completion.GetWorkspaceSuggestions(
@@ -105,7 +105,6 @@ func NewSSHCmd(f *flags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				log.Default,
 			)
 		},
 	}
@@ -172,7 +171,7 @@ func (cmd *SSHCmd) Run(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	client client2.BaseWorkspaceClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	// add ssh keys to agent
 	if devsyConfig.ContextOption(config.ContextOptionSSHAgentForwarding) == config.BoolTrue &&
@@ -224,7 +223,7 @@ func (cmd *SSHCmd) jumpContainerTailscale(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	client client2.DaemonClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	log.Debugf("Starting tailscale connection")
 
@@ -309,7 +308,7 @@ func (cmd *SSHCmd) startProxyTunnel(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	client client2.ProxyClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	log.Debugf("Start proxy tunnel")
 	return tunnel.NewTunnel(
@@ -350,7 +349,7 @@ func (cmd *SSHCmd) jumpContainer(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	client client2.WorkspaceClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	// lock the workspace as long as we init the connection
 	err := client.Lock(ctx)
@@ -381,7 +380,7 @@ func (cmd *SSHCmd) jumpContainer(
 		}, devsyConfig, envVars)
 }
 
-func (cmd *SSHCmd) forwardTimeout(log log.Logger) (time.Duration, error) {
+func (cmd *SSHCmd) forwardTimeout(log oldlog.Logger) (time.Duration, error) {
 	timeout := time.Duration(0)
 	if cmd.ForwardPortsTimeout != "" {
 		timeout, err := time.ParseDuration(cmd.ForwardPortsTimeout)
@@ -398,7 +397,7 @@ func (cmd *SSHCmd) forwardTimeout(log log.Logger) (time.Duration, error) {
 func (cmd *SSHCmd) reverseForwardPorts(
 	ctx context.Context,
 	containerClient *ssh.Client,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	timeout, err := cmd.forwardTimeout(log)
 	if err != nil {
@@ -443,7 +442,7 @@ func (cmd *SSHCmd) reverseForwardPorts(
 func (cmd *SSHCmd) forwardPorts(
 	ctx context.Context,
 	containerClient *ssh.Client,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	timeout, err := cmd.forwardTimeout(log)
 	if err != nil {
@@ -490,7 +489,7 @@ func (cmd *SSHCmd) startTunnel(
 	devsyConfig *config.Config,
 	containerClient *ssh.Client,
 	workspaceClient client2.BaseWorkspaceClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	// check if we should forward ports
 	if len(cmd.ForwardPorts) > 0 {
@@ -614,7 +613,7 @@ func (cmd *SSHCmd) startTunnel(
 func resolveWorkdir(
 	workdir string,
 	workspaceClient client2.BaseWorkspaceClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) string {
 	if workdir != "" {
 		return workdir
@@ -632,7 +631,7 @@ func resolveWorkdir(
 
 func resolveMergedWorkspaceFolder(
 	workspaceClient client2.BaseWorkspaceClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) string {
 	workspaceConfig := workspaceClient.WorkspaceConfig()
 	if workspaceConfig == nil || workspaceConfig.Context == "" || workspaceConfig.ID == "" {
@@ -658,7 +657,7 @@ func (cmd *SSHCmd) startServices(
 	workspace *provider.Workspace,
 	configureDockerCredentials, configureGitCredentials, configureGitSSHSignatureHelper bool,
 	gitSSHSigningKey string,
-	log log.Logger,
+	log oldlog.Logger,
 ) {
 	if cmd.User != "" {
 		err := tunnel.RunServices(
@@ -689,7 +688,7 @@ func (cmd *SSHCmd) startServices(
 func (cmd *SSHCmd) setupGPGAgent(
 	ctx context.Context,
 	containerClient *ssh.Client,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	log.Debugf("[GPG] exporting gpg owner trust from host")
 	ownerTrustExport, err := gpg.GetHostOwnerTrust()
@@ -767,7 +766,7 @@ func (cmd *SSHCmd) setupGPGAgent(
 // gpgSigningKey returns the user's GPG signing key from git config,
 // or empty string if no key is configured or the signing format is SSH
 // (SSH signing keys are handled by the separate SSH signature helper).
-func gpgSigningKey(log log.Logger) string {
+func gpgSigningKey(log oldlog.Logger) string {
 	format, err := exec.Command("git", "config", "--get", "gpg.format").Output()
 	formatStr := ""
 	if err == nil {
@@ -807,7 +806,7 @@ func startSSHKeepAlive(
 	ctx context.Context,
 	client *ssh.Client,
 	interval time.Duration,
-	log log.Logger,
+	log oldlog.Logger,
 ) {
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()

--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,7 +21,7 @@ func writeGitConfig(t *testing.T, content string) {
 
 func TestGpgSigningKey_GPGFormat(t *testing.T) {
 	writeGitConfig(t, "[user]\n\tsigningKey = TESTKEY123\n")
-	result := gpgSigningKey(log.Discard)
+	result := gpgSigningKey(oldlog.Discard)
 	assert.Equal(t, "TESTKEY123", result)
 }
 
@@ -30,30 +30,30 @@ func TestGpgSigningKey_SSHFormat_Skipped(t *testing.T) {
 		t,
 		"[gpg]\n\tformat = ssh\n[user]\n\tsigningKey = /home/user/.ssh/id_ed25519.pub\n",
 	)
-	result := gpgSigningKey(log.Discard)
+	result := gpgSigningKey(oldlog.Discard)
 	assert.Empty(t, result)
 }
 
 func TestGpgSigningKey_NoKeyConfigured(t *testing.T) {
 	writeGitConfig(t, "[user]\n\tname = Test\n")
-	result := gpgSigningKey(log.Discard)
+	result := gpgSigningKey(oldlog.Discard)
 	assert.Empty(t, result)
 }
 
 func TestGpgSigningKey_X509Format_Returned(t *testing.T) {
 	writeGitConfig(t, "[gpg]\n\tformat = x509\n[user]\n\tsigningKey = /path/to/cert\n")
-	result := gpgSigningKey(log.Discard)
+	result := gpgSigningKey(oldlog.Discard)
 	assert.Equal(t, "/path/to/cert", result)
 }
 
 func TestGpgSigningKey_SSHKeyPath_Skipped(t *testing.T) {
 	writeGitConfig(t, "[user]\n\tsigningKey = /home/user/.ssh/id_ed25519.pub\n")
-	result := gpgSigningKey(log.Discard)
+	result := gpgSigningKey(oldlog.Discard)
 	assert.Empty(t, result)
 }
 
 func TestGpgSigningKey_TildeKeyPath_Skipped(t *testing.T) {
 	writeGitConfig(t, "[user]\n\tsigningKey = ~/.ssh/id_ed25519.pub\n")
-	result := gpgSigningKey(log.Discard)
+	result := gpgSigningKey(oldlog.Discard)
 	assert.Empty(t, result)
 }

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -12,7 +12,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -48,12 +48,12 @@ func NewStatusCmd(flags *flags.GlobalFlags) *cobra.Command {
 				return err
 			}
 
-			logger := log.Default.ErrorStreamOnly()
+			logger := oldlog.Default.ErrorStreamOnly()
 			client, err := workspace2.Get(ctx, workspace2.GetOptions{
 				DevsyConfig: devsyConfig,
 				Args:        args,
 				Owner:       cmd.Owner,
-				Log:         logger,
+				Log:         oldlog.Default,
 			})
 			if err != nil {
 				return err
@@ -69,7 +69,6 @@ func NewStatusCmd(flags *flags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				log.Default,
 			)
 		},
 	}
@@ -86,7 +85,7 @@ func NewStatusCmd(flags *flags.GlobalFlags) *cobra.Command {
 func (cmd *StatusCmd) Run(
 	ctx context.Context,
 	client client2.BaseWorkspaceClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	// parse timeout
 	if cmd.Timeout != "" {

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -9,8 +9,9 @@ import (
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +46,7 @@ func NewStopCmd(flags *flags.GlobalFlags) *cobra.Command {
 				DevsyConfig: devsyConfig,
 				Args:        args,
 				Owner:       cmd.Owner,
-				Log:         log.Default,
+				Log:         oldlog.Default,
 			})
 			if err != nil {
 				return err
@@ -61,7 +62,6 @@ func NewStopCmd(flags *flags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				log.Default,
 			)
 		},
 	}
@@ -115,14 +115,18 @@ func (cmd *StopCmd) stopSingleMachine(
 	devsyConfig *config.Config,
 ) (bool, error) {
 	// check if single machine
-	singleMachineName := workspace2.SingleMachineName(devsyConfig, client.Provider(), log.Default)
+	singleMachineName := workspace2.SingleMachineName(
+		devsyConfig,
+		client.Provider(),
+		oldlog.Default,
+	)
 	if !devsyConfig.Current().IsSingleMachine(client.Provider()) ||
 		client.WorkspaceConfig().Machine.ID != singleMachineName {
 		return false, nil
 	}
 
 	// try to find other workspace with same machine
-	workspaces, err := workspace2.List(ctx, devsyConfig, false, cmd.Owner, log.Default)
+	workspaces, err := workspace2.List(ctx, devsyConfig, false, cmd.Owner, oldlog.Default)
 	if err != nil {
 		return false, fmt.Errorf("list workspaces: %w", err)
 	}
@@ -145,7 +149,7 @@ func (cmd *StopCmd) stopSingleMachine(
 	machineClient, err := workspace2.GetMachine(
 		devsyConfig,
 		[]string{singleMachineName},
-		log.Default,
+		oldlog.Default,
 	)
 	if err != nil {
 		return false, fmt.Errorf("get machine: %w", err)
@@ -157,6 +161,6 @@ func (cmd *StopCmd) stopSingleMachine(
 		return false, fmt.Errorf("delete machine: %w", err)
 	}
 
-	log.Default.Donef("stopped workspace: workspace=%s", client.Workspace())
+	log.Infof("stopped workspace: workspace=%s", client.Workspace())
 	return true, nil
 }

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -17,7 +17,7 @@ import (
 	pkgprovider "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/version"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -44,7 +44,6 @@ func NewTroubleshootCmd(flags *flags.GlobalFlags) *cobra.Command {
 				args,
 				toComplete,
 				cmd.Owner,
-				log.Default,
 			)
 		},
 		Hidden: true,
@@ -96,7 +95,7 @@ func (cmd *TroubleshootCmd) Run(ctx context.Context, args []string) {
 		return
 	}
 
-	logger := log.Default.ErrorStreamOnly()
+	logger := oldlog.Default.ErrorStreamOnly()
 	info.Providers, err = collectProviders(info.Config, logger)
 	if err != nil {
 		info.Errors = append(info.Errors, PrintableError{fmt.Errorf("collect providers: %w", err)})
@@ -114,7 +113,7 @@ func (cmd *TroubleshootCmd) Run(ctx context.Context, args []string) {
 		DevsyConfig: info.Config,
 		Args:        args,
 		Owner:       cmd.Owner,
-		Log:         logger,
+		Log:         oldlog.Default,
 	})
 	if err == nil {
 		info.Workspace = workspaceClient.WorkspaceConfig()
@@ -180,7 +179,7 @@ func collectProWorkspaceInfo(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	host string,
-	logger log.Logger,
+	logger oldlog.Logger,
 	workspaceUID string,
 	project string,
 ) (*managementv1.DevsyWorkspaceInstanceTroubleshoot, error) {
@@ -218,7 +217,7 @@ func collectProWorkspaceInfo(
 // It returns a map of providers with their default settings and an error if any occurs.
 func collectProviders(
 	devsyConfig *config.Config,
-	logger log.Logger,
+	logger oldlog.Logger,
 ) (map[string]provider.ProviderWithDefault, error) {
 	providers, err := workspace.LoadAllProviders(devsyConfig, logger)
 	if err != nil {
@@ -262,7 +261,7 @@ type DevsyProInstance struct {
 // This means that even when an error value is returned, the pro instance slice will contain valid values.
 func collectPlatformInfo(
 	devsyConfig *config.Config,
-	logger log.Logger,
+	logger oldlog.Logger,
 ) ([]DevsyProInstance, error) {
 	proInstanceList, err := workspace.ListProInstances(devsyConfig, logger)
 	if err != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -28,7 +28,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/telemetry"
 	"github.com/devsy-org/devsy/pkg/util"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -253,7 +253,7 @@ func (cmd *UpCmd) Run(
 	devsyConfig *config.Config,
 	client client2.BaseWorkspaceClient,
 	args []string,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	cmd.prepareWorkspace(client, log)
 
@@ -280,7 +280,7 @@ type workspaceContext struct {
 }
 
 // prepareWorkspace handles initial setup and validation.
-func (cmd *UpCmd) prepareWorkspace(client client2.BaseWorkspaceClient, log log.Logger) {
+func (cmd *UpCmd) prepareWorkspace(client client2.BaseWorkspaceClient, log oldlog.Logger) {
 	if cmd.Reset {
 		cmd.Recreate = true
 	}
@@ -305,7 +305,7 @@ func (cmd *UpCmd) executeDevsyUp(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	client client2.BaseWorkspaceClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) (*workspaceContext, error) {
 	result, err := cmd.devsyUp(ctx, devsyConfig, client, log)
 	if err != nil {
@@ -339,7 +339,7 @@ func (cmd *UpCmd) configureWorkspace(
 	devsyConfig *config.Config,
 	client client2.BaseWorkspaceClient,
 	wctx *workspaceContext,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	if cmd.ConfigureSSH {
 		devsyHome := ""
@@ -385,7 +385,7 @@ func (cmd *UpCmd) openIDE(
 	devsyConfig *config.Config,
 	client client2.BaseWorkspaceClient,
 	wctx *workspaceContext,
-	log log.Logger,
+	log oldlog.Logger,
 ) error {
 	if !cmd.OpenIDE {
 		return nil
@@ -408,7 +408,7 @@ func (cmd *UpCmd) devsyUp(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	client client2.BaseWorkspaceClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) (*config2.Result, error) {
 	var err error
 
@@ -456,7 +456,7 @@ func (cmd *UpCmd) devsyUp(
 func (cmd *UpCmd) devsyUpProxy(
 	ctx context.Context,
 	client client2.ProxyClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) (*config2.Result, error) {
 	// create pipes
 	stdoutReader, stdoutWriter, err := os.Pipe()
@@ -560,7 +560,7 @@ func (cmd *UpCmd) devsyUpMachine(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	client client2.WorkspaceClient,
-	log log.Logger,
+	log oldlog.Logger,
 ) (*config2.Result, error) {
 	err := clientimplementation.StartWait(ctx, client, true, log)
 	if err != nil {
@@ -694,7 +694,7 @@ func configureSSH(client client2.BaseWorkspaceClient, params configureSSHParams)
 		GPGAgent:             params.gpgagent,
 		DevsyHome:            params.devsyHome,
 		Provider:             client.Provider(),
-		Log:                  log.Default,
+		Log:                  oldlog.Default,
 	})
 	if err != nil {
 		return err
@@ -755,13 +755,13 @@ func (cmd *UpCmd) prepareClient(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	args []string,
-) (client2.BaseWorkspaceClient, log.Logger, error) {
+) (client2.BaseWorkspaceClient, oldlog.Logger, error) {
 	// try to parse flags from env
 	if err := mergeDevsyUpOptions(&cmd.CLIOptions); err != nil {
 		return nil, nil, err
 	}
 
-	var logger log.Logger = log.Default
+	var logger oldlog.Logger = oldlog.Default
 	if cmd.Platform.Enabled {
 		logger = logger.ErrorStreamOnly()
 		logger.Debug("Running in platform mode")

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -4,27 +4,26 @@ import (
 	"fmt"
 
 	"github.com/devsy-org/devsy/pkg/upgrade"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
 // UpgradeCmd is a struct that defines a command call for "upgrade".
 type UpgradeCmd struct {
-	log     log.Logger
 	Version string
 	DryRun  bool
 }
 
 // NewUpgradeCmd creates a new upgrade command.
 func NewUpgradeCmd() *cobra.Command {
-	cmd := &UpgradeCmd{log: log.GetInstance()}
+	cmd := &UpgradeCmd{}
 	upgradeCmd := &cobra.Command{
 		Use:   "upgrade",
 		Short: "Upgrade the Devsy CLI to the newest version",
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			ctx := cobraCmd.Context()
-			if err := upgrade.Upgrade(ctx, cmd.Version, cmd.DryRun, cmd.log); err != nil {
+			if err := upgrade.Upgrade(ctx, cmd.Version, cmd.DryRun, oldlog.Default); err != nil {
 				return fmt.Errorf("unable to upgrade: %w", err)
 			}
 			return nil


### PR DESCRIPTION
## Summary

- Migrate ~83 files across cmd/pro/, cmd/provider/, cmd/helper/, cmd/machine/, and top-level cmd/
- Remove Log struct fields from all command structs
- Remove log.GetInstance() and log.Default usage
- Replace Donef → Infof, remove ErrorStreamOnly/MakeRaw/SetFormat calls
- Update completion functions to remove logger parameters

Part 3 of logging overhaul.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated internal logging architecture by migrating from external logging dependency to internal package logger for command execution paths and status messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->