### PR TITLE
refactor(log): migrate devcontainer runner and agent to pkg/log

### DIFF
--- a/cmd/agent/container_tunnel.go
+++ b/cmd/agent/container_tunnel.go
@@ -64,13 +64,13 @@ func (cmd *ContainerTunnelCmd) Run(ctx context.Context) error {
 	}
 
 	// make sure content folder exists
-	_, err = workspace.InitContentFolder(workspaceInfo, logger)
+	_, err = workspace.InitContentFolder(workspaceInfo)
 	if err != nil {
 		return err
 	}
 
 	// create runner
-	runner, err := workspace.CreateRunner(workspaceInfo, logger)
+	runner, err := workspace.CreateRunner(workspaceInfo)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/workspace/build.go
+++ b/cmd/agent/workspace/build.go
@@ -61,7 +61,7 @@ func (cmd *BuildCmd) Run(ctx context.Context) error {
 	// initialize the workspace
 	cancelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	_, logger, credentialsDir, err := initWorkspace(initWorkspaceParams{
+	_, _, credentialsDir, err := initWorkspace(initWorkspaceParams{
 		ctx:                 cancelCtx,
 		workspaceInfo:       workspaceInfo,
 		debug:               cmd.Debug,
@@ -75,7 +75,7 @@ func (cmd *BuildCmd) Run(ctx context.Context) error {
 		}()
 	}
 
-	runner, err := CreateRunner(workspaceInfo, logger)
+	runner, err := CreateRunner(workspaceInfo)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/workspace/delete.go
+++ b/cmd/agent/workspace/delete.go
@@ -88,7 +88,7 @@ func removeContainer(
 	logger oldlog.Logger,
 ) error {
 	log.Debugf("removing Devsy container from server: workspaceId=%s", workspaceInfo.Workspace.ID)
-	runner, err := CreateRunner(workspaceInfo, logger)
+	runner, err := CreateRunner(workspaceInfo)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/workspace/logs.go
+++ b/cmd/agent/workspace/logs.go
@@ -59,7 +59,6 @@ func (cmd *LogsCmd) Run(ctx context.Context) error {
 		agent.ContainerDevsyHelperLocation,
 		agent.DefaultAgentDownloadURL(),
 		workspaceInfo,
-		logger,
 	)
 	if err != nil {
 		return fmt.Errorf("create runner: %w", err)

--- a/cmd/agent/workspace/status.go
+++ b/cmd/agent/workspace/status.go
@@ -49,7 +49,7 @@ func (cmd *StatusCmd) Run(ctx context.Context) error {
 	}
 
 	// create runner
-	runner, err := CreateRunner(workspaceInfo, logger)
+	runner, err := CreateRunner(workspaceInfo)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/workspace/stop.go
+++ b/cmd/agent/workspace/stop.go
@@ -66,7 +66,7 @@ func stopContainer(
 	logger oldlog.Logger,
 ) error {
 	log.Debugf("stopping Devsy container")
-	runner, err := CreateRunner(workspaceInfo, logger)
+	runner, err := CreateRunner(workspaceInfo)
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -85,7 +85,7 @@ func (cmd *UpCmd) Run(ctx context.Context) error {
 		return cmd.handleInitError(err, workspaceInfo, logger)
 	}
 
-	if err := cmd.up(ctx, workspaceInfo, tunnelClient, logger); err != nil {
+	if err := cmd.up(ctx, workspaceInfo, tunnelClient); err != nil {
 		return fmt.Errorf("devcontainer up: %w", err)
 	}
 
@@ -150,9 +150,8 @@ func (cmd *UpCmd) up(
 	ctx context.Context,
 	workspaceInfo *provider.AgentWorkspaceInfo,
 	tunnelClient tunnel.TunnelClient,
-	logger oldlog.Logger,
 ) error {
-	result, err := cmd.devsyUp(ctx, workspaceInfo, logger)
+	result, err := cmd.devsyUp(ctx, workspaceInfo)
 	if err != nil {
 		return err
 	}
@@ -181,9 +180,8 @@ func (cmd *UpCmd) sendResult(
 func (cmd *UpCmd) devsyUp(
 	ctx context.Context,
 	workspaceInfo *provider.AgentWorkspaceInfo,
-	logger oldlog.Logger,
 ) (*config2.Result, error) {
-	runner, err := CreateRunner(workspaceInfo, logger)
+	runner, err := CreateRunner(workspaceInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -196,19 +194,16 @@ func (cmd *UpCmd) devsyUp(
 
 func CreateRunner(
 	workspaceInfo *provider.AgentWorkspaceInfo,
-	logger oldlog.Logger,
 ) (devcontainer.Runner, error) {
 	return devcontainer.NewRunner(
 		agent.ContainerDevsyHelperLocation,
 		agent.DefaultAgentDownloadURL(),
 		workspaceInfo,
-		logger,
 	)
 }
 
 func InitContentFolder(
 	workspaceInfo *provider.AgentWorkspaceInfo,
-	logger oldlog.Logger,
 ) (bool, error) {
 	exists, err := contentFolderExists(workspaceInfo.ContentFolder)
 	if err != nil {
@@ -515,7 +510,7 @@ func prepareWorkspace(params prepareWorkspaceParams) error {
 		)
 	}
 
-	exists, err := InitContentFolder(params.workspaceInfo, params.log)
+	exists, err := InitContentFolder(params.workspaceInfo)
 	if err != nil {
 		return err
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -642,7 +642,6 @@ func (cmd *UpCmd) devsyUpMachine(
 		AgentInject: agentInjectFunc,
 		SSHCommand:  sshTunnelCmd,
 		Command:     agentCommand,
-		Log:         log,
 		TunnelServerFunc: func(ctx context.Context, stdin io.WriteCloser, stdout io.Reader) (*config2.Result, error) {
 			return tunnelserver.RunUpServer(
 				ctx,

--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -18,6 +18,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/dockerfile"
 	"github.com/devsy-org/devsy/pkg/driver"
 	"github.com/devsy-org/devsy/pkg/image"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 )
 
@@ -186,7 +187,7 @@ func (r *runner) getDockerfilePath(parsedConfig *config.DevContainerConfig) (str
 	dockerfilePathFromConfig := parsedConfig.GetDockerfile()
 	var dockerfilePath string
 	if filepath.IsAbs(dockerfilePathFromConfig) {
-		r.Log.Debugf(
+		log.Debugf(
 			"using absolute dockerfile path: dockerfilePath=%s, pathType=absolute",
 			dockerfilePathFromConfig,
 		)
@@ -194,14 +195,14 @@ func (r *runner) getDockerfilePath(parsedConfig *config.DevContainerConfig) (str
 	} else {
 		configFileDir := filepath.Dir(parsedConfig.Origin)
 		dockerfilePath = filepath.Join(configFileDir, dockerfilePathFromConfig)
-		r.Log.Debugf(
+		log.Debugf(
 			"using relative dockerfile path: dockerfilePath=%s, configDir=%s, pathType=relative",
 			dockerfilePathFromConfig,
 			configFileDir,
 		)
 	}
 
-	r.Log.Debugf("resolved dockerfile path: finalPath=%s", dockerfilePath)
+	log.Debugf("resolved dockerfile path: finalPath=%s", dockerfilePath)
 
 	_, err := os.Stat(dockerfilePath)
 	if err != nil {
@@ -331,7 +332,7 @@ func (r *runner) buildImage(
 			options.PrebuildRepositories,
 			devsyCustomizations.PrebuildRepository...)
 
-		r.Log.Debugf(
+		log.Debugf(
 			"Try to find prebuild image %s in repositories %s",
 			prebuildHash,
 			strings.Join(options.PrebuildRepositories, ","),
@@ -341,7 +342,7 @@ func (r *runner) buildImage(
 			img, err := image.GetImageForArch(ctx, prebuildImage, targetArch)
 			if err == nil && img != nil {
 				// prebuild image found
-				r.Log.Infof("Found existing prebuilt image %s", prebuildImage)
+				log.Infof("Found existing prebuilt image %s", prebuildImage)
 
 				// inspect image
 				imageDetails, err := r.inspectImage(ctx, prebuildImage)
@@ -358,7 +359,7 @@ func (r *runner) buildImage(
 					Tags:          options.Tag,
 				}, nil
 			} else if err != nil {
-				r.Log.Debugf("Error trying to find prebuild image %s: %v", prebuildImage, err)
+				log.Debugf("Error trying to find prebuild image %s: %v", prebuildImage, err)
 			}
 		}
 	}
@@ -373,7 +374,6 @@ func (r *runner) buildImage(
 			LocalWorkspaceFolder: r.LocalWorkspaceFolder,
 			Options:              options,
 			TargetArch:           targetArch,
-			Log:                  r.Log,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("(remote): %w", err)
@@ -444,13 +444,13 @@ func (r *runner) buildDevImageCompose(
 		composeGlobalArgs = append(composeGlobalArgs, "--env-file", envFile)
 	}
 
-	r.Log.Debugf("Loading docker compose project %+v", composeFiles)
+	log.Debugf("Loading docker compose project %+v", composeFiles)
 	project, err := compose.LoadDockerComposeProject(ctx, composeFiles, envFiles)
 	if err != nil {
 		return nil, fmt.Errorf("load docker compose project: %w", err)
 	}
 	project.Name = composeHelper.GetProjectName(r.ID)
-	r.Log.Debugf("Loaded project %s", project.Name)
+	log.Debugf("Loaded project %s", project.Name)
 
 	service := parsedConfig.Config.Service
 	composeService, err := project.GetService(service)

--- a/pkg/devcontainer/buildkit/remote.go
+++ b/pkg/devcontainer/buildkit/remote.go
@@ -18,8 +18,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/feature"
 	"github.com/devsy-org/devsy/pkg/image"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 	"github.com/docker/cli/cli/config/types"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -29,7 +29,6 @@ import (
 	"github.com/moby/buildkit/exporter/containerimage/exptypes"
 	"github.com/moby/buildkit/session"
 	"github.com/moby/buildkit/session/auth/authprovider"
-	"github.com/sirupsen/logrus"
 	"github.com/tonistiigi/fsutil"
 )
 
@@ -42,7 +41,6 @@ type BuildRemoteOptions struct {
 	LocalWorkspaceFolder string
 	Options              provider.BuildOptions
 	TargetArch           string
-	Log                  log.Logger
 }
 
 func BuildRemote(ctx context.Context, opts BuildRemoteOptions) (*config.BuildInfo, error) {
@@ -89,7 +87,6 @@ func BuildRemote(ctx context.Context, opts BuildRemoteOptions) (*config.BuildInf
 		Client:    c,
 		Info:      info,
 		SolveOpts: solveOpts,
-		Logger:    opts.Log,
 	}); err != nil {
 		return nil, err
 	}
@@ -202,11 +199,11 @@ type checkExistingImageParams struct {
 func checkExistingImage(params checkExistingImageParams) *config.BuildInfo {
 	imageDetails, err := getImageDetails(params.Ctx, params.Ref, params.TargetArch, params.Keychain)
 	if err != nil {
-		params.Opts.Log.Debugf("image check failed, continuing with build: %v", err)
+		log.Debugf("image check failed, continuing with build: %v", err)
 		return nil
 	}
 
-	params.Opts.Log.Infof("skipping build because an existing image was found %s", params.ImageName)
+	log.Infof("skipping build because an existing image was found %s", params.ImageName)
 
 	var imageMetadata *config.ImageMetadataConfig
 	if params.Opts.ExtendedBuildInfo != nil {
@@ -414,17 +411,16 @@ type executeBuildParams struct {
 	Client    *client.Client
 	Info      *client.Info
 	SolveOpts client.SolveOpt
-	Logger    log.Logger
 }
 
 func executeBuild(params executeBuildParams) error {
-	params.Logger.Infof(
+	log.Infof(
 		"start building %s using platform builder (%s)",
 		params.SolveOpts.Exports[0].Attrs[string(exptypes.OptKeyName)],
 		params.Info.BuildkitVersion.Version,
 	)
 
-	writer := params.Logger.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	pw, err := NewPrinter(params.Ctx, writer)

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -18,8 +18,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/metadata"
 	"github.com/devsy-org/devsy/pkg/dockerfile"
 	"github.com/devsy-org/devsy/pkg/driver"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/joho/godotenv"
-	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
 
@@ -160,7 +160,7 @@ func (r *runner) runDockerCompose(
 	}
 	composeGlobalArgs := projFiles.composeGlobalArgs
 
-	r.Log.Debugf("Loading docker compose project %+v", projFiles.composeFiles)
+	log.Debugf("Loading docker compose project %+v", projFiles.composeFiles)
 	project, err := compose.LoadDockerComposeProject(
 		ctx,
 		projFiles.composeFiles,
@@ -170,7 +170,7 @@ func (r *runner) runDockerCompose(
 		return nil, fmt.Errorf("load docker compose project: %w", err)
 	}
 	project.Name = composeHelper.GetProjectName(r.ID)
-	r.Log.Debugf("Loaded project %s", project.Name)
+	log.Debugf("Loaded project %s", project.Name)
 
 	containerDetails, err := composeHelper.FindDevContainer(
 		ctx,
@@ -187,13 +187,13 @@ func (r *runner) runDockerCompose(
 		// Try to find existing project first
 		existingProjectFiles, err := composeHelper.FindProjectFiles(ctx, project.Name)
 		if err != nil {
-			r.Log.Errorf("Error finding project files: %s", err)
+			log.Errorf("Error finding project files: %s", err)
 		} else if len(existingProjectFiles) > 0 && !options.Recreate {
-			r.Log.Debugf("Found existing project files: %s", existingProjectFiles)
+			log.Debugf("Found existing project files: %s", existingProjectFiles)
 			// make sure all project files are still available
 			for _, file := range existingProjectFiles {
 				if _, err := os.Stat(file); err != nil {
-					r.Log.Warnf("Project file %s does not exist anymore, recreating project", file)
+					log.Warnf("Project file %s does not exist anymore, recreating project", file)
 					containerDetails = nil
 					break
 				}
@@ -209,10 +209,10 @@ func (r *runner) runDockerCompose(
 			upArgs = r.onlyRunServices(upArgs, parsedConfig)
 
 			// Run docker-compose
-			writer := r.Log.Writer(logrus.InfoLevel, false)
+			writer := log.Writer(log.LevelInfo)
 			err = composeHelper.Run(ctx, upArgs, nil, writer, writer)
 			if err != nil {
-				r.Log.Errorf("Error starting project: %s", err)
+				log.Errorf("Error starting project: %s", err)
 			} else {
 				// wait for running and get container details
 				details, err := composeHelper.FindDevContainer(
@@ -221,7 +221,7 @@ func (r *runner) runDockerCompose(
 					parsedConfig.Config.Service,
 				)
 				if err != nil {
-					r.Log.Errorf("Error finding dev container: %s", err)
+					log.Errorf("Error finding dev container: %s", err)
 				} else {
 					containerDetails = details
 					didStartProject = true
@@ -262,10 +262,10 @@ func (r *runner) runDockerCompose(
 			ctx,
 			r.ID,
 			parsedConfig.Config,
-			r.Log.Writer(logrus.InfoLevel, false),
+			log.Writer(log.LevelInfo),
 		)
 		if err != nil {
-			r.Log.Errorf("failed to update container user UID/GID: error=%v", err)
+			log.Errorf("failed to update container user UID/GID: error=%v", err)
 			return nil, err
 		}
 	}
@@ -503,7 +503,7 @@ func (r *runner) startContainer(
 	}
 
 	if container != nil && options.Recreate {
-		r.Log.Debugf("Deleting dev container %s due to --recreate", container.ID)
+		log.Debugf("Deleting dev container %s due to --recreate", container.ID)
 
 		if err := r.Driver.StopDevContainer(ctx, r.ID); err != nil {
 			return nil, fmt.Errorf("stop dev container: %w", err)
@@ -523,7 +523,7 @@ func (r *runner) startContainer(
 	upArgs = r.onlyRunServices(upArgs, parsedConfig)
 
 	// start compose
-	writer := r.Log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 	err = composeHelper.Run(ctx, upArgs, nil, writer, writer)
 	if err != nil {
@@ -688,7 +688,7 @@ func (r *runner) buildAndExtendDockerCompose(
 			dockerfileContents,
 		)
 
-		r.Log.Debugf(
+		log.Debugf(
 			"Creating extended Dockerfile %s with content: \n %s",
 			extendedDockerfilePath,
 			extendedDockerfileContent,
@@ -732,9 +732,9 @@ func (r *runner) buildAndExtendDockerCompose(
 	}
 
 	// build image
-	writer := r.Log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
-	r.Log.Debugf("Run %s %s", composeHelper.Command, strings.Join(buildArgs, " "))
+	log.Debugf("Run %s %s", composeHelper.Command, strings.Join(buildArgs, " "))
 	err = composeHelper.Run(ctx, buildArgs, nil, writer, writer)
 	if err != nil {
 		return composeExtendResult{buildImageName: buildImageName}, err
@@ -887,7 +887,7 @@ func (r *runner) prepareBuildContext(
 		if err != nil {
 			return nil, err
 		}
-		r.Log.Debugf(
+		log.Debugf(
 			"modified Dockerfile path in context to %s and content for extended compose build context %s",
 			relDockerFilePath,
 			composeService.Build.Context,
@@ -968,7 +968,7 @@ func (r *runner) writeComposeFile(service *composetypes.ServiceConfig) (string, 
 		fmt.Sprintf("%s-%d.yml", FeaturesBuildOverrideFilePrefix, time.Now().Second()),
 	)
 
-	r.Log.Debugf(
+	log.Debugf(
 		"Creating docker-compose build %s with content:\n %s",
 		dockerComposePath,
 		string(dockerComposeData),
@@ -1026,7 +1026,7 @@ func (r *runner) extendedDockerComposeUp(
 		fmt.Sprintf("%s-%d.yml", FeaturesStartOverrideFilePrefix, time.Now().Second()),
 	)
 
-	r.Log.Debugf(
+	log.Debugf(
 		"Creating docker-compose up %s with content:\n %s",
 		dockerComposePath,
 		string(dockerComposeData),
@@ -1173,7 +1173,7 @@ func (r *runner) configureGPUResources(
 			}
 		}
 		if warnIfMissing {
-			r.Log.Warn("GPU required but not available on host")
+			log.Warn("GPU required but not available on host")
 		}
 	}
 }

--- a/pkg/devcontainer/compose_test.go
+++ b/pkg/devcontainer/compose_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/compose"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/feature"
-	logLib "github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -193,7 +191,7 @@ type PrepareBuildContextSuite struct {
 }
 
 func (s *PrepareBuildContextSuite) SetupTest() {
-	s.runner = &runner{Log: logLib.NewDiscardLogger(logrus.InfoLevel)}
+	s.runner = &runner{}
 }
 
 func (s *PrepareBuildContextSuite) TestNoContextRelativePath() {

--- a/pkg/devcontainer/config.go
+++ b/pkg/devcontainer/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/crane"
 	"github.com/devsy-org/devsy/pkg/language"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 )
 
@@ -107,7 +108,7 @@ func (r *runner) getRawConfig(options provider2.CLIOptions) (*config.DevContaine
 	if err != nil && !os.IsNotExist(err) {
 		return nil, fmt.Errorf("parsing devcontainer.json: %w", err)
 	} else if rawParsedConfig == nil {
-		r.Log.Infof("Couldn't find a devcontainer.json")
+		log.Infof("Couldn't find a devcontainer.json")
 		return r.getDefaultConfig(options)
 	}
 	return rawParsedConfig, nil
@@ -118,12 +119,12 @@ func (r *runner) getDefaultConfig(
 ) (*config.DevContainerConfig, error) {
 	defaultConfig := &config.DevContainerConfig{}
 	if options.FallbackImage != "" {
-		r.Log.Infof("Using fallback image %s", options.FallbackImage)
+		log.Infof("Using fallback image %s", options.FallbackImage)
 		defaultConfig.ImageContainer = config.ImageContainer{
 			Image: options.FallbackImage,
 		}
 	} else {
-		r.Log.Infof("Try detecting project programming language...")
+		log.Infof("Try detecting project programming language...")
 		defaultConfig = language.DefaultConfig(r.LocalWorkspaceFolder)
 	}
 
@@ -208,7 +209,7 @@ func (r *runner) substitute(
 			parsedConfig.Features = make(map[string]any)
 		}
 		maps.Copy(parsedConfig.Features, additionalFeatures)
-		r.Log.Infof(
+		log.Infof(
 			"Merged %d additional feature(s): %v",
 			len(additionalFeatures),
 			slices.Collect(maps.Keys(additionalFeatures)),

--- a/pkg/devcontainer/config_test.go
+++ b/pkg/devcontainer/config_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -23,7 +22,6 @@ func (s *SubstituteTestSuite) SetupTest() {
 	s.runner = &runner{
 		ID:                   "test-id",
 		LocalWorkspaceFolder: "/workspace",
-		Log:                  log.Discard,
 		WorkspaceConfig: &provider2.AgentWorkspaceInfo{
 			Workspace: &provider2.Workspace{
 				ID: "test-workspace",

--- a/pkg/devcontainer/delete.go
+++ b/pkg/devcontainer/delete.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 func (r *runner) Delete(ctx context.Context) error {
@@ -16,7 +17,7 @@ func (r *runner) Delete(ctx context.Context) error {
 		return nil
 	}
 
-	r.Log.Infof("deleting devcontainer: devcontainerID=%s", containerDetails.ID)
+	log.Infof("deleting devcontainer: devcontainerID=%s", containerDetails.ID)
 	if isDockerCompose, projectName := getDockerComposeProject(containerDetails); isDockerCompose {
 		err = r.deleteDockerCompose(ctx, projectName)
 		if err != nil {

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -15,9 +15,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/driver/drivercreate"
 	"github.com/devsy-org/devsy/pkg/encoding"
 	"github.com/devsy-org/devsy/pkg/language"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 )
 
 type Runner interface {
@@ -46,7 +45,6 @@ type Runner interface {
 func NewRunner(
 	agentPath, agentDownloadURL string,
 	workspaceConfig *provider2.AgentWorkspaceInfo,
-	log log.Logger,
 ) (Runner, error) {
 	driver, err := drivercreate.NewDriver(workspaceConfig)
 	if err != nil {
@@ -62,7 +60,6 @@ func NewRunner(
 		LocalWorkspaceFolder: workspaceConfig.ContentFolder,
 		ID:                   GetRunnerIDFromWorkspace(workspaceConfig.Workspace),
 		WorkspaceConfig:      workspaceConfig,
-		Log:                  log,
 	}, nil
 }
 
@@ -76,8 +73,6 @@ type runner struct {
 	LocalWorkspaceFolder string
 
 	ID string
-
-	Log log.Logger
 }
 
 type UpOptions struct {
@@ -93,7 +88,7 @@ func (r *runner) Up(
 	options UpOptions,
 	timeout time.Duration,
 ) (*config.Result, error) {
-	r.Log.Debugf(
+	log.Debugf(
 		"Up devcontainer for workspace '%s' with timeout %s",
 		r.WorkspaceConfig.Workspace.ID,
 		timeout,
@@ -111,12 +106,11 @@ func (r *runner) Up(
 			r.LocalWorkspaceFolder,
 			substitutedConfig.Config,
 			options.InitEnv,
-			r.Log,
 		); err != nil {
 			return nil, err
 		}
 	} else if len(substitutedConfig.Config.InitializeCommand) > 0 {
-		r.Log.Info("Skipping initializeCommand on platform")
+		log.Info("Skipping initializeCommand on platform")
 	}
 
 	switch {
@@ -145,7 +139,7 @@ func (r *runner) runDefaultContainer(
 	timeout time.Duration,
 ) (*config.Result, error) {
 	if options.FallbackImage != "" {
-		r.Log.Warn(
+		log.Warn(
 			"dev container config is missing one of \"image\", \"dockerFile\" or \"dockerComposeFile\" properties, " +
 				"using fallback image " + options.FallbackImage,
 		)
@@ -154,7 +148,7 @@ func (r *runner) runDefaultContainer(
 			Image: options.FallbackImage,
 		}
 	} else {
-		r.Log.Warn(
+		log.Warn(
 			"dev container config is missing one of \"image\", \"dockerFile\" or \"dockerComposeFile\" properties, " +
 				"defaulting to auto-detection",
 		)
@@ -211,7 +205,6 @@ func runInitializeCommand(
 	workspaceFolder string,
 	config *config.DevContainerConfig,
 	extraEnvVars []string,
-	log log.Logger,
 ) error {
 	if len(config.InitializeCommand) == 0 {
 		return nil
@@ -240,8 +233,8 @@ func runInitializeCommand(
 
 		// run the command
 		log.Infof("Running initializeCommand from devcontainer.json: '%s'", strings.Join(args, " "))
-		writer := log.Writer(logrus.InfoLevel, false)
-		errwriter := log.Writer(logrus.ErrorLevel, false)
+		writer := log.Writer(log.LevelInfo)
+		errwriter := log.Writer(log.LevelError)
 		defer func() { _ = writer.Close() }()
 		defer func() { _ = errwriter.Close() }()
 

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -20,9 +20,9 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/sshtunnel"
 	"github.com/devsy-org/devsy/pkg/driver"
 	"github.com/devsy-org/devsy/pkg/ide"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
+	oldlog "github.com/devsy-org/log"
 )
 
 const (
@@ -52,8 +52,8 @@ func (r *runner) setupContainer(
 	if err := r.injectAgentIntoContainer(ctx, params.timeout); err != nil {
 		return nil, err
 	}
-	r.Log.Debugf("injected into container")
-	defer r.Log.Debugf("done setting up container")
+	log.Debugf("injected into container")
+	defer log.Debugf("done setting up container")
 
 	info, err := r.prepareSetupInfo(params)
 	if err != nil {
@@ -127,7 +127,6 @@ func (r *runner) buildResult(params *setupContainerParams) *config.Result {
 		result.MergedConfig.Mounts = filterWorkspaceMounts(
 			result.MergedConfig.Mounts,
 			r.WorkspaceConfig.ContentFolder,
-			r.Log,
 		)
 	}
 
@@ -173,7 +172,7 @@ func (r *runner) compressWorkspaceConfig() (string, error) {
 }
 
 func (r *runner) buildSetupCommand(compressed, workspaceConfigCompressed string) string {
-	r.Log.Infof("setting up container")
+	log.Infof("setting up container")
 	args := []string{
 		shellescape.Quote(agent.ContainerDevsyHelperLocation),
 		"agent", "container", "setup",
@@ -229,7 +228,7 @@ func (r *runner) addDebugFlag(args *[]string) {
 }
 
 func (r *runner) isDebugMode() bool {
-	return r.Log.GetLevel() == logrus.DebugLevel
+	return log.DebugEnabled()
 }
 
 func (r *runner) executeSetup(
@@ -245,7 +244,7 @@ func (r *runner) executeSetup(
 			r.WorkspaceConfig.Agent.InjectGitCredentials != stringFalse,
 			r.WorkspaceConfig.Agent.InjectDockerCredentials != stringFalse,
 			config.GetMounts(result),
-			r.Log,
+			oldlog.Default.ErrorStreamOnly(),
 			tunnelserver.WithPlatformOptions(&r.WorkspaceConfig.CLIOptions.Platform),
 		)
 	}
@@ -275,7 +274,6 @@ func (r *runner) executeSetup(
 		AgentInject:      agentInjectFunc,
 		SSHCommand:       sshTunnelCmd,
 		Command:          setupCommand,
-		Log:              r.Log,
 		TunnelServerFunc: runSetupServer,
 	})
 }
@@ -310,7 +308,6 @@ func getRelativeDevContainerJson(origin, localWorkspaceFolder string) string {
 func filterWorkspaceMounts(
 	mounts []*config.Mount,
 	baseFolder string,
-	log log.Logger,
 ) []*config.Mount {
 	retMounts := []*config.Mount{}
 	for _, mount := range mounts {

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/metadata"
 	"github.com/devsy-org/devsy/pkg/driver"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 )
 
@@ -54,7 +55,7 @@ func (r *runner) runSingleContainer(
 	options UpOptions,
 	timeout time.Duration,
 ) (*config.Result, error) {
-	r.Log.Debugf("starting devcontainer for workspace %s", r.ID)
+	log.Debugf("starting devcontainer for workspace %s", r.ID)
 
 	substitutionContext.Userns = options.Userns
 	substitutionContext.UidMap = options.UidMap
@@ -284,7 +285,7 @@ func (r *runner) injectDaemonEntrypoint(
 	if p.options.Platform.AccessKey == "" {
 		return
 	}
-	r.Log.Debugf("Platform config detected, injecting Devsy daemon entrypoint.")
+	log.Debugf("Platform config detected, injecting Devsy daemon entrypoint.")
 
 	data, err := agent.GetEncodedWorkspaceDaemonConfig(
 		p.options.Platform,
@@ -293,7 +294,7 @@ func (r *runner) injectDaemonEntrypoint(
 		mergedConfig,
 	)
 	if err != nil {
-		r.Log.Errorf("Failed to marshal daemon config: %v", err)
+		log.Errorf("Failed to marshal daemon config: %v", err)
 		return
 	}
 	mergedConfig.ContainerEnv[pkgconfig.EnvWorkspaceDaemonConfig] = data

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -14,10 +14,9 @@ import (
 
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
 	devsshagent "github.com/devsy-org/devsy/pkg/ssh/agent"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -27,21 +26,12 @@ type (
 	TunnelServerFunc func(ctx context.Context, stdin io.WriteCloser, stdout io.Reader) (*config2.Result, error)
 )
 
-var logLevelMap = map[string]logrus.Level{
-	"debug": logrus.DebugLevel,
-	"info":  logrus.InfoLevel,
-	"warn":  logrus.WarnLevel,
-	"error": logrus.ErrorLevel,
-	"fatal": logrus.FatalLevel,
-}
-
 type ExecuteCommandOptions struct {
 	Client           client2.WorkspaceClient
 	AddPrivateKeys   bool
 	AgentInject      AgentInjectFunc
 	SSHCommand       string
 	Command          string
-	Log              log.Logger
 	TunnelServerFunc TunnelServerFunc
 }
 
@@ -64,7 +54,7 @@ type sshSessionTunnel struct {
 
 // ExecuteCommand runs the command in an SSH Tunnel and returns the result.
 func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.Result, error) {
-	opts.Log.Debugf("starting SSH tunnel execution: ssh=%q workspace=%q addKeys=%v",
+	log.Debugf("starting SSH tunnel execution: ssh=%q workspace=%q addKeys=%v",
 		opts.SSHCommand, opts.Command, opts.AddPrivateKeys)
 
 	cancelCtx, cancel := context.WithCancel(ctx)
@@ -84,7 +74,7 @@ func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.R
 	})
 
 	if opts.AddPrivateKeys {
-		addPrivateKeys(cancelCtx, opts)
+		addPrivateKeys(cancelCtx)
 	}
 
 	wg.Go(func() {
@@ -137,9 +127,9 @@ func waitForTunnelCompletion(ctx context.Context, ts *sshSessionTunnel) (*config
 		return nil, fmt.Errorf("tunnel server: %w", err)
 	}
 
-	ts.opts.Log.Debug("awaiting tunnel server command completion")
+	log.Debug("awaiting tunnel server command completion")
 	errs := collectTunnelErrors(ts, result)
-	ts.opts.Log.Debug("SSH tunnel execution completed")
+	log.Debug("SSH tunnel execution completed")
 
 	return result, errors.Join(errs...)
 }
@@ -159,16 +149,16 @@ func collectTunnelErrors(
 		select {
 		case r := <-ts.helperDone:
 			if r.err != nil {
-				ts.opts.Log.Debugf("helper goroutine error: %v", r.err)
+				log.Debugf("helper goroutine error: %v", r.err)
 				errs = append(errs, r.err)
 			}
 		case r := <-ts.tunnelDone:
 			if isTunnelError(r.err, result) {
-				ts.opts.Log.Debugf("tunnel goroutine error: %v", r.err)
+				log.Debugf("tunnel goroutine error: %v", r.err)
 				errs = append(errs, r.err)
 			}
 		case <-timer.C:
-			ts.opts.Log.Debug("timed out waiting for goroutines after successful result")
+			log.Debug("timed out waiting for goroutines after successful result")
 
 			return errs
 		}
@@ -241,13 +231,13 @@ func executeSSHServerHelper(
 	cancel context.CancelFunc,
 	ts *sshSessionTunnel,
 ) sshTunnelResult {
-	defer ts.opts.Log.Debug("done executing SSH server helper command")
+	defer log.Debug("done executing SSH server helper command")
 	defer cancel()
 
-	writer := ts.opts.Log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
-	ts.opts.Log.Debugf("injecting and running SSH server command: %q", ts.opts.SSHCommand)
+	log.Debugf("injecting and running SSH server command: %q", ts.opts.SSHCommand)
 	err := ts.opts.AgentInject(
 		ctx,
 		ts.opts.SSHCommand,
@@ -264,11 +254,11 @@ func executeSSHServerHelper(
 	return sshTunnelResult{source: "helper"}
 }
 
-func addPrivateKeys(ctx context.Context, opts ExecuteCommandOptions) {
-	opts.Log.Debug("adding SSH keys to agent")
+func addPrivateKeys(ctx context.Context) {
+	log.Debug("adding SSH keys to agent")
 	err := devssh.AddPrivateKeysToAgent(ctx)
 	if err != nil {
-		opts.Log.Debugf("failed to add private keys to SSH agent: %v", err)
+		log.Debugf("failed to add private keys to SSH agent: %v", err)
 	}
 }
 
@@ -282,7 +272,7 @@ func runSSHTunnel(
 ) sshTunnelResult {
 	defer cancel()
 
-	ts.opts.Log.Debug("creating SSH client")
+	log.Debug("creating SSH client")
 	sshClient, err := devssh.StdioClient(ts.sshPipes.stdoutReader, ts.sshPipes.stdinWriter, false)
 	if err != nil {
 		return sshTunnelResult{
@@ -290,22 +280,22 @@ func runSSHTunnel(
 			err:    fmt.Errorf("failed to create SSH client: %w", err),
 		}
 	}
-	ts.opts.Log.Debug("SSH client created")
+	log.Debug("SSH client created")
 	defer func() {
 		_ = sshClient.Close()
-		ts.opts.Log.Debug("SSH client closed")
+		log.Debug("SSH client closed")
 	}()
 
-	sess, err := establishSSHSession(ctx, ts, sshClient)
+	sess, err := establishSSHSession(ctx, sshClient)
 	if err != nil {
 		return sshTunnelResult{source: "tunnel", err: err}
 	}
 	defer func() {
 		_ = sess.Close()
-		ts.opts.Log.Debug("SSH session closed")
+		log.Debug("SSH session closed")
 	}()
 
-	if err = setupSSHAgentForwarding(ts, sshClient, sess); err != nil {
+	if err = setupSSHAgentForwarding(sshClient, sess); err != nil {
 		return sshTunnelResult{source: "tunnel", err: fmt.Errorf("forward agent: %w", err)}
 	}
 
@@ -314,7 +304,6 @@ func runSSHTunnel(
 
 func establishSSHSession(
 	ctx context.Context,
-	ts *sshSessionTunnel,
 	sshClient *ssh.Client,
 ) (*ssh.Session, error) {
 	backoff := wait.Backoff{
@@ -331,10 +320,10 @@ func establishSSHSession(
 		func(ctx context.Context) (bool, error) {
 			sess, err := sshClient.NewSession()
 			if err != nil {
-				ts.opts.Log.Debugf("SSH server not ready: %v", err)
+				log.Debugf("SSH server not ready: %v", err)
 				return false, nil // Retry
 			}
-			ts.opts.Log.Debug("SSH session created")
+			log.Debug("SSH session created")
 			session = sess
 			return true, nil // Success
 		},
@@ -359,7 +348,6 @@ func establishSSHSession(
 // Stale SSH_AUTH_SOCK is common in practice (tmux, screen, reconnected
 // terminals), so a fatal error here would break devsy up for many users.
 func setupSSHAgentForwarding(
-	ts *sshSessionTunnel,
 	sshClient *ssh.Client,
 	sess *ssh.Session,
 ) error {
@@ -368,7 +356,7 @@ func setupSSHAgentForwarding(
 		return nil
 	}
 
-	ts.opts.Log.Debugf("forwarding SSH agent: socket=%s", identityAgent)
+	log.Debugf("forwarding SSH agent: socket=%s", identityAgent)
 
 	var err error
 	if err = devsshagent.ForwardToRemote(sshClient, identityAgent); err == nil {
@@ -376,7 +364,7 @@ func setupSSHAgentForwarding(
 	}
 
 	if err != nil {
-		ts.opts.Log.Warnf("SSH agent forwarding failed (continuing without agent): %v", err)
+		log.Warnf("SSH agent forwarding failed (continuing without agent): %v", err)
 	}
 	return nil
 }
@@ -389,10 +377,10 @@ func runCommandInSSHTunnel(
 	ts *sshSessionTunnel,
 	sshClient *ssh.Client,
 ) sshTunnelResult {
-	streamer := NewTunnelLogStreamer(ts.opts.Log)
+	streamer := NewTunnelLogStreamer()
 	defer func() { _ = streamer.Close() }()
 
-	ts.opts.Log.Debugf("running agent command in SSH tunnel: %q", ts.opts.Command)
+	log.Debugf("running agent command in SSH tunnel: %q", ts.opts.Command)
 	err := devssh.Run(ctx, devssh.RunOptions{
 		Client:  sshClient,
 		Command: ts.opts.Command,
@@ -419,19 +407,17 @@ func runCommandInSSHTunnel(
 const maxLogLines = 1
 
 type TunnelLogStreamer struct {
-	pw     *io.PipeWriter
-	logger log.Logger
-	done   chan struct{}
+	pw   *io.PipeWriter
+	done chan struct{}
 
 	mu        sync.Mutex
 	lastLines []string
 }
 
-func NewTunnelLogStreamer(logger log.Logger) *TunnelLogStreamer {
+func NewTunnelLogStreamer() *TunnelLogStreamer {
 	pr, pw := io.Pipe()
 	l := &TunnelLogStreamer{
 		pw:        pw,
-		logger:    logger,
 		done:      make(chan struct{}),
 		lastLines: make([]string, 0, maxLogLines),
 	}
@@ -481,7 +467,7 @@ func (l *TunnelLogStreamer) process(r io.Reader) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		l.logger.Debugf("error reading tunnel output: %v", err)
+		log.Debugf("error reading tunnel output: %v", err)
 	}
 }
 
@@ -493,20 +479,41 @@ func (l *TunnelLogStreamer) logLine(line string) {
 		return
 	}
 
-	if matched, level := l.extractLogLevel(line); matched {
-		l.logger.Print(level, line)
+	if matched, level := extractLogLevel(line); matched {
+		logAtLevel(level, line)
 	} else {
-		l.logger.Debug(line)
+		log.Debug(line)
 	}
 }
 
-func (l *TunnelLogStreamer) extractLogLevel(line string) (bool, logrus.Level) {
+func extractLogLevel(line string) (bool, string) {
 	parts := strings.SplitN(line, " ", 3)
 	if len(parts) < 2 || !strings.Contains(parts[0], ":") {
-		return false, logrus.DebugLevel
+		return false, ""
 	}
 
-	level, ok := logLevelMap[strings.ToLower(parts[1])]
+	level := strings.ToLower(parts[1])
+	switch level {
+	case "debug", "info", "warn", "error", "fatal":
+		return true, level
+	default:
+		return false, ""
+	}
+}
 
-	return ok, level
+func logAtLevel(level, msg string) {
+	switch level {
+	case "debug":
+		log.Debug(msg)
+	case "info":
+		log.Info(msg)
+	case "warn":
+		log.Warn(msg)
+	case "error":
+		log.Error(msg)
+	case "fatal":
+		log.Fatal(msg)
+	default:
+		log.Debug(msg)
+	}
 }


### PR DESCRIPTION
## Summary
- Remove logger dependency injection from devcontainer runner (`NewRunner`, `runner` struct, setup, buildkit, sshtunnel)
- Remove `Log log.Logger` fields from `ExecuteCommandOptions`, `BuildRemoteOptions`, `executeBuildParams`, `TunnelLogStreamer`
- Replace all internal logging calls with `pkg/log` package-level functions (`log.Debugf`, `log.Infof`, etc.)
- Replace `log.Writer(logrus.InfoLevel, false)` with `log.Writer(log.LevelInfo)`
- Replace `r.Log.GetLevel() == logrus.DebugLevel` with `log.DebugEnabled()`
- Remove `logger` parameter from `CreateRunner`, `InitContentFolder`, and `runInitializeCommand`
- Keep `oldlog.Default.ErrorStreamOnly()` for `tunnelserver.RunSetupServer` which still accepts `oldlog.Logger`
- Update all callers in `cmd/agent/workspace/`, `cmd/agent/container_tunnel.go`, and `cmd/up.go`
- Update test files to remove old logger struct field references