### PR TITLE
refactor(log): migrate pkg/agent/ to pkg/log

### DIFF
--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -136,7 +136,6 @@ func (cmd *SetupContainerCmd) prepareWorkspace(sctx *setupContext) error {
 		DockerlessOptions: &sctx.workspaceInfo.Dockerless,
 		ImageConfigOutput: agent.DefaultImageConfigPath,
 		Debug:             cmd.Debug,
-		Log:               sctx.logger,
 		ConfigureCredentialsFunc: func(ctx context.Context) (string, error) {
 			serverPort, err := credentials.StartCredentialsServer(
 				ctx,
@@ -171,7 +170,6 @@ func (cmd *SetupContainerCmd) prepareWorkspace(sctx *setupContext) error {
 		sctx.ctx,
 		sctx.workspaceInfo,
 		sctx.setupInfo,
-		sctx.logger,
 	)
 
 	// Clean up git credentials after cloning
@@ -315,7 +313,6 @@ func (cmd *SetupContainerCmd) cloneRepositoryIfNeeded(
 	ctx context.Context,
 	workspaceInfo *provider2.ContainerWorkspaceInfo,
 	setupInfo *config.Result,
-	logger oldlog.Logger,
 ) error {
 	b, err := workspaceInfo.PullFromInsideContainer.Bool()
 	if err != nil {
@@ -341,7 +338,6 @@ func (cmd *SetupContainerCmd) cloneRepositoryIfNeeded(
 		"",
 		workspaceInfo.CLIOptions,
 		true,
-		logger,
 	)
 }
 

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -595,7 +595,6 @@ func prepareGitWorkspace(params prepareGitWorkspaceParams) error {
 		params.gitHelper,
 		params.workspaceInfo.CLIOptions,
 		false,
-		params.log,
 	)
 }
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -117,7 +117,6 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 			Stdin:           stdinReader,
 			Stdout:          stdoutWriter,
 			Stderr:          stderr,
-			Log:             log.ErrorStreamOnly(),
 			Timeout:         timeout,
 		})
 	}()

--- a/cmd/machine/ssh.go
+++ b/cmd/machine/ssh.go
@@ -161,7 +161,6 @@ func (cmd *SSHCmd) Run(ctx context.Context, args []string) error {
 				Stdin:           stdin,
 				Stdout:          stdout,
 				Stderr:          stderr,
-				Log:             oldlog.Default.ErrorStreamOnly(),
 				Timeout:         timeout,
 			})
 		},

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -631,7 +631,6 @@ func (cmd *UpCmd) devsyUpMachine(
 			Stdin:           sshTunnelStdinReader,
 			Stdout:          sshTunnelStdoutWriter,
 			Stderr:          writer,
-			Log:             log.ErrorStreamOnly(),
 			Timeout:         wInfo.InjectTimeout,
 		})
 	}

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -493,7 +493,6 @@ func Tunnel(
 		RemoteAgentPath:             ContainerDevsyHelperLocation,
 		DownloadURL:                 DefaultAgentDownloadURL(),
 		PreferDownloadFromRemoteUrl: Bool(false),
-		Log:                         log,
 		Timeout:                     timeout,
 	})
 	if err != nil {

--- a/pkg/agent/binary.go
+++ b/pkg/agent/binary.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/config"
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 type BinarySource interface {
@@ -23,10 +23,9 @@ type BinarySource interface {
 
 type BinaryManager struct {
 	sources []BinarySource
-	logger  log.Logger
 }
 
-func NewBinaryManager(logger log.Logger, downloadURL string) *BinaryManager {
+func NewBinaryManager(downloadURL string) *BinaryManager {
 	cachePath := filepath.Join(os.TempDir(), config.BinaryName+"-cache")
 	cache := &BinaryCache{BaseDir: cachePath}
 
@@ -36,7 +35,6 @@ func NewBinaryManager(logger log.Logger, downloadURL string) *BinaryManager {
 			&FileCacheSource{Cache: cache},
 			&HTTPDownloadSource{BaseURL: downloadURL, Cache: cache},
 		},
-		logger: logger,
 	}
 }
 
@@ -44,10 +42,10 @@ func (m *BinaryManager) AcquireBinary(ctx context.Context, arch string) (io.Read
 	for _, source := range m.sources {
 		binary, err := source.GetBinary(ctx, arch)
 		if err == nil {
-			m.logger.Debugf("acquired binary from %s", source.SourceName())
+			log.Debugf("acquired binary from %s", source.SourceName())
 			return binary, nil
 		}
-		m.logger.Debugf("source %s failed: %v", source.SourceName(), err)
+		log.Debugf("source %s failed: %v", source.SourceName(), err)
 	}
 	return nil, ErrBinaryNotFound
 }

--- a/pkg/agent/dockerless.go
+++ b/pkg/agent/dockerless.go
@@ -15,10 +15,9 @@ import (
 	"github.com/devsy-org/devsy/pkg/copy"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/envfile"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -37,7 +36,6 @@ type DockerlessBuildOptions struct {
 	DockerlessOptions        *provider2.ProviderDockerlessOptions
 	ImageConfigOutput        string
 	Debug                    bool
-	Log                      log.Logger
 	ConfigureCredentialsFunc ConfigureCredentialsFunc
 }
 
@@ -71,7 +69,7 @@ func executeBuild(opts DockerlessBuildOptions) error {
 	if err := prepareBuildDirectory(buildContext); err != nil {
 		return err
 	}
-	defer cleanupBuildDirectory(buildContext, opts.Log)
+	defer cleanupBuildDirectory(buildContext)
 
 	binaryPath, err := os.Executable()
 	if err != nil {
@@ -85,11 +83,11 @@ func executeBuild(opts DockerlessBuildOptions) error {
 
 	args := buildDockerlessArgs(binaryPath, opts)
 
-	if err := runDockerlessBuild(opts.Context, args, opts.Debug, opts.Log); err != nil {
+	if err := runDockerlessBuild(opts.Context, args, opts.Debug); err != nil {
 		return err
 	}
 
-	return applyContainerEnv(opts.ImageConfigOutput, opts.Log)
+	return applyContainerEnv(opts.ImageConfigOutput)
 }
 
 func validateBuildOptions(opts DockerlessBuildOptions) error {
@@ -98,9 +96,6 @@ func validateBuildOptions(opts DockerlessBuildOptions) error {
 	}
 	if opts.DockerlessOptions == nil {
 		return fmt.Errorf("dockerless options are required for dockerless build")
-	}
-	if opts.Log == nil {
-		return fmt.Errorf("log is required for dockerless build")
 	}
 	if opts.Context == nil {
 		return fmt.Errorf("context is required for dockerless build")
@@ -114,13 +109,13 @@ func shouldBuild(opts DockerlessBuildOptions) bool {
 	}
 
 	if ImageConfigExists(opts.ImageConfigOutput) {
-		opts.Log.Debugf("skip dockerless build, because container was built already")
+		log.Debugf("skip dockerless build, because container was built already")
 		return false
 	}
 
 	buildContext := GetDockerlessBuildContext()
 	if buildContext == "" {
-		opts.Log.Debugf("build context is missing for dockerless build")
+		log.Debugf("build context is missing for dockerless build")
 		return false
 	}
 
@@ -149,7 +144,7 @@ func prepareBuildDirectory(buildContext string) error {
 
 func setupDockerCredentials(opts DockerlessBuildOptions) func() {
 	if opts.DockerlessOptions.DisableDockerCredentials == trueValue {
-		opts.Log.Debugf("docker credentials disabled via DisableDockerCredentials option")
+		log.Debugf("docker credentials disabled via DisableDockerCredentials option")
 		return nil
 	}
 
@@ -169,7 +164,7 @@ func setupDockerCredentials(opts DockerlessBuildOptions) func() {
 		} else {
 			_ = os.Unsetenv("DOCKER_CONFIG")
 		}
-		opts.Log.Warnf(
+		log.Warnf(
 			"failed to configure docker credentials, private registries may not work: %v",
 			err,
 		)
@@ -188,7 +183,7 @@ func setupDockerCredentials(opts DockerlessBuildOptions) func() {
 	}
 }
 
-func cleanupBuildDirectory(buildContext string, log log.Logger) {
+func cleanupBuildDirectory(buildContext string) {
 	fallbackDir := filepath.Join(
 		config.DevsyDockerlessBuildInfoFolder,
 		config.DevsyContextFeatureFolder,
@@ -208,7 +203,7 @@ func buildDockerlessArgs(binaryPath string, opts DockerlessBuildOptions) []strin
 	args = append(args, "--build-arg", "TARGETARCH="+runtime.GOARCH)
 
 	if opts.DockerlessOptions.RegistryCache != "" {
-		opts.Log.Debugf(
+		log.Debugf(
 			"appending registry cache to dockerless build arguments: %v",
 			opts.DockerlessOptions.RegistryCache,
 		)
@@ -250,8 +245,8 @@ func parseIgnorePaths(ignorePaths string) []string {
 	return retPaths
 }
 
-func runDockerlessBuild(ctx context.Context, args []string, debug bool, log log.Logger) error {
-	errWriter := log.Writer(logrus.InfoLevel, false)
+func runDockerlessBuild(ctx context.Context, args []string, debug bool) error {
+	errWriter := log.Writer(log.LevelInfo)
 	defer func() { _ = errWriter.Close() }()
 
 	var stderrBuf bytes.Buffer
@@ -259,7 +254,7 @@ func runDockerlessBuild(ctx context.Context, args []string, debug bool, log log.
 
 	cmd := exec.CommandContext(ctx, "/.dockerless/dockerless", args...)
 	if debug {
-		debugWriter := log.Writer(logrus.DebugLevel, false)
+		debugWriter := log.Writer(log.LevelDebug)
 		defer func() { _ = debugWriter.Close() }()
 		cmd.Stdout = debugWriter
 	}
@@ -282,7 +277,7 @@ func runDockerlessBuild(ctx context.Context, args []string, debug bool, log log.
 	return nil
 }
 
-func applyContainerEnv(imageConfigPath string, log log.Logger) error {
+func applyContainerEnv(imageConfigPath string) error {
 	// #nosec G304 -- imageConfigPath is controlled by the application, not user input
 	rawConfig, err := os.ReadFile(imageConfigPath)
 	if err != nil {

--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -14,9 +14,10 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/inject"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/shell"
 	"github.com/devsy-org/devsy/pkg/version"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
@@ -39,9 +40,6 @@ type InjectOptions struct {
 	Ctx context.Context
 	// Exec is the function used to execute commands on the remote machine. Required.
 	Exec inject.ExecFunc
-	// Log is the logger for capturing injection output.
-	// Required.
-	Log log.Logger
 
 	// IsLocal indicates if the injection target is the local machine.
 	IsLocal bool
@@ -91,9 +89,6 @@ func (o *InjectOptions) Validate() error {
 	if o.Exec == nil {
 		return fmt.Errorf("exec function is required")
 	}
-	if o.Log == nil {
-		return fmt.Errorf("logger is required")
-	}
 	return nil
 }
 
@@ -125,7 +120,7 @@ func (o *InjectOptions) applyURLDefaults() {
 			"/releases/download/",
 			1,
 		)
-		o.Log.Warnf(
+		log.Warnf(
 			"download URL %s is a tag URL, normalizing to download URL %s",
 			o.DownloadURL,
 			normalizedDownloadUrl,
@@ -160,7 +155,7 @@ func (o *InjectOptions) applyPreferDownloadDefaults() {
 func (o *InjectOptions) applyEnvPreference(preferDownloadEnv string) {
 	pref, err := strconv.ParseBool(preferDownloadEnv)
 	if err != nil {
-		o.Log.Warnf("failed to parse %s, using default", config.EnvAgentPreferDownload)
+		log.Warnf("failed to parse %s, using default", config.EnvAgentPreferDownload)
 		pref = true
 	}
 	o.PreferDownloadFromRemoteUrl = Bool(pref)
@@ -178,7 +173,7 @@ func InjectAgent(opts *InjectOptions) error {
 	}
 
 	vc := newVersionChecker(opts)
-	bm := NewBinaryManager(opts.Log, opts.DownloadURL)
+	bm := NewBinaryManager(opts.DownloadURL)
 
 	backoff := wait.Backoff{
 		Steps:    30,
@@ -188,16 +183,16 @@ func InjectAgent(opts *InjectOptions) error {
 		Cap:      60 * time.Second,
 	}
 
-	opts.Log.Debug("starting agent injection")
+	log.Debug("starting agent injection")
 	return retry.OnError(backoff, func(err error) bool {
 		if opts.Ctx.Err() != nil {
 			return false
 		}
 		if errors.Is(err, docker.ErrContainerTerminal) {
-			opts.Log.Errorf("container entered a terminal state, not retrying: %v", err)
+			log.Errorf("container entered a terminal state, not retrying: %v", err)
 			return false
 		}
-		opts.Log.Debugf("retrying injection: %v", err)
+		log.Debugf("retrying injection: %v", err)
 		return true
 	}, func() error {
 		return injectAgent(&injectContext{
@@ -212,7 +207,7 @@ func injectLocally(opts *InjectOptions) error {
 	if opts.Command == "" {
 		return nil
 	}
-	opts.Log.Debug("execute command locally")
+	log.Debug("execute command locally")
 	return shell.RunEmulatedShell(opts.Ctx, opts.Command, opts.Stdin, opts.Stdout, opts.Stderr, nil)
 }
 
@@ -239,7 +234,7 @@ func injectAgent(ctx *injectContext) error {
 		Stdout:       opts.Stdout,
 		Stderr:       stderr,
 		Timeout:      opts.Timeout,
-		Log:          opts.Log,
+		Log:          oldlog.Default.ErrorStreamOnly(),
 	})
 	if err != nil {
 		return handleInjectError(err, wasExecuted, buf)
@@ -294,7 +289,6 @@ func performVersionCheck(ctx *injectContext) error {
 		opts.Ctx,
 		opts.Exec,
 		opts.RemoteAgentPath,
-		opts.Log,
 	)
 
 	if !opts.SkipVersionCheck {
@@ -304,7 +298,7 @@ func performVersionCheck(ctx *injectContext) error {
 	}
 
 	if detectedVersion != "" && !opts.SkipVersionCheck {
-		opts.Log.Debugf("detected remote agent version: %s", detectedVersion)
+		log.Debugf("detected remote agent version: %s", detectedVersion)
 	}
 
 	return nil
@@ -360,7 +354,6 @@ func (vc *versionChecker) detectRemoteAgentVersion(
 	ctx context.Context,
 	exec inject.ExecFunc,
 	agentPath string,
-	log log.Logger,
 ) (string, error) {
 	buf := &bytes.Buffer{}
 	versionCmd := fmt.Sprintf("%s version", agentPath)

--- a/pkg/agent/inject_test.go
+++ b/pkg/agent/inject_test.go
@@ -5,14 +5,12 @@ import (
 	"io"
 	"testing"
 
-	"github.com/devsy-org/log"
 	"github.com/stretchr/testify/suite"
 )
 
 type InjectTestSuite struct {
 	suite.Suite
-	ctx    context.Context
-	logger log.Logger
+	ctx context.Context
 }
 
 func TestInjectTestSuite(t *testing.T) {
@@ -21,14 +19,12 @@ func TestInjectTestSuite(t *testing.T) {
 
 func (s *InjectTestSuite) SetupTest() {
 	s.ctx = context.Background()
-	s.logger = log.Discard
 }
 
 func (s *InjectTestSuite) TestLocalInjection() {
 	opts := &InjectOptions{
 		Ctx:     s.ctx,
 		Exec:    (&MockExecFunc{}).Exec,
-		Log:     s.logger,
 		IsLocal: true,
 		Command: "echo hello",
 	}
@@ -55,7 +51,7 @@ func (s *InjectTestSuite) TestVersionChecker() {
 		}
 		mockExec := &MockExecFunc{Output: "v1.0.0\n"}
 
-		detected, err := vc.detectRemoteAgentVersion(s.ctx, mockExec.Exec, "/path", s.logger)
+		detected, err := vc.detectRemoteAgentVersion(s.ctx, mockExec.Exec, "/path")
 		s.NoError(err)
 		s.Equal("v1.0.0", detected)
 	})
@@ -67,7 +63,7 @@ func (s *InjectTestSuite) TestVersionChecker() {
 		}
 		mockExec := &MockExecFunc{Output: "v0.9.0\n"}
 
-		detected, err := vc.detectRemoteAgentVersion(s.ctx, mockExec.Exec, "/path", s.logger)
+		detected, err := vc.detectRemoteAgentVersion(s.ctx, mockExec.Exec, "/path")
 		s.NoError(err)
 		s.Equal("v0.9.0", detected)
 	})

--- a/pkg/agent/workspace.go
+++ b/pkg/agent/workspace.go
@@ -19,9 +19,10 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/git"
 	"github.com/devsy-org/devsy/pkg/gitcredentials"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/util"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/moby/patternmatcher/ignorefile"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -253,7 +254,6 @@ func CloneRepositoryForWorkspace(
 	workspaceDir, helper string,
 	options provider2.CLIOptions,
 	overwriteContent bool,
-	log log.Logger,
 ) error {
 	log.Info("Clone repository")
 	log.Infof("URL: %s\n", source.GitRepository)
@@ -289,7 +289,7 @@ func CloneRepositoryForWorkspace(
 				"seems like git isn't installed on your system. Please make sure to install git and make it available in the PATH",
 			)
 		}
-		if err := git.InstallBinary(log); err != nil {
+		if err := git.InstallBinary(oldlog.Default.ErrorStreamOnly()); err != nil {
 			return err
 		}
 	}
@@ -412,7 +412,7 @@ func CloneRepositoryForWorkspace(
 			workspaceDir,
 			helper,
 			options.StrictHostKeyChecking,
-			log,
+			oldlog.Default.ErrorStreamOnly(),
 			getGitOptions(options)...)
 		if err != nil {
 			// cleanup workspace dir if clone failed, otherwise we won't try to clone again when rebuilding this workspace
@@ -423,7 +423,7 @@ func CloneRepositoryForWorkspace(
 		}
 	}
 
-	log.Done("cloned repository")
+	log.Info("cloned repository")
 
 	// Get .devsyignore files to exclude
 	f, err := os.Open(

--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -1069,7 +1069,6 @@ func runAgentInjection(opts agentInjectionOptions) chan error {
 			Stdin:           opts.stdin,
 			Stdout:          opts.stdout,
 			Stderr:          writer,
-			Log:             opts.log.ErrorStreamOnly(),
 			Timeout:         opts.timeout,
 		})
 	}()

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -83,7 +83,6 @@ func (r *runner) injectAgentIntoContainer(ctx context.Context, timeout time.Dura
 		RemoteAgentPath:             agent.ContainerDevsyHelperLocation,
 		DownloadURL:                 agent.DefaultAgentDownloadURL(),
 		PreferDownloadFromRemoteUrl: agent.Bool(false),
-		Log:                         r.Log,
 		Timeout:                     timeout,
 	})
 	if err != nil {

--- a/pkg/tunnel/container.go
+++ b/pkg/tunnel/container.go
@@ -102,7 +102,6 @@ func (c *ContainerTunnel) Run(
 			Stdin:           stdinReader,
 			Stdout:          stdoutWriter,
 			Stderr:          writer,
-			Log:             c.log.ErrorStreamOnly(),
 			Timeout:         timeout,
 		})
 	}()


### PR DESCRIPTION
## Summary
- Migrate pkg/agent/ (excluding tunnelserver/) from old logger to new zap-based pkg/log
- Remove oldlog.Logger function params and struct fields, use package-level log calls
- Update callers in cmd/agent/, cmd/, pkg/tunnel/, pkg/client/, pkg/devcontainer/ to remove logger arguments
- tunnelserver/ skipped — implements old log.Logger interface, needs separate migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified logging configuration across agent operations by consolidating to package-level logging instead of passing explicit loggers throughout the codebase. Functionality and error handling remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->