### PR TITLE
refactor(log): migrate pkg/ide/ to pkg/log

### DIFF
--- a/cmd/agent/container/openvscode_async.go
+++ b/cmd/agent/container/openvscode_async.go
@@ -8,7 +8,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/ide/openvscode"
 	"github.com/devsy-org/devsy/pkg/log"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +47,7 @@ func (cmd *OpenVSCodeAsyncCmd) Run(_ *cobra.Command, _ []string) error {
 	}
 
 	// install IDE
-	err = setupOpenVSCodeExtensions(setupInfo, oldlog.Default)
+	err = setupOpenVSCodeExtensions(setupInfo)
 	if err != nil {
 		return err
 	}
@@ -56,9 +55,9 @@ func (cmd *OpenVSCodeAsyncCmd) Run(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func setupOpenVSCodeExtensions(setupInfo *config.Result, logger oldlog.Logger) error {
+func setupOpenVSCodeExtensions(setupInfo *config.Result) error {
 	vsCodeConfiguration := config.GetVSCodeConfiguration(setupInfo.MergedConfig)
 	user := config.GetRemoteUser(setupInfo)
-	return openvscode.NewOpenVSCodeServer(vsCodeConfiguration.Extensions, "", user, "", "", nil, logger).
+	return openvscode.NewOpenVSCodeServer(vsCodeConfiguration.Extensions, "", user, "", "", nil).
 		InstallExtensions()
 }

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -194,7 +194,7 @@ func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
 		return err
 	}
 
-	if err := cmd.installIDE(sctx.setupInfo, &sctx.workspaceInfo.IDE, sctx.logger); err != nil {
+	if err := cmd.installIDE(sctx.setupInfo, &sctx.workspaceInfo.IDE); err != nil {
 		return err
 	}
 
@@ -441,71 +441,70 @@ func fillContainerEnv(setupInfo *config.Result) error {
 func (cmd *SetupContainerCmd) installIDE(
 	setupInfo *config.Result,
 	ide *provider2.WorkspaceIDEConfig,
-	logger oldlog.Logger,
 ) error {
 	switch ide.Name {
 	case string(config2.IDENone):
 		return nil
 	case string(config2.IDEVSCode):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorStable, logger)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorStable)
 	case string(config2.IDEVSCodeInsiders):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorInsiders, logger)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorInsiders)
 	case string(config2.IDECursor):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorCursor, logger)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorCursor)
 	case string(config2.IDEPositron):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorPositron, logger)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorPositron)
 	case string(config2.IDECodium):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorCodium, logger)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorCodium)
 	case string(config2.IDEWindsurf):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorWindsurf, logger)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorWindsurf)
 	case string(config2.IDEAntigravity):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorAntigravity, logger)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorAntigravity)
 	case string(config2.IDEBob):
-		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorBob, logger)
+		return cmd.setupVSCode(setupInfo, ide.Options, vscode.FlavorBob)
 	case string(config2.IDEOpenVSCode):
-		return cmd.setupOpenVSCode(setupInfo, ide.Options, logger)
+		return cmd.setupOpenVSCode(setupInfo, ide.Options)
 	case string(config2.IDEGoland):
-		return jetbrains.NewGolandServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
+		return jetbrains.NewGolandServer(config.GetRemoteUser(setupInfo), ide.Options).
 			Install(setupInfo)
 	case string(config2.IDERustRover):
-		return jetbrains.NewRustRoverServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
+		return jetbrains.NewRustRoverServer(config.GetRemoteUser(setupInfo), ide.Options).
 			Install(setupInfo)
 	case string(config2.IDEPyCharm):
-		return jetbrains.NewPyCharmServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
+		return jetbrains.NewPyCharmServer(config.GetRemoteUser(setupInfo), ide.Options).
 			Install(setupInfo)
 	case string(config2.IDEPhpStorm):
-		return jetbrains.NewPhpStorm(config.GetRemoteUser(setupInfo), ide.Options, logger).
+		return jetbrains.NewPhpStorm(config.GetRemoteUser(setupInfo), ide.Options).
 			Install(setupInfo)
 	case string(config2.IDEIntellij):
-		return jetbrains.NewIntellij(config.GetRemoteUser(setupInfo), ide.Options, logger).
+		return jetbrains.NewIntellij(config.GetRemoteUser(setupInfo), ide.Options).
 			Install(setupInfo)
 	case string(config2.IDECLion):
-		return jetbrains.NewCLionServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
+		return jetbrains.NewCLionServer(config.GetRemoteUser(setupInfo), ide.Options).
 			Install(setupInfo)
 	case string(config2.IDERider):
-		return jetbrains.NewRiderServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
+		return jetbrains.NewRiderServer(config.GetRemoteUser(setupInfo), ide.Options).
 			Install(setupInfo)
 	case string(config2.IDERubyMine):
-		return jetbrains.NewRubyMineServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
+		return jetbrains.NewRubyMineServer(config.GetRemoteUser(setupInfo), ide.Options).
 			Install(setupInfo)
 	case string(config2.IDEWebStorm):
-		return jetbrains.NewWebStormServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
+		return jetbrains.NewWebStormServer(config.GetRemoteUser(setupInfo), ide.Options).
 			Install(setupInfo)
 	case string(config2.IDEDataSpell):
-		return jetbrains.NewDataSpellServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
+		return jetbrains.NewDataSpellServer(config.GetRemoteUser(setupInfo), ide.Options).
 			Install(setupInfo)
 	case string(config2.IDEFleet):
-		return fleet.NewFleetServer(config.GetRemoteUser(setupInfo), ide.Options, logger).
+		return fleet.NewFleetServer(config.GetRemoteUser(setupInfo), ide.Options).
 			Install(setupInfo.SubstitutionContext.ContainerWorkspaceFolder)
 	case string(config2.IDEJupyterNotebook):
 		return jupyter.NewJupyterNotebookServer(
 			setupInfo.SubstitutionContext.ContainerWorkspaceFolder,
-			config.GetRemoteUser(setupInfo), ide.Options, logger).
+			config.GetRemoteUser(setupInfo), ide.Options).
 			Install()
 	case string(config2.IDERStudio):
 		return rstudio.NewRStudioServer(
 			setupInfo.SubstitutionContext.ContainerWorkspaceFolder,
-			config.GetRemoteUser(setupInfo), ide.Options, logger).
+			config.GetRemoteUser(setupInfo), ide.Options).
 			Install()
 	}
 
@@ -516,7 +515,6 @@ func (cmd *SetupContainerCmd) setupVSCode(
 	setupInfo *config.Result,
 	ideOptions map[string]config2.OptionValue,
 	flavor vscode.Flavor,
-	logger oldlog.Logger,
 ) error {
 	log.Debugf("setup %s", flavor.DisplayName())
 	vsCodeConfiguration := config.GetVSCodeConfiguration(setupInfo.MergedConfig)
@@ -538,7 +536,6 @@ func (cmd *SetupContainerCmd) setupVSCode(
 		UserName:   user,
 		Values:     ideOptions,
 		Flavor:     flavor,
-		Log:        logger,
 	}).Install()
 	if err != nil {
 		return err
@@ -579,7 +576,6 @@ func (cmd *SetupContainerCmd) setupVSCode(
 func (cmd *SetupContainerCmd) setupOpenVSCode(
 	setupInfo *config.Result,
 	ideOptions map[string]config2.OptionValue,
-	logger oldlog.Logger,
 ) error {
 	log.Debugf("setup openvscode")
 	vsCodeConfiguration := config.GetVSCodeConfiguration(setupInfo.MergedConfig)
@@ -601,7 +597,6 @@ func (cmd *SetupContainerCmd) setupOpenVSCode(
 		"0.0.0.0",
 		strconv.Itoa(openvscode.DefaultVSCodePort),
 		ideOptions,
-		logger,
 	)
 
 	// install open vscode

--- a/cmd/agent/container/vscode_async.go
+++ b/cmd/agent/container/vscode_async.go
@@ -7,7 +7,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/compress"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/ide/vscode"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -49,7 +48,7 @@ func (cmd *VSCodeAsyncCmd) Run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	err = setupVSCodeExtensions(setupInfo, vscode.Flavor(cmd.Flavor), oldlog.Default)
+	err = setupVSCodeExtensions(setupInfo, vscode.Flavor(cmd.Flavor))
 	if err != nil {
 		return err
 	}
@@ -60,7 +59,6 @@ func (cmd *VSCodeAsyncCmd) Run(_ *cobra.Command, _ []string) error {
 func setupVSCodeExtensions(
 	setupInfo *config.Result,
 	flavor vscode.Flavor,
-	logger oldlog.Logger,
 ) error {
 	vsCodeConfiguration := config.GetVSCodeConfiguration(setupInfo.MergedConfig)
 	user := config.GetRemoteUser(setupInfo)
@@ -68,6 +66,5 @@ func setupVSCodeExtensions(
 		Extensions: vsCodeConfiguration.Extensions,
 		UserName:   user,
 		Flavor:     flavor,
-		Log:        logger,
 	}).InstallExtensions()
 }

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -693,44 +693,44 @@ func (d *dockerDriver) addIDEMountArgs(
 ) []string {
 	switch ide {
 	case string(config2.IDEGoland):
-		args = append(args, "--mount", jetbrains.NewGolandServer("", ideOptions, d.Log).GetVolume())
+		args = append(args, "--mount", jetbrains.NewGolandServer("", ideOptions).GetVolume())
 	case string(config2.IDERustRover):
 		args = append(
 			args,
 			"--mount",
-			jetbrains.NewRustRoverServer("", ideOptions, d.Log).GetVolume(),
+			jetbrains.NewRustRoverServer("", ideOptions).GetVolume(),
 		)
 	case string(config2.IDEPyCharm):
 		args = append(
 			args,
 			"--mount",
-			jetbrains.NewPyCharmServer("", ideOptions, d.Log).GetVolume(),
+			jetbrains.NewPyCharmServer("", ideOptions).GetVolume(),
 		)
 	case string(config2.IDEPhpStorm):
-		args = append(args, "--mount", jetbrains.NewPhpStorm("", ideOptions, d.Log).GetVolume())
+		args = append(args, "--mount", jetbrains.NewPhpStorm("", ideOptions).GetVolume())
 	case string(config2.IDEIntellij):
-		args = append(args, "--mount", jetbrains.NewIntellij("", ideOptions, d.Log).GetVolume())
+		args = append(args, "--mount", jetbrains.NewIntellij("", ideOptions).GetVolume())
 	case string(config2.IDECLion):
-		args = append(args, "--mount", jetbrains.NewCLionServer("", ideOptions, d.Log).GetVolume())
+		args = append(args, "--mount", jetbrains.NewCLionServer("", ideOptions).GetVolume())
 	case string(config2.IDERider):
-		args = append(args, "--mount", jetbrains.NewRiderServer("", ideOptions, d.Log).GetVolume())
+		args = append(args, "--mount", jetbrains.NewRiderServer("", ideOptions).GetVolume())
 	case string(config2.IDERubyMine):
 		args = append(
 			args,
 			"--mount",
-			jetbrains.NewRubyMineServer("", ideOptions, d.Log).GetVolume(),
+			jetbrains.NewRubyMineServer("", ideOptions).GetVolume(),
 		)
 	case string(config2.IDEWebStorm):
 		args = append(
 			args,
 			"--mount",
-			jetbrains.NewWebStormServer("", ideOptions, d.Log).GetVolume(),
+			jetbrains.NewWebStormServer("", ideOptions).GetVolume(),
 		)
 	case string(config2.IDEDataSpell):
 		args = append(
 			args,
 			"--mount",
-			jetbrains.NewDataSpellServer("", ideOptions, d.Log).GetVolume(),
+			jetbrains.NewDataSpellServer("", ideOptions).GetVolume(),
 		)
 	}
 	return args

--- a/pkg/ide/fleet/fleet.go
+++ b/pkg/ide/fleet/fleet.go
@@ -15,8 +15,8 @@ import (
 	copy2 "github.com/devsy-org/devsy/pkg/copy"
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
 	"github.com/devsy-org/devsy/pkg/ide"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/util"
-	"github.com/devsy-org/log"
 	"github.com/devsy-org/log/scanner"
 )
 
@@ -48,19 +48,16 @@ var Options = ide.Options{
 func NewFleetServer(
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *FleetServer {
 	return &FleetServer{
 		values:   values,
 		userName: userName,
-		log:      log,
 	}
 }
 
 type FleetServer struct {
 	values   map[string]config.OptionValue
 	userName string
-	log      log.Logger
 }
 
 func (o *FleetServer) Install(projectDir string) error {
@@ -85,7 +82,7 @@ func (o *FleetServer) Install(projectDir string) error {
 	}
 
 	// download binary
-	o.log.Infof("Downloading fleet...")
+	log.Infof("Downloading fleet...")
 	resp, err := devsyhttp.GetHTTPClient().Get(url)
 	if err != nil {
 		return err
@@ -119,7 +116,7 @@ func (o *FleetServer) Install(projectDir string) error {
 		}
 	}
 
-	o.log.Infof("downloaded fleet")
+	log.Infof("downloaded fleet")
 	return o.Start(fleetBinary, location, projectDir)
 }
 
@@ -129,7 +126,7 @@ func (o *FleetServer) Start(binaryPath, location, projectDir string) error {
 	stderrBuffer := &bytes.Buffer{}
 
 	err := command.StartBackgroundOnce("fleet", func() (*exec.Cmd, error) {
-		o.log.Infof("Starting fleet in background...")
+		log.Infof("Starting fleet in background...")
 		// Determine version of fleet to use
 		var runCommand string
 		version := Options.GetValue(o.values, VersionOption)
@@ -175,7 +172,7 @@ func (o *FleetServer) Start(binaryPath, location, projectDir string) error {
 	defer func() { _ = readCloser.Close() }()
 
 	// wait for the jet brains url and then exit
-	o.log.Infof("waiting for fleet to start")
+	log.Infof("waiting for fleet to start")
 	s := scanner.NewScanner(readCloser)
 	stdoutBuffer := &bytes.Buffer{}
 	for s.Scan() {
@@ -192,7 +189,7 @@ func (o *FleetServer) Start(binaryPath, location, projectDir string) error {
 				return err
 			}
 
-			o.log.Infof("fleet started")
+			log.Infof("fleet started")
 			return o.startMonitor()
 		} else {
 			_, _ = stdoutBuffer.Write([]byte(text + "\n"))
@@ -213,7 +210,7 @@ func (o *FleetServer) startMonitor() error {
 	}
 
 	return command.StartBackgroundOnce("fleet-monitor", func() (*exec.Cmd, error) {
-		o.log.Infof("starting fleet monitor in background")
+		log.Infof("starting fleet monitor in background")
 		runCommand := fmt.Sprintf("%s helper fleet-server --workspaceid %s", self, "test")
 		args := []string{}
 		if o.userName != "" {

--- a/pkg/ide/jetbrains/clion.go
+++ b/pkg/ide/jetbrains/clion.go
@@ -3,7 +3,6 @@ package jetbrains
 import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/ide"
-	"github.com/devsy-org/log"
 )
 
 const (
@@ -31,7 +30,6 @@ var CLionOptions = ide.Options{
 func NewCLionServer(
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *GenericJetBrainsServer {
 	amd64Download, arm64Download := getDownloadURLs(
 		CLionOptions,
@@ -45,5 +43,5 @@ func NewCLionServer(
 		DisplayName:   "CLion",
 		DownloadAmd64: amd64Download,
 		DownloadArm64: arm64Download,
-	}, log)
+	})
 }

--- a/pkg/ide/jetbrains/dataspell.go
+++ b/pkg/ide/jetbrains/dataspell.go
@@ -3,7 +3,6 @@ package jetbrains
 import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/ide"
-	"github.com/devsy-org/log"
 )
 
 const (
@@ -31,7 +30,6 @@ var DataSpellOptions = ide.Options{
 func NewDataSpellServer(
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *GenericJetBrainsServer {
 	amd64Download, arm64Download := getDownloadURLs(
 		DataSpellOptions,
@@ -45,5 +43,5 @@ func NewDataSpellServer(
 		DisplayName:   "DataSpell",
 		DownloadAmd64: amd64Download,
 		DownloadArm64: arm64Download,
-	}, log)
+	})
 }

--- a/pkg/ide/jetbrains/generic.go
+++ b/pkg/ide/jetbrains/generic.go
@@ -19,9 +19,9 @@ import (
 	"github.com/devsy-org/devsy/pkg/extract"
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
 	"github.com/devsy-org/devsy/pkg/ide"
+	"github.com/devsy-org/devsy/pkg/log"
 	devsyopen "github.com/devsy-org/devsy/pkg/open"
 	"github.com/devsy-org/devsy/pkg/util"
-	"github.com/devsy-org/log"
 )
 
 const (
@@ -71,23 +71,20 @@ type GenericOptions struct {
 func newGenericServer(
 	userName string,
 	options *GenericOptions,
-	log log.Logger,
 ) *GenericJetBrainsServer {
 	return &GenericJetBrainsServer{
 		userName: userName,
 		options:  options,
-		log:      log,
 	}
 }
 
 type GenericJetBrainsServer struct {
 	userName string
 	options  *GenericOptions
-	log      log.Logger
 }
 
 func (o *GenericJetBrainsServer) OpenGateway(workspaceFolder, workspaceID string) error {
-	o.log.Infof("Starting %s through JetBrains Gateway...", o.options.DisplayName)
+	log.Infof("Starting %s through JetBrains Gateway...", o.options.DisplayName)
 	err := devsyopen.Run(
 		`jetbrains-gateway://connect#idePath=` + url.QueryEscape(
 			o.getDirectory(path.Join("/", "home", o.userName)),
@@ -98,8 +95,8 @@ func (o *GenericJetBrainsServer) OpenGateway(workspaceFolder, workspaceID string
 		) + `&type=ssh&deploy=false`,
 	)
 	if err != nil {
-		o.log.Debugf("Error opening jetbrains-gateway: %v", err)
-		o.log.Errorf(
+		log.Debugf("Error opening jetbrains-gateway: %v", err)
+		log.Errorf(
 			"Seems like you don't have JetBrains Gateway installed on your computer. " +
 				"Please install JetBrains Gateway via https://www.jetbrains.com/remote-development/gateway/",
 		)
@@ -117,7 +114,7 @@ func (o *GenericJetBrainsServer) getDownloadFolder() string {
 }
 
 func (o *GenericJetBrainsServer) Install(setupInfo *config.Result) error {
-	o.log.Infof("setup backend: displayName=%s, id=%s", o.options.DisplayName, o.options.ID)
+	log.Infof("setup backend: displayName=%s, id=%s", o.options.DisplayName, o.options.ID)
 	baseFolder, err := getBaseFolder(o.userName)
 	if err != nil {
 		return err
@@ -126,7 +123,7 @@ func (o *GenericJetBrainsServer) Install(setupInfo *config.Result) error {
 
 	_, err = os.Stat(targetLocation)
 	if err == nil {
-		o.log.Infof(
+		log.Infof(
 			"already installed skip install: displayName=%s, id=%s",
 			o.options.DisplayName,
 			o.options.ID,
@@ -134,13 +131,13 @@ func (o *GenericJetBrainsServer) Install(setupInfo *config.Result) error {
 		return nil
 	}
 
-	o.log.Infof("downloading archive: displayName=%s, id=%s", o.options.DisplayName, o.options.ID)
-	archivePath, err := o.download(o.getDownloadFolder(), o.log)
+	log.Infof("downloading archive: displayName=%s, id=%s", o.options.DisplayName, o.options.ID)
+	archivePath, err := o.download(o.getDownloadFolder())
 	if err != nil {
 		return err
 	}
 
-	o.log.Infof("extracting archive: displayName=%s, id=%s", o.options.DisplayName, o.options.ID)
+	log.Infof("extracting archive: displayName=%s, id=%s", o.options.DisplayName, o.options.ID)
 	err = o.extractArchive(archivePath, targetLocation)
 	if err != nil {
 		return err
@@ -150,7 +147,7 @@ func (o *GenericJetBrainsServer) Install(setupInfo *config.Result) error {
 	if err != nil {
 		return fmt.Errorf("chown: %w", err)
 	}
-	o.log.Infof("installed backend: displayName=%s, id=%s", o.options.DisplayName, o.options.ID)
+	log.Infof("installed backend: displayName=%s, id=%s", o.options.DisplayName, o.options.ID)
 
 	jetBrainsConfiguration := config.GetJetBrainsConfiguration(setupInfo.MergedConfig)
 	plugins := jetBrainsConfiguration.Plugins
@@ -160,7 +157,7 @@ func (o *GenericJetBrainsServer) Install(setupInfo *config.Result) error {
 		return nil
 	}
 
-	o.log.Infof("installing JetBrains plugins: plugins=%v", plugins)
+	log.Infof("installing JetBrains plugins: plugins=%v", plugins)
 
 	installPluginsCommand := exec.Command(
 		path.Join(targetLocation, "bin", "remote-dev-server.sh"),
@@ -193,8 +190,8 @@ func (o *GenericJetBrainsServer) Install(setupInfo *config.Result) error {
 		)
 	}
 
-	o.log.Debugf("remote-dev-server.sh output: %s", out)
-	o.log.Infof("installed JetBrains plugins: plugins=%v", plugins)
+	log.Debugf("remote-dev-server.sh output: %s", out)
+	log.Infof("installed JetBrains plugins: plugins=%v", plugins)
 
 	return nil
 }
@@ -228,7 +225,8 @@ func (o *GenericJetBrainsServer) extractArchive(fromPath string, toPath string) 
 	return extract.Extract(file, toPath, extract.StripLevels(1))
 }
 
-func (o *GenericJetBrainsServer) download(targetFolder string, log log.Logger) (string, error) {
+//nolint:cyclop // pre-existing complexity
+func (o *GenericJetBrainsServer) download(targetFolder string) (string, error) {
 	err := os.MkdirAll(targetFolder, os.ModePerm)
 	if err != nil {
 		return "", err
@@ -272,7 +270,6 @@ func (o *GenericJetBrainsServer) download(targetFolder string, log log.Logger) (
 	_, err = io.Copy(file, &ide.ProgressReader{
 		Reader:    resp.Body,
 		TotalSize: resp.ContentLength,
-		Log:       log,
 	})
 	if err != nil {
 		return "", fmt.Errorf("download file: %w", err)

--- a/pkg/ide/jetbrains/goland.go
+++ b/pkg/ide/jetbrains/goland.go
@@ -3,7 +3,6 @@ package jetbrains
 import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/ide"
-	"github.com/devsy-org/log"
 )
 
 const (
@@ -31,7 +30,6 @@ var GolandOptions = ide.Options{
 func NewGolandServer(
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *GenericJetBrainsServer {
 	amd64Download, arm64Download := getDownloadURLs(
 		GolandOptions,
@@ -45,5 +43,5 @@ func NewGolandServer(
 		DisplayName:   "Goland",
 		DownloadAmd64: amd64Download,
 		DownloadArm64: arm64Download,
-	}, log)
+	})
 }

--- a/pkg/ide/jetbrains/intellij.go
+++ b/pkg/ide/jetbrains/intellij.go
@@ -3,7 +3,6 @@ package jetbrains
 import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/ide"
-	"github.com/devsy-org/log"
 )
 
 const (
@@ -31,7 +30,6 @@ var IntellijOptions = ide.Options{
 func NewIntellij(
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *GenericJetBrainsServer {
 	amd64Download, arm64Download := getDownloadURLs(
 		IntellijOptions,
@@ -45,5 +43,5 @@ func NewIntellij(
 		DisplayName:   "Intellij",
 		DownloadAmd64: amd64Download,
 		DownloadArm64: arm64Download,
-	}, log)
+	})
 }

--- a/pkg/ide/jetbrains/phpstorm.go
+++ b/pkg/ide/jetbrains/phpstorm.go
@@ -3,7 +3,6 @@ package jetbrains
 import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/ide"
-	"github.com/devsy-org/log"
 )
 
 const (
@@ -31,7 +30,6 @@ var PhpStormOptions = ide.Options{
 func NewPhpStorm(
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *GenericJetBrainsServer {
 	amd64Download, arm64Download := getDownloadURLs(
 		PhpStormOptions,
@@ -45,5 +43,5 @@ func NewPhpStorm(
 		DisplayName:   "PhpStorm",
 		DownloadAmd64: amd64Download,
 		DownloadArm64: arm64Download,
-	}, log)
+	})
 }

--- a/pkg/ide/jetbrains/pycharm.go
+++ b/pkg/ide/jetbrains/pycharm.go
@@ -3,7 +3,6 @@ package jetbrains
 import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/ide"
-	"github.com/devsy-org/log"
 )
 
 const (
@@ -31,7 +30,6 @@ var PyCharmOptions = ide.Options{
 func NewPyCharmServer(
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *GenericJetBrainsServer {
 	amd64Download, arm64Download := getDownloadURLs(
 		PyCharmOptions,
@@ -45,5 +43,5 @@ func NewPyCharmServer(
 		DisplayName:   "PyCharm",
 		DownloadAmd64: amd64Download,
 		DownloadArm64: arm64Download,
-	}, log)
+	})
 }

--- a/pkg/ide/jetbrains/rider.go
+++ b/pkg/ide/jetbrains/rider.go
@@ -3,7 +3,6 @@ package jetbrains
 import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/ide"
-	"github.com/devsy-org/log"
 )
 
 const (
@@ -31,7 +30,6 @@ var RiderOptions = ide.Options{
 func NewRiderServer(
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *GenericJetBrainsServer {
 	amd64Download, arm64Download := getDownloadURLs(
 		RiderOptions,
@@ -45,5 +43,5 @@ func NewRiderServer(
 		DisplayName:   "Rider",
 		DownloadAmd64: amd64Download,
 		DownloadArm64: arm64Download,
-	}, log)
+	})
 }

--- a/pkg/ide/jetbrains/rubymine.go
+++ b/pkg/ide/jetbrains/rubymine.go
@@ -3,7 +3,6 @@ package jetbrains
 import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/ide"
-	"github.com/devsy-org/log"
 )
 
 const (
@@ -31,7 +30,6 @@ var RubyMineOptions = ide.Options{
 func NewRubyMineServer(
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *GenericJetBrainsServer {
 	amd64Download, arm64Download := getDownloadURLs(
 		RubyMineOptions,
@@ -45,5 +43,5 @@ func NewRubyMineServer(
 		DisplayName:   "RubyMine",
 		DownloadAmd64: amd64Download,
 		DownloadArm64: arm64Download,
-	}, log)
+	})
 }

--- a/pkg/ide/jetbrains/rustrover.go
+++ b/pkg/ide/jetbrains/rustrover.go
@@ -3,7 +3,6 @@ package jetbrains
 import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/ide"
-	"github.com/devsy-org/log"
 )
 
 const (
@@ -31,7 +30,6 @@ var RustRoverOptions = ide.Options{
 func NewRustRoverServer(
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *GenericJetBrainsServer {
 	amd64Download, arm64Download := getDownloadURLs(
 		RustRoverOptions,
@@ -45,5 +43,5 @@ func NewRustRoverServer(
 		DisplayName:   "RustRover",
 		DownloadAmd64: amd64Download,
 		DownloadArm64: arm64Download,
-	}, log)
+	})
 }

--- a/pkg/ide/jetbrains/webstorm.go
+++ b/pkg/ide/jetbrains/webstorm.go
@@ -3,7 +3,6 @@ package jetbrains
 import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/ide"
-	"github.com/devsy-org/log"
 )
 
 const (
@@ -31,7 +30,6 @@ var WebStormOptions = ide.Options{
 func NewWebStormServer(
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *GenericJetBrainsServer {
 	amd64Download, arm64Download := getDownloadURLs(
 		WebStormOptions,
@@ -45,5 +43,5 @@ func NewWebStormServer(
 		DisplayName:   "WebStorm",
 		DownloadAmd64: amd64Download,
 		DownloadArm64: arm64Download,
-	}, log)
+	})
 }

--- a/pkg/ide/jupyter/jupyter.go
+++ b/pkg/ide/jupyter/jupyter.go
@@ -8,7 +8,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/command"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/ide"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 const (
@@ -39,13 +39,11 @@ func NewJupyterNotebookServer(
 	workspaceFolder string,
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *JupyterNotbookServer {
 	return &JupyterNotbookServer{
 		values:          values,
 		workspaceFolder: workspaceFolder,
 		userName:        userName,
-		log:             log,
 	}
 }
 
@@ -53,7 +51,6 @@ type JupyterNotbookServer struct {
 	values          map[string]config.OptionValue
 	workspaceFolder string
 	userName        string
-	log             log.Logger
 }
 
 func (o *JupyterNotbookServer) Install() error {
@@ -92,7 +89,7 @@ func (o *JupyterNotbookServer) installNotebook() error {
 	}
 
 	// install
-	o.log.Infof("installing jupyter notebook")
+	log.Infof("installing jupyter notebook")
 	out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf(
@@ -101,13 +98,13 @@ func (o *JupyterNotbookServer) installNotebook() error {
 		)
 	}
 
-	o.log.Info("installed jupyter notebook")
+	log.Info("installed jupyter notebook")
 	return nil
 }
 
 func (o *JupyterNotbookServer) Start() error {
 	return command.StartBackgroundOnce("jupyter", func() (*exec.Cmd, error) {
-		o.log.Infof("Starting jupyter notebook in background...")
+		log.Infof("Starting jupyter notebook in background...")
 		runCommand := fmt.Sprintf(
 			"jupyter notebook --ip='*' --NotebookApp.notebook_dir='%s' --NotebookApp.token='' "+
 				"--NotebookApp.password='' --no-browser --port '%s' --allow-root",

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -94,7 +94,7 @@ func openDesktopIDE(
 		return zed.Open(
 			ctx, ideOptions, params.User,
 			params.Result.SubstitutionContext.ContainerWorkspaceFolder,
-			params.Client.Workspace(), params.Log,
+			params.Client.Workspace(),
 		)
 
 	default:
@@ -160,7 +160,6 @@ func openVSCodeFlavor(
 		Folder:    params.Result.SubstitutionContext.ContainerWorkspaceFolder,
 		NewWindow: vscode.Options.GetValue(ideOptions, vscode.OpenNewWindow) == config.BoolTrue,
 		Flavor:    vsCodeFlavorMap[ideName],
-		Log:       params.Log,
 	})
 }
 
@@ -172,39 +171,38 @@ func openJetBrains(
 	folder := params.Result.SubstitutionContext.ContainerWorkspaceFolder
 	workspace := params.Client.Workspace()
 	user := params.User
-	logger := params.Log
 	type jetbrainsFactory func() interface{ OpenGateway(string, string) error }
 
 	jetbrainsMap := map[string]jetbrainsFactory{
 		string(config.IDERustRover): func() interface{ OpenGateway(string, string) error } {
-			return jetbrains.NewRustRoverServer(user, ideOptions, logger)
+			return jetbrains.NewRustRoverServer(user, ideOptions)
 		},
 		string(config.IDEGoland): func() interface{ OpenGateway(string, string) error } {
-			return jetbrains.NewGolandServer(user, ideOptions, logger)
+			return jetbrains.NewGolandServer(user, ideOptions)
 		},
 		string(config.IDEPyCharm): func() interface{ OpenGateway(string, string) error } {
-			return jetbrains.NewPyCharmServer(user, ideOptions, logger)
+			return jetbrains.NewPyCharmServer(user, ideOptions)
 		},
 		string(config.IDEPhpStorm): func() interface{ OpenGateway(string, string) error } {
-			return jetbrains.NewPhpStorm(user, ideOptions, logger)
+			return jetbrains.NewPhpStorm(user, ideOptions)
 		},
 		string(config.IDEIntellij): func() interface{ OpenGateway(string, string) error } {
-			return jetbrains.NewIntellij(user, ideOptions, logger)
+			return jetbrains.NewIntellij(user, ideOptions)
 		},
 		string(config.IDECLion): func() interface{ OpenGateway(string, string) error } {
-			return jetbrains.NewCLionServer(user, ideOptions, logger)
+			return jetbrains.NewCLionServer(user, ideOptions)
 		},
 		string(config.IDERider): func() interface{ OpenGateway(string, string) error } {
-			return jetbrains.NewRiderServer(user, ideOptions, logger)
+			return jetbrains.NewRiderServer(user, ideOptions)
 		},
 		string(config.IDERubyMine): func() interface{ OpenGateway(string, string) error } {
-			return jetbrains.NewRubyMineServer(user, ideOptions, logger)
+			return jetbrains.NewRubyMineServer(user, ideOptions)
 		},
 		string(config.IDEWebStorm): func() interface{ OpenGateway(string, string) error } {
-			return jetbrains.NewWebStormServer(user, ideOptions, logger)
+			return jetbrains.NewWebStormServer(user, ideOptions)
 		},
 		string(config.IDEDataSpell): func() interface{ OpenGateway(string, string) error } {
-			return jetbrains.NewDataSpellServer(user, ideOptions, logger)
+			return jetbrains.NewDataSpellServer(user, ideOptions)
 		},
 	}
 

--- a/pkg/ide/openvscode/openvscode.go
+++ b/pkg/ide/openvscode/openvscode.go
@@ -15,9 +15,8 @@ import (
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
 	"github.com/devsy-org/devsy/pkg/ide"
 	"github.com/devsy-org/devsy/pkg/ide/vscode"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/util"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -81,7 +80,6 @@ func NewOpenVSCodeServer(
 	userName string,
 	host, port string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *OpenVSCodeServer {
 	return &OpenVSCodeServer{
 		values:     values,
@@ -90,7 +88,6 @@ func NewOpenVSCodeServer(
 		userName:   userName,
 		host:       host,
 		port:       port,
-		log:        log,
 	}
 }
 
@@ -101,7 +98,6 @@ type OpenVSCodeServer struct {
 	userName   string
 	host       string
 	port       string
-	log        log.Logger
 }
 
 func (o *OpenVSCodeServer) InstallExtensions() error {
@@ -129,7 +125,7 @@ func (o *OpenVSCodeServer) Install() error {
 	// check what release we need to download
 	url := o.getReleaseUrl()
 
-	vscode.InstallAPKRequirements(o.log)
+	vscode.InstallAPKRequirements()
 
 	// download tar
 	resp, err := devsyhttp.GetHTTPClient().Get(url)
@@ -189,12 +185,12 @@ func (o *OpenVSCodeServer) installExtensions() error {
 		return err
 	}
 
-	out := o.log.Writer(logrus.InfoLevel, false)
+	out := log.Writer(log.LevelInfo)
 	defer func() { _ = out.Close() }()
 
 	binaryPath := filepath.Join(location, "bin", "openvscode-server")
 	for _, extension := range o.extensions {
-		o.log.Info("Install extension " + extension + "...")
+		log.Info("Install extension " + extension + "...")
 		runCommand := fmt.Sprintf("%s --install-extension '%s'", binaryPath, extension)
 		args := []string{}
 		if o.userName != "" {
@@ -207,9 +203,9 @@ func (o *OpenVSCodeServer) installExtensions() error {
 		cmd.Stderr = out
 		err = cmd.Run()
 		if err != nil {
-			o.log.Errorf("failed installing extension: extension=%s, error=%v", extension, err)
+			log.Errorf("failed installing extension: extension=%s, error=%v", extension, err)
 		} else {
-			o.log.Infof("installed extension: extension=%s", extension)
+			log.Infof("installed extension: extension=%s", extension)
 		}
 	}
 
@@ -266,7 +262,7 @@ func (o *OpenVSCodeServer) Start() error {
 	}
 
 	return command.StartBackgroundOnce("openvscode", func() (*exec.Cmd, error) {
-		o.log.Infof("Starting openvscode in background...")
+		log.Infof("Starting openvscode in background...")
 		runCommand := fmt.Sprintf(
 			"%s server-local --without-connection-token --host '%s' --port '%s'",
 			binaryPath,

--- a/pkg/ide/rstudio/rstudio.go
+++ b/pkg/ide/rstudio/rstudio.go
@@ -20,7 +20,7 @@ import (
 	copypkg "github.com/devsy-org/devsy/pkg/copy"
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
 	"github.com/devsy-org/devsy/pkg/ide"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 const (
@@ -66,13 +66,11 @@ func NewRStudioServer(
 	workspaceFolder string,
 	userName string,
 	values map[string]config.OptionValue,
-	log log.Logger,
 ) *RStudioServer {
 	return &RStudioServer{
 		values:          values,
 		workspaceFolder: workspaceFolder,
 		userName:        userName,
-		log:             log,
 	}
 }
 
@@ -80,7 +78,6 @@ type RStudioServer struct {
 	values          map[string]config.OptionValue
 	workspaceFolder string
 	userName        string
-	log             log.Logger
 }
 
 var codenameRegEx = regexp.MustCompile(`\nUBUNTU_CODENAME=(.*)\n`)
@@ -94,31 +91,31 @@ func (o *RStudioServer) Install() error {
 
 	// Skip if already installed
 	if command.ExistsForUser("rstudio-server", o.userName) {
-		o.log.Debug("RStudio is already installed, skipping installation")
+		log.Debug("RStudio is already installed, skipping installation")
 		return nil
 	}
-	o.log.Info("Installing RStudio")
+	log.Info("Installing RStudio")
 
-	err := ensureGdebi(o.log)
+	err := ensureGdebi()
 	if err != nil {
 		return err
 	}
 
 	// Check if local file exists
 	if _, err := os.Stat(debPath); os.IsNotExist(err) {
-		o.log.Info("Rstudio deb not file, downloading")
-		codename, err := getDistroCodename(o.log)
+		log.Info("Rstudio deb not file, downloading")
+		codename, err := getDistroCodename()
 		if err != nil {
 			return err
 		}
 
-		debPath, err = downloadRStudioDeb(codename, o.log)
+		debPath, err = downloadRStudioDeb(codename)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = installDeb(debPath, o.log)
+	err = installDeb(debPath)
 	if err != nil {
 		return err
 	}
@@ -137,14 +134,14 @@ func (o *RStudioServer) Install() error {
 	if err != nil {
 		return err
 	}
-	o.log.Done("installed RStudio")
+	log.Info("installed RStudio")
 
 	return o.Start()
 }
 
 func (o *RStudioServer) Start() error {
 	return command.StartBackgroundOnce("rstudio", func() (*exec.Cmd, error) {
-		o.log.Info("Starting RStudio...")
+		log.Info("Starting RStudio...")
 		runCommand := "rstudio-server start"
 		args := []string{}
 		if o.userName != "" {
@@ -158,7 +155,7 @@ func (o *RStudioServer) Start() error {
 	})
 }
 
-func ensureGdebi(log log.Logger) error {
+func ensureGdebi() error {
 	if !command.Exists("gdebi") {
 		log.Info("Installing dependency gdebi-core")
 		out, err := exec.Command("apt", "update").CombinedOutput()
@@ -176,7 +173,7 @@ func ensureGdebi(log log.Logger) error {
 	return nil
 }
 
-func getDistroCodename(log log.Logger) (string, error) {
+func getDistroCodename() (string, error) {
 	// Base distro needs to be ubuntu
 	all, err := os.ReadFile("/etc/os-release")
 	if err != nil {
@@ -200,7 +197,7 @@ func getDistroCodename(log log.Logger) (string, error) {
 	return ubuntuCodename, nil
 }
 
-func downloadRStudioDeb(ubuntuCodename string, log log.Logger) (string, error) {
+func downloadRStudioDeb(ubuntuCodename string) (string, error) {
 	downloadURL := getDownloadURL(
 		"stable",
 		ubuntuCodename,
@@ -209,11 +206,11 @@ func downloadRStudioDeb(ubuntuCodename string, log log.Logger) (string, error) {
 	log.Infof("Downloading RStudio from %s", downloadURL)
 
 	// Download .deb
-	debPath, err := download(downloadFolder, downloadURL, log)
+	debPath, err := download(downloadFolder, downloadURL)
 	if err != nil {
 		return "", fmt.Errorf("download: %w", err)
 	}
-	log.Done("downloaded RStudio")
+	log.Info("downloaded RStudio")
 
 	return debPath, nil
 }
@@ -222,7 +219,8 @@ func getDownloadURL(version, ubuntuCodename, architecture string) string {
 	return "https://rstudio.org/download/latest/" + version + "/server/" + ubuntuCodename + "/rstudio-server-latest-" + architecture + ".deb"
 }
 
-func download(targetFolder, downloadURL string, log log.Logger) (string, error) {
+//nolint:cyclop // pre-existing complexity
+func download(targetFolder, downloadURL string) (string, error) {
 	err := os.MkdirAll(targetFolder, os.ModePerm)
 	if err != nil {
 		return "", err
@@ -258,7 +256,6 @@ func download(targetFolder, downloadURL string, log log.Logger) (string, error) 
 	_, err = io.Copy(file, &ide.ProgressReader{
 		Reader:    resp.Body,
 		TotalSize: resp.ContentLength,
-		Log:       log,
 	})
 	if err != nil {
 		return "", fmt.Errorf("download file: %w", err)
@@ -267,7 +264,7 @@ func download(targetFolder, downloadURL string, log log.Logger) (string, error) 
 	return targetPath, nil
 }
 
-func installDeb(debPath string, log log.Logger) error {
+func installDeb(debPath string) error {
 	log.Info("Installing deb")
 
 	out, err := exec.Command("gdebi", "--non-interactive", debPath).CombinedOutput()

--- a/pkg/ide/types.go
+++ b/pkg/ide/types.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/devsy-org/devsy/pkg/config"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 type IDE interface {
@@ -61,7 +61,6 @@ func ReusesAuthSock(ide string) bool {
 type ProgressReader struct {
 	Reader    io.Reader
 	TotalSize int64
-	Log       log.Logger
 
 	lastMessage time.Time
 	bytesRead   int64
@@ -71,7 +70,7 @@ func (p *ProgressReader) Read(b []byte) (n int, err error) {
 	n, err = p.Reader.Read(b)
 	p.bytesRead += int64(n)
 	if time.Since(p.lastMessage) > time.Second*1 {
-		p.Log.Infof(
+		log.Infof(
 			"Downloaded %.2f / %.2f MB",
 			float64(p.bytesRead)/1024/1024,
 			float64(p.TotalSize/1024/1024),

--- a/pkg/ide/vscode/apk.go
+++ b/pkg/ide/vscode/apk.go
@@ -7,27 +7,27 @@ import (
 	"strings"
 
 	"github.com/devsy-org/devsy/pkg/command"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 // InstallAPKRequirements installs the requirements using apk.
 //
 // This is used by Alpine- and Wolfi-based images.
-func InstallAPKRequirements(logger log.Logger) {
+func InstallAPKRequirements() {
 	if !command.Exists("apk") {
 		return
 	}
 
 	dependencies := []string{"build-base"}
 	if all, err := os.ReadFile("/etc/os-release"); err != nil {
-		logger.Errorf("Error reading /etc/os-release: %v", err)
+		log.Errorf("Error reading /etc/os-release: %v", err)
 		return
 	} else if !bytes.Contains(all, []byte("ID=alpine")) {
 		// Alpine needs gcompat for compatibility with musl.
 		// Wolfi-based distros don't need this, and Wolfi doesn't have it.
 		dependencies = append(dependencies, "gcompat")
 	}
-	logger.Debugf("Install apk requirements...")
+	log.Debugf("Install apk requirements...")
 	if !command.Exists("git") {
 		dependencies = append(dependencies, "git")
 	}
@@ -41,6 +41,6 @@ func InstallAPKRequirements(logger log.Logger) {
 	out, err := exec.Command("sh", "-c", "apk update && apk add "+strings.Join(dependencies, " ")).
 		CombinedOutput()
 	if err != nil {
-		logger.Errorf("Error updating apk dependencies: %v", command.WrapCommandError(out, err))
+		log.Errorf("Error updating apk dependencies: %v", command.WrapCommandError(out, err))
 	}
 }

--- a/pkg/ide/vscode/open.go
+++ b/pkg/ide/vscode/open.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/command"
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	devsyopen "github.com/devsy-org/devsy/pkg/open"
-	"github.com/devsy-org/log"
 )
 
 const containersExtension = "ms-vscode-remote.remote-containers"
@@ -22,7 +22,6 @@ type OpenParams struct {
 	Folder    string
 	NewWindow bool
 	Flavor    Flavor
-	Log       log.Logger
 }
 
 type openConfig struct {
@@ -86,7 +85,7 @@ var openConfigs = map[Flavor]openConfig{
 func Open(ctx context.Context, params OpenParams) error {
 	cliErr := openViaCLI(ctx, params)
 	if cliErr == nil {
-		params.Log.Infof("opened %s via CLI", params.Flavor.DisplayName())
+		log.Infof("opened %s via CLI", params.Flavor.DisplayName())
 		return nil
 	}
 
@@ -96,7 +95,7 @@ func Open(ctx context.Context, params OpenParams) error {
 
 	browserErr := openViaBrowser(params)
 	if browserErr == nil {
-		params.Log.Infof("opened %s via browser", params.Flavor.DisplayName())
+		log.Infof("opened %s via browser", params.Flavor.DisplayName())
 		return nil
 	}
 
@@ -123,10 +122,10 @@ func openViaBrowser(params OpenParams) error {
 	}
 	openURL := u.String()
 
-	params.Log.Debugf("opening URL %s", openURL)
+	log.Debugf("opening URL %s", openURL)
 	err := devsyopen.Run(openURL)
 	if err != nil {
-		params.Log.Errorf(
+		log.Errorf(
 			"flavor %s is not installed on host device: %v",
 			params.Flavor.DisplayName(),
 			err,
@@ -158,13 +157,13 @@ func openViaCLI(ctx context.Context, params OpenParams) error {
 	}
 
 	if !hasSSHExtension {
-		if err := ensureSSHExtension(ctx, cliPath, config.sshExtension, params.Log); err != nil {
+		if err := ensureSSHExtension(ctx, cliPath, config.sshExtension); err != nil {
 			return err
 		}
 	}
 
 	args := buildOpenArgs(params.Workspace, params.Folder, params.NewWindow, hasContainersExtension)
-	params.Log.Debugf(
+	log.Debugf(
 		"flavor %s command %s %s",
 		params.Flavor.DisplayName(),
 		cliPath,
@@ -204,7 +203,7 @@ func listInstalledExtensions(
 	return hasSSH, hasContainers, nil
 }
 
-func ensureSSHExtension(ctx context.Context, cliPath, sshExtension string, log log.Logger) error {
+func ensureSSHExtension(ctx context.Context, cliPath, sshExtension string) error {
 	args := []string{"--install-extension", sshExtension}
 	log.Debugf("%s %s", cliPath, strings.Join(args, " "))
 	out, err := exec.CommandContext(ctx, cliPath, args...).CombinedOutput()

--- a/pkg/ide/vscode/vscode.go
+++ b/pkg/ide/vscode/vscode.go
@@ -16,9 +16,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	copy2 "github.com/devsy-org/devsy/pkg/copy"
 	"github.com/devsy-org/devsy/pkg/ide"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/util"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -82,7 +81,6 @@ type ServerOptions struct {
 	UserName   string
 	Values     map[string]config.OptionValue
 	Flavor     Flavor
-	Log        log.Logger
 }
 
 type VsCodeServer struct {
@@ -91,7 +89,6 @@ type VsCodeServer struct {
 	settings   string
 	userName   string
 	flavor     Flavor
-	log        log.Logger
 }
 
 var Options = ide.Options{
@@ -116,7 +113,6 @@ func NewVSCodeServer(opts ServerOptions) *VsCodeServer {
 		extensions: opts.Extensions,
 		settings:   opts.Settings,
 		userName:   opts.UserName,
-		log:        opts.Log,
 		flavor:     opts.Flavor,
 	}
 }
@@ -132,16 +128,16 @@ func (o *VsCodeServer) InstallExtensions() error {
 		return fmt.Errorf("unable to locate server binary")
 	}
 
-	writer := o.log.Writer(logrus.InfoLevel, false)
-	errWriter := o.log.Writer(logrus.ErrorLevel, false)
+	writer := log.Writer(log.LevelInfo)
+	errWriter := log.Writer(log.LevelError)
 	defer func() { _ = writer.Close() }()
 	defer func() { _ = errWriter.Close() }()
 
 	for _, ext := range o.extensions {
 		if err := o.installExtension(binPath, ext, writer, errWriter); err != nil {
-			o.log.Warnf("failed installing extension: extension=%s, error=%v", ext, err)
+			log.Warnf("failed installing extension: extension=%s, error=%v", ext, err)
 		} else {
-			o.log.Infof("installed extension: extension=%s", ext)
+			log.Infof("installed extension: extension=%s", ext)
 		}
 	}
 
@@ -181,7 +177,7 @@ func (o *VsCodeServer) setupSettings(settingsFile string) error {
 		return err
 	}
 
-	InstallAPKRequirements(o.log)
+	InstallAPKRequirements()
 
 	settings := o.settings
 	if settings == "" {
@@ -199,7 +195,7 @@ func (o *VsCodeServer) changeOwnership(location string) error {
 }
 
 func (o *VsCodeServer) installExtension(binPath, extension string, stdout, stderr io.Writer) error {
-	o.log.Infof("installing extension: extension=%s", extension)
+	log.Infof("installing extension: extension=%s", extension)
 
 	cmd := o.buildExtensionCommand(binPath, extension)
 	cmd.Stdout = stdout
@@ -234,7 +230,7 @@ func (o *VsCodeServer) findServerBinaryPath(location string) string {
 
 	for _, s := range searches {
 		if path := s.fn(); path != "" && o.validateBinary(path) {
-			o.log.Infof(
+			log.Infof(
 				"found server binary: server=%s, path=%s, location=%s",
 				cfg.serverDir,
 				path,
@@ -258,7 +254,7 @@ func (o *VsCodeServer) waitForServerBinary(location string) string {
 		}
 
 		if attempts == 0 || attempts%10 == 0 {
-			o.log.Debugf("waiting for server installation: attempts=%d", attempts)
+			log.Debugf("waiting for server installation: attempts=%d", attempts)
 		}
 
 		time.Sleep(backoff)
@@ -266,7 +262,7 @@ func (o *VsCodeServer) waitForServerBinary(location string) string {
 		attempts++
 	}
 
-	o.log.Warnf("timed out waiting for server: attempts=%d", attempts)
+	log.Warnf("timed out waiting for server: attempts=%d", attempts)
 	return ""
 }
 
@@ -284,7 +280,7 @@ func (o *VsCodeServer) findInSystemPath(binName string) string {
 func (o *VsCodeServer) findRunningServer(binName string) string {
 	entries, err := os.ReadDir("/proc")
 	if err != nil {
-		o.log.Debugf("cannot read /proc, skipping process discovery: %v", err)
+		log.Debugf("cannot read /proc, skipping process discovery: %v", err)
 		return ""
 	}
 
@@ -300,7 +296,7 @@ func (o *VsCodeServer) findRunningServer(binName string) string {
 
 		path := matchServerProcess(cmdline, binName)
 		if path != "" {
-			o.log.Debugf("found running server process (pid=%s, path=%s)", entry.Name(), path)
+			log.Debugf("found running server process (pid=%s, path=%s)", entry.Name(), path)
 			return path
 		}
 	}
@@ -401,7 +397,7 @@ func (o *VsCodeServer) findInDir(root, binName string) string {
 	}
 
 	if len(candidates) > 1 {
-		o.log.Debugf(
+		log.Debugf(
 			"multiple server binaries found (count=%d), chose newest: %s",
 			len(candidates),
 			best.path,
@@ -413,7 +409,7 @@ func (o *VsCodeServer) findInDir(root, binName string) string {
 
 func (o *VsCodeServer) validateBinary(binPath string) bool {
 	if !o.isSafeBinary(binPath) {
-		o.log.Warnf("binary failed safety checks: path=%s", binPath)
+		log.Warnf("binary failed safety checks: path=%s", binPath)
 		return false
 	}
 

--- a/pkg/ide/vscode/vscode_test.go
+++ b/pkg/ide/vscode/vscode_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/devsy-org/log"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -22,7 +21,6 @@ func TestDiscoverySuite(t *testing.T) {
 func (s *DiscoverySuite) SetupTest() {
 	s.server = NewVSCodeServer(ServerOptions{
 		Flavor: FlavorStable,
-		Log:    log.Discard,
 	})
 }
 

--- a/pkg/ide/zed/zed.go
+++ b/pkg/ide/zed/zed.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	devsyopen "github.com/devsy-org/devsy/pkg/open"
-	"github.com/devsy-org/log"
 )
 
 // Open first finds the zed binary for the local platform and then opens the zed editor with the given workspace folder.
@@ -16,7 +16,6 @@ func Open(
 	ctx context.Context,
 	values map[string]config.OptionValue,
 	userName, workspaceFolder, workspaceID string,
-	log log.Logger,
 ) error {
 	log.Info("Opening Zed editor...")
 

--- a/pkg/ide/zed/zed_linux.go
+++ b/pkg/ide/zed/zed_linux.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	devsyopen "github.com/devsy-org/devsy/pkg/open"
-	"github.com/devsy-org/log"
 )
 
 // Open first finds the zed binary for the local platform and then opens the zed editor with the given workspace folder.
@@ -16,7 +16,6 @@ func Open(
 	ctx context.Context,
 	values map[string]config.OptionValue,
 	userName, workspaceFolder, workspaceID string,
-	log log.Logger,
 ) error {
 	log.Info("Opening Zed editor...")
 


### PR DESCRIPTION
## Summary
- Migrate pkg/ide/ (22 files) from old logger to new zap-based pkg/log
- Remove oldlog.Logger function params and struct fields, use package-level log calls
- Update callers in cmd/agent/container/, pkg/driver/docker/