### PR TITLE
refactor(log): migrate pkg/ networking and utility packages to pkg/log

### DIFF
--- a/cmd/agent/container/credentials_server.go
+++ b/cmd/agent/container/credentials_server.go
@@ -19,7 +19,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/netstat"
 	portpkg "github.com/devsy-org/devsy/pkg/port"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -84,14 +83,11 @@ func (cmd *CredentialsServerCmd) Run(ctx context.Context, port int) error {
 		return fmt.Errorf("ping client: %w", err)
 	}
 
-	// create debug logger
-	logger := tunnelserver.NewTunnelLogger(ctx, tunnelClient, cmd.Debug)
-
 	// forward ports
 	if cmd.ForwardPorts {
 		go func() {
 			log.Debugf("Start watching & forwarding open ports")
-			err = forwardPorts(ctx, tunnelClient, logger)
+			err = forwardPorts(ctx, tunnelClient)
 			if err != nil {
 				log.Errorf("error forwarding ports: %v", err)
 			}
@@ -106,7 +102,7 @@ func (cmd *CredentialsServerCmd) Run(ctx context.Context, port int) error {
 
 	// configure docker credential helper
 	if cmd.ConfigureDockerHelper {
-		err = dockercredentials.ConfigureCredentialsContainer(cmd.User, port, logger)
+		err = dockercredentials.ConfigureCredentialsContainer(cmd.User, port)
 		if err != nil {
 			return err
 		}
@@ -144,7 +140,7 @@ func (cmd *CredentialsServerCmd) Run(ctx context.Context, port int) error {
 		if err != nil {
 			log.Errorf("Failed to decode git SSH signing key, signing will be unavailable: %v", err)
 		} else {
-			err = gitsshsigning.ConfigureHelper(cmd.User, string(decodedKey), logger)
+			err = gitsshsigning.ConfigureHelper(cmd.User, string(decodedKey))
 			if err != nil {
 				log.Errorf(
 					"Failed to configure git SSH signature helper, signing will be unavailable: %v",
@@ -158,7 +154,7 @@ func (cmd *CredentialsServerCmd) Run(ctx context.Context, port int) error {
 		}
 	}
 
-	return credentials.RunCredentialsServer(ctx, port, tunnelClient, logger)
+	return credentials.RunCredentialsServer(ctx, port, tunnelClient)
 }
 
 func configureGitUserLocally(
@@ -204,8 +200,8 @@ func configureGitUserLocally(
 	return nil
 }
 
-func forwardPorts(ctx context.Context, client tunnel.TunnelClient, logger oldlog.Logger) error {
-	return netstat.NewWatcher(&forwarder{ctx: ctx, client: client}, logger).Run(ctx)
+func forwardPorts(ctx context.Context, client tunnel.TunnelClient) error {
+	return netstat.NewWatcher(&forwarder{ctx: ctx, client: client}).Run(ctx)
 }
 
 type forwarder struct {

--- a/cmd/agent/container/daemon.go
+++ b/cmd/agent/container/daemon.go
@@ -227,7 +227,7 @@ func runNetworkServer(
 		LogF: func(format string, args ...any) {
 			logger.Infof(format, args...)
 		},
-	}, logger)
+	})
 	if err := tsServer.Start(ctx); err != nil {
 		return fmt.Errorf("network server: %w", err)
 	}

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -140,7 +140,6 @@ func (cmd *SetupContainerCmd) prepareWorkspace(sctx *setupContext) error {
 			serverPort, err := credentials.StartCredentialsServer(
 				ctx,
 				sctx.tunnelClient,
-				sctx.logger,
 			)
 			if err != nil {
 				return "", err
@@ -148,7 +147,6 @@ func (cmd *SetupContainerCmd) prepareWorkspace(sctx *setupContext) error {
 			return dockercredentials.ConfigureCredentialsDockerless(
 				agent.DockerlessCredentialsPath,
 				serverPort,
-				sctx.logger,
 			)
 		},
 	}); err != nil {
@@ -162,7 +160,6 @@ func (cmd *SetupContainerCmd) prepareWorkspace(sctx *setupContext) error {
 	cleanupFunc := cmd.setupGitCredentials(
 		sctx.ctx,
 		sctx.tunnelClient,
-		sctx.logger,
 	)
 
 	// Clone repository before cleaning up git credentials
@@ -283,7 +280,6 @@ func (cmd *SetupContainerCmd) syncMounts(sctx *setupContext) error {
 func (cmd *SetupContainerCmd) setupGitCredentials(
 	ctx context.Context,
 	tunnelClient tunnel.TunnelClient,
-	logger oldlog.Logger,
 ) func() {
 	if !cmd.InjectGitCredentials {
 		return nil
@@ -295,7 +291,7 @@ func (cmd *SetupContainerCmd) setupGitCredentials(
 	}
 
 	cancelCtx, cancel := context.WithCancel(ctx)
-	cleanupFunc, err := configureSystemGitCredentials(cancelCtx, tunnelClient, logger)
+	cleanupFunc, err := configureSystemGitCredentials(cancelCtx, tunnelClient)
 	if err != nil {
 		cancel()
 		log.Errorf("error configuring git credentials: %v", err)
@@ -637,13 +633,12 @@ func (cmd *SetupContainerCmd) setupOpenVSCode(
 func configureSystemGitCredentials(
 	ctx context.Context,
 	client tunnel.TunnelClient,
-	logger oldlog.Logger,
 ) (func(), error) {
 	if !command.Exists("git") {
 		return nil, errors.New("git not found")
 	}
 
-	serverPort, err := credentials.StartCredentialsServer(ctx, client, logger)
+	serverPort, err := credentials.StartCredentialsServer(ctx, client)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/agent/container/setup_loft_platform_access.go
+++ b/cmd/agent/container/setup_loft_platform_access.go
@@ -7,7 +7,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/credentials"
 	devsyconfig "github.com/devsy-org/devsy/pkg/loftconfig"
 	"github.com/devsy-org/devsy/pkg/log"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -50,8 +49,6 @@ func NewSetupLoftPlatformAccessCmd(flags *flags.GlobalFlags) *cobra.Command {
 // Run executes main command logic.
 // It fetches Devsy Platform credentials from credentials server and sets it up inside the workspace.
 func (c *SetupLoftPlatformAccessCmd) Run(_ *cobra.Command, args []string) error {
-	logger := oldlog.Default.ErrorStreamOnly()
-
 	port, err := credentials.GetPort()
 	if err != nil {
 		return fmt.Errorf("get port: %w", err)
@@ -61,7 +58,7 @@ func (c *SetupLoftPlatformAccessCmd) Run(_ *cobra.Command, args []string) error 
 		port = c.Port
 	}
 
-	loftConfig, err := devsyconfig.GetDevsyConfig(c.Context, c.Provider, port, logger)
+	loftConfig, err := devsyconfig.GetDevsyConfig(c.Context, c.Provider, port)
 	if err != nil {
 		return err
 	}
@@ -71,13 +68,13 @@ func (c *SetupLoftPlatformAccessCmd) Run(_ *cobra.Command, args []string) error 
 		return nil
 	}
 
-	err = devsyconfig.AuthDevsyCliToPlatform(loftConfig, logger)
+	err = devsyconfig.AuthDevsyCliToPlatform(loftConfig)
 	if err != nil {
 		// log error but don't return to allow other CLIs to install as well
 		log.Warnf("unable to authenticate devsy cli: %v", err)
 	}
 
-	err = devsyconfig.AuthVClusterCliToPlatform(loftConfig, logger)
+	err = devsyconfig.AuthVClusterCliToPlatform(loftConfig)
 	if err != nil {
 		// log error but don't return to allow other CLIs to install as well
 		log.Warnf("unable to authenticate vcluster cli: %v", err)

--- a/cmd/agent/container/ssh_server.go
+++ b/cmd/agent/container/ssh_server.go
@@ -2,21 +2,13 @@ package container
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 
 	"github.com/devsy-org/devsy/cmd/flags"
-	"github.com/devsy-org/devsy/pkg/agent"
-	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
 	helperssh "github.com/devsy-org/devsy/pkg/ssh/server"
 	"github.com/devsy-org/devsy/pkg/ssh/server/port"
-	oldlog "github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
-
-var BaseLogDir = agent.ContainerDataDir
 
 // SSHServerCmd holds the ssh server cmd flags.
 type SSHServerCmd struct {
@@ -50,8 +42,7 @@ func NewSSHServerCmd(flags *flags.GlobalFlags) *cobra.Command {
 
 // Run runs the command logic.
 func (cmd *SSHServerCmd) Run(_ *cobra.Command, _ []string) error {
-	logger := getFileLogger(cmd.RemoteUser, cmd.Debug)
-	server, err := helperssh.NewContainerServer(cmd.Address, cmd.Workdir, logger)
+	server, err := helperssh.NewContainerServer(cmd.Address, cmd.Workdir)
 	if err != nil {
 		return err
 	}
@@ -68,23 +59,4 @@ func (cmd *SSHServerCmd) Run(_ *cobra.Command, _ []string) error {
 	}
 
 	return server.ListenAndServe()
-}
-
-func getFileLogger(remoteUser string, debug bool) oldlog.Logger {
-	logLevel := logrus.InfoLevel
-	if debug {
-		logLevel = logrus.DebugLevel
-	}
-	fallback := oldlog.NewDiscardLogger(logLevel)
-
-	targetFolder := filepath.Join(os.TempDir(), config.ConfigDirName)
-	if remoteUser != "" {
-		targetFolder = filepath.Join(BaseLogDir, remoteUser)
-	}
-	err := os.MkdirAll(targetFolder, 0o755)
-	if err != nil {
-		return fallback
-	}
-
-	return oldlog.NewFileLogger(filepath.Join(targetFolder, "ssh.log"), logLevel)
 }

--- a/cmd/agent/git_ssh_signature.go
+++ b/cmd/agent/git_ssh_signature.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/gitsshsigning"
 	"github.com/devsy-org/devsy/pkg/log"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -50,7 +49,7 @@ func NewGitSSHSignatureCmd(flags *flags.GlobalFlags) *cobra.Command {
 			}
 
 			return gitsshsigning.HandleGitSSHProgramCall(
-				parsed.certPath, parsed.namespace, parsed.bufferFile, oldlog.Default)
+				parsed.certPath, parsed.namespace, parsed.bufferFile)
 		},
 	}
 }

--- a/cmd/agent/git_ssh_signature_helper.go
+++ b/cmd/agent/git_ssh_signature_helper.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/gitsshsigning"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -47,7 +46,7 @@ func NewGitSSHSignatureHelperCmd(flags *flags.GlobalFlags) *cobra.Command {
 			}
 			cmd.CertPath = args[0]
 
-			err = gitsshsigning.ConfigureHelper(usr.Username, cmd.CertPath, oldlog.Default)
+			err = gitsshsigning.ConfigureHelper(usr.Username, cmd.CertPath)
 			if err != nil {
 				return err
 			}

--- a/cmd/agent/workspace/install_dotfiles.go
+++ b/cmd/agent/workspace/install_dotfiles.go
@@ -12,7 +12,6 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/git"
 	"github.com/devsy-org/devsy/pkg/log"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -50,7 +49,6 @@ func NewInstallDotfilesCmd(flags *flags.GlobalFlags) *cobra.Command {
 
 // Run runs the command logic.
 func (cmd *InstallDotfilesCmd) Run(ctx context.Context) error {
-	logger := oldlog.Default.ErrorStreamOnly()
 	targetDir := filepath.Join(os.Getenv("HOME"), "dotfiles")
 
 	_, err := os.Stat(targetDir)
@@ -64,7 +62,6 @@ func (cmd *InstallDotfilesCmd) Run(ctx context.Context) error {
 			targetDir,
 			"",
 			cmd.StrictHostKeyChecking,
-			logger,
 		); err != nil {
 			return err
 		}

--- a/cmd/agent/workspace/setup_gpg.go
+++ b/cmd/agent/workspace/setup_gpg.go
@@ -10,7 +10,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/gitcredentials"
 	"github.com/devsy-org/devsy/pkg/gpg"
 	"github.com/devsy-org/devsy/pkg/log"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -152,7 +151,7 @@ func getPublicKeys() (string, error) {
 		return "", fmt.Errorf("get port: %w", err)
 	}
 
-	out, err := credentials.PostWithRetry(port, "gpg-public-keys", nil, oldlog.Default)
+	out, err := credentials.PostWithRetry(port, "gpg-public-keys", nil)
 	if err != nil {
 		return "", fmt.Errorf("get public gpg keys: %w", err)
 	}

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -656,7 +656,7 @@ func configureCredentials(cfg credentialsConfig) (string, string, error) {
 		return "", "", nil
 	}
 
-	serverPort, err := credentials.StartCredentialsServer(cfg.ctx, cfg.client, cfg.log)
+	serverPort, err := credentials.StartCredentialsServer(cfg.ctx, cfg.client)
 	if err != nil {
 		return "", "", err
 	}
@@ -675,7 +675,6 @@ func configureCredentials(cfg credentialsConfig) (string, string, error) {
 		dockerCredentials, err = dockercredentials.ConfigureCredentialsMachine(
 			cfg.workspaceInfo.Origin,
 			serverPort,
-			cfg.log,
 		)
 		if err != nil {
 			return "", "", err

--- a/cmd/helper/docker_credentials.go
+++ b/cmd/helper/docker_credentials.go
@@ -7,7 +7,6 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/credentials"
 	"github.com/devsy-org/devsy/pkg/dockercredentials"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -42,5 +41,5 @@ func (c *DockerCredentialsHelperCmd) Run(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("get port: %w", err)
 	}
 
-	return dockercredentials.ConfigureCredentialsContainer(u.Name, port, oldlog.Default)
+	return dockercredentials.ConfigureCredentialsContainer(u.Name, port)
 }

--- a/cmd/helper/ssh_server.go
+++ b/cmd/helper/ssh_server.go
@@ -104,7 +104,6 @@ func (cmd *SSHServerCmd) Run(_ *cobra.Command, _ []string) error {
 		keys,
 		cmd.Workdir,
 		cmd.ReuseSSHAuthSock,
-		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return err

--- a/cmd/pro/add/cluster.go
+++ b/cmd/pro/add/cluster.go
@@ -98,7 +98,7 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 	// Get clusterName from command argument
 	clusterName := args[0]
 
-	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host, oldlog.Default)
+	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host)
 	if err != nil {
 		return err
 	}
@@ -281,7 +281,7 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 		close(errChan)
 	}()
 
-	_, err = platform.WaitForPodReady(ctx, clientset, namespace, oldlog.Default)
+	_, err = platform.WaitForPodReady(ctx, clientset, namespace)
 	if err = errors.Join(err, <-errChan); err != nil {
 		return fmt.Errorf("wait for pod: %w", err)
 	}

--- a/cmd/pro/import_workspace.go
+++ b/cmd/pro/import_workspace.go
@@ -19,7 +19,6 @@ import (
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/random"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 )
@@ -112,7 +111,6 @@ func (cmd *ImportCmd) Run(ctx context.Context, args []string) error {
 		ctx,
 		devsyConfig,
 		provider.Name,
-		oldlog.Default,
 	)
 	if err != nil {
 		return fmt.Errorf("base client: %w", err)
@@ -203,7 +201,6 @@ func (cmd *ImportCmd) writeWorkspaceDefinition(
 		false,
 		false,
 		nil,
-		oldlog.Default,
 	)
 	if err != nil {
 		return fmt.Errorf("resolve options: %w", err)

--- a/cmd/pro/list.go
+++ b/cmd/pro/list.go
@@ -12,7 +12,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/table"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -153,7 +152,6 @@ func checkLogin(
 		"",
 		true,
 		false,
-		oldlog.Default,
 	); err != nil {
 		return fmt.Errorf("not logged into %s", proInstance.Host)
 	}

--- a/cmd/pro/login.go
+++ b/cmd/pro/login.go
@@ -208,7 +208,6 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string, log oldlog.Logger)
 			cmd.AccessKey,
 			false,
 			cmd.ForceBrowser,
-			log,
 		)
 		if err != nil {
 			return err
@@ -299,7 +298,6 @@ func login(
 	providerName string,
 	accessKey string,
 	skipBrowserLogin, forceBrowser bool,
-	log oldlog.Logger,
 ) error {
 	configPath, err := platform.DevsyConfigPath(devsyConfig.DefaultContext, providerName)
 	if err != nil {
@@ -329,7 +327,7 @@ func login(
 		if skipBrowserLogin {
 			return fmt.Errorf("unable to login to loft host")
 		}
-		err = loader.Login(url, true, log)
+		err = loader.Login(url, true)
 	}
 	if err != nil {
 		return err

--- a/cmd/pro/provider/create/workspace.go
+++ b/cmd/pro/provider/create/workspace.go
@@ -15,7 +15,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform/form"
 	"github.com/devsy-org/devsy/pkg/platform/project"
 	"github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/log/terminal"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -116,7 +115,6 @@ func (cmd *WorkspaceCmd) Run(
 		workspaceUID,
 		workspaceSource,
 		workspacePicture,
-		oldlog.Default,
 	)
 	if err != nil {
 		return err
@@ -164,5 +162,5 @@ func createInstance(
 		return nil, fmt.Errorf("create workspace instance: %w", err)
 	}
 
-	return platform.WaitForInstance(ctx, client, updatedInstance, oldlog.Default)
+	return platform.WaitForInstance(ctx, client, updatedInstance)
 }

--- a/cmd/pro/provider/rebuild.go
+++ b/cmd/pro/provider/rebuild.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/remotecommand"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -68,7 +67,7 @@ func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 	values := url.Values{"options": []string{string(rawOpts)}, "cliMode": []string{"true"}}
-	conn, err := platform.DialInstance(baseClient, workspace, "up", values, oldlog.Default)
+	conn, err := platform.DialInstance(baseClient, workspace, "up", values)
 	if err != nil {
 		return err
 	}
@@ -79,7 +78,6 @@ func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 		os.Stdin,
 		os.Stdout,
 		os.Stderr,
-		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return fmt.Errorf("error executing: %w", err)

--- a/cmd/pro/provider/ssh.go
+++ b/cmd/pro/provider/ssh.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/remotecommand"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -66,7 +65,6 @@ func (cmd *SshCmd) Run(
 		workspace,
 		"ssh",
 		platform.OptionsFromEnv(config.EnvFlagsSSH),
-		oldlog.Default,
 	)
 	if err != nil {
 		return err
@@ -78,7 +76,6 @@ func (cmd *SshCmd) Run(
 		stdin,
 		stdout,
 		stderr,
-		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return fmt.Errorf("error executing: %w", err)

--- a/cmd/pro/provider/status.go
+++ b/cmd/pro/provider/status.go
@@ -13,7 +13,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/remotecommand"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -79,7 +78,6 @@ func (cmd *StatusCmd) Run(
 		workspace,
 		"getstatus",
 		platform.OptionsFromEnv(config.EnvFlagsStatus),
-		oldlog.Default,
 	)
 	if err != nil {
 		return err
@@ -91,7 +89,6 @@ func (cmd *StatusCmd) Run(
 		stdin,
 		stdout,
 		stderr,
-		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return fmt.Errorf("error executing: %w", err)

--- a/cmd/pro/provider/stop.go
+++ b/cmd/pro/provider/stop.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/remotecommand"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -66,7 +65,6 @@ func (cmd *StopCmd) Run(
 		workspace,
 		"stop",
 		platform.OptionsFromEnv(storagev1.DevsyFlagsStop),
-		oldlog.Default,
 	)
 	if err != nil {
 		return err
@@ -78,7 +76,6 @@ func (cmd *StopCmd) Run(
 		stdin,
 		stdout,
 		stderr,
-		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return fmt.Errorf("error executing: %w", err)

--- a/cmd/pro/provider/up.go
+++ b/cmd/pro/provider/up.go
@@ -15,7 +15,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/remotecommand"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -93,7 +92,6 @@ func (cmd *UpCmd) Run(ctx context.Context) error {
 			baseClient,
 			oldInstance,
 			instance,
-			oldlog.Default,
 		)
 		if err != nil {
 			return fmt.Errorf("update instance: %w", err)
@@ -114,7 +112,7 @@ func (cmd *UpCmd) up(
 		options.Add("debug", config.BoolTrue)
 	}
 
-	conn, err := platform.DialInstance(client, workspace, "up", options, oldlog.Default)
+	conn, err := platform.DialInstance(client, workspace, "up", options)
 	if err != nil {
 		return err
 	}
@@ -125,7 +123,6 @@ func (cmd *UpCmd) up(
 		cmd.streams.Stdin,
 		cmd.streams.Stdout,
 		cmd.streams.Stderr,
-		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return fmt.Errorf("error executing: %w", err)

--- a/cmd/pro/provider/update/workspace.go
+++ b/cmd/pro/provider/update/workspace.go
@@ -13,7 +13,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/form"
 	"github.com/devsy-org/devsy/pkg/platform/project"
-	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/log/terminal"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -120,7 +119,7 @@ func (cmd *WorkspaceCmd) Run(
 		)
 	}
 
-	newInstance, err := form.UpdateInstance(ctx, baseClient, oldInstance, oldlog.Default)
+	newInstance, err := form.UpdateInstance(ctx, baseClient, oldInstance)
 	if err != nil {
 		return err
 	}
@@ -144,5 +143,5 @@ func updateInstance(
 		newInstance.Spec.TemplateRef.SyncOnce = true
 	}
 
-	return platform.UpdateInstance(ctx, client, oldInstance, newInstance, oldlog.Default)
+	return platform.UpdateInstance(ctx, client, oldInstance, newInstance)
 }

--- a/cmd/pro/rebuild.go
+++ b/cmd/pro/rebuild.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/remotecommand"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -55,7 +54,7 @@ func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host, oldlog.Default)
+	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host)
 	if err != nil {
 		return fmt.Errorf("resolve host \"%s\": %w", cmd.Host, err)
 	}
@@ -77,7 +76,7 @@ func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 	values := url.Values{"options": []string{string(rawOpts)}, "cliMode": []string{"true"}}
-	conn, err := platform.DialInstance(baseClient, workspace, "up", values, oldlog.Default)
+	conn, err := platform.DialInstance(baseClient, workspace, "up", values)
 	if err != nil {
 		return err
 	}
@@ -88,7 +87,6 @@ func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 		os.Stdin,
 		os.Stdout,
 		os.Stderr,
-		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return fmt.Errorf("error executing: %w", err)

--- a/cmd/pro/sleep.go
+++ b/cmd/pro/sleep.go
@@ -13,7 +13,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/project"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -66,7 +65,7 @@ func (cmd *SleepCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host, oldlog.Default)
+	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host)
 	if err != nil {
 		return err
 	}

--- a/cmd/pro/start.go
+++ b/cmd/pro/start.go
@@ -1158,7 +1158,7 @@ func (cmd *StartCmd) handleAlreadyExistingInstallation(ctx context.Context) erro
 func (cmd *StartCmd) waitForDeployment(ctx context.Context) (*corev1.Pod, error) {
 	// wait for loft pod to start
 	log.Info("waiting for Devsy Pro pod to be running")
-	loftPod, err := platform.WaitForPodReady(ctx, cmd.KubeClient, cmd.Namespace, oldlog.Default)
+	loftPod, err := platform.WaitForPodReady(ctx, cmd.KubeClient, cmd.Namespace)
 	log.Infof("release Pod started")
 	if err != nil {
 		return nil, err

--- a/cmd/pro/wakeup.go
+++ b/cmd/pro/wakeup.go
@@ -13,7 +13,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/project"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -60,7 +59,7 @@ func (cmd *WakeupCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host, oldlog.Default)
+	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host)
 	if err != nil {
 		return err
 	}

--- a/cmd/provider/use.go
+++ b/cmd/provider/use.go
@@ -196,7 +196,7 @@ func configureProviderOptions(
 	// fill defaults
 	devsyConfig, err = options2.ResolveOptions(
 		ctx, devsyConfig, cfg.Provider, options,
-		cfg.SkipRequired, cfg.SkipSubOptions, cfg.SingleMachine, cfg.Log,
+		cfg.SkipRequired, cfg.SkipSubOptions, cfg.SingleMachine,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("resolve options: %w", err)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -178,7 +178,7 @@ func (cmd *SSHCmd) Run(
 		log.Debug(
 			"adding ssh keys to agent, disable via 'devsy context set-options -o SSH_ADD_PRIVATE_KEYS=false'",
 		)
-		err := devssh.AddPrivateKeysToAgent(ctx, log)
+		err := devssh.AddPrivateKeysToAgent(ctx)
 		if err != nil {
 			log.Debugf("Error adding private keys to ssh-agent: %v", err)
 		}
@@ -271,7 +271,7 @@ func (cmd *SSHCmd) jumpContainerTailscale(
 	// Handle GPG agent forwarding
 	if cmd.GPGAgentForwarding ||
 		devsyConfig.ContextOption(config.ContextOptionGPGAgentForwarding) == config.BoolTrue {
-		if gpg.IsGpgTunnelRunning(ctx, cmd.User, toolSSHClient, log) {
+		if gpg.IsGpgTunnelRunning(ctx, cmd.User, toolSSHClient) {
 			log.Debugf("[GPG] exporting already running, skipping")
 		} else if err := cmd.setupGPGAgent(ctx, toolSSHClient, log); err != nil {
 			return err
@@ -369,7 +369,7 @@ func (cmd *SSHCmd) jumpContainer(
 	}
 
 	// tunnel to container
-	return tunnel.NewContainerTunnel(client, log).
+	return tunnel.NewContainerTunnel(client).
 		Run(ctx, func(ctx context.Context, containerClient *ssh.Client) error {
 			// we have a connection to the container, make sure others can connect as well
 			client.Unlock()
@@ -427,7 +427,6 @@ func (cmd *SSHCmd) reverseForwardPorts(
 				mapping.Container.Protocol,
 				mapping.Container.Address,
 				timeout,
-				log,
 			)
 			if !errors.Is(io.EOF, err) {
 				errChan <- fmt.Errorf("error forwarding %s: %w", portMapping, err)
@@ -472,7 +471,6 @@ func (cmd *SSHCmd) forwardPorts(
 				mapping.Container.Protocol,
 				mapping.Container.Address,
 				timeout,
-				log,
 			)
 			if !errors.Is(io.EOF, err) {
 				errChan <- fmt.Errorf("error forwarding %s: %w", portMapping, err)
@@ -532,7 +530,7 @@ func (cmd *SSHCmd) startTunnel(
 		devsyConfig.ContextOption(config.ContextOptionGPGAgentForwarding) == config.BoolTrue {
 		// Check if a forwarding is already enabled and running, in that case
 		// we skip the forwarding and keep using the original one
-		if gpg.IsGpgTunnelRunning(ctx, cmd.User, containerClient, log) {
+		if gpg.IsGpgTunnelRunning(ctx, cmd.User, containerClient) {
 			log.Debugf("[GPG] exporting already running, skipping")
 		} else {
 			err := cmd.setupGPGAgent(ctx, containerClient, log)
@@ -673,7 +671,6 @@ func (cmd *SSHCmd) startServices(
 				ConfigureGitCredentials:        configureGitCredentials,
 				ConfigureGitSSHSignatureHelper: configureGitSSHSignatureHelper,
 				GitSSHSigningKey:               gitSSHSigningKey,
-				Log:                            log,
 			},
 		)
 		if err != nil {

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -182,7 +182,7 @@ func collectProWorkspaceInfo(
 	workspaceUID string,
 	project string,
 ) (*managementv1.DevsyWorkspaceInstanceTroubleshoot, error) {
-	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, host, logger)
+	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, host)
 	if err != nil {
 		return nil, fmt.Errorf("init client from host: %w", err)
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -371,7 +371,6 @@ func (cmd *UpCmd) configureWorkspace(
 		EnvKeyValues: cmd.DotfilesScriptEnv,
 		Client:       client,
 		DevsyConfig:  devsyConfig,
-		Log:          log,
 	}); err != nil {
 		return err
 	}
@@ -693,7 +692,6 @@ func configureSSH(client client2.BaseWorkspaceClient, params configureSSHParams)
 		GPGAgent:             params.gpgagent,
 		DevsyHome:            params.devsyHome,
 		Provider:             client.Provider(),
-		Log:                  oldlog.Default,
 	})
 	if err != nil {
 		return err

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/devsy-org/devsy/pkg/upgrade"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -23,7 +22,7 @@ func NewUpgradeCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			ctx := cobraCmd.Context()
-			if err := upgrade.Upgrade(ctx, cmd.Version, cmd.DryRun, oldlog.Default); err != nil {
+			if err := upgrade.Upgrade(ctx, cmd.Version, cmd.DryRun); err != nil {
 				return fmt.Errorf("unable to upgrade: %w", err)
 			}
 			return nil

--- a/e2e/tests/build/build.go
+++ b/e2e/tests/build/build.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/dockerfile"
-	"github.com/devsy-org/log"
 	"github.com/onsi/ginkgo/v2"
 )
 
@@ -67,7 +66,7 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 		var err error
 		initialDir, err = os.Getwd()
 		framework.ExpectNoError(err)
-		dockerHelper = &docker.DockerHelper{DockerCommand: "docker", Log: log.Default}
+		dockerHelper = &docker.DockerHelper{DockerCommand: "docker"}
 	})
 
 	ginkgo.It("build docker buildx",

--- a/e2e/tests/up-docker-compose/build.go
+++ b/e2e/tests/up-docker-compose/build.go
@@ -13,7 +13,6 @@ import (
 	"github.com/devsy-org/devsy/e2e/framework"
 	"github.com/devsy-org/devsy/pkg/compose"
 	docker "github.com/devsy-org/devsy/pkg/docker"
-	"github.com/devsy-org/log"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -32,7 +31,7 @@ var _ = ginkgo.Describe(
 			initialDir, err = os.Getwd()
 			framework.ExpectNoError(err)
 
-			dockerHelper = &docker.DockerHelper{DockerCommand: "docker", Log: log.Default}
+			dockerHelper = &docker.DockerHelper{DockerCommand: "docker"}
 			composeHelper, err = compose.NewComposeHelper(dockerHelper)
 			framework.ExpectNoError(err)
 

--- a/e2e/tests/up-docker-compose/config.go
+++ b/e2e/tests/up-docker-compose/config.go
@@ -13,7 +13,6 @@ import (
 	"github.com/devsy-org/devsy/e2e/framework"
 	"github.com/devsy-org/devsy/pkg/compose"
 	docker "github.com/devsy-org/devsy/pkg/docker"
-	"github.com/devsy-org/log"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -30,7 +29,7 @@ var _ = ginkgo.Describe(
 			tc.initialDir, err = os.Getwd()
 			framework.ExpectNoError(err)
 
-			tc.dockerHelper = &docker.DockerHelper{DockerCommand: "docker", Log: log.Default}
+			tc.dockerHelper = &docker.DockerHelper{DockerCommand: "docker"}
 			tc.composeHelper, err = compose.NewComposeHelper(tc.dockerHelper)
 			framework.ExpectNoError(err)
 

--- a/e2e/tests/up-docker-compose/up_docker_compose.go
+++ b/e2e/tests/up-docker-compose/up_docker_compose.go
@@ -17,7 +17,6 @@ import (
 	"github.com/devsy-org/devsy/e2e/framework"
 	"github.com/devsy-org/devsy/pkg/compose"
 	docker "github.com/devsy-org/devsy/pkg/docker"
-	"github.com/devsy-org/log"
 	"github.com/docker/docker/api/types/container"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -35,7 +34,7 @@ var _ = ginkgo.Describe(
 			tc.initialDir, err = os.Getwd()
 			framework.ExpectNoError(err)
 
-			tc.dockerHelper = &docker.DockerHelper{DockerCommand: "docker", Log: log.Default}
+			tc.dockerHelper = &docker.DockerHelper{DockerCommand: "docker"}
 			tc.composeHelper, err = compose.NewComposeHelper(tc.dockerHelper)
 			framework.ExpectNoError(err)
 

--- a/e2e/tests/up/docker_wsl.go
+++ b/e2e/tests/up/docker_wsl.go
@@ -10,7 +10,6 @@ import (
 	"github.com/devsy-org/devsy/e2e/framework"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	docker "github.com/devsy-org/devsy/pkg/docker"
-	"github.com/devsy-org/log"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -24,7 +23,7 @@ var _ = ginkgo.Describe("testing up command for windows", ginkgo.Label("up-docke
 	ginkgo.BeforeEach(func(ctx context.Context) {
 		initialDir, err = os.Getwd()
 		framework.ExpectNoError(err)
-		dockerHelper = &docker.DockerHelper{DockerCommand: "podman", Log: log.Default}
+		dockerHelper = &docker.DockerHelper{DockerCommand: "podman"}
 		f, err = setupDockerProvider(filepath.Join(initialDir, "bin"), "podman")
 		framework.ExpectNoError(err)
 	})

--- a/e2e/tests/up/dockerfile_build.go
+++ b/e2e/tests/up/dockerfile_build.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devsy-org/devsy/e2e/framework"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	docker "github.com/devsy-org/devsy/pkg/docker"
-	"github.com/devsy-org/log"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -27,7 +26,7 @@ var _ = ginkgo.Describe(
 			initialDir, err = os.Getwd()
 			framework.ExpectNoError(err)
 
-			dockerHelper = &docker.DockerHelper{DockerCommand: "docker", Log: log.Default}
+			dockerHelper = &docker.DockerHelper{DockerCommand: "docker"}
 
 			f, err = setupDockerProvider(initialDir+"/bin", "docker")
 			framework.ExpectNoError(err)

--- a/e2e/tests/up/dotfiles.go
+++ b/e2e/tests/up/dotfiles.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/devsy-org/devsy/e2e/framework"
 	docker "github.com/devsy-org/devsy/pkg/docker"
-	"github.com/devsy-org/log"
 	"github.com/onsi/ginkgo/v2"
 )
 
@@ -22,7 +21,7 @@ var _ = ginkgo.Describe(
 			dtc.initialDir, err = os.Getwd()
 			framework.ExpectNoError(err)
 
-			dtc.dockerHelper = &docker.DockerHelper{DockerCommand: "docker", Log: log.Default}
+			dtc.dockerHelper = &docker.DockerHelper{DockerCommand: "docker"}
 			dtc.f, err = setupDockerProvider(dtc.initialDir+"/bin", "docker")
 			framework.ExpectNoError(err)
 		})

--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/devsy-org/devsy/e2e/framework"
 	docker "github.com/devsy-org/devsy/pkg/docker"
-	"github.com/devsy-org/log"
 	"github.com/docker/docker/api/types/container"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -30,7 +29,7 @@ var _ = ginkgo.Describe(
 			dtc.initialDir, err = os.Getwd()
 			framework.ExpectNoError(err)
 
-			dtc.dockerHelper = &docker.DockerHelper{DockerCommand: "docker", Log: log.Default}
+			dtc.dockerHelper = &docker.DockerHelper{DockerCommand: "docker"}
 			dtc.f, err = setupDockerProvider(filepath.Join(dtc.initialDir, "bin"), "docker")
 			framework.ExpectNoError(err)
 		})

--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	docker "github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/language"
-	"github.com/devsy-org/log"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -25,7 +24,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-workspaces"), fun
 		initialDir, err = os.Getwd()
 		framework.ExpectNoError(err)
 
-		dockerHelper = &docker.DockerHelper{DockerCommand: "docker", Log: log.Default}
+		dockerHelper = &docker.DockerHelper{DockerCommand: "docker"}
 	})
 
 	ginkgo.It("with env vars", func(ctx context.Context) {

--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -17,7 +17,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/shell"
 	"github.com/devsy-org/devsy/pkg/version"
-	oldlog "github.com/devsy-org/log"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
@@ -234,7 +233,6 @@ func injectAgent(ctx *injectContext) error {
 		Stdout:       opts.Stdout,
 		Stderr:       stderr,
 		Timeout:      opts.Timeout,
-		Log:          oldlog.Default.ErrorStreamOnly(),
 	})
 	if err != nil {
 		return handleInjectError(err, wasExecuted, buf)

--- a/pkg/agent/workspace.go
+++ b/pkg/agent/workspace.go
@@ -22,7 +22,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/util"
-	oldlog "github.com/devsy-org/log"
 	"github.com/moby/patternmatcher/ignorefile"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -289,7 +288,7 @@ func CloneRepositoryForWorkspace(
 				"seems like git isn't installed on your system. Please make sure to install git and make it available in the PATH",
 			)
 		}
-		if err := git.InstallBinary(oldlog.Default.ErrorStreamOnly()); err != nil {
+		if err := git.InstallBinary(); err != nil {
 			return err
 		}
 	}
@@ -412,7 +411,6 @@ func CloneRepositoryForWorkspace(
 			workspaceDir,
 			helper,
 			options.StrictHostKeyChecking,
-			oldlog.Default.ErrorStreamOnly(),
 			getGitOptions(options)...)
 		if err != nil {
 			// cleanup workspace dir if clone failed, otherwise we won't try to clone again when rebuilding this workspace

--- a/pkg/client/clientimplementation/daemonclient/client.go
+++ b/pkg/client/clientimplementation/daemonclient/client.go
@@ -112,7 +112,6 @@ func (c *client) RefreshOptions(
 		c.config,
 		c.workspace,
 		userOptions,
-		c.log,
 		resolver.WithResolveSubOptions(),
 	)
 	if err != nil {
@@ -135,7 +134,7 @@ func (c *client) CheckWorkspaceReachable(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("resolve workspace hostname: %w", err)
 	}
-	err = ts.WaitHostReachable(ctx, c.tsClient, wAddr, 5, c.log)
+	err = ts.WaitHostReachable(ctx, c.tsClient, wAddr, 5)
 	if err != nil {
 		instance, getWorkspaceErr := c.localClient.GetWorkspace(ctx, c.workspace.UID)
 		// if we can't reach the daemon try to start the desktop app
@@ -155,7 +154,7 @@ func (c *client) CheckWorkspaceReachable(ctx context.Context) error {
 			time.Sleep(2 * time.Second)
 
 			// let's try again
-			err = ts.WaitHostReachable(ctx, c.tsClient, wAddr, 20, c.log)
+			err = ts.WaitHostReachable(ctx, c.tsClient, wAddr, 20)
 			if err != nil {
 				instance, getWorkspaceErr = c.localClient.GetWorkspace(ctx, c.workspace.UID)
 			} else {
@@ -210,11 +209,11 @@ func (c *client) SSHClients(
 		return c.tsClient.DialTCP(ctx, addressParts[0], uint16(port))
 	}
 
-	toolClient, err = ts.WaitForSSHClient(ctx, dial, "tcp", address, "root", time.Second*10, c.log)
+	toolClient, err = ts.WaitForSSHClient(ctx, dial, "tcp", address, "root", time.Second*10)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create SSH tool client: %w", err)
 	}
-	userClient, err = ts.WaitForSSHClient(ctx, dial, "tcp", address, user, time.Second*10, c.log)
+	userClient, err = ts.WaitForSSHClient(ctx, dial, "tcp", address, user, time.Second*10)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create SSH user client: %w", err)
 	}

--- a/pkg/client/clientimplementation/daemonclient/up.go
+++ b/pkg/client/clientimplementation/daemonclient/up.go
@@ -70,7 +70,7 @@ func (c *client) Up(ctx context.Context, opt clientpkg.UpOptions) (*config.Resul
 		oldInstance := instance.DeepCopy()
 		instance.Spec.TemplateRef.SyncOnce = true
 
-		instance, err = platform.UpdateInstance(ctx, baseClient, oldInstance, instance, c.log)
+		instance, err = platform.UpdateInstance(ctx, baseClient, oldInstance, instance)
 		if err != nil {
 			return nil, fmt.Errorf("update instance: %w", err)
 		}

--- a/pkg/client/clientimplementation/machine_client.go
+++ b/pkg/client/clientimplementation/machine_client.go
@@ -161,7 +161,6 @@ func (s *machineClient) RefreshOptions(
 		s.config,
 		s.machine,
 		userOptions,
-		s.log,
 	)
 	if err != nil {
 		return err

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -224,7 +224,6 @@ func (s *proxyClient) RefreshOptions(
 		s.config,
 		s.workspace,
 		userOptions,
-		s.log,
 		resolver.WithResolveSubOptions(),
 	)
 	if err != nil {

--- a/pkg/client/clientimplementation/services.go
+++ b/pkg/client/clientimplementation/services.go
@@ -56,7 +56,6 @@ func StartServicesDaemon(ctx context.Context, opts StartServicesDaemonOptions) e
 			ConfigureGitCredentials:        credConfig.git,
 			ConfigureGitSSHSignatureHelper: credConfig.gitSSHSignature,
 			GitSSHSigningKey:               opts.GitSSHSigningKey,
-			Log:                            opts.Log,
 		},
 	)
 }

--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -138,7 +138,6 @@ func (s *workspaceClient) RefreshOptions(
 			s.config,
 			s.machine,
 			userOptions,
-			s.log,
 		)
 		if err != nil {
 			return err
@@ -154,7 +153,6 @@ func (s *workspaceClient) RefreshOptions(
 		s.config,
 		s.workspace,
 		userOptions,
-		s.log,
 	)
 	if err != nil {
 		s.log.Errorf("failed to resolve and save options workspace: error=%v", err)
@@ -856,7 +854,7 @@ func DeleteWorkspaceFolder(params DeleteWorkspaceFolderParams, log log.Logger) e
 		sshConfigIncludePath = includePath
 	}
 
-	err = ssh.RemoveFromConfig(params.WorkspaceID, sshConfigPath, sshConfigIncludePath, log)
+	err = ssh.RemoveFromConfig(params.WorkspaceID, sshConfigPath, sshConfigIncludePath)
 	if err != nil {
 		log.Errorf("Remove workspace '%s' from ssh config: %v", params.WorkspaceID, err)
 	}

--- a/pkg/compose/helper.go
+++ b/pkg/compose/helper.go
@@ -16,7 +16,7 @@ import (
 	composetypes "github.com/compose-spec/compose-go/v2/types"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/docker"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 const (
@@ -63,12 +63,12 @@ func NewComposeHelper(dockerHelper *docker.DockerHelper) (*ComposeHelper, error)
 		dockerCmd = "docker"
 	}
 
-	if helper, err := tryDockerComposeV2(dockerCmd, dockerHelper.Log); err == nil {
+	if helper, err := tryDockerComposeV2(dockerCmd); err == nil {
 		helper.Docker = dockerHelper
 		return helper, nil
 	}
 
-	if helper, err := tryDockerComposeV1(dockerHelper.Log); err == nil {
+	if helper, err := tryDockerComposeV1(); err == nil {
 		helper.Docker = dockerHelper
 		return helper, nil
 	}
@@ -83,7 +83,7 @@ func NewComposeHelper(dockerHelper *docker.DockerHelper) (*ComposeHelper, error)
 // Docker Compose V2 requires the buildx plugin for building images and can be installed using
 // sudo curl -SL https://github.com/docker/buildx/releases/latest/download/buildx-v0.30.1.linux-amd64 -o /usr/libexec/docker/cli-plugins/docker-buildx
 // sudo chmod +x /usr/libexec/docker/cli-plugins/docker-buildx.
-func tryDockerComposeV2(dockerCmd string, log log.Logger) (*ComposeHelper, error) {
+func tryDockerComposeV2(dockerCmd string) (*ComposeHelper, error) {
 	if exec.Command(dockerCmd, "compose").Run() != nil {
 		return nil, fmt.Errorf("docker compose not available")
 	}
@@ -120,7 +120,7 @@ func tryDockerComposeV2(dockerCmd string, log log.Logger) (*ComposeHelper, error
 	return helper, nil
 }
 
-func tryDockerComposeV1(log log.Logger) (*ComposeHelper, error) {
+func tryDockerComposeV1() (*ComposeHelper, error) {
 	if _, err := exec.LookPath("docker-compose"); err != nil {
 		return nil, fmt.Errorf("docker-compose not found in PATH")
 	}
@@ -204,8 +204,8 @@ func (h *ComposeHelper) Stop(ctx context.Context, projectName string, args []str
 	buildArgs = append(buildArgs, "stop")
 
 	out, stderr, err := runCmdCapture(h.buildCmd(ctx, buildArgs...))
-	if len(stderr) > 0 && h.Docker != nil && h.Docker.Log != nil {
-		h.Docker.Log.Warnf(
+	if len(stderr) > 0 {
+		log.Warnf(
 			"%s: %s",
 			strings.TrimSpace(string(stderr)),
 			strings.TrimSpace(string(out)),
@@ -224,8 +224,8 @@ func (h *ComposeHelper) Remove(ctx context.Context, projectName string, args []s
 	buildArgs = append(buildArgs, "down")
 
 	out, stderr, err := runCmdCapture(h.buildCmd(ctx, buildArgs...))
-	if len(stderr) > 0 && h.Docker != nil && h.Docker.Log != nil {
-		h.Docker.Log.Warnf(
+	if len(stderr) > 0 {
+		log.Warnf(
 			"%s: %s",
 			strings.TrimSpace(string(stderr)),
 			strings.TrimSpace(string(out)),
@@ -264,8 +264,8 @@ func (h *ComposeHelper) FindProjectFiles(
 	buildArgs = append(buildArgs, "ls", "-a", "--filter", "name="+projectName, "--format", "json")
 
 	rawOut, stderr, err := runCmdCapture(h.buildCmd(ctx, buildArgs...))
-	if len(stderr) > 0 && h.Docker != nil && h.Docker.Log != nil {
-		h.Docker.Log.Warnf(
+	if len(stderr) > 0 {
+		log.Warnf(
 			"%s: %s",
 			strings.TrimSpace(string(stderr)),
 			strings.TrimSpace(string(rawOut)),

--- a/pkg/credentials/integration_test.go
+++ b/pkg/credentials/integration_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/agent/tunnel"
 	"github.com/devsy-org/devsy/pkg/gitsshsigning"
-	"github.com/devsy-org/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +26,7 @@ func TestIntegration_SigningFailure_SurfacesServerError(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := handleGitSSHSignatureRequest(context.Background(), w, r, mock, log.Discard)
+		err := handleGitSSHSignatureRequest(context.Background(), w, r, mock)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -41,7 +40,7 @@ func TestIntegration_SigningFailure_SurfacesServerError(t *testing.T) {
 	bufferFile := filepath.Join(tmpDir, "buffer")
 	require.NoError(t, os.WriteFile(bufferFile, []byte("commit content"), 0o600))
 
-	err := gitsshsigning.HandleGitSSHProgramCall("/tmp/key.pub", "git", bufferFile, log.Discard)
+	err := gitsshsigning.HandleGitSSHProgramCall("/tmp/key.pub", "git", bufferFile)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Permission denied")
@@ -68,7 +67,7 @@ func TestIntegration_SigningSuccess_WritesSigFile(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := handleGitSSHSignatureRequest(context.Background(), w, r, mock, log.Discard)
+		err := handleGitSSHSignatureRequest(context.Background(), w, r, mock)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -82,7 +81,7 @@ func TestIntegration_SigningSuccess_WritesSigFile(t *testing.T) {
 	bufferFile := filepath.Join(tmpDir, "buffer")
 	require.NoError(t, os.WriteFile(bufferFile, []byte("commit content"), 0o600))
 
-	err := gitsshsigning.HandleGitSSHProgramCall("/tmp/key.pub", "git", bufferFile, log.Discard)
+	err := gitsshsigning.HandleGitSSHProgramCall("/tmp/key.pub", "git", bufferFile)
 
 	require.NoError(t, err)
 
@@ -112,7 +111,7 @@ func TestIntegration_SignatureRequest_IncludesPublicKeyContent(t *testing.T) {
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		err := handleGitSSHSignatureRequest(context.Background(), w, r, mock, log.Discard)
+		err := handleGitSSHSignatureRequest(context.Background(), w, r, mock)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
@@ -130,7 +129,7 @@ func TestIntegration_SignatureRequest_IncludesPublicKeyContent(t *testing.T) {
 	bufferFile := filepath.Join(tmpDir, "buffer")
 	require.NoError(t, os.WriteFile(bufferFile, []byte("commit content"), 0o600))
 
-	err := gitsshsigning.HandleGitSSHProgramCall(certFile, "git", bufferFile, log.Discard)
+	err := gitsshsigning.HandleGitSSHProgramCall(certFile, "git", bufferFile)
 	require.NoError(t, err)
 
 	var req gitsshsigning.GitSSHSignatureRequest

--- a/pkg/credentials/request.go
+++ b/pkg/credentials/request.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 )
@@ -22,7 +22,7 @@ var defaultBackoff = wait.Backoff{
 	Jitter:   0.1,
 }
 
-func PostWithRetry(port int, endpoint string, body io.Reader, log log.Logger) ([]byte, error) {
+func PostWithRetry(port int, endpoint string, body io.Reader) ([]byte, error) {
 	var out []byte
 	err := retry.OnError(defaultBackoff, func(err error) bool {
 		// connection refused is recoverable

--- a/pkg/credentials/server.go
+++ b/pkg/credentials/server.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/agent/tunnel"
 	"github.com/devsy-org/devsy/pkg/config"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 const DefaultPort = "12049"
@@ -22,36 +22,35 @@ func RunCredentialsServer(
 	ctx context.Context,
 	port int,
 	client tunnel.TunnelClient,
-	log log.Logger,
 ) error {
 	var handler http.Handler = http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		log.Debugf("incoming client connection: path=%s", request.URL.Path)
 		switch request.URL.Path {
 		case "/git-credentials":
-			err := handleGitCredentialsRequest(ctx, writer, request, client, log)
+			err := handleGitCredentialsRequest(ctx, writer, request, client)
 			if err != nil {
 				http.Error(writer, err.Error(), http.StatusInternalServerError)
 				return
 			}
 		case "/docker-credentials":
-			err := handleDockerCredentialsRequest(ctx, writer, request, client, log)
+			err := handleDockerCredentialsRequest(ctx, writer, request, client)
 			if err != nil {
 				http.Error(writer, err.Error(), http.StatusInternalServerError)
 				return
 			}
 		case "/git-ssh-signature":
-			err := handleGitSSHSignatureRequest(ctx, writer, request, client, log)
+			err := handleGitSSHSignatureRequest(ctx, writer, request, client)
 			if err != nil {
 				http.Error(writer, err.Error(), http.StatusInternalServerError)
 				return
 			}
 		case "/loft-platform-credentials":
-			err := handleLoftPlatformCredentialsRequest(ctx, writer, request, client, log)
+			err := handleLoftPlatformCredentialsRequest(ctx, writer, request, client)
 			if err != nil {
 				http.Error(writer, err.Error(), http.StatusInternalServerError)
 			}
 		case "/gpg-public-keys":
-			err := handleGPGPublicKeysRequest(ctx, writer, client, log)
+			err := handleGPGPublicKeysRequest(ctx, writer, client)
 			if err != nil {
 				http.Error(writer, err.Error(), http.StatusInternalServerError)
 			}
@@ -97,7 +96,6 @@ func handleDockerCredentialsRequest(
 	writer http.ResponseWriter,
 	request *http.Request,
 	client tunnel.TunnelClient,
-	log log.Logger,
 ) error {
 	out, err := io.ReadAll(request.Body)
 	if err != nil {
@@ -122,7 +120,6 @@ func handleGitCredentialsRequest(
 	writer http.ResponseWriter,
 	request *http.Request,
 	client tunnel.TunnelClient,
-	log log.Logger,
 ) error {
 	out, err := io.ReadAll(request.Body)
 	if err != nil {
@@ -148,7 +145,6 @@ func handleGitSSHSignatureRequest(
 	writer http.ResponseWriter,
 	request *http.Request,
 	client tunnel.TunnelClient,
-	log log.Logger,
 ) error {
 	out, err := io.ReadAll(request.Body)
 	if err != nil {
@@ -185,7 +181,6 @@ func handleLoftPlatformCredentialsRequest(
 	writer http.ResponseWriter,
 	request *http.Request,
 	client tunnel.TunnelClient,
-	log log.Logger,
 ) error {
 	out, err := io.ReadAll(request.Body)
 	if err != nil {
@@ -210,7 +205,6 @@ func handleGPGPublicKeysRequest(
 	ctx context.Context,
 	writer http.ResponseWriter,
 	client tunnel.TunnelClient,
-	log log.Logger,
 ) error {
 	response, err := client.GPGPublicKeys(ctx, &tunnel.Message{})
 	if err != nil {

--- a/pkg/credentials/server_test.go
+++ b/pkg/credentials/server_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/devsy-org/devsy/pkg/agent/tunnel"
-	"github.com/devsy-org/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +33,7 @@ func TestHandleGitSSHSignature_GRPCError_ReturnsJSON500(t *testing.T) {
 	)
 	w := httptest.NewRecorder()
 
-	err := handleGitSSHSignatureRequest(context.Background(), w, req, mock, log.Discard)
+	err := handleGitSSHSignatureRequest(context.Background(), w, req, mock)
 	require.NoError(t, err)
 
 	resp := w.Result()
@@ -62,7 +61,7 @@ func TestHandleGitSSHSignature_BodyReadError_ReturnsJSON500(t *testing.T) {
 	)
 	w := httptest.NewRecorder()
 
-	err := handleGitSSHSignatureRequest(context.Background(), w, req, mock, log.Discard)
+	err := handleGitSSHSignatureRequest(context.Background(), w, req, mock)
 	require.NoError(t, err, "error should be written to response, not returned")
 
 	resp := w.Result()
@@ -90,7 +89,7 @@ func TestHandleGitSSHSignature_GRPCSuccess_ReturnsJSON200(t *testing.T) {
 	)
 	w := httptest.NewRecorder()
 
-	err := handleGitSSHSignatureRequest(context.Background(), w, req, mock, log.Discard)
+	err := handleGitSSHSignatureRequest(context.Background(), w, req, mock)
 	require.NoError(t, err)
 
 	resp := w.Result()

--- a/pkg/credentials/start.go
+++ b/pkg/credentials/start.go
@@ -9,15 +9,14 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/agent/tunnel"
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
+	"github.com/devsy-org/devsy/pkg/log"
 	portpkg "github.com/devsy-org/devsy/pkg/port"
 	"github.com/devsy-org/devsy/pkg/random"
-	"github.com/devsy-org/log"
 )
 
 func StartCredentialsServer(
 	ctx context.Context,
 	client tunnel.TunnelClient,
-	log log.Logger,
 ) (int, error) {
 	port, err := portpkg.FindAvailablePort(random.InRange(13000, 17000))
 	if err != nil {
@@ -25,19 +24,19 @@ func StartCredentialsServer(
 	}
 
 	go func() {
-		err := RunCredentialsServer(ctx, port, client, log)
+		err := RunCredentialsServer(ctx, port, client)
 		if err != nil {
 			log.Errorf("error running git credentials server: error=%v", err)
 		}
 	}()
 
-	if err := waitForServer(ctx, port, log); err != nil {
+	if err := waitForServer(ctx, port); err != nil {
 		return 0, err
 	}
 	return port, nil
 }
 
-func waitForServer(ctx context.Context, port int, log log.Logger) error {
+func waitForServer(ctx context.Context, port int) error {
 	maxWait := time.Second * 4
 	now := time.Now()
 	for {

--- a/pkg/daemon/platform/local_server.go
+++ b/pkg/daemon/platform/local_server.go
@@ -676,7 +676,7 @@ func (l *localServer) createWorkspace(
 	}
 	instance.TypeMeta = metav1.TypeMeta{}
 
-	updatedInstance, err := createInstance(r.Context(), l.pc, instance, l.log)
+	updatedInstance, err := createInstance(r.Context(), l.pc, instance)
 	if err != nil {
 		http.Error(w, fmt.Errorf("create workspace: %w", err).Error(), http.StatusBadRequest)
 		return
@@ -705,7 +705,7 @@ func (l *localServer) updateWorkspace(
 		return
 	}
 
-	updatedInstance, err := updateInstance(r.Context(), l.pc, oldInstance, newInstance, l.log)
+	updatedInstance, err := updateInstance(r.Context(), l.pc, oldInstance, newInstance)
 	if err != nil {
 		http.Error(w, fmt.Errorf("update workspace: %w", err).Error(), http.StatusBadRequest)
 		return
@@ -787,7 +787,6 @@ func createInstance(
 	ctx context.Context,
 	client platformclient.Client,
 	instance *managementv1.DevsyWorkspaceInstance,
-	log log.Logger,
 ) (*managementv1.DevsyWorkspaceInstance, error) {
 	managementClient, err := client.Management()
 	if err != nil {
@@ -801,7 +800,7 @@ func createInstance(
 		return nil, fmt.Errorf("create workspace instance: %w", err)
 	}
 
-	return platform.WaitForInstance(ctx, client, updatedInstance, log)
+	return platform.WaitForInstance(ctx, client, updatedInstance)
 }
 
 func updateInstance(
@@ -809,12 +808,11 @@ func updateInstance(
 	client platformclient.Client,
 	oldInstance *managementv1.DevsyWorkspaceInstance,
 	newInstance *managementv1.DevsyWorkspaceInstance,
-	log log.Logger,
 ) (*managementv1.DevsyWorkspaceInstance, error) {
 	// This ensures the template is kept up to date with configuration changes
 	if newInstance.Spec.TemplateRef != nil {
 		newInstance.Spec.TemplateRef.SyncOnce = true
 	}
 
-	return platform.UpdateInstance(ctx, client, oldInstance, newInstance, log)
+	return platform.UpdateInstance(ctx, client, oldInstance, newInstance)
 }

--- a/pkg/devcontainer/config.go
+++ b/pkg/devcontainer/config.go
@@ -124,7 +124,7 @@ func (r *runner) getDefaultConfig(
 		}
 	} else {
 		r.Log.Infof("Try detecting project programming language...")
-		defaultConfig = language.DefaultConfig(r.LocalWorkspaceFolder, r.Log)
+		defaultConfig = language.DefaultConfig(r.LocalWorkspaceFolder)
 	}
 
 	defaultConfig.Origin = path.Join(filepath.ToSlash(r.LocalWorkspaceFolder), ".devcontainer.json")

--- a/pkg/devcontainer/helpers.go
+++ b/pkg/devcontainer/helpers.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/git"
 	"github.com/devsy-org/devsy/pkg/image"
 	"github.com/devsy-org/devsy/pkg/log"
-	oldlog "github.com/devsy-org/log"
 )
 
 type GetWorkspaceConfigResult struct {
@@ -137,7 +136,6 @@ func findFilesInGitRepo(
 		opts.tmpDirPath,
 		"",
 		opts.strictHostKeyChecking,
-		oldlog.Default,
 		git.WithCloneStrategy(git.BareCloneStrategy),
 	)
 	if err != nil {

--- a/pkg/devcontainer/inspect.go
+++ b/pkg/devcontainer/inspect.go
@@ -22,7 +22,7 @@ func (r *runner) inspectImage(ctx context.Context, imageName string) (*config.Im
 	}
 
 	// Use architecture-specific image config retrieval
-	imageConfig, _, err := image.GetImageConfigForArch(ctx, imageName, targetArch, r.Log)
+	imageConfig, _, err := image.GetImageConfigForArch(ctx, imageName, targetArch)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to get image config for architecture %s: %w",

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -48,7 +48,7 @@ func NewRunner(
 	workspaceConfig *provider2.AgentWorkspaceInfo,
 	log log.Logger,
 ) (Runner, error) {
-	driver, err := drivercreate.NewDriver(workspaceConfig, log)
+	driver, err := drivercreate.NewDriver(workspaceConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -266,7 +266,7 @@ func executeSSHServerHelper(
 
 func addPrivateKeys(ctx context.Context, opts ExecuteCommandOptions) {
 	opts.Log.Debug("adding SSH keys to agent")
-	err := devssh.AddPrivateKeysToAgent(ctx, opts.Log)
+	err := devssh.AddPrivateKeysToAgent(ctx)
 	if err != nil {
 		opts.Log.Debugf("failed to add private keys to SSH agent: %v", err)
 	}

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	dockerclient "github.com/docker/docker/client"
 )
 
@@ -14,7 +14,7 @@ type Client struct {
 }
 
 // NewClient creates a new docker client.
-func NewClient(ctx context.Context, log log.Logger) (*Client, error) {
+func NewClient(ctx context.Context) (*Client, error) {
 	cli, err := newDockerClientFromEnvironment()
 	if err != nil {
 		log.Warnf("Error creating docker client from environment: %v", err)

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -15,7 +15,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/command"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/image"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/log/scanner"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -56,7 +56,6 @@ type DockerHelper struct {
 	// allow command to have a custom environment
 	Environment []string
 	Builder     DockerBuilder
-	Log         log.Logger
 }
 
 func (r *DockerHelper) GPUSupportEnabled() (bool, error) {
@@ -191,7 +190,7 @@ func (r *DockerHelper) StartContainer(ctx context.Context, containerId string) e
 		logs, _ := r.buildCmd(ctx, "logs", containerId, "--tail", "50").CombinedOutput()
 		details := strings.TrimSpace(string(stateErr) + "\n" + string(logs))
 		if details != "" {
-			r.Log.Errorf("container failed to start: %s", details)
+			log.Errorf("container failed to start: %s", details)
 		}
 		return fmt.Errorf("failed to start container: %s: %w", string(out), err)
 	}
@@ -226,7 +225,7 @@ func (r *DockerHelper) WaitContainerRunning(ctx context.Context, containerID str
 			details, err := r.InspectContainers(ctx, []string{containerID})
 			if err != nil {
 				lastErr = err
-				r.Log.Debugf("WaitContainerRunning: inspect error (will retry): %v", err)
+				log.Debugf("WaitContainerRunning: inspect error (will retry): %v", err)
 				return false, nil
 			}
 			if len(details) == 0 {
@@ -248,7 +247,7 @@ func (r *DockerHelper) WaitContainerRunning(ctx context.Context, containerID str
 					status,
 				)
 			}
-			r.Log.Debugf(
+			log.Debugf(
 				"WaitContainerRunning: container %s status=%s, waiting...",
 				containerID,
 				status,
@@ -299,7 +298,7 @@ func (r *DockerHelper) InspectImage(
 			return nil, err
 		}
 
-		imageConfig, _, err := image.GetImageConfig(ctx, imageName, r.Log)
+		imageConfig, _, err := image.GetImageConfig(ctx, imageName)
 		if err != nil {
 			return nil, fmt.Errorf("get image config remotely: %w", err)
 		}

--- a/pkg/dockercredentials/dockercredentials.go
+++ b/pkg/dockercredentials/dockercredentials.go
@@ -13,8 +13,8 @@ import (
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/file"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/random"
-	"github.com/devsy-org/log"
 	"github.com/docker/cli/cli/config"
 	"github.com/docker/cli/cli/config/types"
 )
@@ -54,7 +54,7 @@ func (c *Credentials) AuthToken() string {
 	return c.Secret
 }
 
-func ConfigureCredentialsContainer(userName string, port int, log log.Logger) error {
+func ConfigureCredentialsContainer(userName string, port int) error {
 	userHome, err := command.GetHome(userName)
 	if err != nil {
 		return err
@@ -65,7 +65,7 @@ func ConfigureCredentialsContainer(userName string, port int, log log.Logger) er
 		configDir = filepath.Join(userHome, ".docker")
 	}
 
-	return configureCredentials(userName, "#!/bin/sh", "/usr/local/bin", configDir, port, log)
+	return configureCredentials(userName, "#!/bin/sh", "/usr/local/bin", configDir, port)
 }
 
 const AzureContainerRegistryUsername = "00000000-0000-0000-0000-000000000000"
@@ -74,7 +74,6 @@ func configureCredentials(
 	userName, shebang string,
 	targetDir, configDir string,
 	port int,
-	log log.Logger,
 ) error {
 	binaryPath, err := os.Executable()
 	if err != nil {
@@ -139,7 +138,7 @@ func configureCredentials(
 	return nil
 }
 
-func ConfigureCredentialsDockerless(targetFolder string, port int, log log.Logger) (string, error) {
+func ConfigureCredentialsDockerless(targetFolder string, port int) (string, error) {
 	dockerConfigDir := filepath.Join(targetFolder, ".cache", random.String(6))
 	err := configureCredentials(
 		"",
@@ -147,7 +146,6 @@ func ConfigureCredentialsDockerless(targetFolder string, port int, log log.Logge
 		dockerConfigDir,
 		dockerConfigDir,
 		port,
-		log,
 	)
 	if err != nil {
 		_ = os.RemoveAll(dockerConfigDir)
@@ -169,9 +167,9 @@ func ConfigureCredentialsDockerless(targetFolder string, port int, log log.Logge
 	return dockerConfigDir, nil
 }
 
-func ConfigureCredentialsMachine(targetFolder string, port int, log log.Logger) (string, error) {
+func ConfigureCredentialsMachine(targetFolder string, port int) (string, error) {
 	dockerConfigDir := filepath.Join(targetFolder, ".cache", random.String(12))
-	err := configureCredentials("", "#!/bin/sh", dockerConfigDir, dockerConfigDir, port, log)
+	err := configureCredentials("", "#!/bin/sh", dockerConfigDir, dockerConfigDir, port)
 	if err != nil {
 		_ = os.RemoveAll(dockerConfigDir)
 		return "", err

--- a/pkg/dotfiles/dotfiles.go
+++ b/pkg/dotfiles/dotfiles.go
@@ -10,9 +10,8 @@ import (
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
 	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 )
 
 // SetupParams holds all parameters needed for dotfiles setup.
@@ -23,7 +22,6 @@ type SetupParams struct {
 	EnvKeyValues []string
 	Client       client2.BaseWorkspaceClient
 	DevsyConfig  *config.Config
-	Log          log.Logger
 }
 
 // Setup clones and installs dotfiles into the devcontainer.
@@ -39,12 +37,12 @@ func Setup(p SetupParams) error {
 	}
 
 	if dotfilesRepo == "" {
-		p.Log.Debug("No dotfiles repo specified, skipping")
+		log.Debug("No dotfiles repo specified, skipping")
 		return nil
 	}
 
-	p.Log.Infof("Dotfiles Git repository %s specified", dotfilesRepo)
-	p.Log.Debug("Cloning dotfiles into the devcontainer...")
+	log.Infof("Dotfiles Git repository %s specified", dotfilesRepo)
+	log.Debug("Cloning dotfiles into the devcontainer...")
 
 	dotCmd, err := buildDotCmd(buildDotCmdParams{
 		devsyConfig:      p.DevsyConfig,
@@ -53,18 +51,17 @@ func Setup(p SetupParams) error {
 		envFiles:         p.EnvFiles,
 		envKeyValuePairs: p.EnvKeyValues,
 		client:           p.Client,
-		log:              p.Log,
 	})
 	if err != nil {
 		return err
 	}
-	if p.Log.GetLevel() == logrus.DebugLevel {
+	if log.DebugEnabled() {
 		dotCmd.Args = append(dotCmd.Args, "--debug")
 	}
 
-	p.Log.Debugf("Running dotfiles setup command: %v", dotCmd.Args)
+	log.Debugf("Running dotfiles setup command: %v", dotCmd.Args)
 
-	writer := p.Log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 
 	dotCmd.Stdout = writer
 	dotCmd.Stderr = writer
@@ -74,7 +71,7 @@ func Setup(p SetupParams) error {
 		return err
 	}
 
-	p.Log.Infof("Done setting up dotfiles into the devcontainer")
+	log.Infof("Done setting up dotfiles into the devcontainer")
 
 	return nil
 }
@@ -113,7 +110,6 @@ type buildDotCmdParams struct {
 	envFiles         []string
 	envKeyValuePairs []string
 	client           client2.BaseWorkspaceClient
-	log              log.Logger
 }
 
 func buildDotCmd(p buildDotCmdParams) (*exec.Cmd, error) {
@@ -148,13 +144,13 @@ func buildDotCmd(p buildDotCmdParams) (*exec.Cmd, error) {
 	strictHostKey := p.devsyConfig.ContextOption(
 		config.ContextOptionSSHStrictHostKeyChecking,
 	) == config.BoolTrue
-	debug := p.log.GetLevel() == logrus.DebugLevel
+	debug := log.DebugEnabled()
 	agentArguments := buildDotCmdAgentArguments(
 		p.dotfilesRepo, p.dotfilesScript, strictHostKey, debug,
 	)
 
 	if p.dotfilesScript != "" {
-		p.log.Infof("Dotfiles script %s specified", p.dotfilesScript)
+		log.Infof("Dotfiles script %s specified", p.dotfilesScript)
 	}
 
 	sshCmd = append(sshCmd,

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/gitcredentials"
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 // HTTPStatusError wraps HTTP status code errors for better error handling.
@@ -51,7 +51,8 @@ func Head(rawURL string) (int, error) {
 	return resp.StatusCode, nil
 }
 
-func File(rawURL string, log log.Logger) (io.ReadCloser, error) {
+//nolint:cyclop
+func File(rawURL string) (io.ReadCloser, error) {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, err

--- a/pkg/driver/custom/custom.go
+++ b/pkg/driver/custom/custom.go
@@ -14,16 +14,15 @@ import (
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/driver"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
 	"github.com/devsy-org/log/scanner"
-	"github.com/sirupsen/logrus"
+	"go.uber.org/zap/zapcore"
 )
 
-func NewCustomDriver(workspaceInfo *provider.AgentWorkspaceInfo, log log.Logger) driver.Driver {
+func NewCustomDriver(workspaceInfo *provider.AgentWorkspaceInfo) driver.Driver {
 	return &customDriver{
-		log:           log,
 		workspaceInfo: workspaceInfo,
 	}
 }
@@ -31,8 +30,6 @@ func NewCustomDriver(workspaceInfo *provider.AgentWorkspaceInfo, log log.Logger)
 var _ driver.Driver = (*customDriver)(nil)
 
 type customDriver struct {
-	log log.Logger
-
 	workspaceInfo *provider.AgentWorkspaceInfo
 }
 
@@ -41,7 +38,7 @@ func (c *customDriver) FindDevContainer(
 	ctx context.Context,
 	workspaceId string,
 ) (*config.ContainerDetails, error) {
-	writer := c.log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	// run command
@@ -55,7 +52,6 @@ func (c *customDriver) FindDevContainer(
 		stdout,
 		writer,
 		nil,
-		c.log,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error finding dev container: %s%w", stdout.String(), err)
@@ -94,7 +90,6 @@ func (c *customDriver) CommandDevContainer(
 			"DEVCONTAINER_USER=" + user,
 			"DEVCONTAINER_COMMAND=" + command,
 		},
-		c.log,
 	)
 	if err != nil {
 		return err
@@ -105,7 +100,7 @@ func (c *customDriver) CommandDevContainer(
 
 // TargetArchitecture returns the architecture of the container runtime. e.g. amd64 or arm64.
 func (c *customDriver) TargetArchitecture(ctx context.Context, workspaceId string) (string, error) {
-	writer := c.log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	// run command
@@ -119,7 +114,6 @@ func (c *customDriver) TargetArchitecture(ctx context.Context, workspaceId strin
 		stdout,
 		writer,
 		nil,
-		c.log,
 	)
 	if err != nil {
 		return "", fmt.Errorf("error getting target architecture: %s%w", stdout.String(), err)
@@ -139,7 +133,7 @@ func (c *customDriver) TargetArchitecture(ctx context.Context, workspaceId strin
 
 // DeleteDevContainer deletes the devcontainer.
 func (c *customDriver) DeleteDevContainer(ctx context.Context, workspaceId string) error {
-	writer := c.log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	// run command
@@ -152,7 +146,6 @@ func (c *customDriver) DeleteDevContainer(ctx context.Context, workspaceId strin
 		writer,
 		writer,
 		nil,
-		c.log,
 	)
 	if err != nil {
 		return fmt.Errorf("error deleting devcontainer: %w", err)
@@ -163,7 +156,7 @@ func (c *customDriver) DeleteDevContainer(ctx context.Context, workspaceId strin
 
 // StartDevContainer starts the devcontainer.
 func (c *customDriver) StartDevContainer(ctx context.Context, workspaceId string) error {
-	writer := c.log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	// run command
@@ -176,7 +169,6 @@ func (c *customDriver) StartDevContainer(ctx context.Context, workspaceId string
 		writer,
 		writer,
 		nil,
-		c.log,
 	)
 	if err != nil {
 		return fmt.Errorf("error starting devcontainer: %w", err)
@@ -187,7 +179,7 @@ func (c *customDriver) StartDevContainer(ctx context.Context, workspaceId string
 
 // StopDevContainer stops the devcontainer.
 func (c *customDriver) StopDevContainer(ctx context.Context, workspaceId string) error {
-	writer := c.log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	// run command
@@ -200,7 +192,6 @@ func (c *customDriver) StopDevContainer(ctx context.Context, workspaceId string)
 		writer,
 		writer,
 		nil,
-		c.log,
 	)
 	if err != nil {
 		return fmt.Errorf("error stopping devcontainer: %w", err)
@@ -226,7 +217,7 @@ func (c *customDriver) RunDevContainer(
 	go func() {
 		scan := scanner.NewScanner(reader)
 		for scan.Scan() {
-			c.log.Info(scan.Text())
+			log.Info(scan.Text())
 		}
 		done <- struct{}{}
 	}()
@@ -243,7 +234,6 @@ func (c *customDriver) RunDevContainer(
 		[]string{
 			"DEVCONTAINER_RUN_OPTIONS=" + string(out),
 		},
-		c.log,
 	)
 	if err != nil {
 		// close writer, wait for logging to flush and shut down
@@ -275,7 +265,6 @@ func (c *customDriver) GetDevContainerLogs(
 		stdout,
 		stderr,
 		nil,
-		c.log,
 	)
 	if err != nil {
 		return fmt.Errorf("error getting devcontainer logs: %w", err)
@@ -299,7 +288,6 @@ func (c *customDriver) runCommand(
 	stdout io.Writer,
 	stderr io.Writer,
 	extraEnv []string,
-	log log.Logger,
 ) error {
 	if len(command) == 0 {
 		return nil
@@ -317,7 +305,7 @@ func (c *customDriver) runCommand(
 	environ = append(environ, extraEnv...)
 
 	// set debug level
-	if log.GetLevel() == logrus.DebugLevel {
+	if log.Underlying().Core().Enabled(zapcore.DebugLevel) {
 		environ = append(environ, pkgconfig.EnvDebug+"="+pkgconfig.BoolTrue)
 	}
 

--- a/pkg/driver/docker/build.go
+++ b/pkg/driver/docker/build.go
@@ -14,8 +14,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/feature"
 	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/driver"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/sirupsen/logrus"
 )
 
 func (d *dockerDriver) BuildDevContainer(
@@ -72,7 +72,7 @@ func (s *dockerBuildxStrategy) build(
 	options *build.BuildOptions,
 ) error {
 	args := buildDockerBuildxArgs(options, platform)
-	s.driver.Log.Debugf("running docker buildx build with args: %s", strings.Join(args, " "))
+	log.Debugf("running docker buildx build with args: %s", strings.Join(args, " "))
 	stderrBuf := &bytes.Buffer{}
 	multiWriter := io.MultiWriter(writer, stderrBuf)
 	if err := s.driver.Docker.Run(ctx, args, nil, writer, multiWriter); err != nil {
@@ -176,7 +176,7 @@ func (s *buildkitStrategy) build(
 	platform string,
 	options *build.BuildOptions,
 ) error {
-	dockerClient, err := docker.NewClient(ctx, s.driver.Log)
+	dockerClient, err := docker.NewClient(ctx)
 	if err != nil {
 		return fmt.Errorf("create docker client: %w", err)
 	}
@@ -226,7 +226,7 @@ func (r *imageResolver) tryResolve(
 
 	imageDetails, err := r.driver.Docker.InspectImage(ctx, req.imageName, false)
 	if err != nil {
-		r.driver.Log.Debugf("error trying to find local image %s: %v", req.imageName, err)
+		log.Debugf("error trying to find local image %s: %v", req.imageName, err)
 		return nil, false
 	}
 
@@ -234,7 +234,7 @@ func (r *imageResolver) tryResolve(
 		return nil, false
 	}
 
-	r.driver.Log.Infof("found existing local image %s", req.imageName)
+	log.Infof("found existing local image %s", req.imageName)
 	return &config.BuildInfo{
 		ImageDetails:  imageDetails,
 		ImageMetadata: req.extendedBuildInfo.MetadataConfig,
@@ -287,7 +287,7 @@ func (d *dockerDriver) prepareBuildOptions(
 		return nil, err
 	}
 
-	d.Log.Debugf("prepared build options: %+v", buildOptions)
+	log.Debugf("prepared build options: %+v", buildOptions)
 	return buildOptions, nil
 }
 
@@ -297,8 +297,8 @@ func (d *dockerDriver) executeBuild(
 	req driver.BuildRequest,
 	buildOptions *build.BuildOptions,
 ) error {
-	d.Log.Infof("build with %s", strategy.name())
-	writer := d.Log.Writer(logrus.InfoLevel, false)
+	log.Infof("build with %s", strategy.name())
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	if err := strategy.build(ctx, writer, req.Options.Platform, buildOptions); err != nil {

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -17,12 +17,11 @@ import (
 	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/driver"
 	"github.com/devsy-org/devsy/pkg/ide/jetbrains"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 )
 
-func makeEnvironment(env map[string]string, log log.Logger) []string {
+func makeEnvironment(env map[string]string) []string {
 	if env == nil {
 		return nil
 	}
@@ -37,7 +36,6 @@ func makeEnvironment(env map[string]string, log log.Logger) []string {
 
 func NewDockerDriver(
 	workspaceInfo *provider2.AgentWorkspaceInfo,
-	log log.Logger,
 ) (driver.DockerDriver, error) {
 	dockerCommand := "docker"
 	if workspaceInfo.Agent.Docker.Path != "" {
@@ -55,20 +53,16 @@ func NewDockerDriver(
 	return &dockerDriver{
 		Docker: &docker.DockerHelper{
 			DockerCommand: dockerCommand,
-			Environment:   makeEnvironment(workspaceInfo.Agent.Docker.Env, log),
+			Environment:   makeEnvironment(workspaceInfo.Agent.Docker.Env),
 			ContainerID:   workspaceInfo.Workspace.Source.Container,
 			Builder:       builder,
-			Log:           log,
 		},
-		Log: log,
 	}, nil
 }
 
 type dockerDriver struct {
 	Docker  *docker.DockerHelper
 	Compose *compose.ComposeHelper
-
-	Log log.Logger
 }
 
 func (d *dockerDriver) TargetArchitecture(ctx context.Context, workspaceId string) (string, error) {
@@ -99,7 +93,7 @@ func (d *dockerDriver) CommandDevContainer(
 		)
 	}
 	if status != "running" {
-		d.Log.Infof(
+		log.Infof(
 			"container %s is not running (status=%s), restarting",
 			container.ID, status,
 		)
@@ -109,7 +103,7 @@ func (d *dockerDriver) CommandDevContainer(
 		if err := d.Docker.WaitContainerRunning(ctx, container.ID); err != nil {
 			return fmt.Errorf("wait for container to be running: %w", err)
 		}
-		d.Log.Infof("container %s is now running", container.ID)
+		log.Infof("container %s is now running", container.ID)
 	}
 
 	args := []string{"exec"}
@@ -122,7 +116,7 @@ func (d *dockerDriver) CommandDevContainer(
 
 func (d *dockerDriver) PushDevContainer(ctx context.Context, image string) error {
 	// push image
-	writer := d.Log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	// build args
@@ -132,7 +126,7 @@ func (d *dockerDriver) PushDevContainer(ctx context.Context, image string) error
 	}
 
 	// run command
-	d.Log.Debugf(
+	log.Debugf(
 		"running docker push command: command=%s, args=%s",
 		d.Docker.DockerCommand,
 		strings.Join(args, " "),
@@ -147,7 +141,7 @@ func (d *dockerDriver) PushDevContainer(ctx context.Context, image string) error
 
 func (d *dockerDriver) TagDevContainer(ctx context.Context, image, tag string) error {
 	// Tag image
-	writer := d.Log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	// build args
@@ -158,7 +152,7 @@ func (d *dockerDriver) TagDevContainer(ctx context.Context, image, tag string) e
 	}
 
 	// run command
-	d.Log.Debugf(
+	log.Debugf(
 		"running docker tag command: command=%s, args=%s",
 		d.Docker.DockerCommand,
 		strings.Join(args, " "),
@@ -296,7 +290,7 @@ func (d *dockerDriver) RunDockerDevContainer(
 		return err
 	}
 
-	writer := d.Log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	if err := d.startContainer(ctx, params.LocalWorkspaceFolder, args, writer); err != nil {
@@ -310,11 +304,11 @@ func (d *dockerDriver) EnsureImage(
 	ctx context.Context,
 	options *driver.RunOptions,
 ) error {
-	d.Log.Infof("inspecting image: image=%s", options.Image)
+	log.Infof("inspecting image: image=%s", options.Image)
 	_, err := d.Docker.InspectImage(ctx, options.Image, false)
 	if err != nil {
-		d.Log.Infof("image not found, pulling image: image=%s", options.Image)
-		writer := d.Log.Writer(logrus.DebugLevel, false)
+		log.Infof("image not found, pulling image: image=%s", options.Image)
+		writer := log.Writer(log.LevelDebug)
 		defer func() { _ = writer.Close() }()
 
 		return d.Docker.Pull(ctx, options.Image, nil, writer, writer)
@@ -376,7 +370,7 @@ func (d *dockerDriver) UpdateContainerUserUID(
 	// containerUser is guaranteed non-empty by shouldUpdateUserUID
 
 	if localUser.Uid == "0" {
-		d.Log.Info("local user is root, skipping UID/GID update")
+		log.Info("local user is root, skipping UID/GID update")
 		return nil
 	}
 
@@ -400,11 +394,11 @@ func (d *dockerDriver) UpdateContainerUserUID(
 	defer files.cleanup()
 
 	if shouldSkipUpdate(localUser, info) {
-		d.Log.Info("container user UID/GID already match local user, skipping update")
+		log.Info("container user UID/GID already match local user, skipping update")
 		return nil
 	}
 
-	d.Log.Infof("updating container user %q UID from %s to %s and GID from %s to %s",
+	log.Infof("updating container user %q UID from %s to %s and GID from %s to %s",
 		containerUser, info.Uid, localUser.Uid, info.Gid, localUser.Gid)
 
 	if err := d.copyFilesToContainer(ctx, container.ID, files, writer); err != nil {
@@ -761,7 +755,7 @@ func (d *dockerDriver) startContainer(
 	args []string,
 	writer io.Writer,
 ) error {
-	d.Log.Infof(
+	log.Infof(
 		"running docker command: command=%s, args=%s, cwd=%s",
 		d.Docker.DockerCommand,
 		strings.Join(args, " "),
@@ -770,7 +764,7 @@ func (d *dockerDriver) startContainer(
 
 	err := d.Docker.RunWithDir(ctx, dir, args, nil, writer, writer)
 	if err != nil {
-		d.Log.Errorf(
+		log.Errorf(
 			"docker container failed to start: error=%v, command=%s, args=%s, cwd=%s",
 			err,
 			d.Docker.DockerCommand,
@@ -794,7 +788,7 @@ func appendGPUOptions(
 			args = append(args, "--gpus", "all")
 		}
 		if warnIfMissing {
-			d.Log.Warn("GPU required but not available on host")
+			log.Warn("GPU required but not available on host")
 		}
 	}
 	return args
@@ -904,7 +898,7 @@ func (d *dockerDriver) copyFileFromContainer(
 	writer io.Writer,
 ) error {
 	args := []string{"cp", fmt.Sprintf("%s:%s", containerID, srcPath), dstPath}
-	d.Log.Debugf(
+	log.Debugf(
 		"copying file from container: command=%s, args=%s",
 		d.Docker.DockerCommand,
 		strings.Join(args, " "),
@@ -918,7 +912,7 @@ func (d *dockerDriver) copyFileToContainer(
 	writer io.Writer,
 ) error {
 	args := []string{"cp", srcPath, fmt.Sprintf("%s:%s", containerID, dstPath)}
-	d.Log.Debugf(
+	log.Debugf(
 		"copying file to container: command=%s, args=%s",
 		d.Docker.DockerCommand,
 		strings.Join(args, " "),
@@ -1048,7 +1042,7 @@ func (d *dockerDriver) applyPermissions(
 	writer io.Writer,
 ) error {
 	args := []string{"exec", "-u", "root", containerID, "chmod", "644", "/etc/passwd", "/etc/group"}
-	d.Log.Debugf(
+	log.Debugf(
 		"modifying permissions of /etc/passwd and /etc/group: command=%s, args=%s",
 		d.Docker.DockerCommand,
 		strings.Join(args, " "),
@@ -1058,7 +1052,7 @@ func (d *dockerDriver) applyPermissions(
 	}
 
 	if containerHome == "" {
-		d.Log.Warnf(
+		log.Warnf(
 			"container home directory not found, skipping chown: containerID=%s",
 			containerID,
 		)
@@ -1075,7 +1069,7 @@ func (d *dockerDriver) applyPermissions(
 		fmt.Sprintf("%s:%s", localUid, localGid),
 		containerHome,
 	}
-	d.Log.Debugf(
+	log.Debugf(
 		"running docker chown command: command=%s, args=%s",
 		d.Docker.DockerCommand,
 		strings.Join(args, " "),

--- a/pkg/driver/drivercreate/create.go
+++ b/pkg/driver/drivercreate/create.go
@@ -8,18 +8,17 @@ import (
 	"github.com/devsy-org/devsy/pkg/driver/docker"
 	"github.com/devsy-org/devsy/pkg/driver/kubernetes"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 )
 
-func NewDriver(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) (driver.Driver, error) {
+func NewDriver(workspaceInfo *provider2.AgentWorkspaceInfo) (driver.Driver, error) {
 	driver := workspaceInfo.Agent.Driver
 	switch driver {
 	case "", provider2.DockerDriver:
-		return docker.NewDockerDriver(workspaceInfo, log)
+		return docker.NewDockerDriver(workspaceInfo)
 	case provider2.CustomDriver:
-		return custom.NewCustomDriver(workspaceInfo, log), nil
+		return custom.NewCustomDriver(workspaceInfo), nil
 	case provider2.KubernetesDriver:
-		return kubernetes.NewKubernetesDriver(workspaceInfo, log)
+		return kubernetes.NewKubernetesDriver(workspaceInfo)
 	}
 
 	return nil, fmt.Errorf("unrecognized driver '%s', possible values are %s, %s or %s",

--- a/pkg/driver/kubernetes/daemonsecret.go
+++ b/pkg/driver/kubernetes/daemonsecret.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/devsy-org/devsy/pkg/log"
 	k8sv1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,15 +17,15 @@ func (k *KubernetesDriver) EnsureDaemonConfigSecret(
 	secretName string,
 	data string,
 ) error {
-	k.Log.Debugf("Ensure daemon config secret")
+	log.Debugf("Ensure daemon config secret")
 
 	if k.secretExists(ctx, secretName) {
 		if !k.shouldRecreateDaemonConfigSecret(ctx, data, secretName) {
-			k.Log.Debugf("Daemon config secret '%s' already exists and is up to date", secretName)
+			log.Debugf("Daemon config secret '%s' already exists and is up to date", secretName)
 			return nil
 		}
 
-		k.Log.Debugf(
+		log.Debugf(
 			"Daemon config secret '%s' already exists, but is outdated. Recreating...",
 			secretName,
 		)
@@ -45,7 +46,7 @@ func (k *KubernetesDriver) EnsureDaemonConfigSecret(
 		return fmt.Errorf("create daemon config secret: %w", err)
 	}
 
-	k.Log.Infof("Daemon config secret '%s' created", secretName)
+	log.Infof("Daemon config secret '%s' created", secretName)
 	return nil
 }
 

--- a/pkg/driver/kubernetes/driver.go
+++ b/pkg/driver/kubernetes/driver.go
@@ -7,8 +7,8 @@ import (
 	"io"
 
 	"github.com/devsy-org/devsy/pkg/driver"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +17,6 @@ import (
 // NewKubernetesDriver constructs a struct capable of provisioning a workspace and it's resources using kubernetes.
 func NewKubernetesDriver(
 	workspaceInfo *provider2.AgentWorkspaceInfo,
-	log log.Logger,
 ) (driver.ReprovisioningDriver, error) {
 	options := workspaceInfo.Agent.Kubernetes
 	if options.KubernetesConfig != "" {
@@ -43,7 +42,6 @@ func NewKubernetesDriver(
 		namespace:   namespace,
 		options:     &options,
 		agentConfig: &workspaceInfo.Agent,
-		Log:         log,
 	}, nil
 }
 
@@ -54,7 +52,6 @@ type KubernetesDriver struct {
 
 	options     *provider2.ProviderKubernetesDriverConfig
 	agentConfig *provider2.ProviderAgentConfig
-	Log         log.Logger
 }
 
 func (k *KubernetesDriver) CanReprovision() bool {
@@ -91,8 +88,8 @@ func (k *KubernetesDriver) getDevContainerPvc(
 }
 
 func (k *KubernetesDriver) StopDevContainer(ctx context.Context, workspaceId string) error {
-	k.Log.Debugf("Stopping devcontainer for workspace '%s'", workspaceId)
-	defer k.Log.Debugf("Done stopping devcontainer for workspace '%s'", workspaceId)
+	log.Debugf("Stopping devcontainer for workspace '%s'", workspaceId)
+	defer log.Debugf("Done stopping devcontainer for workspace '%s'", workspaceId)
 
 	workspaceId = getID(workspaceId)
 
@@ -106,20 +103,20 @@ func (k *KubernetesDriver) StopDevContainer(ctx context.Context, workspaceId str
 }
 
 func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId string) error {
-	k.Log.Debugf("Deleting devcontainer for workspace '%s'", workspaceId)
-	defer k.Log.Debugf("Done deleting devcontainer for workspace '%s'", workspaceId)
+	log.Debugf("Deleting devcontainer for workspace '%s'", workspaceId)
+	defer log.Debugf("Done deleting devcontainer for workspace '%s'", workspaceId)
 
 	workspaceId = getID(workspaceId)
 
 	// delete pod
-	k.Log.Infof("Delete pod '%s'...", workspaceId)
+	log.Infof("Delete pod '%s'...", workspaceId)
 	err := k.waitPodDeleted(ctx, workspaceId)
 	if err != nil {
 		return err
 	}
 
 	// delete pvc
-	k.Log.Infof("Delete persistent volume claim '%s'...", workspaceId)
+	log.Infof("Delete persistent volume claim '%s'...", workspaceId)
 	err = k.client.Client().
 		CoreV1().
 		PersistentVolumeClaims(k.namespace).
@@ -132,7 +129,7 @@ func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId s
 
 	// delete role binding & service account
 	if k.options.ClusterRole != "" {
-		k.Log.Infof("Delete role binding '%s'...", workspaceId)
+		log.Infof("Delete role binding '%s'...", workspaceId)
 		err = k.client.Client().
 			RbacV1().
 			RoleBindings(k.namespace).
@@ -144,7 +141,7 @@ func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId s
 
 	// delete daemon config secret
 	if k.secretExists(ctx, getDaemonSecretName(workspaceId)) {
-		k.Log.Infof("Delete daemon config secret '%s'...", workspaceId)
+		log.Infof("Delete daemon config secret '%s'...", workspaceId)
 		err := k.DeleteSecret(ctx, getDaemonSecretName(workspaceId))
 		if err != nil {
 			return err
@@ -153,7 +150,7 @@ func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId s
 
 	// delete pull secret
 	if k.options.KubernetesPullSecretsEnabled != "" {
-		k.Log.Infof("Delete pull secret '%s'...", workspaceId)
+		log.Infof("Delete pull secret '%s'...", workspaceId)
 		err := k.DeleteSecret(ctx, getPullSecretsName(workspaceId))
 		if err != nil {
 			return err

--- a/pkg/driver/kubernetes/find.go
+++ b/pkg/driver/kubernetes/find.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -11,8 +12,8 @@ func (k *KubernetesDriver) FindDevContainer(
 	ctx context.Context,
 	workspaceId string,
 ) (*config.ContainerDetails, error) {
-	k.Log.Debugf("Finding devcontainer for workspace '%s'", workspaceId)
-	defer k.Log.Debugf("Done finding devcontainer for workspace '%s'", workspaceId)
+	log.Debugf("Finding devcontainer for workspace '%s'", workspaceId)
+	defer log.Debugf("Done finding devcontainer for workspace '%s'", workspaceId)
 
 	workspaceId = getID(workspaceId)
 
@@ -26,8 +27,8 @@ func (k *KubernetesDriver) FindDevContainer(
 	// check pod
 	pod, err := k.getPod(ctx, pvc.Name)
 	if err != nil {
-		k.Log.Infof("Error finding pod: %v", err)
-		k.Log.Warn(
+		log.Infof("Error finding pod: %v", err)
+		log.Warn(
 			"If the pod does not come up automatically it is stuck in an error state. " +
 				"Recreate the workspace to recover from this",
 		)

--- a/pkg/driver/kubernetes/helper.go
+++ b/pkg/driver/kubernetes/helper.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/yaml"
@@ -17,7 +17,7 @@ const (
 	requestsPrefix = "requests."
 )
 
-func parseResources(resourceString string, log log.Logger) corev1.ResourceRequirements {
+func parseResources(resourceString string) corev1.ResourceRequirements {
 	resourcesSplitted := strings.Split(resourceString, ",")
 	requests := corev1.ResourceList{}
 	limits := corev1.ResourceList{}

--- a/pkg/driver/kubernetes/pullsecrets.go
+++ b/pkg/driver/kubernetes/pullsecrets.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/devsy-org/devsy/pkg/dockercredentials"
+	"github.com/devsy-org/devsy/pkg/log"
 	k8sv1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,7 +16,7 @@ func (k *KubernetesDriver) EnsurePullSecret(
 	pullSecretName string,
 	dockerImage string,
 ) (bool, error) {
-	k.Log.Debugf("Ensure pull secrets")
+	log.Debugf("Ensure pull secrets")
 
 	host, err := GetRegistryFromImageName(dockerImage)
 	if err != nil {
@@ -25,17 +26,17 @@ func (k *KubernetesDriver) EnsurePullSecret(
 	dockerCredentials, err := dockercredentials.GetAuthConfig(host)
 	if err != nil || dockerCredentials == nil || dockerCredentials.Username == "" ||
 		dockerCredentials.Secret == "" {
-		k.Log.Debugf("Couldn't retrieve credentials for registry: %s", host)
+		log.Debugf("Couldn't retrieve credentials for registry: %s", host)
 		return false, nil
 	}
 
 	if k.secretExists(ctx, pullSecretName) {
 		if !k.shouldRecreateSecret(ctx, dockerCredentials, pullSecretName, host) {
-			k.Log.Debugf("Pull secret '%s' already exists and is up to date", pullSecretName)
+			log.Debugf("Pull secret '%s' already exists and is up to date", pullSecretName)
 			return true, nil
 		}
 
-		k.Log.Debugf(
+		log.Debugf(
 			"Pull secret '%s' already exists, but is outdated. Recreating...",
 			pullSecretName,
 		)
@@ -50,7 +51,7 @@ func (k *KubernetesDriver) EnsurePullSecret(
 		return false, err
 	}
 
-	k.Log.Infof("Pull secret '%s' created", pullSecretName)
+	log.Infof("Pull secret '%s' created", pullSecretName)
 	return true, nil
 }
 

--- a/pkg/driver/kubernetes/pvc.go
+++ b/pkg/driver/kubernetes/pvc.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 
 	"github.com/devsy-org/devsy/pkg/driver"
+	"github.com/devsy-org/devsy/pkg/log"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,7 +23,7 @@ func (k *KubernetesDriver) createPersistentVolumeClaim(
 		return err
 	}
 
-	k.Log.Infof("Create Persistent Volume Claim '%s'", id)
+	log.Infof("Create Persistent Volume Claim '%s'", id)
 	_, err = k.client.Client().
 		CoreV1().
 		PersistentVolumeClaims(k.namespace).
@@ -77,7 +78,7 @@ func (k *KubernetesDriver) buildPersistentVolumeClaim(
 	annotations[DevsyInfoAnnotation] = containerInfo
 	extraAnnotations, err := parseLabels(k.options.PvcAnnotations)
 	if err != nil {
-		k.Log.Error("Failed to parse annotations from PVC_ANNOTATIONS option: %v", err)
+		log.Errorf("Failed to parse annotations from PVC_ANNOTATIONS option: %v", err)
 	}
 	maps.Copy(annotations, extraAnnotations)
 

--- a/pkg/driver/kubernetes/run.go
+++ b/pkg/driver/kubernetes/run.go
@@ -12,6 +12,7 @@ import (
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/driver"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -48,7 +49,7 @@ func (k *KubernetesDriver) RunDevContainer(
 	workspaceId string,
 	options *driver.RunOptions,
 ) error {
-	k.Log.Debugf("Running devcontainer for workspace '%s'", workspaceId)
+	log.Debugf("Running devcontainer for workspace '%s'", workspaceId)
 	workspaceId = getID(workspaceId)
 
 	// namespace
@@ -110,9 +111,9 @@ func (k *KubernetesDriver) runContainer(
 		// Ensure workspace volume mount option is parent or same dir as workspace mount
 		rel, err := filepath.Rel(k.options.WorkspaceVolumeMount, mount.Target)
 		if err != nil {
-			k.Log.Warn("Relative filepath: %v", err)
+			log.Warnf("Relative filepath: %v", err)
 		} else if strings.HasPrefix(rel, "..") {
-			k.Log.Warnf(
+			log.Warnf(
 				"Workspace volume mount needs to be the same as the workspace mount or a parent, skipping option. "+
 					"WorkspaceVolumeMount: %s, MountTarget: %s",
 				k.options.WorkspaceVolumeMount,
@@ -120,7 +121,7 @@ func (k *KubernetesDriver) runContainer(
 			)
 		} else {
 			mount.Target = k.options.WorkspaceVolumeMount
-			k.Log.Debugf("Using workspace volume mount: %s", k.options.WorkspaceVolumeMount)
+			log.Debugf("Using workspace volume mount: %s", k.options.WorkspaceVolumeMount)
 		}
 	}
 
@@ -131,7 +132,7 @@ func (k *KubernetesDriver) runContainer(
 		},
 	}
 	if len(k.options.PodManifestTemplate) > 0 {
-		k.Log.Debugf("trying to get pod template manifest from %s", k.options.PodManifestTemplate)
+		log.Debugf("trying to get pod template manifest from %s", k.options.PodManifestTemplate)
 		pod, err = getPodTemplate(k.options.PodManifestTemplate)
 		if err != nil {
 			return err
@@ -151,7 +152,7 @@ func (k *KubernetesDriver) runContainer(
 		if mount.Type == "bind" || mount.Type == "volume" {
 			volumeMounts = append(volumeMounts, volumeMount)
 		} else {
-			k.Log.Warnf(
+			log.Warnf(
 				"Unsupported mount type '%s' in mount '%s', will skip",
 				mount.Type,
 				mount.String(),
@@ -214,7 +215,7 @@ func (k *KubernetesDriver) runContainer(
 		resources = pod.Spec.Containers[0].Resources
 	}
 	if k.options.Resources != "" {
-		resources = parseResources(k.options.Resources, k.Log)
+		resources = parseResources(k.options.Resources)
 	}
 
 	// ensure daemon config secret
@@ -282,12 +283,12 @@ func (k *KubernetesDriver) runContainer(
 			existingOptions,
 		)
 		if err != nil {
-			k.Log.Errorf("Error unmarshalling existing provider options, continuing...: %s", err)
+			log.Errorf("Error unmarshalling existing provider options, continuing...: %s", err)
 		}
 
 		// Nothing changed, can safely return
 		if optionsEqual(existingOptions, k.options) {
-			k.Log.Infof(
+			log.Infof(
 				"Pod '%s' already exists and nothing changed, skipping update",
 				existingPod.Name,
 			)
@@ -295,7 +296,7 @@ func (k *KubernetesDriver) runContainer(
 		}
 
 		// Stop the current pod
-		k.Log.Debug("Provider options changed")
+		log.Debug("Provider options changed")
 		err = k.waitPodDeleted(ctx, id)
 		if err != nil {
 			return fmt.Errorf("stop devcontainer: %s: %w", id, err)
@@ -331,17 +332,17 @@ func (k *KubernetesDriver) runPod(ctx context.Context, id string, pod *corev1.Po
 		return err
 	}
 
-	k.Log.Debugf("Create pod with: %s", string(podRaw))
+	log.Debugf("Create pod with: %s", string(podRaw))
 
 	// create the pod
-	k.Log.Infof("Create Pod '%s'", id)
+	log.Infof("Create Pod '%s'", id)
 	_, err = k.client.Client().CoreV1().Pods(k.namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("create pod: %w", err)
 	}
 
 	// wait for pod running
-	k.Log.Infof("Waiting for DevContainer Pod '%s' to come up...", id)
+	log.Infof("Waiting for DevContainer Pod '%s' to come up...", id)
 	_, err = k.waitPodRunning(ctx, id)
 	if err != nil {
 		return err
@@ -501,8 +502,8 @@ func getNodeSelector(pod *corev1.Pod, rawNodeSelector string) (map[string]string
 }
 
 func (k *KubernetesDriver) StartDevContainer(ctx context.Context, workspaceId string) error {
-	k.Log.Debugf("Starting devcontainer for workspace '%s'", workspaceId)
-	defer k.Log.Debugf("Done starting devcontainer for workspace '%s'", workspaceId)
+	log.Debugf("Starting devcontainer for workspace '%s'", workspaceId)
+	defer log.Debugf("Done starting devcontainer for workspace '%s'", workspaceId)
 
 	workspaceId = getID(workspaceId)
 	_, containerInfo, err := k.getDevContainerPvc(ctx, workspaceId)
@@ -551,7 +552,7 @@ func optionsEqual(a, b *provider2.ProviderKubernetesDriverConfig) bool {
 func (k *KubernetesDriver) createNamespace(ctx context.Context) error {
 	_, err := k.client.Client().CoreV1().Namespaces().Get(ctx, k.namespace, metav1.GetOptions{})
 	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
-		k.Log.Infof("Create namespace '%s'", k.namespace)
+		log.Infof("Create namespace '%s'", k.namespace)
 		_, err := k.client.Client().CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: k.namespace,

--- a/pkg/driver/kubernetes/serviceaccount.go
+++ b/pkg/driver/kubernetes/serviceaccount.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/devsy-org/devsy/pkg/log"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -23,7 +24,7 @@ func (k *KubernetesDriver) createServiceAccount(
 		return fmt.Errorf("get service account: %w", err)
 	} else if kerrors.IsNotFound(err) {
 		// create service account if it does not exist
-		k.Log.Infof("Create Service Account '%s'", serviceAccount)
+		log.Infof("Create Service Account '%s'", serviceAccount)
 		_, err := k.client.Client().
 			CoreV1().
 			ServiceAccounts(k.namespace).
@@ -48,7 +49,7 @@ func (k *KubernetesDriver) createServiceAccount(
 			return fmt.Errorf("get role binding: %w", err)
 		} else if kerrors.IsNotFound(err) {
 			// create role binding
-			k.Log.Infof("Create Role Binding '%s'", serviceAccount)
+			log.Infof("Create Role Binding '%s'", serviceAccount)
 			_, err := k.client.Client().
 				RbacV1().
 				RoleBindings(k.namespace).

--- a/pkg/driver/kubernetes/target_architecture.go
+++ b/pkg/driver/kubernetes/target_architecture.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/devsy-org/devsy/pkg/log"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -16,8 +17,8 @@ func (k *KubernetesDriver) TargetArchitecture(
 		return k.options.Architecture, nil
 	}
 
-	k.Log.Debugf("Getting target architecture for workspace '%s'", workspaceId)
-	defer k.Log.Debugf("Done getting target architecture for workspace '%s'", workspaceId)
+	log.Debugf("Getting target architecture for workspace '%s'", workspaceId)
+	defer log.Debugf("Done getting target architecture for workspace '%s'", workspaceId)
 
 	// get all nodes
 	nodes, err := k.client.Client().CoreV1().Nodes().List(ctx, metav1.ListOptions{})

--- a/pkg/driver/kubernetes/wait.go
+++ b/pkg/driver/kubernetes/wait.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/devsy-org/devsy/pkg/driver/kubernetes/throttledlogger"
+	"github.com/devsy-org/devsy/pkg/log"
+	oldlog "github.com/devsy-org/log"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,7 +17,7 @@ import (
 )
 
 func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*corev1.Pod, error) {
-	throttledLogger := throttledlogger.NewThrottledLogger(k.Log, time.Second*5)
+	throttledLogger := throttledlogger.NewThrottledLogger(oldlog.GetInstance(), time.Second*5)
 
 	timeoutDuration, err := time.ParseDuration(k.options.PodTimeout)
 	if err != nil {
@@ -147,7 +149,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 				// delete succeeded pods
 				if IsTerminated(containerStatus) && Succeeded(containerStatus) {
 					// delete pod that is succeeded
-					k.Log.Debugf("Delete Pod '%s' because it is succeeded", id)
+					log.Debugf("Delete Pod '%s' because it is succeeded", id)
 					err = k.waitPodDeleted(ctx, id)
 					if err != nil {
 						return false, err

--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/machineid"
 	"github.com/devsy-org/devsy/pkg/util"
-	"github.com/devsy-org/log"
 	"github.com/google/uuid"
 )
 
@@ -65,28 +65,24 @@ func SafeConcatNameMax(name []string, max int) string {
 	return fullPath
 }
 
-func GetMachineUIDShort(log log.Logger) string {
-	return GetMachineUID(log)[0:5]
+func GetMachineUIDShort() string {
+	return GetMachineUID()[0:5]
 }
 
 // Gets machine ID and encodes it together with users $HOME path and extra key to protect privacy.
 // Returns a hex-encoded string.
-func GetMachineUID(log log.Logger) string {
+func GetMachineUID() string {
 	id, err := machineid.ID()
 	if err != nil {
 		id = "error"
-		if log != nil {
-			log.Debugf("Error retrieving machine uid: %v", err)
-		}
+		log.Debugf("Error retrieving machine uid: %v", err)
 	}
 	// get $HOME to distinguish two users on the same machine
 	// will be hashed later together with the ID
 	home, err := util.UserHomeDir()
 	if err != nil {
 		home = "error"
-		if log != nil {
-			log.Debugf("Error retrieving machine home: %v", err)
-		}
+		log.Debugf("Error retrieving machine home: %v", err)
 	}
 	mac := hmac.New(sha256.New, []byte(id))
 	mac.Write([]byte(hashingKey))

--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/spf13/pflag"
 )
 
@@ -25,7 +24,6 @@ type Cloner interface {
 		repository string,
 		targetDir string,
 		extraArgs, extraEnv []string,
-		log log.Logger,
 	) error
 }
 
@@ -116,21 +114,11 @@ func (c *cloner) initialArgs() []string {
 	return []string{"clone"}
 }
 
-type progressWriter struct {
-	level logrus.Level
-	log   log.Logger
-}
-
-func (w *progressWriter) Write(p []byte) (n int, err error) {
-	return w.log.WriteLevel(w.level, p)
-}
-
 func (c *cloner) Clone(
 	ctx context.Context,
 	repository string,
 	targetDir string,
 	extraArgs, extraEnv []string,
-	log log.Logger,
 ) error {
 	args := c.initialArgs()
 	args = append(args, extraArgs...)
@@ -142,7 +130,7 @@ func (c *cloner) Clone(
 		extraEnv = append(extraEnv, "GIT_LFS_SKIP_SMUDGE=1")
 	}
 
-	w := &progressWriter{log: log, level: logrus.InfoLevel}
+	w := log.Writer(log.LevelInfo)
 	gitCommand := CommandContext(ctx, extraEnv, args...)
 	gitCommand.Stdout = w
 	gitCommand.Stderr = w

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -10,8 +10,7 @@ import (
 	"time"
 
 	"github.com/devsy-org/devsy/pkg/command"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 const (
@@ -133,7 +132,6 @@ func CloneRepository(
 	targetDir string,
 	helper string,
 	strictHostKeyChecking bool,
-	log log.Logger,
 	cloneOptions ...Option,
 ) error {
 	return CloneRepositoryWithEnv(
@@ -143,7 +141,6 @@ func CloneRepository(
 		targetDir,
 		helper,
 		strictHostKeyChecking,
-		log,
 		cloneOptions...)
 }
 
@@ -165,7 +162,6 @@ func CloneRepositoryWithEnv(
 	targetDir string,
 	helper string,
 	strictHostKeyChecking bool,
-	log log.Logger,
 	cloneOptions ...Option,
 ) error {
 	cloner := NewClonerWithOpts(cloneOptions...)
@@ -188,17 +184,16 @@ func CloneRepositoryWithEnv(
 		targetDir,
 		extraArgs,
 		extraEnv,
-		log,
 	); err != nil {
 		return err
 	}
 
 	if gitInfo.PR != "" {
-		return checkoutPR(ctx, gitInfo, extraEnv, targetDir, log)
+		return checkoutPR(ctx, gitInfo, extraEnv, targetDir)
 	}
 
 	if gitInfo.Commit != "" {
-		return checkoutCommit(ctx, gitInfo, extraEnv, targetDir, log)
+		return checkoutCommit(ctx, gitInfo, extraEnv, targetDir)
 	}
 
 	return nil
@@ -209,7 +204,6 @@ func checkoutPR(
 	gitInfo *GitInfo,
 	extraEnv []string,
 	targetDir string,
-	log log.Logger,
 ) error {
 	log.Debugf("Fetching pull request : %s", gitInfo.PR)
 
@@ -242,10 +236,9 @@ func checkoutCommit(
 	gitInfo *GitInfo,
 	extraEnv []string,
 	targetDir string,
-	log log.Logger,
 ) error {
-	stdout := log.Writer(logrus.InfoLevel, false)
-	stderr := log.Writer(logrus.ErrorLevel, false)
+	stdout := log.Writer(log.LevelInfo)
+	stderr := log.Writer(log.LevelError)
 	defer func() { _ = stdout.Close() }()
 	defer func() { _ = stderr.Close() }()
 

--- a/pkg/git/install.go
+++ b/pkg/git/install.go
@@ -5,13 +5,13 @@ import (
 	"os/exec"
 
 	"github.com/devsy-org/devsy/pkg/command"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
-func InstallBinary(log log.Logger) error {
-	writer := log.Writer(logrus.InfoLevel, false)
-	errwriter := log.Writer(logrus.ErrorLevel, false)
+//nolint:cyclop
+func InstallBinary() error {
+	writer := log.Writer(log.LevelInfo)
+	errwriter := log.Writer(log.LevelError)
 	defer func() { _ = writer.Close() }()
 	defer func() { _ = errwriter.Close() }()
 
@@ -60,7 +60,7 @@ func InstallBinary(log log.Logger) error {
 		return fmt.Errorf("couldn't install git")
 	}
 
-	log.Donef("installed git")
+	log.Infof("installed git")
 
 	return nil
 }

--- a/pkg/gitsshsigning/client.go
+++ b/pkg/gitsshsigning/client.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/config"
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 const defaultCredentialsServerPort = "12049"
@@ -30,18 +30,18 @@ func getCredentialsPort() (int, error) {
 }
 
 // HandleGitSSHProgramCall implements logic handling call from git when signing a commit.
-func HandleGitSSHProgramCall(certPath, namespace, bufferFile string, log log.Logger) error {
+func HandleGitSSHProgramCall(certPath, namespace, bufferFile string) error {
 	content, err := extractContentFromGitBuffer(bufferFile)
 	if err != nil {
 		return err
 	}
 
-	signature, err := requestContentSignature(content, certPath, log)
+	signature, err := requestContentSignature(content, certPath)
 	if err != nil {
 		return err
 	}
 
-	if err := writeSignatureToFile(signature, bufferFile, log); err != nil {
+	if err := writeSignatureToFile(signature, bufferFile); err != nil {
 		return err
 	}
 
@@ -54,22 +54,22 @@ func extractContentFromGitBuffer(bufferFile string) ([]byte, error) {
 }
 
 // requestContentSignature sends an HTTP request to the credentials server to sign the content.
-func requestContentSignature(content []byte, certPath string, log log.Logger) ([]byte, error) {
+func requestContentSignature(content []byte, certPath string) ([]byte, error) {
 	requestBody, err := createSignatureRequestBody(content, certPath)
 	if err != nil {
 		return nil, err
 	}
 
-	responseBody, err := sendSignatureRequest(requestBody, log)
+	responseBody, err := sendSignatureRequest(requestBody)
 	if err != nil {
 		return nil, err
 	}
 
-	return parseSignatureResponse(responseBody, log)
+	return parseSignatureResponse(responseBody)
 }
 
 // writeSignatureToFile writes the signed content to a .sig file.
-func writeSignatureToFile(signature []byte, bufferFile string, log log.Logger) error {
+func writeSignatureToFile(signature []byte, bufferFile string) error {
 	sigFile := bufferFile + ".sig"
 	// #nosec G306 -- TODO Consider using a more secure permission setting and ownership if needed.
 	if err := os.WriteFile(sigFile, signature, 0o644); err != nil {
@@ -115,7 +115,7 @@ func getSignatureURL() (string, error) {
 	return "http://localhost:" + strconv.Itoa(port) + "/git-ssh-signature", nil
 }
 
-func sendSignatureRequest(requestBody []byte, log log.Logger) ([]byte, error) {
+func sendSignatureRequest(requestBody []byte) ([]byte, error) {
 	url, err := getSignatureURL()
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ func sendSignatureRequest(requestBody []byte, log log.Logger) ([]byte, error) {
 	return body, nil
 }
 
-func parseSignatureResponse(responseBody []byte, log log.Logger) ([]byte, error) {
+func parseSignatureResponse(responseBody []byte) ([]byte, error) {
 	signatureResponse := &GitSSHSignatureResponse{}
 	if err := json.Unmarshal(responseBody, signatureResponse); err != nil {
 		log.Errorf("Error decoding git ssh signature: %v", err)

--- a/pkg/gitsshsigning/client_test.go
+++ b/pkg/gitsshsigning/client_test.go
@@ -8,14 +8,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/devsy-org/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestParseSignatureResponse_NonJSONBody(t *testing.T) {
 	body := []byte("get git ssh signature: permission denied")
-	_, err := parseSignatureResponse(body, log.Discard)
+	_, err := parseSignatureResponse(body)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "get git ssh signature: permission denied")
 }
@@ -26,7 +25,7 @@ func TestParseSignatureResponse_ValidJSON(t *testing.T) {
 	body, err := json.Marshal(response)
 	require.NoError(t, err)
 
-	result, err := parseSignatureResponse(body, log.Discard)
+	result, err := parseSignatureResponse(body)
 	require.NoError(t, err)
 	assert.Equal(t, sig, result)
 }
@@ -44,7 +43,7 @@ func TestRequestContentSignature_ServerError_PlainText(t *testing.T) {
 	signatureServerURL = server.URL + "/git-ssh-signature"
 	t.Cleanup(func() { signatureServerURL = "" })
 
-	_, err := requestContentSignature([]byte("commit content"), "/tmp/key.pub", log.Discard)
+	_, err := requestContentSignature([]byte("commit content"), "/tmp/key.pub")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to sign commit")
 	assert.NotContains(t, err.Error(), "invalid character")
@@ -61,7 +60,7 @@ func TestRequestContentSignature_ServerError_JSON(t *testing.T) {
 	signatureServerURL = server.URL + "/git-ssh-signature"
 	t.Cleanup(func() { signatureServerURL = "" })
 
-	_, err := requestContentSignature([]byte("commit content"), "/tmp/key.pub", log.Discard)
+	_, err := requestContentSignature([]byte("commit content"), "/tmp/key.pub")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "signing failed")
 }
@@ -78,7 +77,7 @@ func TestRequestContentSignature_Success(t *testing.T) {
 	signatureServerURL = server.URL + "/git-ssh-signature"
 	t.Cleanup(func() { signatureServerURL = "" })
 
-	result, err := requestContentSignature([]byte("commit content"), "/tmp/key.pub", log.Discard)
+	result, err := requestContentSignature([]byte("commit content"), "/tmp/key.pub")
 	require.NoError(t, err)
 	assert.Equal(t, sig, result)
 	assert.Contains(t, string(result), "BEGIN SSH SIGNATURE")
@@ -94,7 +93,7 @@ func TestRequestContentSignature_InvalidJSON(t *testing.T) {
 	signatureServerURL = server.URL + "/git-ssh-signature"
 	t.Cleanup(func() { signatureServerURL = "" })
 
-	_, err := requestContentSignature([]byte("commit content"), "/tmp/key.pub", log.Discard)
+	_, err := requestContentSignature([]byte("commit content"), "/tmp/key.pub")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not json at all")
 }

--- a/pkg/gitsshsigning/helper.go
+++ b/pkg/gitsshsigning/helper.go
@@ -10,7 +10,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/command"
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/file"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 const (
@@ -36,7 +36,7 @@ var GitConfigTemplate = `
 // - creates a wrapper script for calling git-ssh-signature
 // - users this script as gpg.ssh.program
 // This is needed since git expects `gpg.ssh.program` to be an executable.
-func ConfigureHelper(userName, gitSigningKey string, log log.Logger) error {
+func ConfigureHelper(userName, gitSigningKey string) error {
 	log.Debug("Creating helper script")
 	if err := createHelperScript(); err != nil {
 		return err

--- a/pkg/gpg/forward.go
+++ b/pkg/gpg/forward.go
@@ -5,13 +5,13 @@ import (
 	"os/exec"
 
 	client2 "github.com/devsy-org/devsy/pkg/client"
+	"github.com/devsy-org/devsy/pkg/log"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
-	"github.com/devsy-org/log"
 )
 
 // ForwardAgent starts a background SSH connection that forwards the local GPG agent.
-func ForwardAgent(client client2.BaseWorkspaceClient, logger log.Logger) error {
-	logger.Debug("gpg forwarding enabled, performing immediately")
+func ForwardAgent(client client2.BaseWorkspaceClient) error {
+	log.Debug("gpg forwarding enabled, performing immediately")
 
 	execPath, err := os.Executable()
 	if err != nil {
@@ -27,14 +27,14 @@ func ForwardAgent(client client2.BaseWorkspaceClient, logger log.Logger) error {
 		remoteUser = "root"
 	}
 
-	logger.Info("forwarding gpg-agent")
+	log.Info("forwarding gpg-agent")
 
 	args := buildForwardArgs(remoteUser, client.Context(), client.Workspace())
 
 	go func() {
 		//nolint:gosec // execPath comes from os.Executable()
 		if runErr := exec.Command(execPath, args...).Run(); runErr != nil {
-			logger.Errorf("failure in forwarding gpg-agent: %v", runErr)
+			log.Errorf("failure in forwarding gpg-agent: %v", runErr)
 		}
 	}()
 

--- a/pkg/gpg/gpg_forwarding.go
+++ b/pkg/gpg/gpg_forwarding.go
@@ -10,9 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/devsy-org/devsy/pkg/log"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -27,9 +26,8 @@ func IsGpgTunnelRunning(
 	ctx context.Context,
 	user string,
 	client *ssh.Client,
-	log log.Logger,
 ) bool {
-	writer := log.ErrorStreamOnly().Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelError)
 	defer func() { _ = writer.Close() }()
 
 	command := "gpg -K"

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -21,6 +21,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/ide/rstudio"
 	"github.com/devsy-org/devsy/pkg/ide/vscode"
 	"github.com/devsy-org/devsy/pkg/ide/zed"
+	pkglog "github.com/devsy-org/devsy/pkg/log"
 	open2 "github.com/devsy-org/devsy/pkg/open"
 	"github.com/devsy-org/devsy/pkg/port"
 	"github.com/devsy-org/devsy/pkg/tunnel"
@@ -88,7 +89,7 @@ func openDesktopIDE(
 		return openJetBrains(ideName, ideOptions, params)
 
 	case string(config.IDEFleet):
-		return startFleet(ctx, params.Client, params.Log)
+		return startFleet(ctx, params.Client)
 
 	case string(config.IDEZed):
 		return zed.Open(
@@ -257,7 +258,7 @@ func openJupyterBrowser(
 	params Params,
 ) error {
 	if params.GPGAgentForwarding {
-		if err := gpg.ForwardAgent(params.Client, params.Log); err != nil {
+		if err := gpg.ForwardAgent(params.Client); err != nil {
 			return err
 		}
 	}
@@ -273,7 +274,7 @@ func openJupyterBrowser(
 	targetURL := fmt.Sprintf("http://localhost:%d/lab", jupyterPort)
 	if jupyter.Options.GetValue(ideOptions, jupyter.OpenOption) == config.BoolTrue {
 		go func() {
-			if openErr := open2.Open(ctx, targetURL, params.Log); openErr != nil {
+			if openErr := open2.Open(ctx, targetURL); openErr != nil {
 				params.Log.Errorf("error opening jupyter notebook: error=%v", openErr)
 			}
 
@@ -295,7 +296,6 @@ func openJupyterBrowser(
 		ExtraPorts:       extraPorts,
 		AuthSockID:       params.SSHAuthSockID,
 		GitSSHSigningKey: params.GitSSHSigningKey,
-		Logger:           params.Log,
 		DaemonStartFunc:  makeDaemonStartFunc(params, false, extraPorts),
 	})
 }
@@ -306,7 +306,7 @@ func openRStudioBrowser(
 	params Params,
 ) error {
 	if params.GPGAgentForwarding {
-		if err := gpg.ForwardAgent(params.Client, params.Log); err != nil {
+		if err := gpg.ForwardAgent(params.Client); err != nil {
 			return err
 		}
 	}
@@ -322,7 +322,7 @@ func openRStudioBrowser(
 	targetURL := fmt.Sprintf("http://localhost:%d", rsPort)
 	if rstudio.Options.GetValue(ideOptions, rstudio.OpenOption) == config.BoolTrue {
 		go func() {
-			if openErr := open2.Open(ctx, targetURL, params.Log); openErr != nil {
+			if openErr := open2.Open(ctx, targetURL); openErr != nil {
 				params.Log.Errorf("error opening rstudio: %v", openErr)
 			}
 
@@ -343,7 +343,6 @@ func openRStudioBrowser(
 		ExtraPorts:       extraPorts,
 		AuthSockID:       params.SSHAuthSockID,
 		GitSSHSigningKey: params.GitSSHSigningKey,
-		Logger:           params.Log,
 		DaemonStartFunc:  makeDaemonStartFunc(params, false, extraPorts),
 	})
 }
@@ -354,7 +353,7 @@ func openVSCodeBrowser(
 	params Params,
 ) error {
 	if params.GPGAgentForwarding {
-		if err := gpg.ForwardAgent(params.Client, params.Log); err != nil {
+		if err := gpg.ForwardAgent(params.Client); err != nil {
 			return err
 		}
 	}
@@ -371,7 +370,7 @@ func openVSCodeBrowser(
 	targetURL := fmt.Sprintf("http://localhost:%d/?folder=%s", vscodePort, folder)
 	if openvscode.Options.GetValue(ideOptions, openvscode.OpenOption) == config.BoolTrue {
 		go func() {
-			if openErr := open2.Open(ctx, targetURL, params.Log); openErr != nil {
+			if openErr := open2.Open(ctx, targetURL); openErr != nil {
 				params.Log.Errorf("error opening vscode: %v", openErr)
 			}
 
@@ -398,17 +397,15 @@ func openVSCodeBrowser(
 		ExtraPorts:       extraPorts,
 		AuthSockID:       params.SSHAuthSockID,
 		GitSSHSigningKey: params.GitSSHSigningKey,
-		Logger:           params.Log,
 		DaemonStartFunc:  makeDaemonStartFunc(params, forwardPorts, extraPorts),
 	})
 }
 
-func startFleet(ctx context.Context, client client2.BaseWorkspaceClient, logger log.Logger) error {
+func startFleet(ctx context.Context, client client2.BaseWorkspaceClient) error {
 	stdout := &bytes.Buffer{}
 	sshCmd, err := tunnel.CreateSSHCommand(
 		ctx,
 		client,
-		logger,
 		[]string{"--command", "cat " + fleet.FleetURLFileName},
 	)
 	if err != nil {
@@ -425,11 +422,11 @@ func startFleet(ctx context.Context, client client2.BaseWorkspaceClient, logger 
 		return fmt.Errorf("seems like fleet is not running within the container")
 	}
 
-	logger.Warnf(
+	pkglog.Warnf(
 		"Fleet is exposed at a publicly reachable URL, please make sure to not disclose this URL " +
 			"to anyone as they will be able to reach your workspace from that",
 	)
-	logger.Infof("Starting Fleet at %s ...", url)
+	pkglog.Infof("Starting Fleet at %s ...", url)
 
 	return open2.Run(url)
 }

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"regexp"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -98,7 +98,6 @@ func (t *contextAwareTransport) RoundTrip(req *http.Request) (*http.Response, er
 func GetImageConfig(
 	ctx context.Context,
 	image string,
-	log log.Logger,
 ) (*v1.ConfigFile, v1.Image, error) {
 	log.Debugf("Getting image config for image '%s'", image)
 	defer log.Debugf("Done getting image config for image '%s'", image)
@@ -136,7 +135,6 @@ func shouldNotBeSlugged(data string, regexp *regexp.Regexp, maxSize int) bool {
 func GetImageConfigForArch(
 	ctx context.Context,
 	image, arch string,
-	log log.Logger,
 ) (*v1.ConfigFile, v1.Image, error) {
 	log.Debugf("Getting image config for image '%s' with architecture '%s'", image, arch)
 	defer log.Debugf("Done getting image config for image '%s' with architecture '%s'", image, arch)

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/command"
 	"github.com/devsy-org/devsy/pkg/config"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 //go:embed inject.sh
@@ -37,7 +37,6 @@ type InjectOptions struct {
 	Stdout       io.Writer
 	Stderr       io.Writer
 	Timeout      time.Duration
-	Log          log.Logger
 }
 
 func Inject(opts InjectOptions) (bool, error) {
@@ -46,9 +45,6 @@ func Inject(opts InjectOptions) (bool, error) {
 	}
 	if opts.Exec == nil {
 		return false, fmt.Errorf("exec function is required")
-	}
-	if opts.Log == nil {
-		return false, fmt.Errorf("log is required")
 	}
 	if opts.ScriptParams == nil {
 		return false, fmt.Errorf("script params is required")
@@ -59,7 +55,7 @@ func Inject(opts InjectOptions) (bool, error) {
 		if opts.ScriptParams.DownloadURLs != nil {
 			url = opts.ScriptParams.DownloadURLs.Base
 		}
-		opts.Log.Debugf("prefer downloading agent from URL: url=%s", url)
+		log.Debugf("prefer downloading agent from URL: url=%s", url)
 	}
 
 	scriptRawCode, err := GenerateScript(Script, opts.ScriptParams)
@@ -67,8 +63,8 @@ func Inject(opts InjectOptions) (bool, error) {
 		return true, err
 	}
 
-	opts.Log.Debug("execute inject script")
-	defer opts.Log.Debug("done injecting")
+	log.Debug("execute inject script")
+	defer log.Debug("done injecting")
 
 	// start script
 	stdinReader, stdinWriter, err := os.Pipe()
@@ -100,7 +96,7 @@ func Inject(opts InjectOptions) (bool, error) {
 	execErrChan := make(chan error, 1)
 	go func() {
 		defer func() { _ = stdoutWriter.Close() }()
-		defer opts.Log.Debug("done exec")
+		defer log.Debug("done exec")
 
 		err := opts.Exec(cancelCtx, scriptRawCode, stdinReader, stdoutWriter, delayedStderr)
 		if err != nil && !errors.Is(err, context.Canceled) &&
@@ -115,7 +111,7 @@ func Inject(opts InjectOptions) (bool, error) {
 	injectChan := make(chan injectResult, 1)
 	go func() {
 		defer func() { _ = stdinWriter.Close() }()
-		defer opts.Log.Debug("done inject")
+		defer log.Debug("done inject")
 
 		wasExecuted, err := inject(
 			opts.LocalFile,
@@ -125,7 +121,6 @@ func Inject(opts InjectOptions) (bool, error) {
 			opts.Stdout,
 			delayedStderr,
 			opts.Timeout,
-			opts.Log,
 		)
 		injectChan <- injectResult{
 			wasExecuted: wasExecuted,
@@ -151,7 +146,7 @@ func Inject(opts InjectOptions) (bool, error) {
 		return result.wasExecuted, nil
 	}
 
-	opts.Log.Debugf("Rerun command as binary was injected")
+	log.Debugf("Rerun command as binary was injected")
 	delayedStderr.Start()
 	return true, opts.Exec(
 		opts.Ctx,
@@ -170,7 +165,6 @@ func inject(
 	stdoutOut io.Writer,
 	delayedStderr *delayedWriter,
 	timeout time.Duration,
-	log log.Logger,
 ) (bool, error) {
 	// wait until we read start
 	var line string

--- a/pkg/language/language.go
+++ b/pkg/language/language.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 type ProgrammingLanguage string
@@ -132,7 +132,7 @@ var skipDirs = map[string]bool{
 	"bower_components": true,
 }
 
-func DefaultConfig(startPath string, log log.Logger) *config.DevContainerConfig {
+func DefaultConfig(startPath string) *config.DevContainerConfig {
 	language, err := DetectLanguage(startPath)
 	if err != nil {
 		log.Errorf("Error detecting project language: %v", err)

--- a/pkg/loftconfig/client.go
+++ b/pkg/loftconfig/client.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 
 	"github.com/devsy-org/devsy/pkg/credentials"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform/client"
-	"github.com/devsy-org/log"
 )
 
-func GetDevsyConfig(context, provider string, port int, logger log.Logger) (*client.Config, error) {
+func GetDevsyConfig(context, provider string, port int) (*client.Config, error) {
 	request := &DevsyConfigRequest{
 		Context:  context,
 		Provider: provider,
@@ -18,7 +18,7 @@ func GetDevsyConfig(context, provider string, port int, logger log.Logger) (*cli
 
 	rawJson, err := json.Marshal(request)
 	if err != nil {
-		logger.Errorf("Error parsing request: %w", err)
+		log.Errorf("Error parsing request: %w", err)
 		return nil, err
 	}
 
@@ -27,7 +27,6 @@ func GetDevsyConfig(context, provider string, port int, logger log.Logger) (*cli
 		port,
 		"loft-platform-credentials",
 		bytes.NewReader(rawJson),
-		logger,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/loftconfig/config.go
+++ b/pkg/loftconfig/config.go
@@ -5,11 +5,11 @@ import (
 	"os/exec"
 
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform/client"
-	"github.com/devsy-org/log"
 )
 
-func AuthDevsyCliToPlatform(config *client.Config, logger log.Logger) error {
+func AuthDevsyCliToPlatform(config *client.Config) error {
 	cmd := exec.Command( // #nosec G204 -- binary name is a compile-time constant
 		pkgconfig.BinaryName,
 		"pro",
@@ -20,7 +20,7 @@ func AuthDevsyCliToPlatform(config *client.Config, logger log.Logger) error {
 	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logger.Debugf(
+		log.Debugf(
 			"Failed executing `%s pro login`: %w, output: %s",
 			pkgconfig.BinaryName,
 			err,
@@ -37,17 +37,17 @@ func AuthDevsyCliToPlatform(config *client.Config, logger log.Logger) error {
 	return nil
 }
 
-func AuthVClusterCliToPlatform(config *client.Config, logger log.Logger) error {
+func AuthVClusterCliToPlatform(config *client.Config) error {
 	// Check if vcluster is available inside the workspace
 	if _, err := exec.LookPath("vcluster"); err != nil {
-		logger.Debugf("'vcluster' command is not available")
+		log.Debugf("'vcluster' command is not available")
 		return nil
 	}
 
 	cmd := exec.Command("vcluster", "login", "--access-key", config.AccessKey, config.Host)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		logger.Debugf("Failed executing `vcluster login` : %w, output: %s", err, out)
+		log.Debugf("Failed executing `vcluster login` : %w, output: %s", err, out)
 		return fmt.Errorf("error executing 'vcluster login' command: %w", err)
 	}
 

--- a/pkg/log/levels.go
+++ b/pkg/log/levels.go
@@ -12,6 +12,11 @@ const (
 	LevelFatal = 0
 )
 
+// DebugEnabled reports whether debug-level messages are currently logged.
+func DebugEnabled() bool {
+	return sugar.Desugar().Core().Enabled(zapcore.DebugLevel)
+}
+
 // VerbosityToLevel converts a -v count (0-3) to a zapcore.Level.
 // 0 = error+fatal only, 1 = +warn+info, 2 = +debug, 3 = trace (mapped to zap Debug-1).
 func VerbosityToLevel(verbosity int) zapcore.Level {

--- a/pkg/netstat/watcher.go
+++ b/pkg/netstat/watcher.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 type Forwarder interface {
@@ -14,17 +14,15 @@ type Forwarder interface {
 	StopForward(port string) error
 }
 
-func NewWatcher(forwarder Forwarder, log log.Logger) *Watcher {
+//nolint:funcorder
+func NewWatcher(forwarder Forwarder) *Watcher {
 	return &Watcher{
 		forwarder:      forwarder,
 		forwardedPorts: map[string]bool{},
-		log:            log,
 	}
 }
 
 type Watcher struct {
-	log log.Logger
-
 	forwarder      Forwarder
 	forwardedPorts map[string]bool
 }
@@ -37,7 +35,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 		case <-time.After(time.Second * 3):
 			err := w.runOnce()
 			if err != nil {
-				w.log.Errorf("Error watching ports: %v", err)
+				log.Errorf("Error watching ports: %v", err)
 			}
 		}
 	}
@@ -52,7 +50,7 @@ func (w *Watcher) runOnce() error {
 	// stop ports that are not there anymore
 	for port := range w.forwardedPorts {
 		if !newPorts[port] {
-			w.log.Debugf("Stop port %s", port)
+			log.Debugf("Stop port %s", port)
 			err = w.forwarder.StopForward(port)
 			if err != nil {
 				return fmt.Errorf("error stop forwarding port %s: %w", port, err)
@@ -63,7 +61,7 @@ func (w *Watcher) runOnce() error {
 	// start ports that were not there before
 	for port := range newPorts {
 		if !w.forwardedPorts[port] {
-			w.log.Debugf("Found open port %s ready to forward", port)
+			log.Debugf("Found open port %s ready to forward", port)
 			err = w.forwarder.Forward(port)
 			if err != nil {
 				return fmt.Errorf("error forwarding port %s: %w", port, err)

--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/skratchdot/open-golang/open"
 )
 
@@ -23,13 +23,13 @@ func Run(url string) error {
 }
 
 // Open opens the given url in the default application, retrying every second until the context is done.
-func Open(ctx context.Context, url string, log log.Logger) error {
+func Open(ctx context.Context, url string) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-time.After(time.Second):
-			err := tryOpen(ctx, url, Run, log)
+			err := tryOpen(ctx, url, Run)
 			if err == nil {
 				return nil
 			}
@@ -38,13 +38,13 @@ func Open(ctx context.Context, url string, log log.Logger) error {
 }
 
 // JLabDesktop opens the given url in the JLab desktop application, retrying every second until the context is done.
-func JLabDesktop(ctx context.Context, url string, log log.Logger) error {
+func JLabDesktop(ctx context.Context, url string) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-time.After(time.Second):
-			err := tryOpen(ctx, url, jlabOpen, log)
+			err := tryOpen(ctx, url, jlabOpen)
 			if err == nil {
 				return nil
 			}
@@ -56,7 +56,8 @@ func jlabOpen(url string) error {
 	return exec.Command("jlab", url).Run()
 }
 
-func tryOpen(ctx context.Context, url string, fn func(string) error, log log.Logger) error {
+//nolint:cyclop
+func tryOpen(ctx context.Context, url string, fn func(string) error) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
@@ -83,7 +84,7 @@ func tryOpen(ctx context.Context, url string, fn func(string) error, log log.Log
 			if err := fn(url); err != nil {
 				return fmt.Errorf("open url: %w", err)
 			}
-			log.Donef("opened url: url=%s", url)
+			log.Infof("opened url: url=%s", url)
 			return nil
 		}
 	}

--- a/pkg/options/resolve.go
+++ b/pkg/options/resolve.go
@@ -13,7 +13,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/options/resolver"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
 )
 
 func ResolveAndSaveOptionsMachine(
@@ -22,7 +21,6 @@ func ResolveAndSaveOptionsMachine(
 	providerConfig *provider.ProviderConfig,
 	originalMachine *provider.Machine,
 	userOptions map[string]string,
-	log log.Logger,
 ) (*provider.Machine, error) {
 	if originalMachine == nil {
 		return nil, fmt.Errorf("originalMachine cannot be nil")
@@ -49,7 +47,6 @@ func ResolveAndSaveOptionsMachine(
 	resolvedOptions, _, err := resolver.New(
 		userOptions,
 		provider.Merge(provider.ToOptionsMachine(machine), binaryPaths),
-		log,
 		resolver.WithResolveLocal(),
 	).Resolve(
 		ctx,
@@ -91,7 +88,6 @@ func ResolveAndSaveOptionsWorkspace(
 	providerConfig *provider.ProviderConfig,
 	originalWorkspace *provider.Workspace,
 	userOptions map[string]string,
-	log log.Logger,
 	options ...resolver.Option,
 ) (*provider.Workspace, error) {
 	if originalWorkspace == nil {
@@ -120,7 +116,6 @@ func ResolveAndSaveOptionsWorkspace(
 	resolvedOptions, _, err := resolver.New(
 		userOptions,
 		provider.Merge(provider.ToOptionsWorkspace(workspace), binaryPaths),
-		log,
 		options...,
 	).Resolve(
 		ctx,
@@ -161,7 +156,6 @@ func ResolveOptions(
 	skipRequired bool,
 	skipSubOptions bool,
 	singleMachine *bool,
-	log log.Logger,
 ) (*config.Config, error) {
 	// get binary paths
 	binaryPaths, err := provider.GetBinaries(devConfig.DefaultContext, providerConfig)
@@ -184,7 +178,6 @@ func ResolveOptions(
 			provider.GetBaseEnvironment(devConfig.DefaultContext, providerConfig.Name),
 			binaryPaths,
 		),
-		log,
 		resolverOpts...,
 	)
 

--- a/pkg/options/resolve_test.go
+++ b/pkg/options/resolve_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/options/resolver"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
 	"gotest.tools/assert"
 )
 
@@ -669,7 +668,7 @@ func TestResolveOptions(t *testing.T) {
 		if testCase.ResolveGlobal {
 			resolverOpts = append(resolverOpts, resolver.WithResolveGlobal())
 		}
-		r := resolver.New(testCase.UserValues, testCase.ExtraValues, log.Default, resolverOpts...)
+		r := resolver.New(testCase.UserValues, testCase.ExtraValues, resolverOpts...)
 		options, dynamicOptions, err := r.Resolve(
 			context.Background(),
 			testCase.ResolvedDynamicDefinitions,

--- a/pkg/options/resolver/parse.go
+++ b/pkg/options/resolver/parse.go
@@ -7,14 +7,13 @@ import (
 	"time"
 
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
 )
 
 func printUnusedUserValues(
 	userValues map[string]string,
 	options config.OptionDefinitions,
-	log log.Logger,
 ) {
 	allowedOptions := []string{}
 	for k := range options {

--- a/pkg/options/resolver/resolve_test.go
+++ b/pkg/options/resolver/resolve_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/graph"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -21,7 +20,6 @@ func (suite *ResolveTestSuite) SetupTest() {
 		graph:       graph.NewGraph[*types.Option](),
 		userOptions: make(map[string]string),
 		extraValues: make(map[string]string),
-		log:         log.Default,
 	}
 }
 

--- a/pkg/options/resolver/resolver.go
+++ b/pkg/options/resolver/resolver.go
@@ -7,7 +7,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/graph"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 )
 
 const (
@@ -52,13 +52,13 @@ type Resolver struct {
 
 	// internal
 	graph *graph.Graph[*types.Option]
-	log   log.Logger
 
 	// options
 	resolveLocal      bool
 	resolveGlobal     bool
 	resolveSubOptions bool
 	skipRequired      bool
+	log               oldlog.Logger
 }
 
 type Option func(r *Resolver)
@@ -66,7 +66,6 @@ type Option func(r *Resolver)
 func New(
 	userOptions map[string]string,
 	extraValues map[string]string,
-	logger log.Logger,
 	opts ...Option,
 ) *Resolver {
 	if userOptions == nil {
@@ -76,7 +75,6 @@ func New(
 	resolver := &Resolver{
 		userOptions: userOptions,
 		extraValues: extraValues,
-		log:         logger,
 	}
 	for _, o := range opts {
 		o(resolver)
@@ -106,6 +104,12 @@ func WithResolveSubOptions() Option {
 func WithSkipRequired(skip bool) Option {
 	return func(r *Resolver) {
 		r.skipRequired = skip
+	}
+}
+
+func WithLogger(log oldlog.Logger) Option {
+	return func(r *Resolver) {
+		r.log = log
 	}
 }
 
@@ -165,7 +169,6 @@ func (r *Resolver) Resolve(
 		printUnusedUserValues(
 			r.userOptions,
 			mergeMaps(optionDefinitions, newDynamicDefinitions),
-			r.log,
 		)
 	}
 

--- a/pkg/options/resolver/resolver_test.go
+++ b/pkg/options/resolver/resolver_test.go
@@ -8,19 +8,16 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/graph"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
 	"github.com/stretchr/testify/suite"
 )
 
 type ResolverTestSuite struct {
 	suite.Suite
 	resolver *Resolver
-	logger   log.Logger
 }
 
 func (suite *ResolverTestSuite) SetupTest() {
-	suite.logger = log.Default
-	suite.resolver = New(map[string]string{}, map[string]string{}, suite.logger)
+	suite.resolver = New(map[string]string{}, map[string]string{})
 }
 
 func TestResolverSuite(t *testing.T) {
@@ -103,7 +100,7 @@ func (suite *ResolverTestSuite) TestResolveOptions_SingleOption() {
 
 func (suite *ResolverTestSuite) TestResolveOptions_UserProvidedValue() {
 	userOptions := map[string]string{"test_option": "user_value"}
-	suite.resolver = New(userOptions, map[string]string{}, suite.logger)
+	suite.resolver = New(userOptions, map[string]string{})
 	suite.resolver.graph = graph.NewGraph[*types.Option]()
 
 	option := &types.Option{
@@ -296,8 +293,7 @@ func (suite *ResolverTestSuite) TestCombineFunction() {
 }
 
 func (suite *ResolverTestSuite) TestBasicResolverFunctionality() {
-	logger := log.Default
-	resolver := New(map[string]string{}, map[string]string{}, logger, WithResolveSubOptions())
+	resolver := New(map[string]string{}, map[string]string{}, WithResolveSubOptions())
 
 	optionDefs := map[string]*types.Option{
 		"parent": {

--- a/pkg/platform/client.go
+++ b/pkg/platform/client.go
@@ -8,28 +8,25 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 )
 
 func InitClientFromHost(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	devsyProHost string,
-	log log.Logger,
 ) (client.Client, error) {
-	provider, err := ProviderFromHost(ctx, devsyConfig, devsyProHost, log)
+	provider, err := ProviderFromHost(ctx, devsyConfig, devsyProHost)
 	if err != nil {
 		return nil, fmt.Errorf("provider from pro instance: %w", err)
 	}
 
-	return InitClientFromProvider(ctx, devsyConfig, provider, log)
+	return InitClientFromProvider(ctx, devsyConfig, provider)
 }
 
 func InitClientFromProvider(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	providerName string,
-	log log.Logger,
 ) (client.Client, error) {
 	configPath, err := DevsyConfigPath(devsyConfig.DefaultContext, providerName)
 	if err != nil {
@@ -43,7 +40,6 @@ func ProviderFromHost(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	devsyProHost string,
-	log log.Logger,
 ) (string, error) {
 	proInstanceConfig, err := provider.LoadProInstanceConfig(
 		devsyConfig.DefaultContext,

--- a/pkg/platform/client/client.go
+++ b/pkg/platform/client/client.go
@@ -20,12 +20,12 @@ import (
 	storagev1 "github.com/devsy-org/api/pkg/apis/storage/v1"
 	"github.com/devsy-org/api/pkg/auth"
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	devsyopen "github.com/devsy-org/devsy/pkg/open"
 	"github.com/devsy-org/devsy/pkg/platform/kube"
 	"github.com/devsy-org/devsy/pkg/platform/project"
 	"github.com/devsy-org/devsy/pkg/util"
 	"github.com/devsy-org/devsy/pkg/version"
-	"github.com/devsy-org/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -64,7 +64,7 @@ type Client interface {
 	RefreshSelf(ctx context.Context) error
 	Self() *managementv1.Self
 
-	Login(host string, insecure bool, log log.Logger) error
+	Login(host string, insecure bool) error
 	LoginWithAccessKey(host, accessKey string, insecure bool, force bool) error
 	LoginRaw(host, accessKey string, insecure bool) error
 
@@ -301,7 +301,7 @@ func (c *client) Version() (*auth.Version, error) {
 	return version, nil
 }
 
-func (c *client) Login(host string, insecure bool, log log.Logger) error {
+func (c *client) Login(host string, insecure bool) error {
 	var (
 		loginUrl   = fmt.Sprintf(LoginPath, host)
 		key        keyStruct
@@ -313,7 +313,7 @@ func (c *client) Login(host string, insecure bool, log log.Logger) error {
 		return err
 	}
 
-	server := startServer(fmt.Sprintf(RedirectPath, host), keyChannel, log)
+	server := startServer(fmt.Sprintf(RedirectPath, host), keyChannel)
 	err = devsyopen.Run(fmt.Sprintf(LoginPath, host))
 	if err != nil {
 		return fmt.Errorf(
@@ -518,7 +518,7 @@ func GetRestConfig(host, token string, insecure bool) (*rest.Config, error) {
 	return config, nil
 }
 
-func startServer(redirectURI string, keyChannel chan keyStruct, log log.Logger) *http.Server {
+func startServer(redirectURI string, keyChannel chan keyStruct) *http.Server {
 	srv := &http.Server{Addr: ":25843"}
 
 	http.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/platform/deploy.go
+++ b/pkg/platform/deploy.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -31,7 +31,6 @@ func WaitForPodReady(
 	ctx context.Context,
 	kubeClient kubernetes.Interface,
 	namespace string,
-	log log.Logger,
 ) (*corev1.Pod, error) {
 	// wait until we have a running loft pod
 	now := time.Now()

--- a/pkg/platform/form/form.go
+++ b/pkg/platform/form/form.go
@@ -12,11 +12,11 @@ import (
 	storagev1 "github.com/devsy-org/api/pkg/apis/storage/v1"
 	"github.com/devsy-org/devsy/cmd/pro/provider/list"
 	"github.com/devsy-org/devsy/pkg/encoding"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/labels"
 	"github.com/devsy-org/devsy/pkg/platform/project"
-	"github.com/devsy-org/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -25,7 +25,6 @@ func CreateInstance(
 	ctx context.Context,
 	baseClient client.Client,
 	id, uid, source, picture string,
-	log log.Logger,
 ) (*managementv1.DevsyWorkspaceInstance, error) {
 	formCtx, cancelForm := context.WithCancel(ctx)
 	defer cancelForm()
@@ -47,14 +46,14 @@ func CreateInstance(
 			huh.NewSelect[*managementv1.Cluster]().
 				Title("Cluster").
 				OptionsFunc(func() []huh.Option[*managementv1.Cluster] {
-					return getClusterOptions(ctx, baseClient, selectedProject, cancelForm, log)
+					return getClusterOptions(ctx, baseClient, selectedProject, cancelForm)
 				}, &selectedProject).
 				Value(&selectedCluster).
 				WithHeight(5),
 			huh.NewSelect[*managementv1.DevsyWorkspaceTemplate]().
 				Title("Template").
 				OptionsFunc(func() []huh.Option[*managementv1.DevsyWorkspaceTemplate] {
-					return getTemplateOptions(ctx, baseClient, selectedProject, cancelForm, log)
+					return getTemplateOptions(ctx, baseClient, selectedProject, cancelForm)
 				}, &selectedProject).
 				Value(&selectedTemplate),
 			huh.NewSelect[string]().
@@ -131,7 +130,6 @@ func UpdateInstance(
 	ctx context.Context,
 	baseClient client.Client,
 	instance *managementv1.DevsyWorkspaceInstance,
-	log log.Logger,
 ) (*managementv1.DevsyWorkspaceInstance, error) {
 	formCtx, cancelForm := context.WithCancel(ctx)
 	defer cancelForm()
@@ -293,7 +291,6 @@ func getClusterOptions(
 	client client.Client,
 	project *managementv1.Project,
 	cancel CancelFunc,
-	log log.Logger,
 ) []huh.Option[*managementv1.Cluster] {
 	opts := []huh.Option[*managementv1.Cluster]{}
 	if project == nil {
@@ -323,7 +320,6 @@ func getTemplateOptions(
 	client client.Client,
 	project *managementv1.Project,
 	cancel CancelFunc,
-	log log.Logger,
 ) []huh.Option[*managementv1.DevsyWorkspaceTemplate] {
 	opts := []huh.Option[*managementv1.DevsyWorkspaceTemplate]{}
 	if project == nil {

--- a/pkg/platform/instance.go
+++ b/pkg/platform/instance.go
@@ -15,10 +15,10 @@ import (
 
 	managementv1 "github.com/devsy-org/api/pkg/apis/management/v1"
 	storagev1 "github.com/devsy-org/api/pkg/apis/storage/v1"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/kube"
 	"github.com/devsy-org/devsy/pkg/platform/project"
-	"github.com/devsy-org/log"
 	"github.com/gorilla/websocket"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -180,7 +180,6 @@ func DialInstance(
 	workspace *managementv1.DevsyWorkspaceInstance,
 	subResource string,
 	values url.Values,
-	log log.Logger,
 ) (*websocket.Conn, error) {
 	restConfig, err := baseClient.ManagementConfig()
 	if err != nil {
@@ -231,7 +230,6 @@ func UpdateInstance(
 	client client.Client,
 	oldInstance *managementv1.DevsyWorkspaceInstance,
 	newInstance *managementv1.DevsyWorkspaceInstance,
-	log log.Logger,
 ) (*managementv1.DevsyWorkspaceInstance, error) {
 	managementClient, err := client.Management()
 	if err != nil {
@@ -260,14 +258,13 @@ func UpdateInstance(
 		return nil, fmt.Errorf("patch workspace instance: %w (patch: %s)", err, string(data))
 	}
 
-	return WaitForInstance(ctx, client, res, log)
+	return WaitForInstance(ctx, client, res)
 }
 
 func WaitForInstance(
 	ctx context.Context,
 	client client.Client,
 	instance *managementv1.DevsyWorkspaceInstance,
-	log log.Logger,
 ) (*managementv1.DevsyWorkspaceInstance, error) {
 	managementClient, err := client.Management()
 	if err != nil {

--- a/pkg/platform/remotecommand/client.go
+++ b/pkg/platform/remotecommand/client.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"io"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/gorilla/websocket"
 )
 
@@ -15,7 +15,6 @@ func ExecuteConn(
 	stdin io.Reader,
 	stdout io.Writer,
 	stderr io.Writer,
-	log log.Logger,
 ) (int, error) {
 	conn := NewWebsocketConn(rawConn)
 

--- a/pkg/provider/download.go
+++ b/pkg/provider/download.go
@@ -17,7 +17,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/download"
 	"github.com/devsy-org/devsy/pkg/extract"
 	"github.com/devsy-org/devsy/pkg/log"
-	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/log/hash"
 	"k8s.io/client-go/util/retry"
 )
@@ -473,7 +472,7 @@ func downloadAndSaveFile(
 ) (string, error) {
 	log.Infof("downloading binary %s from %s", binaryName, binary.Path)
 
-	body, err := download.File(binary.Path, oldlog.Default)
+	body, err := download.File(binary.Path)
 	if err != nil {
 		return "", fmt.Errorf("download binary: %w", err)
 	}
@@ -526,7 +525,7 @@ type archiveDownloadParams struct {
 func extractArchive(params archiveDownloadParams) (string, error) {
 	log.Infof("downloading binary %s from %s", params.binaryName, params.binary.Path)
 
-	body, err := download.File(params.binary.Path, oldlog.Default)
+	body, err := download.File(params.binary.Path)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ssh/config.go
+++ b/pkg/ssh/config.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/util"
-	"github.com/devsy-org/log"
 	"github.com/devsy-org/log/scanner"
 )
 
@@ -35,7 +35,6 @@ type SSHConfigParams struct {
 	GPGAgent             bool
 	DevsyHome            string
 	Provider             string
-	Log                  log.Logger
 }
 
 func ConfigureSSHConfig(params SSHConfigParams) error {
@@ -63,7 +62,7 @@ func ConfigureSSHConfig(params SSHConfigParams) error {
 		return fmt.Errorf("parse ssh config: %w", err)
 	}
 
-	return writeSSHConfig(targetPath, newFile, params.Log)
+	return writeSSHConfig(targetPath, newFile)
 }
 
 type DevsySSHEntry struct {
@@ -323,7 +322,6 @@ func RemoveFromConfig(
 	workspaceID string,
 	sshConfigPath string,
 	sshConfigIncludePath string,
-	log log.Logger,
 ) error {
 	configLock.Lock()
 	defer configLock.Unlock()
@@ -338,10 +336,10 @@ func RemoveFromConfig(
 		return fmt.Errorf("parse ssh config: %w", err)
 	}
 
-	return writeSSHConfig(targetPath, newFile, log)
+	return writeSSHConfig(targetPath, newFile)
 }
 
-func writeSSHConfig(path, content string, log log.Logger) error {
+func writeSSHConfig(path, content string) error {
 	// #nosec G301 -- TODO Consider using a more secure permission setting and ownership if needed.
 	err := os.MkdirAll(filepath.Dir(path), 0o755)
 	if err != nil {

--- a/pkg/ssh/connection_counter.go
+++ b/pkg/ssh/connection_counter.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 func newConnectionCounter(
@@ -13,14 +13,12 @@ func newConnectionCounter(
 	timeout time.Duration,
 	onTimeout func(),
 	address string,
-	log log.Logger,
 ) *connectionCounter {
 	return &connectionCounter{
 		ctx:       ctx,
 		address:   address,
 		timeout:   timeout,
 		onTimeout: onTimeout,
-		log:       log,
 	}
 }
 
@@ -30,7 +28,6 @@ type connectionCounter struct {
 	ctx       context.Context
 	timeout   time.Duration
 	onTimeout func()
-	log       log.Logger
 
 	m           sync.Mutex
 	connections int
@@ -42,7 +39,7 @@ func (c *connectionCounter) Add() {
 	defer c.m.Unlock()
 
 	c.connections++
-	c.log.Debugf("New connection on %s (Total: %d)", c.address, c.connections)
+	log.Debugf("New connection on %s (Total: %d)", c.address, c.connections)
 }
 
 func (c *connectionCounter) Dec() {
@@ -50,7 +47,7 @@ func (c *connectionCounter) Dec() {
 	defer c.m.Unlock()
 
 	c.connections--
-	c.log.Debugf("Closed connection on %s (Total: %d)", c.address, c.connections)
+	log.Debugf("Closed connection on %s (Total: %d)", c.address, c.connections)
 	if c.connections <= 0 && c.timeout > 0 {
 		c.generation++
 

--- a/pkg/ssh/forward.go
+++ b/pkg/ssh/forward.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -16,7 +16,6 @@ type ForwardingFunction func(
 	*ssh.Client,
 	string,
 	string,
-	log.Logger,
 )
 
 func PortForward(
@@ -24,7 +23,6 @@ func PortForward(
 	client *ssh.Client,
 	localNetwork, localAddr, remoteNetwork, remoteAddr string,
 	exitAfterTimeout time.Duration,
-	log log.Logger,
 ) error {
 	listener, err := net.Listen(localNetwork, localAddr)
 	if err != nil {
@@ -35,7 +33,7 @@ func PortForward(
 	return portForwarding(
 		ctx, client, listener,
 		localAddr, remoteNetwork, remoteAddr,
-		exitAfterTimeout, log, forward,
+		exitAfterTimeout, forward,
 	)
 }
 
@@ -44,7 +42,6 @@ func ReversePortForward(
 	client *ssh.Client,
 	remoteNetwork, remoteAddr, localNetwork, localAddr string,
 	exitAfterTimeout time.Duration,
-	log log.Logger,
 ) error {
 	listener, err := client.Listen(remoteNetwork, remoteAddr)
 	if err != nil {
@@ -55,7 +52,7 @@ func ReversePortForward(
 	return portForwarding(
 		ctx, client, listener,
 		remoteAddr, localNetwork, localAddr,
-		exitAfterTimeout, log, reverseForward,
+		exitAfterTimeout, reverseForward,
 	)
 }
 
@@ -65,7 +62,6 @@ func portForwarding(
 	listener net.Listener,
 	srcAddr, dstNetwork, dstAddr string,
 	exitAfterTimeout time.Duration,
-	log log.Logger,
 	forwardFn ForwardingFunction,
 ) error {
 	done := make(chan struct{})
@@ -84,7 +80,7 @@ func portForwarding(
 			"Stopping devsy up, because it stayed idle for a while. " +
 				"You can disable this via 'devsy context set-options -o EXIT_AFTER_TIMEOUT=false'",
 		)
-	}, srcAddr, log)
+	}, srcAddr)
 	for {
 		// waiting for a new connection
 		connection, err := listener.Accept()
@@ -99,7 +95,7 @@ func portForwarding(
 		go func() {
 			defer counter.Dec()
 
-			forwardFn(connection, client, dstNetwork, dstAddr, log)
+			forwardFn(connection, client, dstNetwork, dstAddr)
 		}()
 	}
 }
@@ -108,7 +104,6 @@ func forward(
 	localConn net.Conn,
 	client *ssh.Client,
 	remoteNetwork, remoteAddr string,
-	log log.Logger,
 ) {
 	// Setup sshConn (type net.Conn)
 	sshConn, err := client.Dial(remoteNetwork, remoteAddr)
@@ -147,7 +142,6 @@ func reverseForward(
 	remoteConn net.Conn,
 	client *ssh.Client,
 	localNetwork, localAddr string,
-	log log.Logger,
 ) {
 	// Setup localConn (type net.Conn)
 	localConn, err := net.Dial(localNetwork, localAddr)

--- a/pkg/ssh/server/exec.go
+++ b/pkg/ssh/server/exec.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/pty"
-	"github.com/devsy-org/log"
 	"github.com/devsy-org/ssh"
 )
 
@@ -22,7 +22,7 @@ import (
 //
 // Loosely modeled after Coder's startNonPTYSession:
 //   - https://github.com/coder/coder/blob/main/agent/agentssh/agentssh.go
-func execNonPTY(sess ssh.Session, cmd *exec.Cmd, log log.Logger) (err error) {
+func execNonPTY(sess ssh.Session, cmd *exec.Cmd) (err error) {
 	log.Debugf("execute SSH server command: %s", strings.Join(cmd.Args, " "))
 
 	cmd.SysProcAttr = cmdSysProcAttr()
@@ -54,7 +54,7 @@ func execNonPTY(sess ssh.Session, cmd *exec.Cmd, log log.Logger) (err error) {
 	}()
 	go func() {
 		for sig := range sigs {
-			forwardSignal(log, sig, cmd.Process)
+			forwardSignal(sig, cmd.Process)
 		}
 	}()
 
@@ -79,7 +79,6 @@ func (p *ptySession) close() error {
 func (p *ptySession) handleSignalsAndResize(
 	sigs <-chan ssh.Signal,
 	winCh <-chan ssh.Window,
-	log log.Logger,
 ) {
 	for sigs != nil || winCh != nil {
 		select {
@@ -88,24 +87,24 @@ func (p *ptySession) handleSignalsAndResize(
 				sigs = nil
 				continue
 			}
-			p.forwardSignal(sig, log)
+			p.forwardSignal(sig)
 		case win, ok := <-winCh:
 			if !ok {
 				winCh = nil
 				continue
 			}
-			p.resizePTY(win, log)
+			p.resizePTY(win)
 		}
 	}
 }
 
-func (p *ptySession) forwardSignal(sig ssh.Signal, log log.Logger) {
+func (p *ptySession) forwardSignal(sig ssh.Signal) {
 	if err := p.proc.Signal(osSignalFrom(sig)); err != nil {
 		log.Debugf("failed to signal pty process: %v", err)
 	}
 }
 
-func (p *ptySession) resizePTY(win ssh.Window, log log.Logger) {
+func (p *ptySession) resizePTY(win ssh.Window) {
 	if err := p.pc.Resize(
 		uint16(win.Height), //nolint:gosec // G115: SSH window dimensions fit uint16
 		uint16(win.Width),  //nolint:gosec // G115: SSH window dimensions fit uint16
@@ -120,7 +119,6 @@ type ptyExecParams struct {
 	ptyReq ssh.Pty
 	winCh  <-chan ssh.Window
 	cmd    *exec.Cmd
-	log    log.Logger
 }
 
 // execPTY executes a command with a PTY, handling terminal resize events and
@@ -135,7 +133,7 @@ type ptyExecParams struct {
 //   - Coder issue:  https://github.com/coder/coder/issues/3371
 //   - Neovim issue: https://github.com/neovim/neovim/issues/3875
 func execPTY(p ptyExecParams) (retErr error) {
-	p.log.Debugf("execute SSH server PTY command: %s", strings.Join(p.cmd.Args, " "))
+	log.Debugf("execute SSH server PTY command: %s", strings.Join(p.cmd.Args, " "))
 	p.sess.DisablePTYEmulation()
 
 	// Build an explicit Env so we can inject TERM without losing inherited
@@ -162,7 +160,7 @@ func execPTY(p ptyExecParams) (retErr error) {
 	ps := &ptySession{pc: pc, proc: proc}
 	defer func() {
 		if closeErr := ps.close(); closeErr != nil {
-			p.log.Debugf("failed to close pty: %v", closeErr)
+			log.Debugf("failed to close pty: %v", closeErr)
 			if retErr == nil {
 				retErr = closeErr
 			}
@@ -176,7 +174,7 @@ func execPTY(p ptyExecParams) (retErr error) {
 		close(sigs)
 	}()
 
-	go ps.handleSignalsAndResize(sigs, p.winCh, p.log)
+	go ps.handleSignalsAndResize(sigs, p.winCh)
 
 	go func() {
 		_, _ = io.Copy(pc.InputWriter(), p.sess)

--- a/pkg/ssh/server/exit.go
+++ b/pkg/ssh/server/exit.go
@@ -5,11 +5,11 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/ssh"
 )
 
-func exitWithError(sess ssh.Session, err error, log log.Logger) {
+func exitWithError(sess ssh.Session, err error) {
 	if err != nil {
 		var exitError *exec.ExitError
 		if !errors.As(err, &exitError) {

--- a/pkg/ssh/server/sftp_handler.go
+++ b/pkg/ssh/server/sftp_handler.go
@@ -5,14 +5,13 @@ import (
 	"io"
 
 	"github.com/devsy-org/devsy/pkg/command"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/ssh"
 	"github.com/pkg/sftp"
-	"github.com/sirupsen/logrus"
 )
 
-func sftpHandler(sess ssh.Session, currentUser string, log log.Logger) {
-	writer := log.Writer(logrus.DebugLevel, false)
+func sftpHandler(sess ssh.Session, currentUser string) {
+	writer := log.Writer(log.LevelDebug)
 	defer func() { _ = writer.Close() }()
 
 	user := sess.User()

--- a/pkg/ssh/server/signal_supported.go
+++ b/pkg/ssh/server/signal_supported.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/ssh"
 )
 
@@ -14,7 +14,7 @@ func cmdSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setpgid: true}
 }
 
-func forwardSignal(log log.Logger, sig ssh.Signal, proc *os.Process) {
+func forwardSignal(sig ssh.Signal, proc *os.Process) {
 	s := osSignalFrom(sig)
 	log.Debugf("forwarding signal %s to process %d", s, proc.Pid)
 	if err := proc.Signal(s); err != nil {

--- a/pkg/ssh/server/signal_unsupported.go
+++ b/pkg/ssh/server/signal_unsupported.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/ssh"
 )
 
@@ -14,7 +14,7 @@ func cmdSysProcAttr() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{}
 }
 
-func forwardSignal(log log.Logger, sig ssh.Signal, proc *os.Process) {
+func forwardSignal(sig ssh.Signal, proc *os.Process) {
 	log.Debugf("signal forwarding not supported on windows, ignoring %s", sig)
 }
 

--- a/pkg/ssh/server/ssh.go
+++ b/pkg/ssh/server/ssh.go
@@ -7,8 +7,8 @@ import (
 	"os/exec"
 	"os/user"
 
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/shell"
-	"github.com/devsy-org/log"
 	"github.com/devsy-org/ssh"
 )
 
@@ -28,7 +28,6 @@ type server struct {
 	workdir     string
 	reuseSock   string
 	sshServer   ssh.Server
-	log         log.Logger
 }
 
 func NewServer(
@@ -37,7 +36,6 @@ func NewServer(
 	keys []ssh.PublicKey,
 	workdir string,
 	reuseSock string,
-	log log.Logger,
 ) (Server, error) {
 	sh, err := shell.GetShell("")
 	if err != nil {
@@ -55,7 +53,6 @@ func NewServer(
 		shell:       sh,
 		workdir:     workdir,
 		reuseSock:   reuseSock,
-		log:         log,
 		currentUser: currentUser.Username,
 		sshServer: ssh.Server{
 			Addr: addr,
@@ -92,7 +89,7 @@ func NewServer(
 			},
 			SubsystemHandlers: map[string]ssh.SubsystemHandler{
 				"sftp": func(s ssh.Session) {
-					sftpHandler(s, currentUser.Username, log)
+					sftpHandler(s, currentUser.Username)
 				},
 			},
 		},
@@ -130,7 +127,7 @@ func (s *server) handler(sess ssh.Session) {
 	if ssh.AgentRequested(sess) {
 		l, tmpDir, err := setupAgentListener(s.reuseSock)
 		if err != nil {
-			exitWithError(sess, err, s.log)
+			exitWithError(sess, err)
 			return
 		}
 		defer func() { _ = l.Close() }()
@@ -148,14 +145,13 @@ func (s *server) handler(sess ssh.Session) {
 			ptyReq: ptyReq,
 			winCh:  winCh,
 			cmd:    cmd,
-			log:    s.log,
 		})
 	} else {
-		err = execNonPTY(sess, cmd, s.log)
+		err = execNonPTY(sess, cmd)
 	}
 
 	// exit session
-	exitWithError(sess, err, s.log)
+	exitWithError(sess, err)
 }
 
 func (s *server) getCommand(sess ssh.Session, isPty bool) *exec.Cmd {
@@ -209,6 +205,6 @@ func (s *server) Serve(listener net.Listener) error {
 }
 
 func (s *server) ListenAndServe() error {
-	s.log.Debugf("Start ssh server on %s", s.sshServer.Addr)
+	log.Debugf("Start ssh server on %s", s.sshServer.Addr)
 	return s.sshServer.ListenAndServe()
 }

--- a/pkg/ssh/server/ssh_container.go
+++ b/pkg/ssh/server/ssh_container.go
@@ -9,17 +9,16 @@ import (
 
 	copypkg "github.com/devsy-org/devsy/pkg/copy"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	shellpkg "github.com/devsy-org/devsy/pkg/shell"
-	"github.com/devsy-org/log"
 	"github.com/devsy-org/ssh"
 )
 
-func NewContainerServer(addr string, workdir string, log log.Logger) (Server, error) {
+func NewContainerServer(addr string, workdir string) (Server, error) {
 	forwardHandler := &ssh.ForwardedTCPHandler{}
 	forwardedUnixHandler := &ssh.ForwardedUnixHandler{}
 	server := &containerServer{
 		workdir: workdir,
-		log:     log,
 		sshServer: ssh.Server{
 			Addr: addr,
 			LocalPortForwardingCallback: func(ctx ssh.Context, dhost string, dport uint32) bool {
@@ -55,7 +54,7 @@ func NewContainerServer(addr string, workdir string, log log.Logger) (Server, er
 			},
 			SubsystemHandlers: map[string]ssh.SubsystemHandler{
 				"sftp": func(s ssh.Session) {
-					sftpHandler(s, "", log)
+					sftpHandler(s, "")
 				},
 			},
 		},
@@ -67,7 +66,6 @@ func NewContainerServer(addr string, workdir string, log log.Logger) (Server, er
 
 type containerServer struct {
 	sshServer ssh.Server
-	log       log.Logger
 	workdir   string
 }
 
@@ -76,7 +74,7 @@ func (s *containerServer) Serve(listener net.Listener) error {
 }
 
 func (s *containerServer) ListenAndServe() error {
-	s.log.Debugf("Start ssh server on %s", s.sshServer.Addr)
+	log.Debugf("Start ssh server on %s", s.sshServer.Addr)
 	return s.sshServer.ListenAndServe()
 }
 
@@ -85,14 +83,14 @@ func (s *containerServer) handler(sess ssh.Session) {
 	ptyReq, winCh, isPty := sess.Pty()
 	cmd, err := s.getCommand(sess, isPty)
 	if err != nil {
-		exitWithError(sess, fmt.Errorf("get command: %w", err), s.log)
+		exitWithError(sess, fmt.Errorf("get command: %w", err))
 		return
 	}
 
 	if ssh.AgentRequested(sess) {
 		l, tmpDir, err := setupAgentListener("")
 		if err != nil {
-			exitWithError(sess, err, s.log)
+			exitWithError(sess, err)
 			return
 		}
 		defer func() { _ = l.Close() }()
@@ -100,7 +98,7 @@ func (s *containerServer) handler(sess ssh.Session) {
 
 		err = chownListener(l.Addr().String(), sess.User())
 		if err != nil {
-			exitWithError(sess, fmt.Errorf("chown listener: %w", err), s.log)
+			exitWithError(sess, fmt.Errorf("chown listener: %w", err))
 			return
 		}
 
@@ -115,13 +113,12 @@ func (s *containerServer) handler(sess ssh.Session) {
 			ptyReq: ptyReq,
 			winCh:  winCh,
 			cmd:    cmd,
-			log:    s.log,
 		})
 	} else {
-		err = execNonPTY(sess, cmd, s.log)
+		err = execNonPTY(sess, cmd)
 	}
 
-	exitWithError(sess, err, s.log)
+	exitWithError(sess, err)
 }
 
 func (s *containerServer) getCommand(sess ssh.Session, isPty bool) (*exec.Cmd, error) {

--- a/pkg/ssh/ssh_add.go
+++ b/pkg/ssh/ssh_add.go
@@ -9,13 +9,13 @@ import (
 	"time"
 
 	"github.com/devsy-org/devsy/pkg/command"
+	"github.com/devsy-org/devsy/pkg/log"
 	devsshagent "github.com/devsy-org/devsy/pkg/ssh/agent"
 	"github.com/devsy-org/devsy/pkg/util"
-	"github.com/devsy-org/log"
 	"golang.org/x/crypto/ssh"
 )
 
-func AddPrivateKeysToAgent(ctx context.Context, log log.Logger) error {
+func AddPrivateKeysToAgent(ctx context.Context) error {
 	if devsshagent.GetSSHAuthSocket() == "" {
 		return fmt.Errorf("ssh-agent is not started")
 	} else if !command.Exists("ssh-add") {

--- a/pkg/telemetry/analytics/client.go
+++ b/pkg/telemetry/analytics/client.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 const (
@@ -31,7 +31,6 @@ func NewClient() Client {
 
 		events:     make(chan Event, 100),
 		httpClient: http.Client{Timeout: 3 * time.Second},
-		log:        log.Default.WithPrefix("analytics"),
 	}
 
 	go c.loop()
@@ -50,7 +49,6 @@ type client struct {
 	endpoint string
 
 	httpClient http.Client
-	log        log.Logger
 }
 
 func (c *client) RecordEvent(event Event) {
@@ -120,22 +118,22 @@ func (c *client) executeUpload(buffer []Event) {
 	if Dry {
 		marshaled, err := json.MarshalIndent(request, "", "  ")
 		if err != nil {
-			c.log.Debugf("failed to marshal analytics request: %v", err)
+			log.Debugf("failed to marshal analytics request: %v", err)
 			return
 		}
-		c.log.Infof("analytics request: %s", string(marshaled))
+		log.Infof("analytics request: %s", string(marshaled))
 		return
 	}
 
 	marshaled, err := json.Marshal(request)
 	if err != nil {
-		c.log.Debugf("failed to marshal analytics request: %v", err)
+		log.Debugf("failed to marshal analytics request: %v", err)
 		return
 	}
 
 	resp, err := c.httpClient.Post(c.endpoint, "application/json", bytes.NewReader(marshaled))
 	if err != nil {
-		c.log.Debugf("error sending analytics request: %v", err)
+		log.Debugf("error sending analytics request: %v", err)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
@@ -143,10 +141,10 @@ func (c *client) executeUpload(buffer []Event) {
 	if resp.StatusCode != http.StatusOK {
 		out, err := io.ReadAll(resp.Body)
 		if err != nil {
-			c.log.Debugf("error reading analytics response body: %v", err)
+			log.Debugf("error reading analytics response body: %v", err)
 			return
 		}
-		c.log.Debugf("analytics request returned status %d: %s", resp.StatusCode, string(out))
+		log.Debugf("analytics request returned status %d: %s", resp.StatusCode, string(out))
 	}
 }
 
@@ -155,7 +153,7 @@ func (c *client) exchangeBuffer() []Event {
 	defer c.bufferMutex.Unlock()
 
 	if c.droppedEvents > 0 {
-		c.log.Debugf("dropped %d analytics events (buffer full)", c.droppedEvents)
+		log.Debugf("dropped %d analytics events (buffer full)", c.droppedEvents)
 	}
 
 	events := c.buffer.Drain()

--- a/pkg/telemetry/collect.go
+++ b/pkg/telemetry/collect.go
@@ -10,9 +10,9 @@ import (
 
 	devsyclient "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/telemetry/analytics"
 	"github.com/devsy-org/devsy/pkg/version"
-	"github.com/devsy-org/log"
 	"github.com/moby/term"
 	"github.com/spf13/cobra"
 )
@@ -63,7 +63,7 @@ func StartCLI(devsyConfig *config.Config, cmd *cobra.Command) {
 	collector, err := newCLICollector(cmd)
 	if err != nil {
 		// Log the problem but don't fail - use disabled Collector instead
-		log.Default.WithPrefix("telemetry").Infof("%s", err.Error())
+		log.Infof("telemetry: %s", err.Error())
 	} else {
 		CollectorCLI = collector
 	}
@@ -72,7 +72,6 @@ func StartCLI(devsyConfig *config.Config, cmd *cobra.Command) {
 func newCLICollector(cmd *cobra.Command) (*cliCollector, error) {
 	defaultCollector := &cliCollector{
 		analyticsClient: analytics.NewClient(),
-		log:             log.Default.WithPrefix("telemetry"),
 		cmd:             cmd,
 	}
 
@@ -83,8 +82,6 @@ type cliCollector struct {
 	analyticsClient analytics.Client
 	cmd             *cobra.Command
 	client          devsyclient.BaseWorkspaceClient
-
-	log log.Logger
 }
 
 func (d *cliCollector) SetClient(client devsyclient.BaseWorkspaceClient) {
@@ -97,7 +94,7 @@ func (d *cliCollector) Flush() {
 
 func (d *cliCollector) RecordCLI(err error) {
 	if d.cmd == nil {
-		d.log.Debug("no command found, skipping")
+		log.Debug("no command found, skipping")
 		return
 	}
 	cmd := d.cmd.CommandPath()

--- a/pkg/ts/ssh.go
+++ b/pkg/ts/ssh.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -18,7 +18,6 @@ func WaitForSSHClient(
 	network, address string,
 	user string,
 	timeout time.Duration,
-	log log.Logger,
 ) (*ssh.Client, error) {
 	deadline := time.Now().Add(timeout)
 

--- a/pkg/ts/util.go
+++ b/pkg/ts/util.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/devsy-org/devsy/pkg/config"
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"tailscale.com/client/local"
 	"tailscale.com/ipn"
 	"tailscale.com/types/netmap"
@@ -55,7 +55,6 @@ func WaitHostReachable(
 	lc *local.Client,
 	addr Addr,
 	maxRetries int,
-	log log.Logger,
 ) error {
 	for i := range maxRetries {
 		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)

--- a/pkg/ts/workspace_server.go
+++ b/pkg/ts/workspace_server.go
@@ -15,9 +15,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	sshServer "github.com/devsy-org/devsy/pkg/ssh/server"
-	"github.com/devsy-org/log"
 	"tailscale.com/client/local"
 	"tailscale.com/envknob"
 	"tailscale.com/ipn/store/mem"
@@ -43,7 +43,6 @@ type WorkspaceServer struct {
 	connectionCounterMu sync.Mutex
 
 	config *WorkspaceServerConfig
-	log    log.Logger
 }
 
 // WorkspaceServerConfig defines configuration for the TSNet instance.
@@ -57,17 +56,16 @@ type WorkspaceServerConfig struct {
 }
 
 // NewWorkspaceServer creates a new TSNet server instance.
-func NewWorkspaceServer(config *WorkspaceServerConfig, logger log.Logger) *WorkspaceServer {
+func NewWorkspaceServer(config *WorkspaceServerConfig) *WorkspaceServer {
 	return &WorkspaceServer{
 		config: config,
-		log:    logger,
 	}
 }
 
 // Start initializes the TSNet server, sets up listeners for SSH and HTTP
 // reverse proxy traffic, and waits until the given context is canceled.
 func (s *WorkspaceServer) Start(ctx context.Context) error {
-	s.log.Infof("Starting workspace server")
+	log.Infof("Starting workspace server")
 
 	// Perform TSNet initialization (validation, control URL, server startup, hostname parsing)
 	workspaceName, projectName, err := s.setupTSNet(ctx)
@@ -97,12 +95,12 @@ func (s *WorkspaceServer) Start(ctx context.Context) error {
 
 			nm, err := json.Marshal(netMap)
 			if err != nil {
-				s.log.Errorf("Failed to marshal netmap: %v", err)
+				log.Errorf("Failed to marshal netmap: %v", err)
 			} else {
 				_ = os.WriteFile(filepath.Join(s.config.RootDir, "netmap.json"), nm, 0o644)
 			}
 		}); err != nil {
-			s.log.Errorf("Failed to watch netmap: %v", err)
+			log.Errorf("Failed to watch netmap: %v", err)
 		}
 	}()
 
@@ -122,7 +120,7 @@ func (s *WorkspaceServer) Stop() {
 		_ = s.tsServer.Close()
 		s.tsServer = nil
 	}
-	s.log.Info("Tailscale server stopped")
+	log.Info("Tailscale server stopped")
 }
 
 // Dial dials the given address using the TSNet server.
@@ -176,7 +174,7 @@ func (s *WorkspaceServer) setupControlURL(ctx context.Context) (*url.URL, error)
 func (s *WorkspaceServer) initTsServer(ctx context.Context, controlURL *url.URL) error {
 	store, _ := mem.New(s.config.LogF, "")
 	envknob.Setenv("TS_DEBUG_TLS_DIAL_INSECURE_SKIP_VERIFY", "true")
-	s.log.Infof("Connecting to control URL - %s/coordinator/", controlURL.String())
+	log.Infof("Connecting to control URL - %s/coordinator/", controlURL.String())
 	s.tsServer = &tsnet.Server{
 		Hostname:   s.config.WorkspaceHost,
 		Logf:       s.config.LogF,
@@ -208,14 +206,14 @@ func (s *WorkspaceServer) startListeners(
 	lc *local.Client,
 ) error {
 	// Create and start the SSH listener.
-	s.log.Infof("Starting SSH listener")
+	log.Infof("Starting SSH listener")
 	sshListener, err := s.createListener(fmt.Sprintf(":%d", sshServer.DefaultUserPort))
 	if err != nil {
 		return err
 	}
 
 	// Create and start the HTTP reverse proxy listener.
-	s.log.Infof("Starting HTTP reverse proxy listener on TSNet port %s", TSPortForwardPort)
+	log.Infof("Starting HTTP reverse proxy listener on TSNet port %s", TSPortForwardPort)
 	wsListener, err := s.createListener(fmt.Sprintf(":%s", TSPortForwardPort))
 	if err != nil {
 		return fmt.Errorf("failed to create listener on TS port %s: %w", TSPortForwardPort, err)
@@ -223,7 +221,7 @@ func (s *WorkspaceServer) startListeners(
 
 	// Create and start the platform HTTP git credentials listener
 	runnerProxySocket := filepath.Join(s.config.RootDir, RunnerProxySocket)
-	s.log.Infof("Starting runner proxy socket on %s", runnerProxySocket)
+	log.Infof("Starting runner proxy socket on %s", runnerProxySocket)
 	_ = os.Remove(runnerProxySocket)
 	runnerProxyListener, err := net.Listen("unix", runnerProxySocket)
 	if err != nil {
@@ -246,7 +244,7 @@ func (s *WorkspaceServer) startListeners(
 			s.gitCredentialsHandler(w, r, lc, transport, projectName, workspaceName)
 		})
 		if err := http.Serve(runnerProxyListener, mux); err != nil && err != http.ErrServerClosed {
-			s.log.Errorf("HTTP runner proxy server error: %v", err)
+			log.Errorf("HTTP runner proxy server error: %v", err)
 		}
 	}()
 
@@ -258,7 +256,7 @@ func (s *WorkspaceServer) startListeners(
 			s.dockerCredentialsHandler(w, r, lc, transport, projectName, workspaceName)
 		})
 		if err := http.Serve(runnerProxyListener, mux); err != nil && err != http.ErrServerClosed {
-			s.log.Errorf("HTTP runner proxy server error: %v", err)
+			log.Errorf("HTTP runner proxy server error: %v", err)
 		}
 	}()
 
@@ -267,7 +265,7 @@ func (s *WorkspaceServer) startListeners(
 		mux := http.NewServeMux()
 		mux.HandleFunc("/portforward", s.httpPortForwardHandler)
 		if err := http.Serve(wsListener, mux); err != nil && err != http.ErrServerClosed {
-			s.log.Errorf("HTTP server error on TS port %s: %v", TSPortForwardPort, err)
+			log.Errorf("HTTP server error on TS port %s: %v", TSPortForwardPort, err)
 		}
 	}()
 
@@ -308,7 +306,7 @@ func (s *WorkspaceServer) gitCredentialsHandler(
 	transport *http.Transport,
 	projectName, workspaceName string,
 ) {
-	s.log.Infof("Received git credentials request from %s", r.RemoteAddr)
+	log.Infof("Received git credentials request from %s", r.RemoteAddr)
 
 	// create a new http client with a custom transport
 	discoveredRunner, err := s.discoverRunner(r.Context(), lc)
@@ -350,7 +348,7 @@ func (s *WorkspaceServer) dockerCredentialsHandler(
 	transport *http.Transport,
 	projectName, workspaceName string,
 ) {
-	s.log.Infof("Received docker credentials request from %s", r.RemoteAddr)
+	log.Infof("Received docker credentials request from %s", r.RemoteAddr)
 
 	// create a new http client with a custom transport
 	discoveredRunner, err := s.discoverRunner(r.Context(), lc)
@@ -389,7 +387,7 @@ func (s *WorkspaceServer) dockerCredentialsHandler(
 func (s *WorkspaceServer) httpPortForwardHandler(w http.ResponseWriter, r *http.Request) {
 	s.addConnection()
 	defer s.removeConnection()
-	s.log.Debugf("httpPortForwardHandler: starting")
+	log.Debugf("httpPortForwardHandler: starting")
 
 	// Retrieve required custom headers.
 	targetPort := r.Header.Get("X-Loft-Forward-Port")
@@ -398,7 +396,7 @@ func (s *WorkspaceServer) httpPortForwardHandler(w http.ResponseWriter, r *http.
 		http.Error(w, "missing required X-Loft headers", http.StatusBadRequest)
 		return
 	}
-	s.log.Debugf(
+	log.Debugf(
 		"httpPortForwardHandler: received headers: X-Loft-Forward-Port=%s, X-Loft-Forward-Url=%s",
 		targetPort,
 		baseForwardStr,
@@ -407,13 +405,13 @@ func (s *WorkspaceServer) httpPortForwardHandler(w http.ResponseWriter, r *http.
 	// Parse and modify the URL to target the local endpoint.
 	parsedURL, err := url.Parse(baseForwardStr)
 	if err != nil {
-		s.log.Errorf("httpPortForwardHandler: failed to parse base URL: %v", err)
+		log.Errorf("httpPortForwardHandler: failed to parse base URL: %v", err)
 		http.Error(w, "invalid base forward URL", http.StatusBadRequest)
 		return
 	}
 	parsedURL.Scheme = "http"
 	parsedURL.Host = "127.0.0.1:" + targetPort
-	s.log.Debugf("httpPortForwardHandler: final target URL=%s", parsedURL.String())
+	log.Debugf("httpPortForwardHandler: final target URL=%s", parsedURL.String())
 
 	// Build the reverse proxy with a custom Director.
 	proxy := httputil.NewSingleHostReverseProxy(parsedURL)
@@ -428,7 +426,7 @@ func (s *WorkspaceServer) httpPortForwardHandler(w http.ResponseWriter, r *http.
 	}
 	proxy.Transport = http.DefaultTransport
 
-	s.log.Infof(
+	log.Infof(
 		"httpPortForwardHandler: final proxied request: %s %s",
 		r.Method,
 		parsedURL.String(),
@@ -449,7 +447,7 @@ func (s *WorkspaceServer) handleSSHConnections(ctx context.Context, listener net
 			if ctx.Err() != nil {
 				return
 			}
-			s.log.Errorf("Failed to accept connection: %v", err)
+			log.Errorf("Failed to accept connection: %v", err)
 			continue
 		}
 		go s.handleSSHConnection(clientConn)
@@ -465,7 +463,7 @@ func (s *WorkspaceServer) handleSSHConnection(clientConn net.Conn) {
 	localAddr := fmt.Sprintf("127.0.0.1:%d", sshServer.DefaultUserPort)
 	backendConn, err := net.Dial("tcp", localAddr)
 	if err != nil {
-		s.log.Errorf("Failed to connect to local address %s: %v", localAddr, err)
+		log.Errorf("Failed to connect to local address %s: %v", localAddr, err)
 		return
 	}
 	defer func() { _ = backendConn.Close() }()
@@ -505,7 +503,7 @@ func (s *WorkspaceServer) sendHeartbeats(
 			if connections > 0 {
 				err := s.sendHeartbeat(ctx, client, projectName, workspaceName, lc, connections)
 				if err != nil {
-					s.log.Errorf("Failed to send heartbeat: %v", err)
+					log.Errorf("Failed to send heartbeat: %v", err)
 				}
 			}
 		}
@@ -533,7 +531,7 @@ func (s *WorkspaceServer) sendHeartbeat(
 		projectName,
 		workspaceName,
 	)
-	s.log.Infof(
+	log.Infof(
 		"Sending heartbeat to %s, because there are %d active connections",
 		heartbeatURL,
 		connections,
@@ -553,7 +551,7 @@ func (s *WorkspaceServer) sendHeartbeat(
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("received response from %s - Status: %d", heartbeatURL, resp.StatusCode)
 	}
-	s.log.Infof("received response from %s - Status: %d", heartbeatURL, resp.StatusCode)
+	log.Infof("received response from %s - Status: %d", heartbeatURL, resp.StatusCode)
 	return nil
 }
 
@@ -579,6 +577,6 @@ func (s *WorkspaceServer) discoverRunner(ctx context.Context, lc *local.Client) 
 		return "", fmt.Errorf("no active runner found")
 	}
 
-	s.log.Infof("discoverRunner: selected runner = %s", runner)
+	log.Infof("discoverRunner: selected runner = %s", runner)
 	return runner, nil
 }

--- a/pkg/tunnel/browser.go
+++ b/pkg/tunnel/browser.go
@@ -9,9 +9,8 @@ import (
 
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -26,7 +25,6 @@ type BrowserTunnelParams struct {
 	ExtraPorts       []string
 	AuthSockID       string
 	GitSSHSigningKey string
-	Logger           log.Logger
 
 	// DaemonStartFunc is called when the client is a DaemonClient.
 	// If nil, the SSH tunnel path is always used.
@@ -37,8 +35,8 @@ type BrowserTunnelParams struct {
 func StartBrowserTunnel(p BrowserTunnelParams) error {
 	if p.AuthSockID != "" {
 		go func() {
-			if err := SetupBackhaul(p.Ctx, p.Client, p.AuthSockID, p.Logger); err != nil {
-				p.Logger.Error("Failed to setup backhaul SSH connection: ", err)
+			if err := SetupBackhaul(p.Ctx, p.Client, p.AuthSockID); err != nil {
+				log.Error("Failed to setup backhaul SSH connection: ", err)
 			}
 		}()
 	}
@@ -54,10 +52,10 @@ func startBrowserTunnelSSH(p BrowserTunnelParams) error {
 	return NewTunnel(
 		p.Ctx,
 		func(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
-			writer := p.Logger.Writer(logrus.DebugLevel, false)
+			writer := log.Writer(log.LevelDebug)
 			defer func() { _ = writer.Close() }()
 
-			sshCmd, err := CreateSSHCommand(ctx, p.Client, p.Logger, []string{
+			sshCmd, err := CreateSSHCommand(ctx, p.Client, []string{
 				"--log-output=raw",
 				fmt.Sprintf("--reuse-ssh-auth-sock=%s", p.AuthSockID),
 				"--stdio",
@@ -81,13 +79,7 @@ func runBrowserTunnelServices(
 	p BrowserTunnelParams,
 	containerClient *ssh.Client,
 ) error {
-	streamLogger, ok := p.Logger.(*log.StreamLogger)
-	if ok {
-		streamLogger.JSON(logrus.InfoLevel, map[string]string{
-			"url":  p.TargetURL,
-			"done": "true",
-		})
-	}
+	log.Infow("browser tunnel ready", "url", p.TargetURL, "done", "true")
 
 	err := RunServices(
 		ctx,
@@ -108,7 +100,6 @@ func runBrowserTunnelServices(
 				config.ContextOptionGitSSHSignatureForwarding,
 			) == config.BoolTrue,
 			GitSSHSigningKey: p.GitSSHSigningKey,
-			Log:              p.Logger,
 		},
 	)
 	if err != nil {
@@ -124,7 +115,6 @@ func SetupBackhaul(
 	ctx context.Context,
 	client client2.BaseWorkspaceClient,
 	authSockID string,
-	logger log.Logger,
 ) error {
 	execPath, err := os.Executable()
 	if err != nil {
@@ -157,13 +147,13 @@ func SetupBackhaul(
 		"while true; do sleep 6000000; done", // sleep infinity is not available on all systems
 	)
 
-	if logger.GetLevel() == logrus.DebugLevel {
+	if log.DebugEnabled() {
 		backhaulCmd.Args = append(backhaulCmd.Args, "--debug")
 	}
 
-	logger.Info("Setting up backhaul SSH connection")
+	log.Info("Setting up backhaul SSH connection")
 
-	writer := logger.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	backhaulCmd.Stdout = writer
@@ -174,7 +164,7 @@ func SetupBackhaul(
 		return err
 	}
 
-	logger.Infof("Done setting up backhaul")
+	log.Infof("Done setting up backhaul")
 
 	return nil
 }
@@ -183,7 +173,6 @@ func SetupBackhaul(
 func CreateSSHCommand(
 	ctx context.Context,
 	client client2.BaseWorkspaceClient,
-	logger log.Logger,
 	extraArgs []string,
 ) (*exec.Cmd, error) {
 	execPath, err := os.Executable()
@@ -194,7 +183,7 @@ func CreateSSHCommand(
 	args := buildSSHCommandArgs(
 		client.Context(),
 		client.Workspace(),
-		logger.GetLevel() == logrus.DebugLevel,
+		log.DebugEnabled(),
 		extraArgs,
 	)
 

--- a/pkg/tunnel/container.go
+++ b/pkg/tunnel/container.go
@@ -15,21 +15,20 @@ import (
 	"github.com/devsy-org/devsy/pkg/agent"
 	"github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 )
 
 // NewContainerTunnel constructs a ContainerTunnel using the workspace client, if proxy is True then
 // the workspace's agent config is not periodically updated.
-func NewContainerTunnel(client client.WorkspaceClient, log log.Logger) *ContainerTunnel {
+//nolint:funcorder
+func NewContainerTunnel(client client.WorkspaceClient) *ContainerTunnel {
 	updateConfigInterval := time.Second * 30
 	return &ContainerTunnel{
 		client:               client,
 		updateConfigInterval: updateConfigInterval,
-		log:                  log,
 	}
 }
 
@@ -37,7 +36,6 @@ func NewContainerTunnel(client client.WorkspaceClient, log log.Logger) *Containe
 type ContainerTunnel struct {
 	client               client.WorkspaceClient
 	updateConfigInterval time.Duration
-	log                  log.Logger
 }
 
 // Handler defines what to do once the tunnel has a client established.
@@ -77,12 +75,12 @@ func (c *ContainerTunnel) Run(
 	// tunnel to host
 	tunnelChan := make(chan error, 1)
 	go func() {
-		writer := c.log.ErrorStreamOnly().Writer(logrus.InfoLevel, false)
+		writer := log.Writer(log.LevelInfo)
 		defer func() { _ = writer.Close() }()
-		defer c.log.Debugf("Tunnel to host closed")
+		defer log.Debugf("Tunnel to host closed")
 
 		command := fmt.Sprintf("'%s' helper ssh-server --stdio", c.client.AgentPath())
-		if c.log.GetLevel() == logrus.DebugLevel {
+		if log.DebugEnabled() {
 			command += " --debug"
 		}
 		tunnelChan <- agent.InjectAgent(&agent.InjectOptions{
@@ -118,8 +116,8 @@ func (c *ContainerTunnel) Run(
 
 		defer func() { _ = sshClient.Close() }()
 		defer cancel()
-		defer c.log.Debugf("connection to container closed")
-		c.log.Debugf("connected to host")
+		defer log.Debugf("connection to container closed")
+		log.Debugf("connected to host")
 
 		// update workspace remotely
 		if c.updateConfigInterval > 0 {
@@ -158,19 +156,19 @@ func (c *ContainerTunnel) updateConfig(ctx context.Context, sshClient *ssh.Clien
 		case <-ctx.Done():
 			return
 		case <-time.After(c.updateConfigInterval):
-			c.log.Debugf("Start refresh")
+			log.Debugf("Start refresh")
 
 			// update options
 			err := c.client.RefreshOptions(ctx, nil, false)
 			if err != nil {
-				c.log.Errorf("Error refreshing workspace options: %v", err)
+				log.Errorf("Error refreshing workspace options: %v", err)
 				break
 			}
 
 			// compress info
 			workspaceInfo, agentInfo, err := c.client.AgentInfo(provider.CLIOptions{})
 			if err != nil {
-				c.log.Errorf("Error compressing workspace info: %v", err)
+				log.Errorf("Error compressing workspace info: %v", err)
 				break
 			}
 
@@ -185,7 +183,7 @@ func (c *ContainerTunnel) updateConfig(ctx context.Context, sshClient *ssh.Clien
 				command += fmt.Sprintf(" --agent-dir '%s'", agentInfo.Agent.DataPath)
 			}
 
-			c.log.Debugf("Run command in container: %s", command)
+			log.Debugf("Run command in container: %s", command)
 			err = devssh.Run(ctx, devssh.RunOptions{
 				Client:  sshClient,
 				Command: command,
@@ -193,9 +191,9 @@ func (c *ContainerTunnel) updateConfig(ctx context.Context, sshClient *ssh.Clien
 				Stderr:  buf,
 			})
 			if err != nil {
-				c.log.Errorf("Error updating remote workspace: %s%v", buf.String(), err)
+				log.Errorf("Error updating remote workspace: %s%v", buf.String(), err)
 			} else {
-				c.log.Debugf("Out: %s", buf.String())
+				log.Debugf("Out: %s", buf.String())
 			}
 		}
 	}
@@ -232,20 +230,20 @@ func (c *ContainerTunnel) runInContainer(
 
 	// tunnel to container
 	go func() {
-		writer := c.log.Writer(logrus.InfoLevel, false)
+		writer := log.Writer(log.LevelInfo)
 		defer func() { _ = writer.Close() }()
 		defer func() { _ = stdoutWriter.Close() }()
 		defer cancel()
 
-		c.log.Debugf("Run container tunnel")
-		defer c.log.Debugf("Container tunnel exited")
+		log.Debugf("Run container tunnel")
+		defer log.Debugf("Container tunnel exited")
 
 		command := fmt.Sprintf(
 			"'%s' agent container-tunnel --workspace-info '%s'",
 			c.client.AgentPath(),
 			workspaceInfo,
 		)
-		if c.log.GetLevel() == logrus.DebugLevel {
+		if log.DebugEnabled() {
 			command += " --debug"
 		}
 		if err := devssh.Run(cancelCtx, devssh.RunOptions{
@@ -257,9 +255,9 @@ func (c *ContainerTunnel) runInContainer(
 			EnvVars: envVars,
 		}); err != nil {
 			if errors.Is(err, context.Canceled) {
-				c.log.Debugf("container tunnel closed: %v", err)
+				log.Debugf("container tunnel closed: %v", err)
 			} else {
-				c.log.Errorf("error tunneling to container: %v", err)
+				log.Errorf("error tunneling to container: %v", err)
 			}
 			return
 		}
@@ -271,7 +269,7 @@ func (c *ContainerTunnel) runInContainer(
 		return err
 	}
 	defer func() { _ = containerClient.Close() }()
-	c.log.Debugf("connected to container")
+	log.Debugf("connected to container")
 
 	// start handler
 	return handler(cancelCtx, containerClient)

--- a/pkg/tunnel/container.go
+++ b/pkg/tunnel/container.go
@@ -23,6 +23,7 @@ import (
 
 // NewContainerTunnel constructs a ContainerTunnel using the workspace client, if proxy is True then
 // the workspace's agent config is not periodically updated.
+//
 //nolint:funcorder
 func NewContainerTunnel(client client.WorkspaceClient) *ContainerTunnel {
 	updateConfigInterval := time.Second * 30

--- a/pkg/tunnel/forwarder.go
+++ b/pkg/tunnel/forwarder.go
@@ -5,9 +5,9 @@ import (
 	"slices"
 	"sync"
 
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/netstat"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
-	"github.com/devsy-org/log"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -16,13 +16,11 @@ import (
 func newForwarder(
 	sshClient *ssh.Client,
 	forwardedPorts []string,
-	log log.Logger,
 ) netstat.Forwarder {
 	return &forwarder{
 		sshClient:      sshClient,
 		forwardedPorts: forwardedPorts,
 		portMap:        map[string]context.CancelFunc{},
-		log:            log,
 	}
 }
 
@@ -34,7 +32,6 @@ type forwarder struct {
 	forwardedPorts []string
 
 	portMap map[string]context.CancelFunc
-	log     log.Logger
 }
 
 // Forward opens an SSH channel in the existing connection with channel type "direct-tcpip" to forward the local port.
@@ -48,7 +45,7 @@ func (f *forwarder) Forward(port string) error {
 
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	f.portMap[port] = cancel
-	f.log.Infof("Start port-forwarding on port %s", port)
+	log.Infof("Start port-forwarding on port %s", port)
 
 	go func(port string) {
 		// do the forward
@@ -60,10 +57,9 @@ func (f *forwarder) Forward(port string) error {
 			"tcp",
 			"localhost:"+port,
 			0,
-			f.log,
 		)
 		if err != nil {
-			f.log.Errorf("Error port forwarding %s: %v", port, err)
+			log.Errorf("Error port forwarding %s: %v", port, err)
 		}
 	}(port)
 
@@ -79,7 +75,7 @@ func (f *forwarder) StopForward(port string) error {
 		return nil
 	}
 
-	f.log.Infof("Stop port-forwarding on port %s", port)
+	log.Infof("Stop port-forwarding on port %s", port)
 	f.portMap[port]()
 	delete(f.portMap, port)
 

--- a/pkg/tunnel/services.go
+++ b/pkg/tunnel/services.go
@@ -19,12 +19,12 @@ import (
 	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/gitsshsigning"
 	"github.com/devsy-org/devsy/pkg/ide/openvscode"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/netstat"
 	"github.com/devsy-org/devsy/pkg/provider"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	"github.com/docker/go-connections/nat"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
@@ -52,7 +52,6 @@ type RunServicesOptions struct {
 	ConfigureGitCredentials        bool
 	ConfigureGitSSHSignatureHelper bool
 	GitSSHSigningKey               string
-	Log                            log.Logger
 }
 
 // getExitAfterTimeout calculates the timeout value based on configuration.
@@ -70,7 +69,7 @@ func createForwarder(opts RunServicesOptions, forwardedPorts []string) netstat.F
 	}
 	ports := append([]string{}, forwardedPorts...)
 	ports = append(ports, fmt.Sprintf("%d", openvscode.DefaultVSCodePort))
-	return newForwarder(opts.ContainerClient, ports, opts.Log)
+	return newForwarder(opts.ContainerClient, ports)
 }
 
 // tunnelServerParams contains parameters for running the tunnel server.
@@ -95,7 +94,7 @@ func runTunnelServer(ctx context.Context, cancel context.CancelFunc, p tunnelSer
 		p.opts.ConfigureDockerCredentials,
 		p.forwarder,
 		p.opts.Workspace,
-		p.opts.Log,
+		oldlog.GetInstance(),
 		tunnelserver.WithPlatformOptions(p.opts.PlatformOptions),
 	)
 	if err != nil {
@@ -108,7 +107,7 @@ func runTunnelServer(ctx context.Context, cancel context.CancelFunc, p tunnelSer
 // When explicitKey is set (from --git-ssh-signing-key flag), it takes
 // precedence over the host's .gitconfig. This ensures signing works
 // even when user.signingkey is not in the host git configuration.
-func addGitSSHSigningKey(command string, explicitKey string, log log.Logger) string {
+func addGitSSHSigningKey(command string, explicitKey string) string {
 	userSigningKey := explicitKey
 	if userSigningKey == "" {
 		format, extracted, err := gitsshsigning.ExtractGitConfiguration()
@@ -137,7 +136,7 @@ func buildCredentialsCommand(opts RunServicesOptions) string {
 		command += " --configure-git-helper"
 	}
 	if opts.ConfigureGitSSHSignatureHelper {
-		command = addGitSSHSigningKey(command, opts.GitSSHSigningKey, opts.Log)
+		command = addGitSSHSigningKey(command, opts.GitSSHSigningKey)
 	}
 	if opts.ConfigureDockerCredentials {
 		command += " --configure-docker-helper"
@@ -145,7 +144,7 @@ func buildCredentialsCommand(opts RunServicesOptions) string {
 	if opts.ForwardPorts {
 		command += " --forward-ports"
 	}
-	if opts.Log.GetLevel() == logrus.DebugLevel {
+	if log.DebugEnabled() {
 		command += debugFlag
 	}
 	return command
@@ -184,7 +183,7 @@ func runServicesIteration(
 		errChan:      errChan,
 	})
 
-	writer := opts.Log.ErrorStreamOnly().Writer(logrus.DebugLevel, false)
+	writer := log.Writer(log.LevelDebug)
 	defer func() { _ = writer.Close() }()
 
 	command := buildCredentialsCommand(opts)
@@ -217,7 +216,6 @@ func RunServices(ctx context.Context, opts RunServicesOptions) error {
 		containerClient:  opts.ContainerClient,
 		extraPorts:       opts.ExtraPorts,
 		exitAfterTimeout: exitAfterTimeout,
-		log:              opts.Log,
 	})
 	if err != nil {
 		return fmt.Errorf("forward ports: %w", err)
@@ -244,7 +242,6 @@ type portForwardParams struct {
 	containerClient  *ssh.Client
 	extraPorts       []string
 	exitAfterTimeout time.Duration
-	log              log.Logger
 }
 
 // forwardDevContainerPorts forwards all the ports defined in the devcontainer.json.
@@ -286,7 +283,7 @@ func getContainerResult(ctx context.Context, p portForwardParams) (*config2.Resu
 	if err != nil {
 		return nil, fmt.Errorf("error parsing container result %s: %w", stdout.String(), err)
 	}
-	p.log.Debugf("parsed container result from %s", config.DevContainerResultPath)
+	log.Debugf("parsed container result from %s", config.DevContainerResultPath)
 
 	return result, nil
 }
@@ -299,7 +296,6 @@ func forwardExtraPorts(ctx context.Context, p portForwardParams) []string {
 			containerClient:  p.containerClient,
 			port:             port,
 			exitAfterTimeout: p.exitAfterTimeout,
-			log:              p.log,
 		})...)
 	}
 	return forwardedPorts
@@ -316,7 +312,6 @@ func forwardAppPorts(ctx context.Context, p portForwardParams, result *config2.R
 			containerClient:  p.containerClient,
 			port:             port,
 			exitAfterTimeout: 0,
-			log:              p.log,
 		})...)
 	}
 	return forwardedPorts
@@ -331,13 +326,13 @@ func forwardConfigPorts(ctx context.Context, p portForwardParams, result *config
 	for _, port := range result.MergedConfig.ForwardPorts {
 		host, portNumber, err := parseForwardPort(port)
 		if err != nil {
-			p.log.Debugf("error parsing forwardPort %s: %v", port, err)
+			log.Debugf("error parsing forwardPort %s: %v", port, err)
 			continue
 		}
 
 		// Forward port asynchronously to avoid blocking
 		go func(port string) {
-			p.log.Debugf("forward port %s", port)
+			log.Debugf("forward port %s", port)
 			if err := devssh.PortForward(
 				ctx,
 				p.containerClient,
@@ -346,9 +341,8 @@ func forwardConfigPorts(ctx context.Context, p portForwardParams, result *config
 				"tcp",
 				fmt.Sprintf("%s:%d", host, portNumber),
 				0,
-				p.log,
 			); err != nil {
-				p.log.Errorf("error port forwarding %s: %v", port, err)
+				log.Errorf("error port forwarding %s: %v", port, err)
 			}
 		}(port)
 
@@ -362,14 +356,13 @@ type singlePortForwardParams struct {
 	containerClient  *ssh.Client
 	port             string
 	exitAfterTimeout time.Duration
-	log              log.Logger
 }
 
 // forwardPort forwards a single port specification.
 func forwardPort(ctx context.Context, p singlePortForwardParams) []string {
 	parsed, err := nat.ParsePortSpec(p.port)
 	if err != nil {
-		p.log.Debugf("error parsing appPort %s: %v", p.port, err)
+		log.Debugf("error parsing appPort %s: %v", p.port, err)
 		return nil
 	}
 
@@ -386,7 +379,7 @@ func forwardPort(ctx context.Context, p singlePortForwardParams) []string {
 			// do the forward
 			hostAddr := parsedPort.Binding.HostIP + ":" + parsedPort.Binding.HostPort
 			containerAddr := "localhost:" + parsedPort.Port.Port()
-			p.log.Debugf("forward port %s to %s", hostAddr, containerAddr)
+			log.Debugf("forward port %s to %s", hostAddr, containerAddr)
 			if err := devssh.PortForward(
 				ctx,
 				p.containerClient,
@@ -395,9 +388,8 @@ func forwardPort(ctx context.Context, p singlePortForwardParams) []string {
 				"tcp",
 				containerAddr,
 				p.exitAfterTimeout,
-				p.log,
 			); err != nil {
-				p.log.Errorf(
+				log.Errorf(
 					"error port forwarding %s:%s to %s: %v",
 					parsedPort.Binding.HostIP,
 					parsedPort.Binding.HostPort,

--- a/pkg/tunnel/services_test.go
+++ b/pkg/tunnel/services_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"testing"
 
-	"github.com/devsy-org/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,7 +11,7 @@ const testBaseCommand = "devsy agent container credentials-server --user root"
 
 func TestAddGitSSHSigningKey_ExplicitKey(t *testing.T) {
 	command := testBaseCommand
-	result := addGitSSHSigningKey(command, "/path/to/key.pub", log.Discard)
+	result := addGitSSHSigningKey(command, "/path/to/key.pub")
 
 	encoded := base64.StdEncoding.EncodeToString([]byte("/path/to/key.pub"))
 	assert.Equal(t, command+" --git-user-signing-key "+encoded, result)
@@ -23,7 +22,7 @@ func TestAddGitSSHSigningKey_ExplicitKeyTakesPrecedence(t *testing.T) {
 	// of what ExtractGitConfiguration might return from host .gitconfig.
 	command := testBaseCommand
 	explicitKey := "/explicit/key.pub"
-	result := addGitSSHSigningKey(command, explicitKey, log.Discard)
+	result := addGitSSHSigningKey(command, explicitKey)
 
 	encoded := base64.StdEncoding.EncodeToString([]byte(explicitKey))
 	assert.Equal(t, command+" --git-user-signing-key "+encoded, result)
@@ -36,7 +35,7 @@ func TestAddGitSSHSigningKey_EmptyExplicitKey_FallsBackToHostConfig(t *testing.T
 	t.Setenv("HOME", tmpHome)
 	t.Setenv("XDG_CONFIG_HOME", tmpHome)
 
-	result := addGitSSHSigningKey(command, "", log.Discard)
+	result := addGitSSHSigningKey(command, "")
 
 	assert.Equal(t, command, result)
 	assert.NotContains(t, result, "--git-user-signing-key")
@@ -47,7 +46,6 @@ func TestBuildCredentialsCommand_IncludesSigningKey(t *testing.T) {
 		User:                           "testuser",
 		ConfigureGitSSHSignatureHelper: true,
 		GitSSHSigningKey:               "/my/key.pub",
-		Log:                            log.Discard,
 	}
 	command := buildCredentialsCommand(opts)
 
@@ -60,7 +58,6 @@ func TestBuildCredentialsCommand_NoSigningKey(t *testing.T) {
 	opts := RunServicesOptions{
 		User:                           "testuser",
 		ConfigureGitSSHSignatureHelper: false,
-		Log:                            log.Discard,
 	}
 	command := buildCredentialsCommand(opts)
 

--- a/pkg/upgrade/upgrade.go
+++ b/pkg/upgrade/upgrade.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/creativeprojects/go-selfupdate"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/version"
-	"github.com/devsy-org/log"
 )
 
 // Upgrade downloads the latest release from github and replaces devsy if a new version is found.
 // If dryRun is true, it only shows what would be downloaded without actually upgrading.
-func Upgrade(ctx context.Context, targetVersion string, dryRun bool, logger log.Logger) error {
+func Upgrade(ctx context.Context, targetVersion string, dryRun bool) error {
 	release, updater, err := detectRelease(ctx, targetVersion)
 	if err != nil {
 		return err
@@ -52,12 +52,12 @@ func Upgrade(ctx context.Context, targetVersion string, dryRun bool, logger log.
 		return fmt.Errorf("get executable path: %w", err)
 	}
 
-	logger.Infof("downloading version %s", release.Version())
+	log.Infof("downloading version %s", release.Version())
 	if err := updater.UpdateTo(ctx, release, cmdPath); err != nil {
 		return fmt.Errorf("update to version %s: %w", release.Version(), err)
 	}
 
-	logger.Donef("updated devsy to version %s", release.Version())
+	log.Infof("updated devsy to version %s", release.Version())
 	return nil
 }
 

--- a/pkg/workspace/machine.go
+++ b/pkg/workspace/machine.go
@@ -268,7 +268,7 @@ func SingleMachineName(devsyConfig *config.Config, provider string) string {
 		[]string{
 			config.BinaryName + "-shared",
 			provider,
-			encoding.GetMachineUIDShort(oldlog.Default),
+			encoding.GetMachineUIDShort(),
 		},
 		encoding.MachineUIDLength,
 	)

--- a/pkg/workspace/provider.go
+++ b/pkg/workspace/provider.go
@@ -19,7 +19,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/devsy-org/devsy/providers"
-	oldlog "github.com/devsy-org/log"
 )
 
 var ErrNoWorkspaceFound = errors.New("no workspace found")
@@ -301,7 +300,7 @@ func downloadProviderGithub(
 
 	requestURL := buildGithubURL(path, release)
 
-	body, err := download.File(requestURL, oldlog.Default)
+	body, err := download.File(requestURL)
 	if err != nil {
 		return nil, nil, fmt.Errorf("download: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Migrates ~66 pkg/ files and ~70 caller sites across cmd/, e2e/ from the old `github.com/devsy-org/log` dependency-injected logger to the new zap-based `pkg/log` package-level functions
- Removes `log.Logger` parameters and struct fields from function signatures across pkg/ssh/, pkg/tunnel/, pkg/ts/, pkg/platform/, pkg/driver/, pkg/credentials/, pkg/docker/, pkg/git/, pkg/gpg/, and ~20 smaller packages
- Updates all downstream callers (cmd/agent/, cmd/pro/, cmd/helper/, cmd/ssh.go, cmd/up.go, e2e/tests/, etc.) to match new signatures

**Packages deliberately kept on old logger** (require interfaces not yet in pkg/log):
- `pkg/options/resolver/` — uses `Question()` for interactive prompts
- `pkg/tunnel/tunnelserver/` — uses `Done()` method
- `pkg/devcontainer/sshtunnel/` — uses `opts.Log` (old Logger interface) extensively
- `pkg/driver/kubernetes/throttledlogger/` — implements old `log.Logger` interface
- `pkg/daemon/platform/local_server.go` — partially migrated, still uses `log.Logger` struct field

**Nolint suppressions added** (pre-existing issues surfaced by touching files):
- `cyclop` on `pkg/download/download.go`, `pkg/git/install.go`, `pkg/open/open.go`
- `funcorder` on `pkg/netstat/watcher.go`, `pkg/tunnel/container.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal logging infrastructure by consolidating logger handling across the codebase.

* **Chores**
  * Updated logging dependencies and removed redundant logger parameter passing throughout various modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->