### PR TITLE
refactor(log): migrate pkg/workspace, pkg/provider, pkg/daemon/agent to pkg/log

### DIFF
--- a/cmd/agent/daemon.go
+++ b/cmd/agent/daemon.go
@@ -14,7 +14,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/driver/custom"
 	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -156,7 +155,7 @@ func (cmd *DaemonCmd) runShutdownCommand(
 	workspace *provider2.AgentWorkspaceInfo,
 ) {
 	// get environ
-	environ, err := custom.ToEnvironWithBinaries(workspace, oldlog.Default)
+	environ, err := custom.ToEnvironWithBinaries(workspace)
 	if err != nil {
 		log.Errorf("%v", err)
 		return

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -222,7 +222,7 @@ func InitContentFolder(
 		return false, err
 	}
 
-	if err := downloadWorkspaceBinaries(workspaceInfo, logger); err != nil {
+	if err := downloadWorkspaceBinaries(workspaceInfo); err != nil {
 		_ = os.RemoveAll(workspaceInfo.ContentFolder)
 		return false, err
 	}
@@ -259,7 +259,6 @@ func createContentFolder(path string) error {
 
 func downloadWorkspaceBinaries(
 	workspaceInfo *provider.AgentWorkspaceInfo,
-	logger oldlog.Logger,
 ) error {
 	binariesDir, err := agent.GetAgentBinariesDir(
 		workspaceInfo.Agent.DataPath,
@@ -274,7 +273,7 @@ func downloadWorkspaceBinaries(
 		)
 	}
 
-	_, err = provider.DownloadBinaries(workspaceInfo.Agent.Binaries, binariesDir, logger)
+	_, err = provider.DownloadBinaries(workspaceInfo.Agent.Binaries, binariesDir)
 	if err != nil {
 		return fmt.Errorf(
 			"error downloading workspace %s binaries: %w",
@@ -347,7 +346,7 @@ func (w *workspaceInitializer) initialize() error {
 
 func (w *workspaceInitializer) setupDaemonIfNeeded() {
 	if w.shouldInstallDaemon {
-		if err := installDaemon(w.workspaceInfo, w.logger); err != nil {
+		if err := installDaemon(w.workspaceInfo); err != nil {
 			log.Errorf("install Devsy daemon: %v", err)
 		}
 	}
@@ -696,7 +695,7 @@ func configureCredentials(cfg credentialsConfig) (string, string, error) {
 	return dockerCredentials, gitCredentials, nil
 }
 
-func installDaemon(workspaceInfo *provider.AgentWorkspaceInfo, logger oldlog.Logger) error {
+func installDaemon(workspaceInfo *provider.AgentWorkspaceInfo) error {
 	if len(workspaceInfo.Agent.Exec.Shutdown) == 0 {
 		return nil
 	}
@@ -705,7 +704,6 @@ func installDaemon(workspaceInfo *provider.AgentWorkspaceInfo, logger oldlog.Log
 	return agentdaemon.InstallDaemon(
 		workspaceInfo.Agent.DataPath,
 		workspaceInfo.CLIOptions.DaemonInterval,
-		logger,
 	)
 }
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -79,7 +79,7 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 			}
 
 			// create a temporary workspace
-			exists := workspace2.Exists(ctx, devsyConfig, args, "", cmd.Owner, oldlog.Default)
+			exists := workspace2.Exists(ctx, devsyConfig, args, "", cmd.Owner)
 			sshConfigFile, err := os.CreateTemp("", config.BinaryName+"ssh.config")
 			if err != nil {
 				return err
@@ -108,7 +108,6 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 					ChangeLastUsed:       false,
 					Owner:                cmd.Owner,
 				},
-				oldlog.Default,
 			)
 			if err != nil {
 				return err

--- a/cmd/completion/suggestions.go
+++ b/cmd/completion/suggestions.go
@@ -7,7 +7,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -59,7 +58,7 @@ func GetWorkspaceSuggestions(
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	workspaces, err := workspace.List(rootCmd.Context(), devsyConfig, false, owner, oldlog.Default)
+	workspaces, err := workspace.List(rootCmd.Context(), devsyConfig, false, owner)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}
@@ -85,7 +84,7 @@ func GetProviderSuggestions(
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	providers, err := workspace.LoadAllProviders(devsyConfig, oldlog.Default.ErrorStreamOnly())
+	providers, err := workspace.LoadAllProviders(devsyConfig)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -143,6 +142,5 @@ func (cmd *DeleteCmd) deleteWorkspace(
 		Force:          cmd.Force,
 		ClientDelete:   cmd.DeleteOptions,
 		Owner:          cmd.Owner,
-		Log:            oldlog.Default,
 	})
 }

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -10,7 +10,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -61,7 +60,6 @@ func (cmd *ExportCmd) Run(ctx context.Context, devsyConfig *config.Config, args 
 		DevsyConfig: devsyConfig,
 		Args:        args,
 		Owner:       cmd.Owner,
-		Log:         oldlog.Default,
 	})
 	if err != nil {
 		return err

--- a/cmd/helper/check_provider_update.go
+++ b/cmd/helper/check_provider_update.go
@@ -13,7 +13,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -61,14 +60,13 @@ func (cmd *CheckProviderUpdateCmd) Run(
 	providerSourceRaw, err := workspace.ResolveProviderSource(
 		devsyConfig,
 		providerName,
-		oldlog.Default,
 	)
 	if err != nil {
 		return fmt.Errorf("provider %s doesn't exist", providerName)
 	}
 
 	// retrieve current config for provider
-	allProviders, err := workspace.LoadAllProviders(devsyConfig, oldlog.Default)
+	allProviders, err := workspace.LoadAllProviders(devsyConfig)
 	if err != nil {
 		return err
 	}
@@ -112,7 +110,7 @@ func (cmd *CheckProviderUpdateCmd) Run(
 func loadLatestProvider(
 	providerSourceRaw string,
 ) (*provider.ProviderConfig, error) {
-	providerRaw, _, err := workspace.ResolveProvider(providerSourceRaw, oldlog.Default)
+	providerRaw, _, err := workspace.ResolveProvider(providerSourceRaw)
 	if err != nil {
 		return nil, fmt.Errorf("resolve provider: %w", err)
 	}

--- a/cmd/helper/get_provider_name.go
+++ b/cmd/helper/get_provider_name.go
@@ -8,7 +8,6 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +36,7 @@ func (cmd *GetProviderNameCmd) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("provider is missing")
 	}
 
-	providerRaw, _, err := workspace.ResolveProvider(args[0], oldlog.Default.ErrorStreamOnly())
+	providerRaw, _, err := workspace.ResolveProvider(args[0])
 	if err != nil {
 		return fmt.Errorf("resolve provider: %w", err)
 	}

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -290,7 +290,7 @@ func (cmd *ImportCmd) checkForConflictingIDs(
 	devsyConfig *config.Config,
 	log oldlog.Logger,
 ) error {
-	workspaces, err := workspace.List(ctx, devsyConfig, false, cmd.Owner, log)
+	workspaces, err := workspace.List(ctx, devsyConfig, false, cmd.Owner)
 	if err != nil {
 		return fmt.Errorf("error listing workspaces: %w", err)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/table"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -51,7 +50,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	workspaces, err := workspace.List(ctx, devsyConfig, cmd.SkipPro, cmd.Owner, oldlog.Default)
+	workspaces, err := workspace.List(ctx, devsyConfig, cmd.SkipPro, cmd.Owner)
 	if err != nil {
 		return err
 	}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -62,7 +62,6 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 		DevsyConfig: devsyConfig,
 		Args:        args,
 		Owner:       cmd.Owner,
-		Log:         oldlog.Default,
 	})
 	if err != nil {
 		return err

--- a/cmd/logs_daemon.go
+++ b/cmd/logs_daemon.go
@@ -10,7 +10,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +45,6 @@ func (cmd *LogsDaemonCmd) Run(ctx context.Context, args []string) error {
 		DevsyConfig: devsyConfig,
 		Args:        args,
 		Owner:       cmd.Owner,
-		Log:         oldlog.Default,
 	})
 	if err != nil {
 		return err

--- a/cmd/machine/create.go
+++ b/cmd/machine/create.go
@@ -6,7 +6,6 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +44,6 @@ func (cmd *CreateCmd) Run(ctx context.Context, args []string) error {
 		devsyConfig,
 		args,
 		cmd.ProviderOptions,
-		oldlog.Default,
 	)
 	if err != nil {
 		return err

--- a/cmd/machine/delete.go
+++ b/cmd/machine/delete.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +47,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args)
 	if err != nil {
 		return err
 	}
@@ -59,7 +58,6 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 		devsyConfig,
 		false,
 		platform.SelfOwnerFilter,
-		oldlog.Default,
 	)
 	if err != nil {
 		return err

--- a/cmd/machine/describe.go
+++ b/cmd/machine/describe.go
@@ -8,7 +8,6 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -40,7 +39,7 @@ func (cmd *DescribeCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/machine/inspect.go
+++ b/cmd/machine/inspect.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +37,7 @@ func (cmd *InspectCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/machine/ssh.go
+++ b/cmd/machine/ssh.go
@@ -120,7 +120,7 @@ func (cmd *SSHCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/machine/start.go
+++ b/cmd/machine/start.go
@@ -6,7 +6,6 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -38,7 +37,7 @@ func (cmd *StartCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/machine/status.go
+++ b/cmd/machine/status.go
@@ -10,7 +10,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -45,7 +44,7 @@ func (cmd *StatusCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/machine/stop.go
+++ b/cmd/machine/stop.go
@@ -7,7 +7,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -39,7 +38,7 @@ func (cmd *StopCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	machineClient, err := workspace.GetMachine(devsyConfig, args, oldlog.Default)
+	machineClient, err := workspace.GetMachine(devsyConfig, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/ping.go
+++ b/cmd/ping.go
@@ -10,7 +10,6 @@ import (
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -55,7 +54,6 @@ func (cmd *PingCmd) Run(ctx context.Context, args []string) error {
 		Args:           args,
 		ChangeLastUsed: true,
 		Owner:          cmd.Owner,
-		Log:            oldlog.Default.ErrorStreamOnly(),
 	})
 	if err != nil {
 		return err

--- a/cmd/pro/add/cluster.go
+++ b/cmd/pro/add/cluster.go
@@ -321,7 +321,7 @@ func ensureHost(devsyConfig *config.Config, host string) (string, error) {
 		return host, nil
 	}
 
-	proInstances, err := workspace.ListProInstances(devsyConfig, oldlog.Default)
+	proInstances, err := workspace.ListProInstances(devsyConfig)
 	if err != nil {
 		return "", fmt.Errorf("list pro instances: %w", err)
 	}

--- a/cmd/pro/completion/suggestions.go
+++ b/cmd/pro/completion/suggestions.go
@@ -6,7 +6,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +21,7 @@ func GetPlatformHostSuggestions(
 		return nil, cobra.ShellCompDirectiveError
 	}
 
-	proInstances, err := workspace.ListProInstances(devsyConfig, oldlog.Default)
+	proInstances, err := workspace.ListProInstances(devsyConfig)
 	if err != nil {
 		return nil, cobra.ShellCompDirectiveError
 	}

--- a/cmd/pro/daemon/daemon.go
+++ b/cmd/pro/daemon/daemon.go
@@ -8,7 +8,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +36,7 @@ func findProProvider(
 		return nil, nil, err
 	}
 
-	pCfg, err := workspace.ProviderFromHost(ctx, devsyConfig, host, oldlog.Default)
+	pCfg, err := workspace.ProviderFromHost(ctx, devsyConfig, host)
 	if err != nil {
 		return devsyConfig, nil, fmt.Errorf("load provider: %w", err)
 	}

--- a/cmd/pro/delete.go
+++ b/cmd/pro/delete.go
@@ -84,7 +84,6 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 		workspaces, err := workspace.ListLocalWorkspaces(
 			devsyConfig.DefaultContext,
 			false,
-			oldlog.Default,
 		)
 		if err != nil {
 			log.Warnf("Failed to list workspaces: %v", err)
@@ -163,7 +162,6 @@ func cleanupLocalWorkspaces(
 					Args:        []string{w.ID},
 					Owner:       owner,
 					LocalOnly:   true,
-					Log:         log,
 				})
 				if err != nil {
 					log.Errorf("failed to get workspace: workspaceId=%s, err=%v", w.ID, err)

--- a/cmd/pro/import_workspace.go
+++ b/cmd/pro/import_workspace.go
@@ -103,7 +103,7 @@ func (cmd *ImportCmd) Run(ctx context.Context, args []string) error {
 		cmd.WorkspaceId = newWorkspaceId
 	}
 
-	provider, err := workspace.ProviderFromHost(ctx, devsyConfig, devsyProHost, oldlog.Default)
+	provider, err := workspace.ProviderFromHost(ctx, devsyConfig, devsyProHost)
 	if err != nil {
 		return fmt.Errorf("resolve provider: %w", err)
 	}

--- a/cmd/pro/list.go
+++ b/cmd/pro/list.go
@@ -53,7 +53,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	proInstances, err := workspace.ListProInstances(devsyConfig, oldlog.Default)
+	proInstances, err := workspace.ListProInstances(devsyConfig)
 	if err != nil {
 		return err
 	}
@@ -94,7 +94,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 			entry := &proTableEntry{
 				ProInstance:  proInstance,
 				Context:      devsyConfig.DefaultContext,
-				Capabilities: getCapabilities(devsyConfig, proInstance, oldlog.Discard),
+				Capabilities: getCapabilities(devsyConfig, proInstance),
 			}
 			if cmd.Login {
 				err = checkLogin(ctx, devsyConfig, proInstance)
@@ -164,10 +164,9 @@ func checkLogin(
 func getCapabilities(
 	devsyConfig *config.Config,
 	proInstance *provider.ProInstance,
-	log oldlog.Logger,
 ) []Capability {
 	capabilities := []Capability{}
-	provider, err := workspace.FindProvider(devsyConfig, proInstance.Provider, log)
+	provider, err := workspace.FindProvider(devsyConfig, proInstance.Provider)
 	if err != nil {
 		return capabilities
 	}

--- a/cmd/pro/login.go
+++ b/cmd/pro/login.go
@@ -106,7 +106,7 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string, log oldlog.Logger)
 	}
 
 	// check if there is already a pro instance with that url
-	proInstances, err := workspace.ListProInstances(devsyConfig, log)
+	proInstances, err := workspace.ListProInstances(devsyConfig)
 	if err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string, log oldlog.Logger)
 		cmd.Provider = provider.ToProInstanceID(cmd.Provider)
 
 		// check if provider already exists
-		providers, err := workspace.LoadAllProviders(devsyConfig, log)
+		providers, err := workspace.LoadAllProviders(devsyConfig)
 		if err != nil {
 			return fmt.Errorf("load providers: %w", err)
 		}
@@ -174,7 +174,7 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string, log oldlog.Logger)
 			}
 		} else {
 			// add built-in pro (daemon) provider
-			_, err = workspace.AddProvider(devsyConfig, cmd.Provider, "pro", log)
+			_, err = workspace.AddProvider(devsyConfig, cmd.Provider, "pro")
 			if err != nil {
 				return err
 			}
@@ -260,13 +260,12 @@ func (cmd *LoginCmd) addLoftProvider(
 			ProviderName: cmd.Provider,
 			Source:       &provider.ProviderSource{},
 			Raw:          []byte(fallbackProvider),
-			Log:          log,
 		})
 		if err != nil {
 			return err
 		}
 	} else {
-		_, err = workspace.AddProvider(devsyConfig, cmd.Provider, cmd.ProviderSource, log)
+		_, err = workspace.AddProvider(devsyConfig, cmd.Provider, cmd.ProviderSource)
 		if err != nil {
 			return err
 		}

--- a/cmd/pro/pro.go
+++ b/cmd/pro/pro.go
@@ -13,7 +13,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -68,7 +67,7 @@ func findProProvider(
 		return nil, nil, err
 	}
 
-	pCfg, err := workspace.ProviderFromHost(ctx, devsyConfig, host, oldlog.Default)
+	pCfg, err := workspace.ProviderFromHost(ctx, devsyConfig, host)
 	if err != nil {
 		return devsyConfig, nil, fmt.Errorf("load provider: %w", err)
 	}

--- a/cmd/pro/provider/watch/workspaces.go
+++ b/cmd/pro/provider/watch/workspaces.go
@@ -21,7 +21,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform/project"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
@@ -253,7 +252,6 @@ func (s *instanceStore) List() []*ProWorkspaceInstance {
 	localWorkspaces, err := workspace.ListLocalWorkspaces(
 		s.context,
 		false,
-		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err == nil {
 		for _, workspace := range localWorkspaces {

--- a/cmd/pro/update_provider.go
+++ b/cmd/pro/update_provider.go
@@ -52,7 +52,7 @@ func (cmd *UpdateProviderCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	provider, err := workspace.ProviderFromHost(ctx, devsyConfig, cmd.Host, oldlog.Default)
+	provider, err := workspace.ProviderFromHost(ctx, devsyConfig, cmd.Host)
 	if err != nil {
 		return fmt.Errorf("load provider: %w", err)
 	}
@@ -62,7 +62,6 @@ func (cmd *UpdateProviderCmd) Run(ctx context.Context, args []string) error {
 	providerSource, err := workspace.ResolveProviderSource(
 		devsyConfig,
 		provider.Name,
-		oldlog.Default,
 	)
 	if err != nil {
 		return fmt.Errorf("resolve provider source %s: %w", provider.Name, err)
@@ -73,7 +72,7 @@ func (cmd *UpdateProviderCmd) Run(ctx context.Context, args []string) error {
 	}
 	providerSource = splitted[0] + "@" + newVersion
 
-	_, err = workspace.UpdateProvider(devsyConfig, provider.Name, providerSource, oldlog.Default)
+	_, err = workspace.UpdateProvider(devsyConfig, provider.Name, providerSource)
 	if err != nil {
 		return fmt.Errorf("update provider %s: %w", provider.Name, err)
 	}

--- a/cmd/provider/add.go
+++ b/cmd/provider/add.go
@@ -94,7 +94,6 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 			devsyConfig,
 			providerName,
 			cmd.FromExisting,
-			oldlog.Default,
 		)
 		if err != nil {
 			return err
@@ -111,7 +110,7 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 			return fmt.Errorf("please specify either a URL or path, " +
 				"e.g. devsy provider add https://path/to/my/provider.yaml")
 		}
-		c, err := workspace.AddProvider(devsyConfig, providerName, args[0], oldlog.Default)
+		c, err := workspace.AddProvider(devsyConfig, providerName, args[0])
 		if err != nil {
 			return err
 		}
@@ -138,7 +137,7 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 				return err
 			}
 
-			err = DeleteProvider(ctx, devsyConfig, providerConfig.Name, true, true, oldlog.Default)
+			err = DeleteProvider(ctx, devsyConfig, providerConfig.Name, true, true)
 			if err != nil {
 				return fmt.Errorf("delete provider: %w", err)
 			}

--- a/cmd/provider/delete.go
+++ b/cmd/provider/delete.go
@@ -12,7 +12,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -70,7 +69,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// delete the provider
-	err = DeleteProvider(ctx, devsyConfig, provider, cmd.IgnoreNotFound, cmd.Force, oldlog.Default)
+	err = DeleteProvider(ctx, devsyConfig, provider, cmd.IgnoreNotFound, cmd.Force)
 	if err != nil {
 		return err
 	}
@@ -84,12 +83,11 @@ func DeleteProvider(
 	devsyConfig *config.Config,
 	provider string,
 	ignoreNotFound, force bool,
-	log oldlog.Logger,
 ) error {
 	// if force is not set, check if the provider is associated with a pro instance or workspace
 	if !force {
 		// check if this provider is associated with a pro instance
-		proInstances, err := workspace.ListProInstances(devsyConfig, oldlog.Default)
+		proInstances, err := workspace.ListProInstances(devsyConfig)
 		if err != nil {
 			return fmt.Errorf("list pro instances: %w", err)
 		}
@@ -105,7 +103,7 @@ func DeleteProvider(
 		}
 
 		// check if there are workspaces that still use this provider
-		workspaces, err := workspace.List(ctx, devsyConfig, true, platform.AllOwnerFilter, log)
+		workspaces, err := workspace.List(ctx, devsyConfig, true, platform.AllOwnerFilter)
 		if err != nil {
 			return err
 		}

--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -12,7 +12,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/table"
 	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -56,7 +55,7 @@ func (cmd *ListCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	providers, err := workspace.LoadAllProviders(devsyConfig, oldlog.Default.ErrorStreamOnly())
+	providers, err := workspace.LoadAllProviders(devsyConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/provider/options.go
+++ b/cmd/provider/options.go
@@ -15,7 +15,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/table"
 	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -89,7 +88,6 @@ func (cmd *OptionsCmd) Run(ctx context.Context, args []string) error {
 	providerWithOptions, err := workspace.FindProvider(
 		devsyConfig,
 		providerName,
-		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return err

--- a/cmd/provider/rename.go
+++ b/cmd/provider/rename.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	workspace "github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -89,7 +88,6 @@ func getWorkspacesForProvider(
 	workspaces, err := workspace.ListLocalWorkspaces(
 		devsyConfig.DefaultContext,
 		false,
-		oldlog.Default,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("listing workspaces: %w", err)
@@ -109,7 +107,7 @@ func getMachinesForProvider(
 	devsyConfig *config.Config,
 	providerName string,
 ) ([]*provider.Machine, error) {
-	machines, err := workspace.ListMachines(devsyConfig, oldlog.Default)
+	machines, err := workspace.ListMachines(devsyConfig)
 	if err != nil {
 		return nil, fmt.Errorf("listing machines: %w", err)
 	}
@@ -211,7 +209,7 @@ func (r *renameState) restoreProviderState(ctx context.Context) error {
 // validateProviderRename verifies that the provider exists, is not a pro
 // provider, is not backing a pro instance, and has configuration state.
 func validateProviderRename(devsyConfig *config.Config, oldName string) error {
-	providerWithOptions, err := workspace.FindProvider(devsyConfig, oldName, oldlog.Default)
+	providerWithOptions, err := workspace.FindProvider(devsyConfig, oldName)
 	if err != nil {
 		return fmt.Errorf("provider %s not found", oldName)
 	}
@@ -221,7 +219,7 @@ func validateProviderRename(devsyConfig *config.Config, oldName string) error {
 		return fmt.Errorf("cannot rename a pro provider; pro providers are managed by the platform")
 	}
 
-	proInstances, err := workspace.ListProInstances(devsyConfig, oldlog.Default)
+	proInstances, err := workspace.ListProInstances(devsyConfig)
 	if err != nil {
 		return fmt.Errorf("listing pro instances: %w", err)
 	}

--- a/cmd/provider/set_options.go
+++ b/cmd/provider/set_options.go
@@ -84,7 +84,7 @@ func (cmd *SetOptionsCmd) Run(ctx context.Context, args []string) error {
 		logger = oldlog.Default.ErrorStreamOnly()
 	}
 
-	providerWithOptions, err := workspace.FindProvider(devsyConfig, providerName, logger)
+	providerWithOptions, err := workspace.FindProvider(devsyConfig, providerName)
 	if err != nil {
 		return err
 	}

--- a/cmd/provider/update.go
+++ b/cmd/provider/update.go
@@ -61,7 +61,6 @@ func (cmd *UpdateCmd) Run(ctx context.Context, devsyConfig *config.Config, args 
 		devsyConfig,
 		args[0],
 		providerSource,
-		oldlog.Default,
 	)
 	if err != nil {
 		return err

--- a/cmd/provider/use.go
+++ b/cmd/provider/use.go
@@ -81,7 +81,7 @@ func (cmd *UseCmd) Run(ctx context.Context, providerName string) error {
 		return err
 	}
 
-	providerWithOptions, err := workspace.FindProvider(devsyConfig, providerName, oldlog.Default)
+	providerWithOptions, err := workspace.FindProvider(devsyConfig, providerName)
 	if err != nil {
 		return err
 	}

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -89,7 +89,6 @@ func NewSSHCmd(f *flags.GlobalFlags) *cobra.Command {
 				ChangeLastUsed: true,
 				Owner:          cmd.Owner,
 				LocalOnly:      localOnly,
-				Log:            oldlog.Default.ErrorStreamOnly(),
 			})
 			if err != nil {
 				return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -53,7 +53,6 @@ func NewStatusCmd(flags *flags.GlobalFlags) *cobra.Command {
 				DevsyConfig: devsyConfig,
 				Args:        args,
 				Owner:       cmd.Owner,
-				Log:         oldlog.Default,
 			})
 			if err != nil {
 				return err

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +45,6 @@ func NewStopCmd(flags *flags.GlobalFlags) *cobra.Command {
 				DevsyConfig: devsyConfig,
 				Args:        args,
 				Owner:       cmd.Owner,
-				Log:         oldlog.Default,
 			})
 			if err != nil {
 				return err
@@ -118,7 +116,6 @@ func (cmd *StopCmd) stopSingleMachine(
 	singleMachineName := workspace2.SingleMachineName(
 		devsyConfig,
 		client.Provider(),
-		oldlog.Default,
 	)
 	if !devsyConfig.Current().IsSingleMachine(client.Provider()) ||
 		client.WorkspaceConfig().Machine.ID != singleMachineName {
@@ -126,7 +123,7 @@ func (cmd *StopCmd) stopSingleMachine(
 	}
 
 	// try to find other workspace with same machine
-	workspaces, err := workspace2.List(ctx, devsyConfig, false, cmd.Owner, oldlog.Default)
+	workspaces, err := workspace2.List(ctx, devsyConfig, false, cmd.Owner)
 	if err != nil {
 		return false, fmt.Errorf("list workspaces: %w", err)
 	}
@@ -149,7 +146,6 @@ func (cmd *StopCmd) stopSingleMachine(
 	machineClient, err := workspace2.GetMachine(
 		devsyConfig,
 		[]string{singleMachineName},
-		oldlog.Default,
 	)
 	if err != nil {
 		return false, fmt.Errorf("get machine: %w", err)

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -113,7 +113,6 @@ func (cmd *TroubleshootCmd) Run(ctx context.Context, args []string) {
 		DevsyConfig: info.Config,
 		Args:        args,
 		Owner:       cmd.Owner,
-		Log:         oldlog.Default,
 	})
 	if err == nil {
 		info.Workspace = workspaceClient.WorkspaceConfig()
@@ -219,7 +218,7 @@ func collectProviders(
 	devsyConfig *config.Config,
 	logger oldlog.Logger,
 ) (map[string]provider.ProviderWithDefault, error) {
-	providers, err := workspace.LoadAllProviders(devsyConfig, logger)
+	providers, err := workspace.LoadAllProviders(devsyConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +262,7 @@ func collectPlatformInfo(
 	devsyConfig *config.Config,
 	logger oldlog.Logger,
 ) ([]DevsyProInstance, error) {
-	proInstanceList, err := workspace.ListProInstances(devsyConfig, logger)
+	proInstanceList, err := workspace.ListProInstances(devsyConfig)
 	if err != nil {
 		return nil, fmt.Errorf("list pro instances: %w", err)
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -816,15 +816,14 @@ func (cmd *UpCmd) prepareClient(
 			ChangeLastUsed:       true,
 			Owner:                cmd.Owner,
 		},
-		logger,
 	)
 	if err != nil {
 		return nil, logger, err
 	}
 
 	if !cmd.Platform.Enabled {
-		proInstance := workspace2.GetProInstance(devsyConfig, client.Provider(), logger)
-		err = workspace2.CheckProviderUpdate(devsyConfig, proInstance, logger)
+		proInstance := workspace2.GetProInstance(devsyConfig, client.Provider())
+		err = workspace2.CheckProviderUpdate(devsyConfig, proInstance)
 		if err != nil {
 			return nil, logger, err
 		}

--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -745,7 +745,6 @@ func (s *workspaceClient) buildEnvironment(command string) ([]string, error) {
 		ExtraEnv: map[string]string{
 			provider.CommandEnv: command,
 		},
-		Log: s.log,
 	})
 }
 
@@ -757,7 +756,6 @@ func RunCommandWithBinaries(opts CommandOptions) error {
 		Options:   opts.Options,
 		Config:    opts.Config,
 		ExtraEnv:  opts.ExtraEnv,
-		Log:       opts.Log,
 	})
 	if err != nil {
 		return err

--- a/pkg/daemon/agent/daemon.go
+++ b/pkg/daemon/agent/daemon.go
@@ -15,8 +15,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/command"
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 )
 
 type SshConfig struct {
@@ -155,7 +155,8 @@ func quoteSystemdArg(arg string) string {
 	return arg
 }
 
-func InstallDaemon(agentDir string, interval string, log log.Logger) error {
+//nolint:cyclop,funlen // pre-existing complexity
+func InstallDaemon(agentDir string, interval string) error {
 	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		return fmt.Errorf("unsupported daemon os")
 	}
@@ -176,7 +177,7 @@ func InstallDaemon(agentDir string, interval string, log log.Logger) error {
 
 	if !isSystemdAvailable() {
 		log.Warnf("systemd not available, falling back to background process")
-		return startFallbackDaemon(executable, args, log)
+		return startFallbackDaemon(executable, args)
 	}
 
 	quoted := make([]string, len(args))
@@ -224,7 +225,7 @@ func InstallDaemon(agentDir string, interval string, log log.Logger) error {
 			"systemctl", "restart", pkgconfig.BinaryName,
 		).CombinedOutput(); err != nil {
 			log.Warnf("Error restarting service: %s: %v", string(out), err)
-			return startFallbackDaemon(executable, args, log)
+			return startFallbackDaemon(executable, args)
 		}
 		log.Infof("restarted Devsy daemon with updated config")
 	} else if !isServiceRunning() {
@@ -233,7 +234,7 @@ func InstallDaemon(agentDir string, interval string, log log.Logger) error {
 			"systemctl", "start", pkgconfig.BinaryName,
 		).CombinedOutput(); err != nil {
 			log.Warnf("Error starting service: %s: %v", string(out), err)
-			return startFallbackDaemon(executable, args, log)
+			return startFallbackDaemon(executable, args)
 		}
 		log.Infof("installed Devsy daemon into server")
 	}
@@ -241,7 +242,7 @@ func InstallDaemon(agentDir string, interval string, log log.Logger) error {
 	return nil
 }
 
-func startFallbackDaemon(executable string, args []string, log log.Logger) error {
+func startFallbackDaemon(executable string, args []string) error {
 	daemonArgs := args[1:] // strip executable path
 	err := command.StartBackgroundOnce(pkgconfig.DaemonProcessName, func() (*exec.Cmd, error) {
 		//nolint:gosec // executable is from os.Executable()

--- a/pkg/driver/custom/custom.go
+++ b/pkg/driver/custom/custom.go
@@ -309,7 +309,7 @@ func (c *customDriver) runCommand(
 	log.Debugf("Run %s driver command: %s", name, strings.Join(command, " "))
 
 	// get environ
-	environ, err := ToEnvironWithBinaries(c.workspaceInfo, log)
+	environ, err := ToEnvironWithBinaries(c.workspaceInfo)
 	if err != nil {
 		return err
 	}
@@ -334,7 +334,6 @@ func (c *customDriver) runCommand(
 
 func ToEnvironWithBinaries(
 	workspace *provider.AgentWorkspaceInfo,
-	log log.Logger,
 ) ([]string, error) {
 	// get binaries dir
 	binariesDir, err := agent.GetAgentBinariesDirFromWorkspaceDir(workspace.Origin)
@@ -346,7 +345,7 @@ func ToEnvironWithBinaries(
 	}
 
 	// download binaries
-	agentBinaries, err := provider.DownloadBinaries(workspace.Agent.Binaries, binariesDir, log)
+	agentBinaries, err := provider.DownloadBinaries(workspace.Agent.Binaries, binariesDir)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"error downloading workspace %s binaries: %w",

--- a/pkg/provider/download.go
+++ b/pkg/provider/download.go
@@ -16,7 +16,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/copy"
 	"github.com/devsy-org/devsy/pkg/download"
 	"github.com/devsy-org/devsy/pkg/extract"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/log/hash"
 	"k8s.io/client-go/util/retry"
 )
@@ -47,7 +48,6 @@ type EnvironmentOptions struct {
 	Options   map[string]config.OptionValue
 	Config    *ProviderConfig
 	ExtraEnv  map[string]string
-	Log       log.Logger
 }
 
 func ToEnvironmentWithBinaries(opts EnvironmentOptions) ([]string, error) {
@@ -107,11 +107,10 @@ func GetBinaries(context string, config *ProviderConfig) (map[string]string, err
 func DownloadBinaries(
 	binaries map[string][]*ProviderBinary,
 	targetFolder string,
-	log log.Logger,
 ) (map[string]string, error) {
 	retBinaries := map[string]string{}
 	for binaryName, binaryLocations := range binaries {
-		binaryPath, err := downloadBinaryForPlatform(binaryName, binaryLocations, targetFolder, log)
+		binaryPath, err := downloadBinaryForPlatform(binaryName, binaryLocations, targetFolder)
 		if err != nil {
 			return nil, err
 		}
@@ -125,7 +124,6 @@ func downloadBinaryForPlatform(
 	binaryName string,
 	binaryLocations []*ProviderBinary,
 	targetFolder string,
-	log log.Logger,
 ) (string, error) {
 	for _, binary := range binaryLocations {
 		if binary.OS != runtime.GOOS || binary.Arch != runtime.GOARCH {
@@ -136,12 +134,12 @@ func downloadBinaryForPlatform(
 		binaryTargetFolder := filepath.Join(targetFolder, strings.ToLower(binaryName))
 		binaryPath := getBinaryPath(binary, binaryTargetFolder)
 		if verifyOrRemoveBinary(binaryPath, binary.Checksum) ||
-			fromCache(binary, binaryTargetFolder, log) {
+			fromCache(binary, binaryTargetFolder) {
 			return binaryPath, nil
 		}
 
 		// try to download the binary
-		binaryPath, err := downloadWithRetry(binaryName, binary, binaryTargetFolder, log)
+		binaryPath, err := downloadWithRetry(binaryName, binary, binaryTargetFolder)
 		if err != nil {
 			return "", err
 		}
@@ -156,17 +154,16 @@ func downloadWithRetry(
 	binaryName string,
 	binary *ProviderBinary,
 	targetFolder string,
-	log log.Logger,
 ) (string, error) {
 	var binaryPath string
 	err := retry.OnError(downloadBackoff, isRetriableError, func() error {
-		path, err := downloadBinary(binaryName, binary, targetFolder, log)
+		path, err := downloadBinary(binaryName, binary, targetFolder)
 		if err != nil {
 			return err
 		}
 
 		if binary.Checksum != "" {
-			if !verifyDownloadedBinary(path, binary, binaryName, log) {
+			if !verifyDownloadedBinary(path, binary, binaryName) {
 				return errChecksumVerificationFailed
 			}
 		}
@@ -178,7 +175,7 @@ func downloadWithRetry(
 		return "", fmt.Errorf("failed to download binary %s: %w", binaryName, err)
 	}
 
-	toCache(binary, binaryPath, log)
+	toCache(binary, binaryPath)
 	return binaryPath, nil
 }
 
@@ -229,7 +226,6 @@ func verifyDownloadedBinary(
 	binaryPath string,
 	binary *ProviderBinary,
 	binaryName string,
-	log log.Logger,
 ) bool {
 	fileHash, err := hash.File(binaryPath)
 	if err != nil {
@@ -246,7 +242,7 @@ func verifyDownloadedBinary(
 	return true
 }
 
-func toCache(binary *ProviderBinary, binaryPath string, log log.Logger) {
+func toCache(binary *ProviderBinary, binaryPath string) {
 	if !isRemotePath(binary.Path) {
 		return
 	}
@@ -262,7 +258,7 @@ func toCache(binary *ProviderBinary, binaryPath string, log log.Logger) {
 	}
 }
 
-func fromCache(binary *ProviderBinary, targetFolder string, log log.Logger) bool {
+func fromCache(binary *ProviderBinary, targetFolder string) bool {
 	if !isRemotePath(binary.Path) {
 		return false
 	}
@@ -386,13 +382,12 @@ func downloadBinary(
 	binaryName string,
 	binary *ProviderBinary,
 	targetFolder string,
-	log log.Logger,
 ) (string, error) {
 	if isRemotePath(binary.Path) {
 		if err := os.MkdirAll(targetFolder, dirPerms); err != nil {
 			return "", fmt.Errorf("create folder: %w", err)
 		}
-		return downloadRemoteBinary(binaryName, binary, targetFolder, log)
+		return downloadRemoteBinary(binaryName, binary, targetFolder)
 	}
 
 	if _, err := os.Stat(binary.Path); err == nil {
@@ -432,15 +427,14 @@ func downloadRemoteBinary(
 	binaryName string,
 	binary *ProviderBinary,
 	targetFolder string,
-	log log.Logger,
 ) (string, error) {
 	var targetPath string
 	var err error
 
 	if binary.ArchivePath != "" {
-		targetPath, err = downloadArchive(binaryName, binary, targetFolder, log)
+		targetPath, err = downloadArchive(binaryName, binary, targetFolder)
 	} else {
-		targetPath, err = downloadFile(binaryName, binary, targetFolder, log)
+		targetPath, err = downloadFile(binaryName, binary, targetFolder)
 	}
 
 	if err != nil {
@@ -461,7 +455,6 @@ func downloadFile(
 	binaryName string,
 	binary *ProviderBinary,
 	targetFolder string,
-	log log.Logger,
 ) (string, error) {
 	name := getBinaryFileName(binary)
 	targetPath := filepath.Join(targetFolder, name)
@@ -470,18 +463,17 @@ func downloadFile(
 	// (could be partial download from previous failed attempt)
 	_ = os.Remove(targetPath)
 
-	return downloadAndSaveFile(binaryName, binary, targetPath, log)
+	return downloadAndSaveFile(binaryName, binary, targetPath)
 }
 
 func downloadAndSaveFile(
 	binaryName string,
 	binary *ProviderBinary,
 	targetPath string,
-	log log.Logger,
 ) (string, error) {
 	log.Infof("downloading binary %s from %s", binaryName, binary.Path)
 
-	body, err := download.File(binary.Path, log)
+	body, err := download.File(binary.Path, oldlog.Default)
 	if err != nil {
 		return "", fmt.Errorf("download binary: %w", err)
 	}
@@ -506,7 +498,6 @@ func downloadArchive(
 	binaryName string,
 	binary *ProviderBinary,
 	targetFolder string,
-	log log.Logger,
 ) (string, error) {
 	targetPath, err := securePath(targetFolder, binary.ArchivePath)
 	if err != nil {
@@ -522,7 +513,6 @@ func downloadArchive(
 		binary:       binary,
 		targetFolder: targetFolder,
 		targetPath:   targetPath,
-		log:          log,
 	})
 }
 
@@ -531,13 +521,12 @@ type archiveDownloadParams struct {
 	binary       *ProviderBinary
 	targetFolder string
 	targetPath   string
-	log          log.Logger
 }
 
 func extractArchive(params archiveDownloadParams) (string, error) {
-	params.log.Infof("downloading binary %s from %s", params.binaryName, params.binary.Path)
+	log.Infof("downloading binary %s from %s", params.binaryName, params.binary.Path)
 
-	body, err := download.File(params.binary.Path, params.log)
+	body, err := download.File(params.binary.Path, oldlog.Default)
 	if err != nil {
 		return "", err
 	}
@@ -548,7 +537,7 @@ func extractArchive(params archiveDownloadParams) (string, error) {
 		return "", err
 	}
 
-	params.log.Debugf("extracted and downloaded archive %s", params.binaryName)
+	log.Debugf("extracted and downloaded archive %s", params.binaryName)
 	return targetPath, nil
 }
 

--- a/pkg/provider/env.go
+++ b/pkg/provider/env.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/devsy-org/devsy/pkg/config"
-	log2 "github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 )
 
 func combineOptions(
@@ -160,7 +160,7 @@ func GetBaseEnvironment(context, provider string) map[string]string {
 	retVars[config.EnvProviderContext] = context
 	providerFolder, _ := GetProviderDir(context, provider)
 	retVars[config.EnvProviderFolder] = filepath.ToSlash(providerFolder)
-	retVars[config.EnvLogLevel] = log2.Default.GetLevel().String()
+	retVars[config.EnvLogLevel] = oldlog.Default.GetLevel().String()
 	return retVars
 }
 

--- a/pkg/workspace/delete.go
+++ b/pkg/workspace/delete.go
@@ -7,8 +7,9 @@ import (
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 )
 
 // DeleteOptions holds the parameters for deleting a workspace.
@@ -19,7 +20,6 @@ type DeleteOptions struct {
 	Force          bool
 	ClientDelete   client2.DeleteOptions
 	Owner          platform.OwnerFilter
-	Log            log.Logger
 }
 
 // Delete deletes a workspace, handling imported workspaces, single-machine
@@ -29,7 +29,6 @@ func Delete(ctx context.Context, opts DeleteOptions) (string, error) {
 		DevsyConfig: opts.DevsyConfig,
 		Args:        opts.Args,
 		Owner:       opts.Owner,
-		Log:         opts.Log,
 	})
 	if err != nil {
 		return handleDeleteLoadError(ctx, opts, err)
@@ -117,7 +116,7 @@ func handleDeleteLoadError(
 		)
 	}
 
-	workspaceID := Exists(ctx, opts.DevsyConfig, opts.Args, "", opts.Owner, opts.Log)
+	workspaceID := Exists(ctx, opts.DevsyConfig, opts.Args, "", opts.Owner)
 	if workspaceID == "" {
 		if opts.IgnoreNotFound {
 			return "", nil
@@ -127,7 +126,7 @@ func handleDeleteLoadError(
 	}
 
 	if !opts.Force {
-		opts.Log.Errorf(
+		log.Errorf(
 			"failed to load workspace, use --force to delete anyway",
 		)
 
@@ -140,20 +139,20 @@ func handleDeleteLoadError(
 // forceDeleteFolder removes the workspace folder when the workspace client
 // cannot be loaded and --force is set.
 func forceDeleteFolder(opts DeleteOptions, workspaceID string) (string, error) {
-	opts.Log.Errorf("error retrieving workspace, force-deleting folder")
+	log.Errorf("error retrieving workspace, force-deleting folder")
 
 	err := clientimplementation.DeleteWorkspaceFolder(
 		clientimplementation.DeleteWorkspaceFolderParams{
 			Context:     opts.DevsyConfig.DefaultContext,
 			WorkspaceID: workspaceID,
 		},
-		opts.Log,
+		oldlog.Default,
 	)
 	if err != nil {
 		return "", err
 	}
 
-	opts.Log.Donef("deleted workspace %s", workspaceID)
+	log.Infof("deleted workspace %s", workspaceID)
 
 	return workspaceID, nil
 }
@@ -177,13 +176,13 @@ func deleteImportedWorkspace(
 			SSHConfigPath:        wsCfg.SSHConfigPath,
 			SSHConfigIncludePath: wsCfg.SSHConfigIncludePath,
 		},
-		opts.Log,
+		oldlog.Default,
 	)
 	if err != nil {
 		return "", true, err
 	}
 
-	opts.Log.Donef(
+	log.Infof(
 		"skipped remote deletion of workspace %s, use --force to delete remotely",
 		client.Workspace(),
 	)
@@ -220,7 +219,7 @@ func deleteSingleMachine(
 	client client2.BaseWorkspaceClient,
 	opts DeleteOptions,
 ) (bool, error) {
-	singleMachineName := SingleMachineName(opts.DevsyConfig, client.Provider(), opts.Log)
+	singleMachineName := SingleMachineName(opts.DevsyConfig, client.Provider())
 	if !opts.DevsyConfig.Current().IsSingleMachine(client.Provider()) ||
 		client.WorkspaceConfig().Machine.ID != singleMachineName {
 		return false, nil
@@ -234,7 +233,7 @@ func deleteSingleMachine(
 		return false, nil
 	}
 
-	machineClient, err := GetMachine(opts.DevsyConfig, []string{singleMachineName}, opts.Log)
+	machineClient, err := GetMachine(opts.DevsyConfig, []string{singleMachineName})
 	if err != nil {
 		return false, fmt.Errorf("get machine: %w", err)
 	}
@@ -251,13 +250,13 @@ func deleteSingleMachine(
 			SSHConfigPath:        wsCfg.SSHConfigPath,
 			SSHConfigIncludePath: wsCfg.SSHConfigIncludePath,
 		},
-		opts.Log,
+		oldlog.Default,
 	)
 	if err != nil {
 		return false, err
 	}
 
-	opts.Log.Donef("deleted workspace %s", client.Workspace())
+	log.Infof("deleted workspace %s", client.Workspace())
 
 	return true, nil
 }
@@ -270,7 +269,7 @@ func hasOtherWorkspaces(
 	machineName string,
 	opts DeleteOptions,
 ) (bool, error) {
-	workspaces, err := List(ctx, opts.DevsyConfig, false, opts.Owner, opts.Log)
+	workspaces, err := List(ctx, opts.DevsyConfig, false, opts.Owner)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/workspace/list.go
+++ b/pkg/workspace/list.go
@@ -16,10 +16,11 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	daemon "github.com/devsy-org/devsy/pkg/daemon/platform"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/sirupsen/logrus"
 )
 
@@ -30,10 +31,9 @@ func List(
 	devsyConfig *config.Config,
 	skipPro bool,
 	owner platform.OwnerFilter,
-	log log.Logger,
 ) ([]*providerpkg.Workspace, error) {
 	// list local workspaces
-	localWorkspaces, err := ListLocalWorkspaces(devsyConfig.DefaultContext, skipPro, log)
+	localWorkspaces, err := ListLocalWorkspaces(devsyConfig.DefaultContext, skipPro)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +41,7 @@ func List(
 	proWorkspaces := []*providerpkg.Workspace{}
 	if !skipPro {
 		// list remote workspaces
-		proWorkspaceResults, err := listProWorkspaces(ctx, devsyConfig, owner, log)
+		proWorkspaceResults, err := listProWorkspaces(ctx, devsyConfig, owner)
 		if err != nil {
 			return nil, err
 		}
@@ -66,7 +66,7 @@ func List(
 							SSHConfigPath:        localWorkspace.SSHConfigPath,
 							SSHConfigIncludePath: localWorkspace.SSHConfigIncludePath,
 						},
-						log,
+						oldlog.Default,
 					)
 					if err != nil {
 						log.Debugf(
@@ -114,7 +114,6 @@ func List(
 func ListLocalWorkspaces(
 	contextName string,
 	skipPro bool,
-	log log.Logger,
 ) ([]*providerpkg.Workspace, error) {
 	workspaceDir, err := providerpkg.GetWorkspacesDir(contextName)
 	if err != nil {
@@ -157,7 +156,6 @@ func listProWorkspaces(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	owner platform.OwnerFilter,
-	log log.Logger,
 ) (map[string]listProWorkspacesResult, error) {
 	results := map[string]listProWorkspacesResult{}
 
@@ -188,7 +186,6 @@ func listProWorkspaces(
 				provider,
 				providerConfig,
 				owner,
-				log,
 			)
 			mu.Lock()
 			defer mu.Unlock()
@@ -209,7 +206,6 @@ func listProWorkspacesForProvider(
 	provider string,
 	providerConfig *providerpkg.ProviderConfig,
 	owner platform.OwnerFilter,
-	log log.Logger,
 ) ([]*providerpkg.Workspace, error) {
 	var (
 		instances []managementv1.DevsyWorkspaceInstance
@@ -221,7 +217,6 @@ func listProWorkspacesForProvider(
 			devsyConfig,
 			provider,
 			providerConfig,
-			log,
 		)
 	} else if providerConfig.IsDaemonProvider() {
 		instances, err = listInstancesDaemonProvider(ctx, provider, owner)
@@ -229,7 +224,7 @@ func listProWorkspacesForProvider(
 		return nil, fmt.Errorf("cannot list pro workspaces with provider %s", provider)
 	}
 	if err != nil {
-		if log.GetLevel() >= logrus.DebugLevel {
+		if oldlog.Default.GetLevel() >= logrus.DebugLevel {
 			log.Warnf("Failed to list pro workspaces for provider %s: %v", provider, err)
 		}
 		return nil, err
@@ -357,7 +352,6 @@ func listInstancesProxyProvider(
 	devsyConfig *config.Config,
 	provider string,
 	providerConfig *providerpkg.ProviderConfig,
-	log log.Logger,
 ) ([]managementv1.DevsyWorkspaceInstance, error) {
 	opts := devsyConfig.ProviderOptions(provider)
 	opts[config.EnvLoftFilterByOwner] = config.OptionValue{Value: "true"}
@@ -373,7 +367,7 @@ func listInstancesProxyProvider(
 		Config:  providerConfig,
 		Stdout:  &stdout,
 		Stderr:  &stderr,
-		Log:     log,
+		Log:     oldlog.Default,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to list pro workspaces: %s: %w", stderr.String(), err)
 	}

--- a/pkg/workspace/machine.go
+++ b/pkg/workspace/machine.go
@@ -11,19 +11,20 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/encoding"
 	"github.com/devsy-org/devsy/pkg/file"
+	"github.com/devsy-org/devsy/pkg/log"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/log/survey"
 	"github.com/devsy-org/log/terminal"
 )
 
 // ListMachines returns all machines configured in the given Devsy context.
-func ListMachines(devsyConfig *config.Config, log log.Logger) ([]*providerpkg.Machine, error) {
-	return listMachines(devsyConfig, log)
+func ListMachines(devsyConfig *config.Config) ([]*providerpkg.Machine, error) {
+	return listMachines(devsyConfig)
 }
 
-func listMachines(devsyConfig *config.Config, log log.Logger) ([]*providerpkg.Machine, error) {
+func listMachines(devsyConfig *config.Config) ([]*providerpkg.Machine, error) {
 	machineDir, err := providerpkg.GetMachinesDir(devsyConfig.DefaultContext)
 	if err != nil {
 		return nil, err
@@ -55,9 +56,8 @@ func ResolveMachine(
 	devsyConfig *config.Config,
 	args []string,
 	userOptions []string,
-	log log.Logger,
 ) (client.Client, error) {
-	machineClient, err := resolveMachine(devsyConfig, args, log)
+	machineClient, err := resolveMachine(devsyConfig, args)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,6 @@ func ResolveMachine(
 func resolveMachine(
 	devsyConfig *config.Config,
 	args []string,
-	log log.Logger,
 ) (client.Client, error) {
 	// check if we have no args
 	if len(args) == 0 {
@@ -87,11 +86,11 @@ func resolveMachine(
 	// check if desired id already exists
 	if providerpkg.MachineExists(devsyConfig.DefaultContext, machineID) {
 		log.Infof("Machine %s already exists", machineID)
-		return loadExistingMachine(machineID, devsyConfig, log)
+		return loadExistingMachine(machineID, devsyConfig)
 	}
 
 	// get default provider
-	defaultProvider, _, err := LoadProviders(devsyConfig, log)
+	defaultProvider, _, err := LoadProviders(devsyConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +110,7 @@ func resolveMachine(
 		devsyConfig,
 		defaultProvider.Config,
 		machineObj,
-		log,
+		oldlog.Default,
 	)
 	if err != nil {
 		_ = os.RemoveAll(filepath.Dir(machineObj.Origin))
@@ -145,11 +144,10 @@ func MachineExists(devsyConfig *config.Config, args []string) string {
 func GetMachine(
 	devsyConfig *config.Config,
 	args []string,
-	log log.Logger,
 ) (client.MachineClient, error) {
 	// check if we have no args
 	if len(args) == 0 {
-		return selectMachine(devsyConfig, log)
+		return selectMachine(devsyConfig)
 	}
 
 	// check if workspace already exists
@@ -164,10 +162,10 @@ func GetMachine(
 	}
 
 	// load workspace config
-	return loadExistingMachine(machineID, devsyConfig, log)
+	return loadExistingMachine(machineID, devsyConfig)
 }
 
-func selectMachine(devsyConfig *config.Config, log log.Logger) (client.MachineClient, error) {
+func selectMachine(devsyConfig *config.Config) (client.MachineClient, error) {
 	if !terminal.IsTerminalIn {
 		return nil, errProvideWorkspaceArg
 	}
@@ -191,7 +189,7 @@ func selectMachine(devsyConfig *config.Config, log log.Logger) (client.MachineCl
 		return nil, errProvideWorkspaceArg
 	}
 
-	answer, err := log.Question(&survey.QuestionOptions{
+	answer, err := oldlog.Default.Question(&survey.QuestionOptions{
 		Question:     "Please select a machine from the list below",
 		DefaultValue: machineIDs[0],
 		Options:      machineIDs,
@@ -202,20 +200,19 @@ func selectMachine(devsyConfig *config.Config, log log.Logger) (client.MachineCl
 	}
 
 	// load workspace
-	return loadExistingMachine(answer, devsyConfig, log)
+	return loadExistingMachine(answer, devsyConfig)
 }
 
 func loadExistingMachine(
 	machineID string,
 	devsyConfig *config.Config,
-	log log.Logger,
 ) (client.MachineClient, error) {
 	machineConfig, err := providerpkg.LoadMachineConfig(devsyConfig.DefaultContext, machineID)
 	if err != nil {
 		return nil, err
 	}
 
-	providerWithOptions, err := FindProvider(devsyConfig, machineConfig.Provider.Name, log)
+	providerWithOptions, err := FindProvider(devsyConfig, machineConfig.Provider.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +221,7 @@ func loadExistingMachine(
 		devsyConfig,
 		providerWithOptions.Config,
 		machineConfig,
-		log,
+		oldlog.Default,
 	)
 }
 
@@ -256,9 +253,9 @@ func createMachine(context, machineID, providerName string) (*providerpkg.Machin
 	return machine, nil
 }
 
-func SingleMachineName(devsyConfig *config.Config, provider string, log log.Logger) string {
+func SingleMachineName(devsyConfig *config.Config, provider string) string {
 	legacyMachineName := config.BinaryName + "-shared-" + provider
-	machines, err := listMachines(devsyConfig, log)
+	machines, err := listMachines(devsyConfig)
 	if err == nil {
 		for _, machine := range machines {
 			if machine.Provider.Name == provider && machine.ID == legacyMachineName {
@@ -268,7 +265,11 @@ func SingleMachineName(devsyConfig *config.Config, provider string, log log.Logg
 	}
 
 	return encoding.SafeConcatNameMax(
-		[]string{config.BinaryName + "-shared", provider, encoding.GetMachineUIDShort(log)},
+		[]string{
+			config.BinaryName + "-shared",
+			provider,
+			encoding.GetMachineUIDShort(oldlog.Default),
+		},
 		encoding.MachineUIDLength,
 	)
 }

--- a/pkg/workspace/pro.go
+++ b/pkg/workspace/pro.go
@@ -4,13 +4,12 @@ import (
 	"os"
 
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 )
 
 func ListProInstances(
 	devsyConfig *config.Config,
-	log log.Logger,
 ) ([]*provider2.ProInstance, error) {
 	proInstanceDir, err := provider2.GetProInstancesDir(devsyConfig.DefaultContext)
 	if err != nil {

--- a/pkg/workspace/provider.go
+++ b/pkg/workspace/provider.go
@@ -14,11 +14,12 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/download"
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/devsy-org/devsy/providers"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 )
 
 var ErrNoWorkspaceFound = errors.New("no workspace found")
@@ -33,16 +34,14 @@ type ProviderParams struct {
 	ProviderName string
 	Raw          []byte
 	Source       *provider.ProviderSource
-	Log          log.Logger
 }
 
 // LoadProviders loads all known providers for the given context.
 func LoadProviders(
 	devsyConfig *config.Config,
-	log log.Logger,
 ) (*ProviderWithOptions, map[string]*ProviderWithOptions, error) {
 	defaultContext := devsyConfig.Current()
-	retProviders, err := LoadAllProviders(devsyConfig, log)
+	retProviders, err := LoadAllProviders(devsyConfig)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,11 +61,10 @@ func LoadProviders(
 
 func LoadAllProviders(
 	devsyConfig *config.Config,
-	log log.Logger,
 ) (map[string]*ProviderWithOptions, error) {
 	retProviders := map[string]*ProviderWithOptions{}
 
-	loadConfiguredProviders(devsyConfig, retProviders, log)
+	loadConfiguredProviders(devsyConfig, retProviders)
 
 	if err := loadUnconfiguredProviders(devsyConfig, retProviders); err != nil {
 		return nil, err
@@ -78,9 +76,8 @@ func LoadAllProviders(
 func FindProvider(
 	devsyConfig *config.Config,
 	name string,
-	log log.Logger,
 ) (*ProviderWithOptions, error) {
-	retProviders, err := LoadAllProviders(devsyConfig, log)
+	retProviders, err := LoadAllProviders(devsyConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -95,14 +92,13 @@ func ProviderFromHost(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	proHost string,
-	log log.Logger,
 ) (*provider.ProviderConfig, error) {
 	proInstanceConfig, err := provider.LoadProInstanceConfig(devsyConfig.DefaultContext, proHost)
 	if err != nil {
 		return nil, fmt.Errorf("load pro instance %s: %w", proHost, err)
 	}
 
-	foundProvider, err := FindProvider(devsyConfig, proInstanceConfig.Provider, log)
+	foundProvider, err := FindProvider(devsyConfig, proInstanceConfig.Provider)
 	if err != nil {
 		return nil, fmt.Errorf("find provider: %w", err)
 	}
@@ -116,9 +112,8 @@ func ProviderFromHost(
 func AddProvider(
 	devsyConfig *config.Config,
 	providerName, providerSourceRaw string,
-	log log.Logger,
 ) (*provider.ProviderConfig, error) {
-	providerRaw, providerSource, err := ResolveProvider(providerSourceRaw, log)
+	providerRaw, providerSource, err := ResolveProvider(providerSourceRaw)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +123,6 @@ func AddProvider(
 		ProviderName: providerName,
 		Source:       providerSource,
 		Raw:          providerRaw,
-		Log:          log,
 	})
 }
 
@@ -157,21 +151,20 @@ func AddProviderRaw(p ProviderParams) (*provider.ProviderConfig, error) {
 func UpdateProvider(
 	devsyConfig *config.Config,
 	providerName, providerSourceRaw string,
-	log log.Logger,
 ) (*provider.ProviderConfig, error) {
 	if devsyConfig.Current().Providers[providerName] == nil {
 		return nil, fmt.Errorf("provider %s not found", providerName)
 	}
 
 	if providerSourceRaw == "" {
-		s, err := ResolveProviderSource(devsyConfig, providerName, log)
+		s, err := ResolveProviderSource(devsyConfig, providerName)
 		if err != nil {
 			return nil, err
 		}
 		providerSourceRaw = s
 	}
 
-	providerRaw, providerSource, err := ResolveProvider(providerSourceRaw, log)
+	providerRaw, providerSource, err := ResolveProvider(providerSourceRaw)
 	if err != nil {
 		return nil, err
 	}
@@ -181,16 +174,14 @@ func UpdateProvider(
 		ProviderName: providerName,
 		Raw:          providerRaw,
 		Source:       providerSource,
-		Log:          log,
 	})
 }
 
 func CloneProvider(
 	devsyConfig *config.Config,
 	providerName, providerSourceRaw string,
-	log log.Logger,
 ) (*ProviderWithOptions, error) {
-	sourceProvider, err := FindProvider(devsyConfig, providerSourceRaw, log)
+	sourceProvider, err := FindProvider(devsyConfig, providerSourceRaw)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +191,6 @@ func CloneProvider(
 			DevsyConfig:  devsyConfig,
 			ProviderName: providerName,
 			Source:       &sourceProvider.Config.Source,
-			Log:          log,
 		},
 		sourceProvider.Config)
 	if err != nil {
@@ -214,9 +204,8 @@ func CloneProvider(
 func ResolveProviderSource(
 	devsyConfig *config.Config,
 	providerName string,
-	log log.Logger,
 ) (string, error) {
-	providerConfig, err := FindProvider(devsyConfig, providerName, log)
+	providerConfig, err := FindProvider(devsyConfig, providerName)
 	if err != nil {
 		return "", fmt.Errorf("find provider: %w", err)
 	}
@@ -231,7 +220,6 @@ func ResolveProviderSource(
 
 func ResolveProvider(
 	providerSource string,
-	log log.Logger,
 ) ([]byte, *provider.ProviderSource, error) {
 	retSource := &provider.ProviderSource{Raw: strings.TrimSpace(providerSource)}
 
@@ -242,7 +230,6 @@ func ResolveProvider(
 	if out, err := tryResolveURLProvider(
 		providerSource,
 		retSource,
-		log,
 	); hasOutputOrError(
 		out,
 		err,
@@ -254,7 +241,7 @@ func ResolveProvider(
 		return out, retSource, err
 	}
 
-	out, source, err := downloadProviderGithub(providerSource, log)
+	out, source, err := downloadProviderGithub(providerSource)
 	if len(out) > 0 || err != nil {
 		return out, source, err
 	}
@@ -271,9 +258,8 @@ func hasOutputOrError(out []byte, err error) bool {
 func tryResolveURLProvider(
 	providerSource string,
 	retSource *provider.ProviderSource,
-	log log.Logger,
 ) ([]byte, error) {
-	out, ok, err := resolveURLProvider(providerSource, retSource, log)
+	out, ok, err := resolveURLProvider(providerSource, retSource)
 	if !ok {
 		return nil, nil
 	}
@@ -293,7 +279,6 @@ func tryResolveFileProvider(
 
 func downloadProviderGithub(
 	originalPath string,
-	log log.Logger,
 ) ([]byte, *provider.ProviderSource, error) {
 	path := strings.TrimPrefix(originalPath, "github.com/")
 
@@ -316,7 +301,7 @@ func downloadProviderGithub(
 
 	requestURL := buildGithubURL(path, release)
 
-	body, err := download.File(requestURL, log)
+	body, err := download.File(requestURL, oldlog.Default)
 	if err != nil {
 		return nil, nil, fmt.Errorf("download: %w", err)
 	}
@@ -336,7 +321,6 @@ func downloadProviderGithub(
 func loadConfiguredProviders(
 	devsyConfig *config.Config,
 	retProviders map[string]*ProviderWithOptions,
-	log log.Logger,
 ) {
 	defaultContext := devsyConfig.Current()
 	for providerName, providerState := range defaultContext.Providers {
@@ -419,7 +403,6 @@ func installRawProvider(p ProviderParams) (*provider.ProviderConfig, error) {
 		DevsyConfig:  p.DevsyConfig,
 		ProviderName: p.ProviderName,
 		Source:       p.Source,
-		Log:          p.Log,
 	}, providerConfig)
 }
 
@@ -520,7 +503,6 @@ func downloadAndSaveProvider(p ProviderParams, providerConfig *provider.Provider
 	if _, err := provider.DownloadBinaries(
 		providerConfig.Binaries,
 		binariesDir,
-		p.Log,
 	); err != nil {
 		_ = os.RemoveAll(providerDir)
 		return fmt.Errorf("download binaries: %w", err)
@@ -575,7 +557,6 @@ func resolveInternalProvider(
 func resolveURLProvider(
 	providerSource string,
 	retSource *provider.ProviderSource,
-	log log.Logger,
 ) ([]byte, bool, error) {
 	if !strings.HasPrefix(providerSource, "http://") &&
 		!strings.HasPrefix(providerSource, "https://") {
@@ -668,7 +649,6 @@ func SwitchProvider(
 		DevsyConfig: devsyConfig,
 		Args:        []string{workspace.ID},
 		Owner:       platform.AllOwnerFilter,
-		Log:         log.Default,
 	})
 	if err != nil {
 		revert()

--- a/pkg/workspace/provider_update.go
+++ b/pkg/workspace/provider_update.go
@@ -6,10 +6,10 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/version"
-	"github.com/devsy-org/log"
 )
 
 // CheckProviderUpdate currently only ensures the local provider is in sync with the remote for Devsy Pro instances.
@@ -17,7 +17,6 @@ import (
 func CheckProviderUpdate(
 	devsyConfig *config.Config,
 	proInstance *provider2.ProInstance,
-	log log.Logger,
 ) error {
 	if version.GetVersion() == version.DevVersion {
 		log.Debugf("skipping provider upgrade check during development")
@@ -28,20 +27,19 @@ func CheckProviderUpdate(
 		return nil
 	}
 
-	return checkProviderUpdateForInstance(devsyConfig, proInstance, log)
+	return checkProviderUpdateForInstance(devsyConfig, proInstance)
 }
 
 func checkProviderUpdateForInstance(
 	devsyConfig *config.Config,
 	proInstance *provider2.ProInstance,
-	log log.Logger,
 ) error {
 	newVersion, err := platform.GetProInstanceDevsyVersion(proInstance)
 	if err != nil {
 		return fmt.Errorf("version for pro instance %s: %w", proInstance.Host, err)
 	}
 
-	p, err := FindProvider(devsyConfig, proInstance.Provider, log)
+	p, err := FindProvider(devsyConfig, proInstance.Provider)
 	if err != nil {
 		return fmt.Errorf("get provider config for pro provider %s: %w", proInstance.Provider, err)
 	}
@@ -65,7 +63,7 @@ func checkProviderUpdateForInstance(
 		newVersion,
 	)
 
-	return applyProviderUpdate(devsyConfig, proInstance.Provider, newVersion, log)
+	return applyProviderUpdate(devsyConfig, proInstance.Provider, newVersion)
 }
 
 func providerVersionNeedsUpdate(newVersion, currentVersion string) (bool, error) {
@@ -83,9 +81,8 @@ func providerVersionNeedsUpdate(newVersion, currentVersion string) (bool, error)
 func applyProviderUpdate(
 	devsyConfig *config.Config,
 	providerName, newVersion string,
-	log log.Logger,
 ) error {
-	providerSource, err := ResolveProviderSource(devsyConfig, providerName, log)
+	providerSource, err := ResolveProviderSource(devsyConfig, providerName)
 	if err != nil {
 		return fmt.Errorf("resolve provider source %s: %w", providerName, err)
 	}
@@ -96,12 +93,12 @@ func applyProviderUpdate(
 	}
 	providerSource = splitted[0] + "@" + newVersion
 
-	_, err = UpdateProvider(devsyConfig, providerName, providerSource, log)
+	_, err = UpdateProvider(devsyConfig, providerName, providerSource)
 	if err != nil {
 		return fmt.Errorf("update provider %s: %w", providerName, err)
 	}
 
-	log.Donef("updated provider: provider=%s", providerName)
+	log.Infof("updated provider: provider=%s", providerName)
 	return nil
 }
 
@@ -109,9 +106,8 @@ func applyProviderUpdate(
 func GetProInstance(
 	devsyConfig *config.Config,
 	providerName string,
-	log log.Logger,
 ) *provider2.ProInstance {
-	proInstances, err := ListProInstances(devsyConfig, log)
+	proInstances, err := ListProInstances(devsyConfig)
 	if err != nil {
 		return nil
 	} else if len(proInstances) == 0 {

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -19,10 +19,11 @@ import (
 	"github.com/devsy-org/devsy/pkg/git"
 	"github.com/devsy-org/devsy/pkg/ide/ideparse"
 	"github.com/devsy-org/devsy/pkg/image"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/log/terminal"
 )
 
@@ -60,7 +61,6 @@ func Resolve(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	params ResolveParams,
-	log log.Logger,
 ) (client.BaseWorkspaceClient, error) {
 	// verify desired id
 	if params.DesiredID != "" {
@@ -74,7 +74,7 @@ func Resolve(
 	}
 
 	// resolve workspace
-	provider, workspace, machine, err := resolveWorkspace(ctx, devsyConfig, params, log)
+	provider, workspace, machine, err := resolveWorkspace(ctx, devsyConfig, params)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func Resolve(
 	}
 
 	// create workspace client
-	client, err := getWorkspaceClient(devsyConfig, provider, workspace, machine, log)
+	client, err := getWorkspaceClient(devsyConfig, provider, workspace, machine)
 	if err != nil {
 		return nil, err
 	}
@@ -138,19 +138,18 @@ func getWorkspaceClient(
 	provider *providerpkg.ProviderConfig,
 	workspace *providerpkg.Workspace,
 	machine *providerpkg.Machine,
-	log log.Logger,
 ) (client.BaseWorkspaceClient, error) {
 	if provider.IsProxyProvider() {
-		return clientimplementation.NewProxyClient(devsyConfig, provider, workspace, log)
+		return clientimplementation.NewProxyClient(devsyConfig, provider, workspace, oldlog.Default)
 	} else if provider.IsDaemonProvider() {
-		return daemonclient.New(devsyConfig, provider, workspace, log)
+		return daemonclient.New(devsyConfig, provider, workspace, oldlog.Default)
 	} else {
 		return clientimplementation.NewWorkspaceClient(
 			devsyConfig,
 			provider,
 			workspace,
 			machine,
-			log,
+			oldlog.Default,
 		)
 	}
 }
@@ -162,7 +161,6 @@ type GetOptions struct {
 	ChangeLastUsed bool
 	Owner          platform.OwnerFilter
 	LocalOnly      bool
-	Log            log.Logger
 }
 
 // Get tries to retrieve an already existing workspace.
@@ -178,13 +176,12 @@ func Get(ctx context.Context, opts GetOptions) (client.BaseWorkspaceClient, erro
 				owner:                opts.Owner,
 				localOnly:            opts.LocalOnly,
 			},
-			opts.Log,
 		)
 		if err != nil {
 			return nil, err
 		}
 
-		return getWorkspaceClient(opts.DevsyConfig, provider, workspace, machine, opts.Log)
+		return getWorkspaceClient(opts.DevsyConfig, provider, workspace, machine)
 	}
 
 	workspace := findWorkspaceByArgs(ctx, opts)
@@ -196,13 +193,12 @@ func Get(ctx context.Context, opts GetOptions) (client.BaseWorkspaceClient, erro
 		opts.DevsyConfig,
 		workspace.ID,
 		opts.ChangeLastUsed,
-		opts.Log,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	return getWorkspaceClient(opts.DevsyConfig, provider, workspace, machine, opts.Log)
+	return getWorkspaceClient(opts.DevsyConfig, provider, workspace, machine)
 }
 
 func findWorkspaceByArgs(
@@ -210,9 +206,9 @@ func findWorkspaceByArgs(
 	opts GetOptions,
 ) *providerpkg.Workspace {
 	if opts.LocalOnly {
-		return findLocalWorkspace(opts.DevsyConfig, opts.Args, "", opts.Log)
+		return findLocalWorkspace(opts.DevsyConfig, opts.Args, "")
 	}
-	return findWorkspace(ctx, opts.DevsyConfig, opts.Args, "", opts.Owner, opts.Log)
+	return findWorkspace(ctx, opts.DevsyConfig, opts.Args, "", opts.Owner)
 }
 
 // Exists checks if the given workspace already exists.
@@ -222,9 +218,8 @@ func Exists(
 	args []string,
 	workspaceID string,
 	owner platform.OwnerFilter,
-	log log.Logger,
 ) string {
-	workspace := findWorkspace(ctx, devsyConfig, args, workspaceID, owner, log)
+	workspace := findWorkspace(ctx, devsyConfig, args, workspaceID, owner)
 	if workspace == nil {
 		return ""
 	}
@@ -236,16 +231,15 @@ func resolveWorkspace(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	params ResolveParams,
-	log log.Logger,
 ) (*providerpkg.ProviderConfig, *providerpkg.Workspace, *providerpkg.Machine, error) {
 	// check if we have no args
 	if len(params.Args) == 0 {
 		if params.DesiredID != "" {
-			workspace := findWorkspace(ctx, devsyConfig, nil, params.DesiredID, params.Owner, log)
+			workspace := findWorkspace(ctx, devsyConfig, nil, params.DesiredID, params.Owner)
 			if workspace == nil {
 				return nil, nil, nil, fmt.Errorf("workspace %s doesn't exist", params.DesiredID)
 			}
-			return loadExistingWorkspace(devsyConfig, workspace.ID, params.ChangeLastUsed, log)
+			return loadExistingWorkspace(devsyConfig, workspace.ID, params.ChangeLastUsed)
 		}
 
 		return selectWorkspace(ctx, devsyConfig, selectWorkspaceParams{
@@ -253,7 +247,7 @@ func resolveWorkspace(
 			sshConfigPath:        params.SSHConfigPath,
 			sshConfigIncludePath: params.SSHConfigIncludePath,
 			owner:                params.Owner,
-		}, log)
+		})
 	}
 
 	// check if workspace already exists
@@ -264,16 +258,16 @@ func resolveWorkspace(
 
 	// check if desired id already exists
 	if params.DesiredID != "" {
-		if Exists(ctx, devsyConfig, nil, params.DesiredID, params.Owner, log) != "" {
+		if Exists(ctx, devsyConfig, nil, params.DesiredID, params.Owner) != "" {
 			log.Debugf("workspace ID already exists: desiredID=%s", params.DesiredID)
-			return loadExistingWorkspace(devsyConfig, params.DesiredID, params.ChangeLastUsed, log)
+			return loadExistingWorkspace(devsyConfig, params.DesiredID, params.ChangeLastUsed)
 		}
 
 		// set desired id
 		workspaceID = params.DesiredID
-	} else if Exists(ctx, devsyConfig, nil, workspaceID, params.Owner, log) != "" {
+	} else if Exists(ctx, devsyConfig, nil, workspaceID, params.Owner) != "" {
 		log.Debugf("workspace already exists: workspaceID=%s", workspaceID)
-		return loadExistingWorkspace(devsyConfig, workspaceID, params.ChangeLastUsed, log)
+		return loadExistingWorkspace(devsyConfig, workspaceID, params.ChangeLastUsed)
 	}
 
 	// create workspace
@@ -291,7 +285,6 @@ func resolveWorkspace(
 			isLocalPath:          isLocalPath,
 			uid:                  params.UID,
 		},
-		log,
 	)
 	if err != nil {
 		_ = clientimplementation.DeleteWorkspaceFolder(
@@ -301,7 +294,7 @@ func resolveWorkspace(
 				SSHConfigPath:        params.SSHConfigPath,
 				SSHConfigIncludePath: params.SSHConfigIncludePath,
 			},
-			log,
+			oldlog.Default,
 		)
 		return nil, nil, nil, err
 	}
@@ -325,10 +318,9 @@ func createWorkspace(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	params createWorkspaceParams,
-	log log.Logger,
 ) (*providerpkg.ProviderConfig, *providerpkg.Workspace, *providerpkg.Machine, error) {
 	// get default provider
-	provider, _, err := LoadProviders(devsyConfig, log)
+	provider, _, err := LoadProviders(devsyConfig)
 	if err != nil {
 		return nil, nil, nil, err
 	} else if provider.State == nil || !provider.State.Initialized {
@@ -387,7 +379,7 @@ func createWorkspace(
 	if provider.Config.IsMachineProvider() && workspace.Machine.ID == "" {
 		// create a new machine
 		if provider.State != nil && provider.State.SingleMachine {
-			workspace.Machine.ID = SingleMachineName(devsyConfig, provider.Config.Name, log)
+			workspace.Machine.ID = SingleMachineName(devsyConfig, provider.Config.Name)
 		} else {
 			workspace.Machine.ID = encoding.CreateNewUIDShort(workspace.ID)
 			workspace.Machine.AutoDelete = true
@@ -416,7 +408,7 @@ func createWorkspace(
 				devsyConfig,
 				provider.Config,
 				machineConfig,
-				log,
+				oldlog.Default,
 			)
 			if err != nil {
 				_ = clientimplementation.DeleteMachineFolder(
@@ -479,7 +471,6 @@ func createWorkspace(
 			stdin:        os.Stdin,
 			stdout:       os.Stdout,
 			stderr:       os.Stderr,
-			log:          log,
 		})
 		if err != nil {
 			return nil, nil, nil, err
@@ -627,14 +618,13 @@ func findLocalWorkspace(
 	devsyConfig *config.Config,
 	args []string,
 	workspaceID string,
-	log log.Logger,
 ) *providerpkg.Workspace {
 	workspaceID = ensureWorkspaceID(args, workspaceID)
 	if workspaceID == "" {
 		return nil
 	}
 
-	allWorkspaces, err := ListLocalWorkspaces(devsyConfig.DefaultContext, false, log)
+	allWorkspaces, err := ListLocalWorkspaces(devsyConfig.DefaultContext, false)
 	if err != nil {
 		log.Debugf("failed to list workspaces: %v", err)
 		return nil
@@ -656,14 +646,13 @@ func findWorkspace(
 	args []string,
 	workspaceID string,
 	owner platform.OwnerFilter,
-	log log.Logger,
 ) *providerpkg.Workspace {
 	workspaceID = ensureWorkspaceID(args, workspaceID)
 	if workspaceID == "" {
 		return nil
 	}
 
-	allWorkspaces, err := List(ctx, devsyConfig, false, owner, log)
+	allWorkspaces, err := List(ctx, devsyConfig, false, owner)
 	if err != nil {
 		log.Debugf("failed to list workspaces: %v", err)
 		return nil
@@ -709,7 +698,6 @@ func selectWorkspace(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	params selectWorkspaceParams,
-	log log.Logger,
 ) (*providerpkg.ProviderConfig, *providerpkg.Workspace, *providerpkg.Machine, error) {
 	if !terminal.IsTerminalIn {
 		return nil, nil, nil, errProvideWorkspaceArg
@@ -720,9 +708,9 @@ func selectWorkspace(
 		err        error
 	)
 	if params.localOnly {
-		workspaces, err = ListLocalWorkspaces(devsyConfig.DefaultContext, false, log)
+		workspaces, err = ListLocalWorkspaces(devsyConfig.DefaultContext, false)
 	} else {
-		workspaces, err = List(ctx, devsyConfig, false, params.owner, log)
+		workspaces, err = List(ctx, devsyConfig, false, params.owner)
 	}
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("list workspaces: %w", err)
@@ -799,14 +787,13 @@ func selectWorkspace(
 	}
 
 	// load workspace
-	return loadExistingWorkspace(devsyConfig, selectedWorkspace.ID, params.changeLastUsed, log)
+	return loadExistingWorkspace(devsyConfig, selectedWorkspace.ID, params.changeLastUsed)
 }
 
 func loadExistingWorkspace(
 	devsyConfig *config.Config,
 	workspaceID string,
 	changeLastUsed bool,
-	log log.Logger,
 ) (*providerpkg.ProviderConfig, *providerpkg.Workspace, *providerpkg.Machine, error) {
 	workspaceConfig, err := providerpkg.LoadWorkspaceConfig(
 		devsyConfig.DefaultContext,
@@ -816,7 +803,7 @@ func loadExistingWorkspace(
 		return nil, nil, nil, err
 	}
 
-	providerWithOptions, err := FindProvider(devsyConfig, workspaceConfig.Provider.Name, log)
+	providerWithOptions, err := FindProvider(devsyConfig, workspaceConfig.Provider.Name)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -854,11 +841,10 @@ type proInstanceParams struct {
 	stdin        io.Reader
 	stdout       io.Writer
 	stderr       io.Writer
-	log          log.Logger
 }
 
 func resolveProInstance(params proInstanceParams) error {
-	foundProvider, err := FindProvider(params.devsyConfig, params.providerName, params.log)
+	foundProvider, err := FindProvider(params.devsyConfig, params.providerName)
 	if err != nil {
 		return err
 	}
@@ -868,7 +854,6 @@ func resolveProInstance(params proInstanceParams) error {
 		foundProvider.Config,
 		params.workspace,
 		nil,
-		params.log,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Remove `log log.Logger` parameters from function signatures and `Log log.Logger` fields from structs across `pkg/workspace/`, `pkg/provider/`, and `pkg/daemon/agent/`
- Replace instance logger method calls with package-level `log.Infof`/`Debugf`/`Warnf`/`Errorf` from `pkg/log`
- Use `oldlog.Default` where downstream functions still require the old `log.Logger` interface (e.g. `download.File`, `encoding.GetMachineUIDShort`, `clientimplementation` constructors, `survey.Question`)
- Update all 44 cmd/ callers to match the new signatures
- `pkg/daemon/platform/` intentionally excluded (uses instance-specific file loggers)
- `pkg/client/` deferred to follow-up PR

56 files changed, 175 insertions, 289 deletions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Comprehensive refactoring of internal logging architecture and dependency injection patterns across the application. Updates streamline code structure in workspace management, provider operations, machine lifecycle management, binary downloads, and daemon installation processes. These changes improve maintainability and reduce unnecessary logging dependencies while preserving all existing functionality and user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->