### PR TITLE
refactor(log): migrate agent, workspace, and utility packages to pkg/log

### DIFF
--- a/cmd/agent/container_tunnel.go
+++ b/cmd/agent/container_tunnel.go
@@ -56,7 +56,7 @@ func (cmd *ContainerTunnelCmd) Run(ctx context.Context) error {
 	logger := oldlog.Default.ErrorStreamOnly()
 
 	// write workspace info
-	shouldExit, workspaceInfo, err := agent.WriteWorkspaceInfo(cmd.WorkspaceInfo, logger)
+	shouldExit, workspaceInfo, err := agent.WriteWorkspaceInfo(cmd.WorkspaceInfo)
 	if err != nil {
 		return err
 	} else if shouldExit {
@@ -99,7 +99,6 @@ func (cmd *ContainerTunnelCmd) Run(ctx context.Context) error {
 		os.Stdin,
 		os.Stdout,
 		os.Stderr,
-		logger,
 		workspaceInfo.InjectTimeout,
 	)
 	if err != nil {

--- a/cmd/agent/workspace/build.go
+++ b/cmd/agent/workspace/build.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/agent"
 	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -43,10 +42,9 @@ func (cmd *BuildCmd) Run(ctx context.Context) error {
 	// write workspace info
 	shouldExit, workspaceInfo, err := agent.WriteWorkspaceInfoAndDeleteOld(
 		cmd.WorkspaceInfo,
-		func(workspaceInfo *provider2.AgentWorkspaceInfo, l oldlog.Logger) error {
-			return deleteWorkspace(ctx, workspaceInfo, l)
+		func(workspaceInfo *provider2.AgentWorkspaceInfo) error {
+			return deleteWorkspace(ctx, workspaceInfo)
 		},
-		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return err
@@ -114,9 +112,8 @@ func (cmd *BuildCmd) Run(ctx context.Context) error {
 func deleteWorkspace(
 	ctx context.Context,
 	workspaceInfo *provider2.AgentWorkspaceInfo,
-	logger oldlog.Logger,
 ) error {
-	err := removeContainer(ctx, workspaceInfo, logger)
+	err := removeContainer(ctx, workspaceInfo)
 	if err != nil {
 		log.Errorf("Removing container: %v", err)
 	}

--- a/cmd/agent/workspace/delete.go
+++ b/cmd/agent/workspace/delete.go
@@ -10,7 +10,6 @@ import (
 	agentdaemon "github.com/devsy-org/devsy/pkg/daemon/agent"
 	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -48,12 +47,9 @@ func NewDeleteCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 func (cmd *DeleteCmd) Run(ctx context.Context) error {
-	logger := oldlog.Default.ErrorStreamOnly()
-
 	// get workspace
 	shouldExit, workspaceInfo, err := agent.WorkspaceInfo(
 		cmd.WorkspaceInfo,
-		logger,
 	)
 	if err != nil {
 		return fmt.Errorf("error parsing workspace info: %w", err)
@@ -71,7 +67,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context) error {
 
 	// cleanup docker container
 	if cmd.Container {
-		err = removeContainer(ctx, workspaceInfo, logger)
+		err = removeContainer(ctx, workspaceInfo)
 		if err != nil {
 			return fmt.Errorf("remove container: %w", err)
 		}
@@ -85,7 +81,6 @@ func (cmd *DeleteCmd) Run(ctx context.Context) error {
 func removeContainer(
 	ctx context.Context,
 	workspaceInfo *provider2.AgentWorkspaceInfo,
-	logger oldlog.Logger,
 ) error {
 	log.Debugf("removing Devsy container from server: workspaceId=%s", workspaceInfo.Workspace.ID)
 	runner, err := CreateRunner(workspaceInfo)

--- a/cmd/agent/workspace/logs.go
+++ b/cmd/agent/workspace/logs.go
@@ -8,7 +8,6 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
 	"github.com/devsy-org/devsy/pkg/devcontainer"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -39,14 +38,11 @@ func NewLogsCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 func (cmd *LogsCmd) Run(ctx context.Context) error {
-	logger := oldlog.Default.ErrorStreamOnly()
-
 	// get workspace info
 	shouldExit, workspaceInfo, err := agent.ReadAgentWorkspaceInfo(
 		cmd.AgentDir,
 		cmd.Context,
 		cmd.ID,
-		logger,
 	)
 	if err != nil {
 		return err

--- a/cmd/agent/workspace/logs_daemon.go
+++ b/cmd/agent/workspace/logs_daemon.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -44,7 +43,6 @@ func (cmd *LogsDaemonCmd) Run(ctx context.Context) error {
 		cmd.AgentDir,
 		cmd.Context,
 		cmd.ID,
-		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return err

--- a/cmd/agent/workspace/status.go
+++ b/cmd/agent/workspace/status.go
@@ -8,7 +8,6 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
 	"github.com/devsy-org/devsy/pkg/client"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -38,10 +37,8 @@ func NewStatusCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 func (cmd *StatusCmd) Run(ctx context.Context) error {
-	logger := oldlog.Default.ErrorStreamOnly()
-
 	// get workspace
-	shouldExit, workspaceInfo, err := agent.WorkspaceInfo(cmd.WorkspaceInfo, logger)
+	shouldExit, workspaceInfo, err := agent.WorkspaceInfo(cmd.WorkspaceInfo)
 	if err != nil {
 		return err
 	} else if shouldExit {

--- a/cmd/agent/workspace/stop.go
+++ b/cmd/agent/workspace/stop.go
@@ -8,7 +8,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/agent"
 	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -38,12 +37,9 @@ func NewStopCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 func (cmd *StopCmd) Run(ctx context.Context) error {
-	logger := oldlog.Default.ErrorStreamOnly()
-
 	// get workspace
 	shouldExit, workspaceInfo, err := agent.WriteWorkspaceInfo(
 		cmd.WorkspaceInfo,
-		logger,
 	)
 	if err != nil {
 		return fmt.Errorf("error parsing workspace info: %w", err)
@@ -52,7 +48,7 @@ func (cmd *StopCmd) Run(ctx context.Context) error {
 	}
 
 	// stop docker container
-	err = stopContainer(ctx, workspaceInfo, logger)
+	err = stopContainer(ctx, workspaceInfo)
 	if err != nil {
 		return fmt.Errorf("stop container: %w", err)
 	}
@@ -63,7 +59,6 @@ func (cmd *StopCmd) Run(ctx context.Context) error {
 func stopContainer(
 	ctx context.Context,
 	workspaceInfo *provider2.AgentWorkspaceInfo,
-	logger oldlog.Logger,
 ) error {
 	log.Debugf("stopping Devsy container")
 	runner, err := CreateRunner(workspaceInfo)

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -95,10 +95,9 @@ func (cmd *UpCmd) Run(ctx context.Context) error {
 func (cmd *UpCmd) loadWorkspaceInfo(ctx context.Context) (*provider.AgentWorkspaceInfo, error) {
 	shouldExit, workspaceInfo, err := agent.WriteWorkspaceInfoAndDeleteOld(
 		cmd.WorkspaceInfo,
-		func(workspaceInfo *provider.AgentWorkspaceInfo, l oldlog.Logger) error {
-			return deleteWorkspace(ctx, workspaceInfo, l)
+		func(workspaceInfo *provider.AgentWorkspaceInfo) error {
+			return deleteWorkspace(ctx, workspaceInfo)
 		},
-		oldlog.Default.ErrorStreamOnly(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing workspace info: %w", err)

--- a/cmd/agent/workspace/update_config.go
+++ b/cmd/agent/workspace/update_config.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +36,7 @@ func NewUpdateConfigCmd(flags *flags.GlobalFlags) *cobra.Command {
 
 func (cmd *UpdateConfigCmd) Run(ctx context.Context) error {
 	// write workspace info
-	shouldExit, _, err := agent.WriteWorkspaceInfo(cmd.WorkspaceInfo, oldlog.Default)
+	shouldExit, _, err := agent.WriteWorkspaceInfo(cmd.WorkspaceInfo)
 	if err != nil {
 		return err
 	} else if shouldExit {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -16,10 +16,9 @@ import (
 	"github.com/devsy-org/devsy/pkg/command"
 	"github.com/devsy-org/devsy/pkg/compress"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/version"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 )
 
 const DefaultInactivityTimeout = time.Minute * 20
@@ -115,7 +114,6 @@ func ParseAgentWorkspaceInfo(workspaceConfigFile string) (*provider2.AgentWorksp
 
 func ReadAgentWorkspaceInfo(
 	agentFolder, context, id string,
-	log log.Logger,
 ) (bool, *provider2.AgentWorkspaceInfo, error) {
 	log.Debugf(
 		"starting to read agent workspace info: agentFolder=%s, context=%s, workspaceId=%s",
@@ -156,7 +154,7 @@ func ReadAgentWorkspaceInfo(
 
 	// check if we need to become root
 	log.Debug("checking if root privileges are required")
-	shouldExit, err := rerunAsRoot(workspaceInfo, log)
+	shouldExit, err := rerunAsRoot(workspaceInfo)
 	if err != nil {
 		log.Errorf("failed to rerun as root: error=%v", err)
 		return false, nil, fmt.Errorf("rerun as root: %w", err)
@@ -178,31 +176,27 @@ func ReadAgentWorkspaceInfo(
 
 func WorkspaceInfo(
 	workspaceInfoEncoded string,
-	log log.Logger,
 ) (bool, *provider2.AgentWorkspaceInfo, error) {
-	return decodeWorkspaceInfoAndWrite(workspaceInfoEncoded, false, nil, log)
+	return decodeWorkspaceInfoAndWrite(workspaceInfoEncoded, false, nil)
 }
 
 func WriteWorkspaceInfo(
 	workspaceInfoEncoded string,
-	log log.Logger,
 ) (bool, *provider2.AgentWorkspaceInfo, error) {
-	return WriteWorkspaceInfoAndDeleteOld(workspaceInfoEncoded, nil, log)
+	return WriteWorkspaceInfoAndDeleteOld(workspaceInfoEncoded, nil)
 }
 
 func WriteWorkspaceInfoAndDeleteOld(
 	workspaceInfoEncoded string,
-	deleteWorkspace func(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) error,
-	log log.Logger,
+	deleteWorkspace func(workspaceInfo *provider2.AgentWorkspaceInfo) error,
 ) (bool, *provider2.AgentWorkspaceInfo, error) {
-	return decodeWorkspaceInfoAndWrite(workspaceInfoEncoded, true, deleteWorkspace, log)
+	return decodeWorkspaceInfoAndWrite(workspaceInfoEncoded, true, deleteWorkspace)
 }
 
 func decodeWorkspaceInfoAndWrite(
 	workspaceInfoEncoded string,
 	writeInfo bool,
-	deleteWorkspace func(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) error,
-	log log.Logger,
+	deleteWorkspace func(workspaceInfo *provider2.AgentWorkspaceInfo) error,
 ) (bool, *provider2.AgentWorkspaceInfo, error) {
 	log.Debugf(
 		"starting to decode and write workspace info: workspaceEncodedLength=%v, writeInfo=%v",
@@ -229,7 +223,7 @@ func decodeWorkspaceInfoAndWrite(
 
 	// check if we need to become root
 	log.Debug("checking if root privileges are required")
-	shouldExit, err := rerunAsRoot(workspaceInfo, log)
+	shouldExit, err := rerunAsRoot(workspaceInfo)
 	if err != nil {
 		log.Errorf("failed to rerun as root: error=%v", err)
 		return false, nil, fmt.Errorf("rerun as root: %w", err)
@@ -279,7 +273,7 @@ func decodeWorkspaceInfoAndWrite(
 				workspaceInfo.Workspace.UID,
 			)
 
-			err = deleteWorkspace(oldWorkspaceInfo, log)
+			err = deleteWorkspace(oldWorkspaceInfo)
 			if err != nil {
 				log.Errorf(
 					"failed to delete old workspace: error=%v, workspaceId=%s",
@@ -416,7 +410,8 @@ func writeWorkspaceInfo(file string, workspaceInfo *provider2.AgentWorkspaceInfo
 	return nil
 }
 
-func rerunAsRoot(workspaceInfo *provider2.AgentWorkspaceInfo, log log.Logger) (bool, error) {
+//nolint:cyclop // pre-existing complexity
+func rerunAsRoot(workspaceInfo *provider2.AgentWorkspaceInfo) (bool, error) {
 	// check if root is required
 	if runtime.GOOS != "linux" || os.Getuid() == 0 ||
 		(workspaceInfo != nil && workspaceInfo.Agent.Local == config.BoolTrue) {
@@ -481,7 +476,6 @@ func Tunnel(
 	stdin io.Reader,
 	stdout io.Writer,
 	stderr io.Writer,
-	log log.Logger,
 	timeout time.Duration,
 ) error {
 	err := InjectAgent(&InjectOptions{
@@ -501,7 +495,7 @@ func Tunnel(
 
 	// build command
 	command := fmt.Sprintf("'%s' helper ssh-server --stdio", ContainerDevsyHelperLocation)
-	if log.GetLevel() == logrus.DebugLevel {
+	if log.DebugEnabled() {
 		command += " --debug"
 	}
 	if user == "" {

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -275,17 +275,17 @@ func openJupyterBrowser(
 	if jupyter.Options.GetValue(ideOptions, jupyter.OpenOption) == config.BoolTrue {
 		go func() {
 			if openErr := open2.Open(ctx, targetURL); openErr != nil {
-				params.Log.Errorf("error opening jupyter notebook: error=%v", openErr)
+				pkglog.Errorf("error opening jupyter notebook: error=%v", openErr)
 			}
 
-			params.Log.Info(
+			pkglog.Info(
 				"started jupyter notebook in browser mode. " +
 					"Please keep this terminal open as long as you use Jupyter Notebook",
 			)
 		}()
 	}
 
-	params.Log.Infof("Starting jupyter notebook in browser mode at %s", targetURL)
+	pkglog.Infof("Starting jupyter notebook in browser mode at %s", targetURL)
 	extraPorts := []string{fmt.Sprintf("%s:%d", addr, jupyter.DefaultServerPort)}
 	return tunnel.StartBrowserTunnel(tunnel.BrowserTunnelParams{
 		Ctx:              ctx,
@@ -323,16 +323,16 @@ func openRStudioBrowser(
 	if rstudio.Options.GetValue(ideOptions, rstudio.OpenOption) == config.BoolTrue {
 		go func() {
 			if openErr := open2.Open(ctx, targetURL); openErr != nil {
-				params.Log.Errorf("error opening rstudio: %v", openErr)
+				pkglog.Errorf("error opening rstudio: %v", openErr)
 			}
 
-			params.Log.Infof(
+			pkglog.Infof(
 				"started RStudio Server in browser mode. Please keep this terminal open as long as you use it",
 			)
 		}()
 	}
 
-	params.Log.Infof("Starting RStudio server in browser mode at %s", targetURL)
+	pkglog.Infof("Starting RStudio server in browser mode at %s", targetURL)
 	extraPorts := []string{fmt.Sprintf("%s:%d", addr, rstudio.DefaultServerPort)}
 	return tunnel.StartBrowserTunnel(tunnel.BrowserTunnelParams{
 		Ctx:              ctx,
@@ -371,17 +371,17 @@ func openVSCodeBrowser(
 	if openvscode.Options.GetValue(ideOptions, openvscode.OpenOption) == config.BoolTrue {
 		go func() {
 			if openErr := open2.Open(ctx, targetURL); openErr != nil {
-				params.Log.Errorf("error opening vscode: %v", openErr)
+				pkglog.Errorf("error opening vscode: %v", openErr)
 			}
 
-			params.Log.Infof(
+			pkglog.Infof(
 				"started vscode in browser mode. " +
 					"Please keep this terminal open as long as you use VSCode browser version",
 			)
 		}()
 	}
 
-	params.Log.Infof("Starting vscode in browser mode at %s", targetURL)
+	pkglog.Infof("Starting vscode in browser mode at %s", targetURL)
 	forwardPorts := openvscode.Options.GetValue(
 		ideOptions,
 		openvscode.ForwardPortsOption,

--- a/pkg/workspace/list.go
+++ b/pkg/workspace/list.go
@@ -21,7 +21,6 @@ import (
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
 	oldlog "github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 )
 
 const ProjectLabel = "devsy.sh/project"
@@ -224,7 +223,7 @@ func listProWorkspacesForProvider(
 		return nil, fmt.Errorf("cannot list pro workspaces with provider %s", provider)
 	}
 	if err != nil {
-		if oldlog.Default.GetLevel() >= logrus.DebugLevel {
+		if log.DebugEnabled() {
 			log.Warnf("Failed to list pro workspaces for provider %s: %v", provider, err)
 		}
 		return nil, err


### PR DESCRIPTION
## Summary
- Remove logger dependency injection from pkg/agent/agent.go functions (ReadAgentWorkspaceInfo, WorkspaceInfo, WriteWorkspaceInfo, WriteWorkspaceInfoAndDeleteOld, Tunnel, rerunAsRoot)
- Update all cmd/agent/ callers to match new signatures, removing unused oldlog imports from 7 files
- Migrate internal logging in pkg/ide/opener to use pkg/log directly (keep Log field for clientimplementation)
- Replace oldlog.Default.GetLevel() check with log.DebugEnabled() in pkg/workspace/list.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated logging infrastructure across agent and workspace management functions to improve code consistency, reduce complexity, and streamline the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->