### PR TITLE
refactor(log): migrate pkg/devcontainer/ to pkg/log

### DIFF
--- a/cmd/agent/container/post_attach.go
+++ b/cmd/agent/container/post_attach.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/setup"
 	"github.com/devsy-org/devsy/pkg/log"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -41,8 +40,6 @@ func NewPostAttachCmd(flags *flags.GlobalFlags) *cobra.Command {
 
 // Run runs the postAttachCommand lifecycle hooks.
 func (cmd *PostAttachCmd) Run(ctx context.Context) error {
-	logger := oldlog.Default
-
 	decompressed, err := compress.Decompress(cmd.SetupInfo)
 	if err != nil {
 		return err
@@ -54,7 +51,7 @@ func (cmd *PostAttachCmd) Run(ctx context.Context) error {
 	}
 
 	log.Debugf("running postAttachCommand hooks")
-	if err := setup.RunPostAttachHooks(ctx, setupInfo, logger); err != nil {
+	if err := setup.RunPostAttachHooks(ctx, setupInfo); err != nil {
 		log.Errorf("postAttachCommand failed: %v", err)
 	}
 

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -187,7 +187,6 @@ func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
 		ChownProjects:     cmd.ChownWorkspace,
 		PlatformOptions:   &sctx.workspaceInfo.CLIOptions.Platform,
 		TunnelClient:      sctx.tunnelClient,
-		Log:               sctx.logger,
 	}
 
 	if err := setup.SetupContainerPreAttach(sctx.ctx, cfg); err != nil {

--- a/cmd/helper/get_workspace_config.go
+++ b/cmd/helper/get_workspace_config.go
@@ -102,7 +102,6 @@ func (cmd *GetWorkspaceConfigCommand) Run(
 			devsyConfig.ContextOption(
 				config.ContextOptionSSHStrictHostKeyChecking,
 			) == config.BoolTrue,
-			logger,
 		)
 		if err != nil {
 			errChan <- err

--- a/e2e/tests/build/build.go
+++ b/e2e/tests/build/build.go
@@ -118,7 +118,6 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 				DockerfilePath:    dockerfilePath,
 				DockerfileContent: contentToParse,
 				BuildInfo:         info,
-				Log:               log.Default,
 			})
 			framework.ExpectNoError(err)
 			_, err = dockerHelper.InspectImage(ctx, prebuildRepoName+":"+prebuildHash, false)
@@ -132,7 +131,6 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 				DockerfilePath:    dockerfilePath,
 				DockerfileContent: contentToParse,
 				BuildInfo:         info,
-				Log:               log.Default,
 			})
 			framework.ExpectNoError(err)
 
@@ -185,7 +183,6 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 				DockerfilePath:    dockerfilePath,
 				DockerfileContent: contentToParse,
 				BuildInfo:         info,
-				Log:               log.Default,
 			})
 			framework.ExpectNoError(err)
 			_, err = dockerHelper.InspectImage(
@@ -296,7 +293,6 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 				DockerfilePath:    dockerfilePath,
 				DockerfileContent: contentToParse,
 				BuildInfo:         info,
-				Log:               log.Default,
 			})
 			framework.ExpectNoError(err)
 

--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -75,7 +75,6 @@ func (r *runner) extendImage(
 		imageBuildInfo,
 		imageBase,
 		parsedConfig,
-		r.Log,
 		options.ForceBuild,
 	)
 	if err != nil {
@@ -157,7 +156,6 @@ func (r *runner) buildAndExtendImage(
 		imageBuildInfo,
 		imageBase,
 		parsedConfig,
-		r.Log,
 		options.ForceBuild,
 	)
 	if err != nil {
@@ -228,7 +226,7 @@ func (r *runner) getImageBuildInfoFromImage(
 		user = imageDetails.Config.User
 	}
 
-	imageMetadata, err := metadata.GetImageMetadata(imageDetails, substitutionContext, r.Log)
+	imageMetadata, err := metadata.GetImageMetadata(imageDetails, substitutionContext)
 	if err != nil {
 		return nil, fmt.Errorf("get image metadata: %w", err)
 	}
@@ -283,7 +281,7 @@ func (r *runner) getImageBuildInfoFromDockerfile(
 	}
 
 	// parse metadata from image details
-	imageMetadataConfig, err := metadata.GetImageMetadata(imageDetails, substitutionContext, r.Log)
+	imageMetadataConfig, err := metadata.GetImageMetadata(imageDetails, substitutionContext)
 	if err != nil {
 		return nil, fmt.Errorf("get image metadata: %w", err)
 	}
@@ -318,7 +316,6 @@ func (r *runner) buildImage(
 		DockerfilePath:    dockerfilePath,
 		DockerfileContent: dockerfileContent,
 		BuildInfo:         buildInfo,
-		Log:               r.Log,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/devcontainer/buildkit/buildkit.go
+++ b/pkg/devcontainer/buildkit/buildkit.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/build"
 	"github.com/devsy-org/devsy/pkg/docker"
-	"github.com/devsy-org/log"
 	buildkit "github.com/moby/buildkit/client"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
@@ -22,7 +21,6 @@ func Build(
 	writer io.Writer,
 	platform string,
 	options *build.BuildOptions,
-	log log.Logger,
 ) error {
 	dockerConfig, err := docker.LoadDockerConfig()
 	if err != nil {

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -252,7 +252,6 @@ func (r *runner) runDockerCompose(
 	imageMetadataConfig, err := metadata.GetImageMetadataFromContainer(
 		containerDetails,
 		substitutionContext,
-		r.Log,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get image metadata from container: %w", err)
@@ -647,7 +646,6 @@ func (r *runner) buildAndExtendDockerCompose(
 		imageBuildInfo,
 		buildTarget,
 		parsedConfig,
-		r.Log,
 		false,
 	)
 	if err != nil {

--- a/pkg/devcontainer/config.go
+++ b/pkg/devcontainer/config.go
@@ -46,7 +46,7 @@ func (r *runner) getRawConfig(options provider2.CLIOptions) (*config.DevContaine
 			Origin: "",
 		}, nil
 	} else if crane.ShouldUse(&options) {
-		localWorkspaceFolder, err := crane.PullConfigFromSource(r.WorkspaceConfig, &options, r.Log)
+		localWorkspaceFolder, err := crane.PullConfigFromSource(r.WorkspaceConfig, &options)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/devcontainer/config/prebuild.go
+++ b/pkg/devcontainer/config/prebuild.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	util "github.com/devsy-org/devsy/pkg/util/hash"
-	"github.com/devsy-org/log"
 	"github.com/devsy-org/log/hash"
 	"github.com/moby/patternmatcher"
 	"github.com/moby/patternmatcher/ignorefile"
@@ -24,7 +24,6 @@ type PrebuildHashParams struct {
 	DockerfilePath    string
 	DockerfileContent string
 	BuildInfo         *ImageBuildInfo
-	Log               log.Logger
 }
 
 // CalculatePrebuildHash computes a deterministic hash for prebuild caching.
@@ -40,7 +39,7 @@ func CalculatePrebuildHash(params PrebuildHashParams) (string, error) {
 
 	excludes, err := readDockerignore(params.ContextPath, params.DockerfilePath)
 	if err != nil {
-		params.Log.Debugf("failed to read .dockerignore: %v", err)
+		log.Debugf("failed to read .dockerignore: %v", err)
 		return "", fmt.Errorf("failed to read dockerignore: %w", err)
 	}
 	excludes = append(excludes, DevsyContextFeatureFolder+"/")
@@ -52,14 +51,14 @@ func CalculatePrebuildHash(params PrebuildHashParams) (string, error) {
 
 	contextHash, err := util.DirectoryHash(params.ContextPath, excludes, includes)
 	if err != nil {
-		params.Log.Debugf("failed to compute context hash for %s: %v", params.ContextPath, err)
+		log.Debugf("failed to compute context hash for %s: %v", params.ContextPath, err)
 		return "", fmt.Errorf("failed to compute context hash: %w", err)
 	}
 
 	combined := arch + string(configJSON) + params.DockerfileContent + contextHash
 	finalHash := pkgconfig.BinaryName + "-" + hash.String(combined)[:32]
 
-	params.Log.Debugf(
+	log.Debugf(
 		"prebuild hash calculated: architecture=%s, contextHash=%s, finalHash=%s, excludeCount=%v, includeCount=%v",
 		arch,
 		contextHash,

--- a/pkg/devcontainer/config/userenvprobe.go
+++ b/pkg/devcontainer/config/userenvprobe.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/shell"
-	"github.com/devsy-org/log"
 )
 
 type UserEnvProbe string
@@ -50,7 +50,6 @@ func ProbeUserEnv(
 	ctx context.Context,
 	probe string,
 	userName string,
-	log log.Logger,
 ) (map[string]string, error) {
 	userEnvProbe, err := NewUserEnvProbe(probe)
 	if err != nil {
@@ -82,7 +81,6 @@ func ProbeUserEnv(
 		userName,
 		"cat /proc/self/environ",
 		'\x00',
-		log,
 	)
 	if err != nil {
 		log.Debugf(
@@ -100,7 +98,6 @@ func ProbeUserEnv(
 			userName,
 			"printenv",
 			'\n',
-			log,
 		)
 		if newErr != nil {
 			log.Warnf("failed to probe user environment variables: %v, %v", err, newErr)
@@ -115,7 +112,7 @@ func ProbeUserEnv(
 	return probedEnv, nil
 }
 
-func parseProbeOutput(out []byte, sep byte, log log.Logger) map[string]string {
+func parseProbeOutput(out []byte, sep byte) map[string]string {
 	// Parse NUL-separated NAME=VALUE entries robustly.
 	entries := bytes.Split(out, []byte{sep})
 	retEnv := make(map[string]string, len(entries))
@@ -145,7 +142,6 @@ func doProbe(
 	userName string,
 	probeCmd string,
 	sep byte,
-	log log.Logger,
 ) (map[string]string, error) {
 	args := preferredShell
 	args = append(args, getShellArgs(userEnvProbe, probeCmd)...)
@@ -164,7 +160,7 @@ func doProbe(
 		return nil, fmt.Errorf("probe user env: %w", err)
 	}
 
-	retEnv := parseProbeOutput(out, sep, log)
+	retEnv := parseProbeOutput(out, sep)
 
 	delete(retEnv, "PWD")
 

--- a/pkg/devcontainer/config/userenvprobe_test.go
+++ b/pkg/devcontainer/config/userenvprobe_test.go
@@ -3,8 +3,6 @@ package config
 import (
 	"reflect"
 	"testing"
-
-	"github.com/devsy-org/log"
 )
 
 //nolint:funlen,lll // It's just test input vectors.
@@ -152,8 +150,7 @@ func TestParseProbeOutput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			testLogger := log.Default.ErrorStreamOnly()
-			result := parseProbeOutput(tt.output, tt.sep, testLogger)
+			result := parseProbeOutput(tt.output, tt.sep)
 
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("parseProbeOutput() mismatch\ngot:  %+v\nwant: %+v", result, tt.expected)

--- a/pkg/devcontainer/crane/run.go
+++ b/pkg/devcontainer/crane/run.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/config"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 )
 
 var craneSigningKey string
@@ -79,7 +78,6 @@ func IsAvailable() bool {
 func PullConfigFromSource(
 	workspaceInfo *provider2.AgentWorkspaceInfo,
 	options *provider2.CLIOptions,
-	log log.Logger,
 ) (string, error) {
 	var data string
 	var err error
@@ -112,13 +110,12 @@ func PullConfigFromSource(
 		return "", err
 	}
 
-	return writeContentToDirectory(workspaceInfo, content, log)
+	return writeContentToDirectory(workspaceInfo, content)
 }
 
 func writeContentToDirectory(
 	workspaceInfo *provider2.AgentWorkspaceInfo,
 	content *Content,
-	_ log.Logger,
 ) (string, error) {
 	path := workspaceInfo.ContentFolder
 	if path == "" {

--- a/pkg/devcontainer/feature/extend.go
+++ b/pkg/devcontainer/feature/extend.go
@@ -13,7 +13,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/graph"
 	"github.com/devsy-org/devsy/pkg/devcontainer/metadata"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
@@ -57,10 +57,9 @@ func GetExtendedBuildInfo(
 	imageBuildInfo *config.ImageBuildInfo,
 	target string,
 	devContainerConfig *config.SubstitutedConfig,
-	log log.Logger,
 	forceBuild bool,
 ) (*ExtendedBuildInfo, error) {
-	features, err := fetchFeatures(devContainerConfig.Config, log, forceBuild)
+	features, err := fetchFeatures(devContainerConfig.Config, forceBuild)
 	if err != nil {
 		return nil, fmt.Errorf("fetch features: %w", err)
 	}
@@ -285,12 +284,10 @@ func findContainerUsers(
 
 func fetchFeatures(
 	devContainerConfig *config.DevContainerConfig,
-	log log.Logger,
 	forceBuild bool,
 ) ([]*config.FeatureSet, error) {
 	processor := &featureProcessor{
 		devContainerConfig: devContainerConfig,
-		log:                log,
 		forceBuild:         forceBuild,
 	}
 
@@ -334,7 +331,6 @@ func getUserFeatures(
 
 type featureProcessor struct {
 	devContainerConfig *config.DevContainerConfig
-	log                log.Logger
 	forceBuild         bool
 }
 
@@ -342,12 +338,12 @@ func (p *featureProcessor) processFeature(
 	featureID string,
 	featureOptions any,
 ) (*config.FeatureSet, error) {
-	featureFolder, err := ProcessFeatureID(featureID, p.devContainerConfig, p.log, p.forceBuild)
+	featureFolder, err := ProcessFeatureID(featureID, p.devContainerConfig, p.forceBuild)
 	if err != nil {
 		return nil, fmt.Errorf("process feature ID %s: %w", featureID, err)
 	}
 
-	p.log.Debugf("parse dev container feature in %s", featureFolder)
+	log.Debugf("parse dev container feature in %s", featureFolder)
 	featureConfig, err := config.ParseDevContainerFeature(featureFolder)
 	if err != nil {
 		return nil, fmt.Errorf("parse feature: %w", err)
@@ -387,7 +383,7 @@ func (r *featureDependencyResolver) resolveFeatureDependency(
 		normalizedDepID := normalizeFeatureID(depID)
 		depFeatureSet, exists := r.features[normalizedDepID]
 		if !exists {
-			r.processor.log.Debugf("installing dependency feature %s", depID)
+			log.Debugf("installing dependency feature %s", depID)
 			var err error
 			depFeatureSet, err = r.processor.processFeature(depID, depOptions)
 			if err != nil {

--- a/pkg/devcontainer/feature/features.go
+++ b/pkg/devcontainer/feature/features.go
@@ -15,7 +15,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/extract"
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/log/hash"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -100,7 +100,6 @@ func escapeQuotesForShell(str string) string {
 func ProcessFeatureID(
 	id string,
 	devContainerConfig *config.DevContainerConfig,
-	log log.Logger,
 	forceBuild bool,
 ) (string, error) {
 	if strings.HasPrefix(id, "https://") || strings.HasPrefix(id, "http://") {
@@ -108,7 +107,6 @@ func ProcessFeatureID(
 		return processDirectTarFeature(
 			id,
 			config.GetDevsyCustomizations(devContainerConfig).FeatureDownloadHTTPHeaders,
-			log,
 			forceBuild,
 		)
 	} else if strings.HasPrefix(id, "./") || strings.HasPrefix(id, "../") {
@@ -120,10 +118,11 @@ func ProcessFeatureID(
 
 	// get oci feature
 	log.Debugf("process feature: type=%s, id=%s", "oci", id)
-	return processOCIFeature(id, log)
+	return processOCIFeature(id)
 }
 
-func processOCIFeature(id string, log log.Logger) (string, error) {
+//nolint:funlen // pre-existing; tracked for cleanup
+func processOCIFeature(id string) (string, error) {
 	log.Debugf("processing OCI feature: featureId=%s", id)
 
 	// feature already exists?
@@ -158,7 +157,7 @@ func processOCIFeature(id string, log log.Logger) (string, error) {
 	}
 
 	destFile := filepath.Join(featureFolder, "feature.tgz")
-	err = downloadLayer(img, id, destFile, log)
+	err = downloadLayer(img, id, destFile)
 	if err != nil {
 		log.Errorf("failed to download feature layer: error=%v, featureId=%s", err, id)
 		return "", err
@@ -191,7 +190,8 @@ func processOCIFeature(id string, log log.Logger) (string, error) {
 	return featureExtractedFolder, nil
 }
 
-func downloadLayer(img v1.Image, id, destFile string, log log.Logger) error {
+//nolint:cyclop // pre-existing; tracked for cleanup
+func downloadLayer(img v1.Image, id, destFile string) error {
 	manifest, err := img.Manifest()
 	if err != nil {
 		return err
@@ -246,7 +246,6 @@ func downloadLayer(img v1.Image, id, destFile string, log log.Logger) error {
 func processDirectTarFeature(
 	id string,
 	httpHeaders map[string]string,
-	log log.Logger,
 	forceDownload bool,
 ) (string, error) {
 	log.Debugf("processing direct tar feature: featureId=%s, forceDownload=%v", id, forceDownload)
@@ -271,7 +270,7 @@ func processDirectTarFeature(
 
 	// download feature tarball
 	downloadFile := filepath.Join(featureFolder, "feature.tgz")
-	err = downloadFeatureFromURL(id, downloadFile, httpHeaders, log)
+	err = downloadFeatureFromURL(id, downloadFile, httpHeaders)
 	if err != nil {
 		log.Errorf("failed to download feature tarball: error=%v, url=%s", err, id)
 		return "", err
@@ -309,7 +308,6 @@ func downloadFeatureFromURL(
 	url string,
 	destFile string,
 	httpHeaders map[string]string,
-	log log.Logger,
 ) error {
 	log.Debugf("starting feature download: url=%s, destFile=%s", url, destFile)
 

--- a/pkg/devcontainer/helpers.go
+++ b/pkg/devcontainer/helpers.go
@@ -10,7 +10,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/file"
 	"github.com/devsy-org/devsy/pkg/git"
 	"github.com/devsy-org/devsy/pkg/image"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
+	oldlog "github.com/devsy-org/log"
 )
 
 type GetWorkspaceConfigResult struct {
@@ -29,7 +30,6 @@ type gitRepoFindOptions struct {
 	tmpDirPath            string
 	strictHostKeyChecking bool
 	maxDepth              int
-	log                   log.Logger
 }
 
 func FindDevcontainerFiles(
@@ -37,12 +37,11 @@ func FindDevcontainerFiles(
 	rawSource, tmpDirPath string,
 	maxDepth int,
 	strictHostKeyChecking bool,
-	log log.Logger,
 ) (*GetWorkspaceConfigResult, error) {
 	// local path
 	isLocalPath, _ := file.IsLocalDir(rawSource)
 	if isLocalPath {
-		return FindFilesInLocalDir(rawSource, maxDepth, log)
+		return FindFilesInLocalDir(rawSource, maxDepth)
 	}
 
 	// git repo
@@ -61,7 +60,6 @@ func FindDevcontainerFiles(
 			tmpDirPath:            tmpDirPath,
 			strictHostKeyChecking: strictHostKeyChecking,
 			maxDepth:              maxDepth,
-			log:                   log,
 		}
 		return findFilesInGitRepo(ctx, opts)
 	}
@@ -84,7 +82,6 @@ func FindDevcontainerFiles(
 func FindFilesInLocalDir(
 	rawSource string,
 	maxDepth int,
-	log log.Logger,
 ) (*GetWorkspaceConfigResult, error) {
 	log.Debug("Local directory detected")
 	result := &GetWorkspaceConfigResult{ConfigPaths: []string{}}
@@ -133,21 +130,21 @@ func findFilesInGitRepo(
 		opts.gitPRReference,
 		opts.gitSubDir,
 	)
-	opts.log.Debugf("Cloning Git repository into %s", opts.tmpDirPath)
+	log.Debugf("Cloning Git repository into %s", opts.tmpDirPath)
 	err := git.CloneRepository(
 		ctx,
 		gitInfo,
 		opts.tmpDirPath,
 		"",
 		opts.strictHostKeyChecking,
-		opts.log,
+		oldlog.Default,
 		git.WithCloneStrategy(git.BareCloneStrategy),
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	opts.log.Debug("Listing git file tree")
+	log.Debug("Listing git file tree")
 	ref := "HEAD"
 	// checkout on branch if available
 	if opts.gitBranch != "" {

--- a/pkg/devcontainer/metadata/metadata.go
+++ b/pkg/devcontainer/metadata/metadata.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 const ImageMetadataLabel = "devcontainer.metadata"
@@ -107,7 +107,6 @@ func DevContainerConfigToImageMetadata(devConfig *config.DevContainerConfig) *co
 func GetImageMetadataFromContainer(
 	containerDetails *config.ContainerDetails,
 	substituteContext *config.SubstitutionContext,
-	log log.Logger,
 ) (*config.ImageMetadataConfig, error) {
 	if containerDetails == nil || containerDetails.Config.Labels == nil ||
 		containerDetails.Config.Labels[ImageMetadataLabel] == "" {
@@ -141,7 +140,6 @@ func GetImageMetadataFromContainer(
 func GetImageMetadata(
 	imageDetails *config.ImageDetails,
 	substituteContext *config.SubstitutionContext,
-	log log.Logger,
 ) (*config.ImageMetadataConfig, error) {
 	if imageDetails == nil {
 		return &config.ImageMetadataConfig{}, nil

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -16,9 +16,8 @@ import (
 
 	"al.essio.dev/pkg/shellescape"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 )
 
 // lifecycleEnv holds the resolved environment for running lifecycle hooks.
@@ -31,11 +30,10 @@ type lifecycleEnv struct {
 func resolveLifecycleEnv(
 	ctx context.Context,
 	setupInfo *config.Result,
-	log log.Logger,
 ) lifecycleEnv {
 	mergedConfig := setupInfo.MergedConfig
 	remoteUser := config.GetRemoteUser(setupInfo)
-	probedEnv, err := config.ProbeUserEnv(ctx, mergedConfig.UserEnvProbe, remoteUser, log)
+	probedEnv, err := config.ProbeUserEnv(ctx, mergedConfig.UserEnvProbe, remoteUser)
 	if err != nil {
 		log.Errorf(
 			"failed to probe environment, this might lead to an incomplete setup of your workspace: error=%v",
@@ -52,14 +50,14 @@ func resolveLifecycleEnv(
 
 // RunPreAttachHooks runs lifecycle hooks up to and including postStartCommand.
 // These must complete before the IDE can be opened.
-func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Logger) error {
-	env := resolveLifecycleEnv(ctx, setupInfo, log)
+func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result) error {
+	env := resolveLifecycleEnv(ctx, setupInfo)
 	containerDetails := setupInfo.ContainerDetails
 	mergedConfig := setupInfo.MergedConfig
 
 	// only run once per container run
 	if err := run(mergedConfig.OnCreateCommands, env.remoteUser, env.workspaceFolder, env.remoteEnv,
-		"onCreateCommands", containerDetails.Created, log); err != nil {
+		"onCreateCommands", containerDetails.Created); err != nil {
 		return err
 	}
 
@@ -71,7 +69,6 @@ func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Lo
 		env.remoteEnv,
 		"updateContentCommands",
 		containerDetails.Created,
-		log,
 	); err != nil {
 		return err
 	}
@@ -84,7 +81,6 @@ func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Lo
 		env.remoteEnv,
 		"postCreateCommands",
 		containerDetails.Created,
-		log,
 	); err != nil {
 		return err
 	}
@@ -97,7 +93,6 @@ func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Lo
 		env.remoteEnv,
 		"postStartCommands",
 		containerDetails.State.StartedAt,
-		log,
 	); err != nil {
 		return err
 	}
@@ -107,8 +102,8 @@ func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Lo
 
 // RunPostAttachHooks runs postAttachCommand only.
 // These run after the IDE has been opened and can be long-running.
-func RunPostAttachHooks(ctx context.Context, setupInfo *config.Result, log log.Logger) error {
-	env := resolveLifecycleEnv(ctx, setupInfo, log)
+func RunPostAttachHooks(ctx context.Context, setupInfo *config.Result) error {
+	env := resolveLifecycleEnv(ctx, setupInfo)
 
 	// run always when attaching to the container
 	return run(
@@ -118,7 +113,6 @@ func RunPostAttachHooks(ctx context.Context, setupInfo *config.Result, log log.L
 		env.remoteEnv,
 		"postAttachCommands",
 		"",
-		log,
 	)
 }
 
@@ -127,7 +121,6 @@ func run(
 	remoteUser, dir string,
 	remoteEnv map[string]string,
 	name, content string,
-	log log.Logger,
 ) error {
 	if len(commands) == 0 {
 		return nil
@@ -193,12 +186,12 @@ func run(
 
 			go func() {
 				defer wg.Done()
-				logPipeOutput(log, stdoutPipe, logrus.InfoLevel)
+				logPipeOutput(stdoutPipe, true)
 			}()
 
 			go func() {
 				defer wg.Done()
-				logPipeOutput(log, stderrPipe, logrus.ErrorLevel)
+				logPipeOutput(stderrPipe, false)
 			}()
 
 			// Wait for command to finish
@@ -214,21 +207,20 @@ func run(
 				return fmt.Errorf("failed to run: %s, error: %w", strings.Join(c, " "), err)
 			}
 
-			log.Donef("ran command: command=%s, args=%s", k, strings.Join(c, " "))
+			log.Infof("ran command: command=%s, args=%s", k, strings.Join(c, " "))
 		}
 	}
 
 	return nil
 }
 
-func logPipeOutput(log log.Logger, pipe io.ReadCloser, level logrus.Level) {
+func logPipeOutput(pipe io.ReadCloser, isStdout bool) {
 	scanner := bufio.NewScanner(pipe)
 	for scanner.Scan() {
 		line := scanner.Text()
-		switch level {
-		case logrus.InfoLevel:
+		if isStdout {
 			log.Info(line)
-		case logrus.ErrorLevel:
+		} else {
 			if containsError(line) {
 				log.Error(line)
 			} else {

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
-	"github.com/devsy-org/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -95,10 +94,10 @@ func (s *LifecycleHookTestSuite) TestLifecycleHooksNoOpWithEmptyConfig() {
 	}
 
 	// Both functions should return nil with empty config (no commands to run)
-	err := RunPreAttachHooks(ctx, result, log.Default)
+	err := RunPreAttachHooks(ctx, result)
 	assert.NoError(s.T(), err)
 
-	err = RunPostAttachHooks(ctx, result, log.Default)
+	err = RunPostAttachHooks(ctx, result)
 	assert.NoError(s.T(), err)
 }
 

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -23,7 +23,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/envfile"
 	"github.com/devsy-org/devsy/pkg/gitcredentials"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -34,7 +34,6 @@ type ContainerSetupConfig struct {
 	ChownProjects     bool
 	PlatformOptions   *devsy.PlatformOptions
 	TunnelClient      tunnel.TunnelClient
-	Log               log.Logger
 }
 
 // SetupContainerPreAttach runs container setup up to and including postStartCommand.
@@ -56,33 +55,30 @@ func SetupContainerPreAttach(ctx context.Context, cfg *ContainerSetupConfig) err
 
 	setupOptionalFeatures(ctx, cfg)
 
-	cfg.Log.Debugf("running pre-attach lifecycle hooks")
-	if err := RunPreAttachHooks(ctx, cfg.SetupInfo, cfg.Log); err != nil {
+	log.Debugf("running pre-attach lifecycle hooks")
+	if err := RunPreAttachHooks(ctx, cfg.SetupInfo); err != nil {
 		return fmt.Errorf("lifecycle hooks pre-attach: %w", err)
 	}
 
-	cfg.Log.Debugf("pre-attach setup completed")
+	log.Debugf("pre-attach setup completed")
 	return nil
 }
 
 // SetupContainerPostAttach runs postAttachCommand only.
 // Called after the IDE has been opened.
 func SetupContainerPostAttach(ctx context.Context, cfg *ContainerSetupConfig) error {
-	cfg.Log.Debugf("running post-attach lifecycle hooks")
-	if err := RunPostAttachHooks(ctx, cfg.SetupInfo, cfg.Log); err != nil {
+	log.Debugf("running post-attach lifecycle hooks")
+	if err := RunPostAttachHooks(ctx, cfg.SetupInfo); err != nil {
 		return fmt.Errorf("lifecycle hooks post-attach: %w", err)
 	}
 
-	cfg.Log.Debugf("devcontainer setup completed")
+	log.Debugf("devcontainer setup completed")
 	return nil
 }
 
 func validateContainerSetupConfig(cfg *ContainerSetupConfig) error {
 	if cfg == nil {
 		return fmt.Errorf("container setup config is nil")
-	}
-	if cfg.Log == nil {
-		return fmt.Errorf("logger not found in container setup config")
 	}
 	if cfg.SetupInfo == nil {
 		return fmt.Errorf("setup info not found in container setup config")
@@ -97,7 +93,7 @@ func validateContainerSetupConfig(cfg *ContainerSetupConfig) error {
 func writeResultFile(cfg *ContainerSetupConfig) {
 	rawBytes, err := json.Marshal(cfg.SetupInfo)
 	if err != nil {
-		cfg.Log.Warnf("error marshal result: %v", err)
+		log.Warnf("error marshal result: %v", err)
 		return
 	}
 
@@ -110,21 +106,21 @@ func writeResultFile(cfg *ContainerSetupConfig) {
 		filepath.Dir(pkgconfig.DevContainerResultPath),
 		0o755,
 	); err != nil {
-		cfg.Log.Warnf("error create %s: %v", filepath.Dir(pkgconfig.DevContainerResultPath), err)
+		log.Warnf("error create %s: %v", filepath.Dir(pkgconfig.DevContainerResultPath), err)
 	}
 
 	if err := os.WriteFile(pkgconfig.DevContainerResultPath, rawBytes, 0o600); err != nil {
-		cfg.Log.Warnf("error write result to %s: %v", pkgconfig.DevContainerResultPath, err)
+		log.Warnf("error write result to %s: %v", pkgconfig.DevContainerResultPath, err)
 	}
 }
 
 func setupWorkspaceOwnership(cfg *ContainerSetupConfig) error {
-	if err := chownWorkspace(cfg.SetupInfo, cfg.ChownProjects, cfg.Log); err != nil {
+	if err := chownWorkspace(cfg.SetupInfo, cfg.ChownProjects); err != nil {
 		return fmt.Errorf("failed to chown workspace: %w", err)
 	}
 
 	if err := linkRootHome(cfg.SetupInfo); err != nil {
-		cfg.Log.Errorf("Error linking /home/root: %v", err)
+		log.Errorf("Error linking /home/root: %v", err)
 	}
 
 	if err := chownAgentSock(cfg.SetupInfo); err != nil {
@@ -135,13 +131,13 @@ func setupWorkspaceOwnership(cfg *ContainerSetupConfig) error {
 }
 
 func setupEnvironment(cfg *ContainerSetupConfig) error {
-	cfg.Log.Debugf("patching etc environment")
+	log.Debugf("patching etc environment")
 
-	if err := patchEtcEnvironment(cfg.SetupInfo.MergedConfig, cfg.Log); err != nil {
+	if err := patchEtcEnvironment(cfg.SetupInfo.MergedConfig); err != nil {
 		return fmt.Errorf("patch etc environment: %w", err)
 	}
 
-	if err := patchEtcEnvironmentFlags(cfg.ExtraWorkspaceEnv, cfg.Log); err != nil {
+	if err := patchEtcEnvironmentFlags(cfg.ExtraWorkspaceEnv); err != nil {
 		return fmt.Errorf("patch etc environment from flags: %w", err)
 	}
 
@@ -153,17 +149,16 @@ func setupEnvironment(cfg *ContainerSetupConfig) error {
 }
 
 func setupOptionalFeatures(ctx context.Context, cfg *ContainerSetupConfig) {
-	if err := setupKubeConfig(ctx, cfg.SetupInfo, cfg.TunnelClient, cfg.Log); err != nil {
-		cfg.Log.Errorf("setup KubeConfig: %v", err)
+	if err := setupKubeConfig(ctx, cfg.SetupInfo, cfg.TunnelClient); err != nil {
+		log.Errorf("setup KubeConfig: %v", err)
 	}
 
 	if cfg.PlatformOptions != nil {
 		if err := setupPlatformGitCredentials(
 			config.GetRemoteUser(cfg.SetupInfo),
 			cfg.PlatformOptions,
-			cfg.Log,
 		); err != nil {
-			cfg.Log.Errorf("setup platform git credentials: %v", err)
+			log.Errorf("setup platform git credentials: %v", err)
 		}
 	}
 }
@@ -201,7 +196,7 @@ func linkRootHome(setupInfo *config.Result) error {
 	return nil
 }
 
-func chownWorkspace(setupInfo *config.Result, recursive bool, log log.Logger) error {
+func chownWorkspace(setupInfo *config.Result, recursive bool) error {
 	user := config.GetRemoteUser(setupInfo)
 	exists, err := markerFileExists("chownWorkspace", "")
 	if err != nil {
@@ -253,7 +248,7 @@ func patchEtcProfile() error {
 	return nil
 }
 
-func patchEtcEnvironmentFlags(workspaceEnv []string, log log.Logger) error {
+func patchEtcEnvironmentFlags(workspaceEnv []string) error {
 	if len(workspaceEnv) == 0 {
 		return nil
 	}
@@ -274,7 +269,7 @@ func patchEtcEnvironmentFlags(workspaceEnv []string, log log.Logger) error {
 	return nil
 }
 
-func patchEtcEnvironment(mergedConfig *config.MergedDevContainerConfig, log log.Logger) error {
+func patchEtcEnvironment(mergedConfig *config.MergedDevContainerConfig) error {
 	if len(mergedConfig.RemoteEnv) == 0 {
 		return nil
 	}
@@ -318,9 +313,8 @@ func setupKubeConfig(
 	ctx context.Context,
 	setupInfo *config.Result,
 	tunnelClient tunnel.TunnelClient,
-	log log.Logger,
 ) error {
-	if shouldSkipKubeConfig(tunnelClient, log) {
+	if shouldSkipKubeConfig(tunnelClient) {
 		return nil
 	}
 	log.Info("setup KubeConfig")
@@ -343,7 +337,7 @@ func setupKubeConfig(
 	return nil
 }
 
-func shouldSkipKubeConfig(tunnelClient tunnel.TunnelClient, log log.Logger) bool {
+func shouldSkipKubeConfig(tunnelClient tunnel.TunnelClient) bool {
 	if tunnelClient == nil {
 		return true
 	}
@@ -454,7 +448,6 @@ func markerFileExists(markerName string, markerContent string) (bool, error) {
 func setupPlatformGitCredentials(
 	userName string,
 	platformOptions *devsy.PlatformOptions,
-	log log.Logger,
 ) error {
 	// platform is not enabled, skip
 	if !platformOptions.Enabled {
@@ -478,13 +471,13 @@ func setupPlatformGitCredentials(
 	}
 
 	// setup platform git http credentials
-	err := setupPlatformGitHTTPCredentials(userName, platformOptions, log)
+	err := setupPlatformGitHTTPCredentials(userName, platformOptions)
 	if err != nil {
 		log.Errorf("Error setting up platform git http credentials: %v", err)
 	}
 
 	// setup platform git ssh keys
-	err = setupPlatformGitSSHKeys(userName, platformOptions, log)
+	err = setupPlatformGitSSHKeys(userName, platformOptions)
 	if err != nil {
 		log.Errorf("Error setting up platform git ssh keys: %v", err)
 	}
@@ -495,7 +488,6 @@ func setupPlatformGitCredentials(
 func setupPlatformGitHTTPCredentials(
 	userName string,
 	platformOptions *devsy.PlatformOptions,
-	log log.Logger,
 ) error {
 	if !platformOptions.Enabled || len(platformOptions.UserCredentials.GitHttp) == 0 {
 		return nil
@@ -517,7 +509,6 @@ func setupPlatformGitHTTPCredentials(
 func setupPlatformGitSSHKeys(
 	userName string,
 	platformOptions *devsy.PlatformOptions,
-	log log.Logger,
 ) error {
 	if !platformOptions.Enabled || len(platformOptions.UserCredentials.GitSsh) == 0 {
 		return nil

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -162,7 +162,6 @@ func (r *runner) mergeExistingContainerConfig(
 	imageMetadataConfig, err := metadata.GetImageMetadataFromContainer(
 		containerDetails,
 		p.substitutionContext,
-		r.Log,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/driver/docker/build.go
+++ b/pkg/driver/docker/build.go
@@ -194,7 +194,6 @@ func (s *buildkitStrategy) build(
 		writer,
 		platform,
 		options,
-		s.driver.Log,
 	); err != nil {
 		return fmt.Errorf("build: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Remove injected `log.Logger` parameters from pkg/devcontainer/ sub-packages (config, setup, feature, metadata, crane, buildkit) and all callers, replacing with package-level `log.Debugf/Infof/Warnf/Errorf` from the new zap-based `pkg/log`
- Refactored `logPipeOutput` in lifecyclehooks.go to use `bool` instead of `logrus.Level`, eliminating the logrus dependency
- Updated 21 files across pkg/devcontainer/, cmd/agent/container/, cmd/helper/, pkg/driver/docker/, and e2e/tests/build/
- Deferred: runner struct `Log` field (cascades to compose Writer paths), buildkit/remote.go, sshtunnel, pkg/client/, pkg/daemon/platform/