### PR TITLE
refactor(log): migrate daemon/platform, workspace, and utility packages to pkg/log

### DIFF
--- a/pkg/daemon/platform/daemon.go
+++ b/pkg/daemon/platform/daemon.go
@@ -13,11 +13,9 @@ import (
 	"time"
 
 	"github.com/devsy-org/devsy/pkg/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/ts"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"tailscale.com/client/local"
 	"tailscale.com/tsnet"
 	"tailscale.com/types/netmap"
@@ -28,7 +26,6 @@ type Daemon struct {
 	tsServer       *tsnet.Server
 	localServer    *localServer
 	rootDir        string
-	log            log.Logger
 }
 
 type InitConfig struct {
@@ -42,8 +39,6 @@ type InitConfig struct {
 }
 
 func Init(ctx context.Context, config InitConfig) (*Daemon, error) {
-	log := initLogging(config.RootDir, config.Debug)
-
 	socketAddr := GetSocketAddr(config.ProviderName)
 	log.Infof("Starting Daemon on address: %s", socketAddr)
 	// listen to socket for early return  in case it's already in use
@@ -60,13 +55,12 @@ func Init(ctx context.Context, config InitConfig) (*Daemon, error) {
 		config.UserName,
 		config.RootDir,
 		platformConfig.Insecure,
-		log,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create tailscale server: %w", err)
 	}
 
-	localServer, err := newLocalServer(lc, config.PlatformClient, config.Context, log)
+	localServer, err := newLocalServer(lc, config.PlatformClient, config.Context)
 	if err != nil {
 		return nil, fmt.Errorf("create local server: %w", err)
 	}
@@ -76,7 +70,6 @@ func Init(ctx context.Context, config InitConfig) (*Daemon, error) {
 		tsServer:       tsServer,
 		localServer:    localServer,
 		rootDir:        config.RootDir,
-		log:            log,
 	}, nil
 }
 
@@ -84,20 +77,20 @@ func (d *Daemon) Start(ctx context.Context) error {
 	errChan := make(chan error, 1)
 
 	go func() {
-		d.log.Infof("Starting local server: %s", d.localServer.Addr())
+		log.Infof("Starting local server: %s", d.localServer.Addr())
 		errChan <- d.localServer.ListenAndServe()
 	}()
 	go func() {
-		d.log.Info("Start proxying connections")
+		log.Info("Start proxying connections")
 		errChan <- d.Listen(d.socketListener)
 	}()
 	go func() {
-		d.log.Info("Start netmap watcher")
+		log.Info("Start netmap watcher")
 		errChan <- d.watchNetmap(ctx)
 	}()
 
 	defer func() {
-		d.log.Info("Cleaning up daemon resources")
+		log.Info("Cleaning up daemon resources")
 		_ = d.tsServer.Close()
 		_ = d.localServer.Close()
 		_ = d.socketListener.Close()
@@ -127,7 +120,7 @@ func (d *Daemon) Listen(ln net.Listener) error {
 	for {
 		rawConn, err := ln.Accept()
 		if err != nil {
-			d.log.Debugf("Failed to accept connection: %v", err)
+			log.Debugf("Failed to accept connection: %v", err)
 			continue
 		}
 
@@ -135,7 +128,7 @@ func (d *Daemon) Listen(ln net.Listener) error {
 		clientType, err := getClientType(bConn)
 		if err != nil {
 			_ = bConn.Close()
-			d.log.Debugf("Unknown client type: %v", err)
+			log.Debugf("Unknown client type: %v", err)
 			continue
 		}
 		switch clientType {
@@ -153,7 +146,7 @@ func (d *Daemon) handler(conn net.Conn, dialFunc dialFunc) {
 	defer cancel()
 	backendConn, err := dialFunc(ctx)
 	if err != nil {
-		d.log.Error("dial: %v", err)
+		log.Errorf("dial: %v", err)
 		return
 	}
 	defer func() { _ = backendConn.Close() }()
@@ -179,30 +172,11 @@ func (d *Daemon) watchNetmap(ctx context.Context) error {
 	return ts.WatchNetmap(ctx, lc, func(netMap *netmap.NetworkMap) {
 		nm, err := json.Marshal(netMap)
 		if err != nil {
-			d.log.Errorf("Failed to marshal netmap: %v", err)
+			log.Errorf("Failed to marshal netmap: %v", err)
 		} else {
 			_ = os.WriteFile(filepath.Join(d.rootDir, "netmap.json"), nm, 0o644)
 		}
 	})
-}
-
-func initLogging(rootDir string, debug bool) log.Logger {
-	logLevel := logrus.InfoLevel
-	if debug {
-		logLevel = logrus.DebugLevel
-	}
-
-	logPath := filepath.Join(rootDir, "daemon.log")
-	logger := log.NewFileLogger(logPath, logLevel)
-	if os.Getenv(config.EnvUI) != config.BoolTrue {
-		logger = devsylog.NewCombinedLogger(
-			logLevel,
-			logger,
-			log.NewStreamLogger(os.Stdout, os.Stderr, logLevel),
-		)
-	}
-
-	return logger
 }
 
 type dialFunc func(context.Context) (net.Conn, error)

--- a/pkg/daemon/platform/local_server.go
+++ b/pkg/daemon/platform/local_server.go
@@ -12,14 +12,13 @@ import (
 	managementv1 "github.com/devsy-org/api/pkg/apis/management/v1"
 	"github.com/devsy-org/devsy/pkg/dockercredentials"
 	"github.com/devsy-org/devsy/pkg/gitcredentials"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	platformclient "github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/kube"
 	"github.com/devsy-org/devsy/pkg/platform/labels"
 	"github.com/devsy-org/devsy/pkg/platform/project"
-	"github.com/devsy-org/log"
 	"github.com/gorilla/handlers"
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 	"tailscale.com/client/local"
@@ -35,7 +34,6 @@ type localServer struct {
 	listener       *memnet.Listener
 	pc             platformclient.Client
 	platformStatus *platformStatus
-	log            log.Logger
 	stopChan       chan struct{}
 }
 
@@ -90,12 +88,10 @@ func newLocalServer(
 	lc *local.Client,
 	pc platformclient.Client,
 	devsyContext string,
-	log log.Logger,
 ) (*localServer, error) {
 	l := &localServer{
 		lc:             lc,
 		pc:             pc,
-		log:            log,
 		devsyContext:   devsyContext,
 		listener:       memnet.Listen("localclient.devsy:80"),
 		platformStatus: &platformStatus{authenticated: true},
@@ -122,27 +118,25 @@ func newLocalServer(
 	mux.HandleFunc("GET "+routeDockerCredentials, l.getDockerCredentials)
 
 	handler := handlers.RecoveryHandler(
-		handlers.RecoveryLogger(panicLogger{log: l.log}),
+		handlers.RecoveryLogger(panicLogger{}),
 		handlers.PrintRecoveryStack(true),
 	)(mux)
-	handler = handlers.LoggingHandler(log.Writer(logrus.DebugLevel, true), handler)
+	handler = handlers.LoggingHandler(log.Writer(log.LevelDebug), handler)
 	l.httpServer = &http.Server{Handler: handler}
 
 	return l, nil
 }
 
-type panicLogger struct {
-	log log.Logger
-}
+type panicLogger struct{}
 
 func (r panicLogger) Println(args ...any) {
-	r.log.Error(args...)
+	log.Error(args...)
 }
 
 func (l *localServer) ListenAndServe() error {
 	errChan := make(chan error, 1)
 	go func() {
-		l.log.Info("Start config watcher")
+		log.Info("Start config watcher")
 		err := l.watchPlatform(l.stopChan)
 		errChan <- err
 	}()
@@ -160,7 +154,7 @@ func (l *localServer) ListenAndServe() error {
 }
 
 func (l *localServer) Close() error {
-	l.log.Info("shutting down local server")
+	log.Info("shutting down local server")
 	l.stopChan <- struct{}{}
 	_ = l.listener.Close()
 	return nil
@@ -176,11 +170,11 @@ func (l *localServer) Dial(ctx context.Context, network, addr string) (net.Conn,
 
 func (l *localServer) watchPlatform(stopChan <-chan struct{}) error {
 	for {
-		l.log.Debug("Check platform status")
+		log.Debug("Check platform status")
 
 		managementClient, err := l.pc.Management()
 		if err != nil {
-			l.log.Error(fmt.Errorf("create mangement client: %w", err))
+			log.Error(fmt.Errorf("create mangement client: %w", err))
 		} else {
 			_, err = managementClient.Loft().
 				ManagementV1().
@@ -189,10 +183,10 @@ func (l *localServer) watchPlatform(stopChan <-chan struct{}) error {
 			l.platformStatus.mu.Lock()
 			if err != nil {
 				if IsAccessKeyNotFound(err) {
-					l.log.Warnf("client not authenticated: %s", err)
+					log.Warnf("client not authenticated: %s", err)
 					l.platformStatus.authenticated = false
 				} else {
-					l.log.Errorf("failed to create self: %v", err)
+					log.Errorf("failed to create self: %v", err)
 				}
 			} else {
 				// We don't want to be too restrictive in case the error
@@ -586,7 +580,6 @@ func (l *localServer) watchWorkspaces(
 		OwnerFilter:    ownerFilter,
 		PlatformClient: l.pc,
 		TsClient:       l.lc,
-		Log:            l.log,
 	},
 		// we need to debounce events here to avoid spamming the client with too many events
 		throttle(func(instanceList []*ProWorkspaceInstance) {
@@ -610,7 +603,7 @@ func (l *localServer) watchWorkspaces(
 			fmt.Errorf("failed to watch workspaces: %w", err).Error(),
 			http.StatusInternalServerError,
 		)
-		l.log.Errorf("watch workspaces: %w", err)
+		log.Errorf("watch workspaces: %w", err)
 		return
 	}
 }

--- a/pkg/daemon/platform/ts_server.go
+++ b/pkg/daemon/platform/ts_server.go
@@ -6,10 +6,9 @@ import (
 	"net/url"
 	"path/filepath"
 
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/ts"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"tailscale.com/client/local"
 	"tailscale.com/envknob"
 	"tailscale.com/ipn/store"
@@ -21,7 +20,6 @@ func newTSServer(
 	ctx context.Context,
 	host, accessKey, userName, rootDir string,
 	insecure bool,
-	log log.Logger,
 ) (*tsnet.Server, *local.Client, error) {
 	// Build the platform URL
 	baseUrl := url.URL{
@@ -46,7 +44,7 @@ func newTSServer(
 
 	logPrefix := "[ts] "
 	logf := func(format string, args ...any) {
-		if log.GetLevel() == logrus.DebugLevel {
+		if log.DebugEnabled() {
 			log.Debugf(logPrefix+format, args...)
 		}
 	}

--- a/pkg/daemon/platform/workspace_watcher.go
+++ b/pkg/daemon/platform/workspace_watcher.go
@@ -13,12 +13,12 @@ import (
 	loftclient "github.com/devsy-org/api/pkg/clientset/versioned"
 	typedmanagementv1 "github.com/devsy-org/api/pkg/clientset/versioned/typed/management/v1"
 	informers "github.com/devsy-org/api/pkg/informers/externalversions"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/project"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/ts"
-	"github.com/devsy-org/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -49,7 +49,6 @@ type watchConfig struct {
 	PlatformClient client.Client
 	TsClient       *local.Client
 	OwnerFilter    platform.OwnerFilter
-	Log            log.Logger
 }
 
 type changeFn func(instanceList []*ProWorkspaceInstance)
@@ -71,7 +70,7 @@ func startWorkspaceWatcher(ctx context.Context, config watchConfig, onChange cha
 		informers.WithNamespace(project.ProjectNamespace(config.Project)),
 	)
 	workspaceInformer := factory.Management().V1().DevsyWorkspaceInstances()
-	instanceStore := newStore(self, config.Context, config.OwnerFilter, config.TsClient, config.Log)
+	instanceStore := newStore(self, config.Context, config.OwnerFilter, config.TsClient)
 	_, err = workspaceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
 			instance, ok := obj.(*managementv1.DevsyWorkspaceInstance)
@@ -123,11 +122,11 @@ func startWorkspaceWatcher(ctx context.Context, config watchConfig, onChange cha
 	go func() {
 		defer func() {
 			if err := recover(); err != nil {
-				config.Log.Errorf("panic in workspace watcher: %v\n%s", err, debug.Stack())
+				log.Errorf("panic in workspace watcher: %v\n%s", err, debug.Stack())
 			}
 		}()
 
-		config.Log.Info("starting workspace watcher")
+		log.Info("starting workspace watcher")
 		factory.Start(ctx.Done())
 		factory.WaitForCacheSync(ctx.Done())
 		started.Store(true)
@@ -140,7 +139,7 @@ func startWorkspaceWatcher(ctx context.Context, config watchConfig, onChange cha
 	}()
 
 	<-ctx.Done()
-	config.Log.Debug("workspace watcher done")
+	log.Debug("workspace watcher done")
 	return nil
 }
 
@@ -156,8 +155,6 @@ type instanceStore struct {
 	metricsMu        sync.RWMutex
 	metrics          map[string][]WorkspaceNetworkMetrics
 	maxMetricSamples int
-
-	log log.Logger
 }
 
 type ConnectionType string
@@ -185,7 +182,6 @@ func newStore(
 	context string,
 	ownerFilter platform.OwnerFilter,
 	tsClient *local.Client,
-	log log.Logger,
 ) *instanceStore {
 	return &instanceStore{
 		self:             self,
@@ -195,7 +191,6 @@ func newStore(
 		tsClient:         tsClient,
 		metrics:          map[string][]WorkspaceNetworkMetrics{},
 		maxMetricSamples: 6,
-		log:              log,
 	}
 }
 
@@ -329,7 +324,7 @@ func (s *instanceStore) collectWorkspaceMetrics(ctx context.Context, onChange ch
 func (s *instanceStore) updateWorkspaceLatencies(ctx context.Context) {
 	status, err := s.tsClient.Status(ctx)
 	if err != nil {
-		s.log.Errorf("Failed to get tailscale status: %v", err)
+		log.Errorf("Failed to get tailscale status: %v", err)
 		return
 	}
 
@@ -340,7 +335,7 @@ func (s *instanceStore) updateWorkspaceLatencies(ctx context.Context) {
 		}
 		instanceName, projectName, err := ts.ParseWorkspaceHostname(peer.HostName)
 		if err != nil {
-			s.log.Debugf("failed to parse hostname for peer %s: %v", peer.HostName, err)
+			log.Debugf("failed to parse hostname for peer %s: %v", peer.HostName, err)
 			continue
 		}
 		key := fmt.Sprintf("%s/%s", project.ProjectNamespace(projectName), instanceName)
@@ -358,10 +353,10 @@ func (s *instanceStore) updateWorkspaceLatencies(ctx context.Context) {
 			timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
-			s.log.Debugf("pinging workspace %s/%s", instance.GetNamespace(), instance.GetName())
+			log.Debugf("pinging workspace %s/%s", instance.GetNamespace(), instance.GetName())
 			pingResult, err := s.tsClient.Ping(timeoutCtx, peer.TailscaleIPs[0], tailcfg.PingDisco)
 			if err != nil {
-				s.log.Debugf(
+				log.Debugf(
 					"Failed to ping workspace %s/%s: %v",
 					instance.GetNamespace(),
 					instance.GetName(),
@@ -370,7 +365,7 @@ func (s *instanceStore) updateWorkspaceLatencies(ctx context.Context) {
 				return
 			}
 			if pingResult.Err != "" {
-				s.log.Debugf(
+				log.Debugf(
 					"Failed to ping workspace %s/%s: %v",
 					instance.GetNamespace(),
 					instance.GetName(),

--- a/pkg/options/resolver/resolve.go
+++ b/pkg/options/resolver/resolve.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/types"
+	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/log/survey"
 	"github.com/devsy-org/log/terminal"
 )
@@ -151,8 +153,8 @@ func (r *Resolver) resolveOption(
 		}
 
 		// check if there is only one option
-		r.log.Info(option.Description)
-		answer, err := r.log.Question(&survey.QuestionOptions{
+		log.Info(option.Description)
+		answer, err := oldlog.Default.Question(&survey.QuestionOptions{
 			Question:               fmt.Sprintf("Please enter a value for %s", optionName),
 			Options:                questionOpts,
 			ValidationRegexPattern: option.ValidationPattern,

--- a/pkg/options/resolver/resolver.go
+++ b/pkg/options/resolver/resolver.go
@@ -7,7 +7,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/graph"
 	"github.com/devsy-org/devsy/pkg/types"
-	oldlog "github.com/devsy-org/log"
 )
 
 const (
@@ -58,7 +57,6 @@ type Resolver struct {
 	resolveGlobal     bool
 	resolveSubOptions bool
 	skipRequired      bool
-	log               oldlog.Logger
 }
 
 type Option func(r *Resolver)
@@ -104,12 +102,6 @@ func WithResolveSubOptions() Option {
 func WithSkipRequired(skip bool) Option {
 	return func(r *Resolver) {
 		r.skipRequired = skip
-	}
-}
-
-func WithLogger(log oldlog.Logger) Option {
-	return func(r *Resolver) {
-		r.log = log
 	}
 }
 


### PR DESCRIPTION
## Summary
- Migrate internal logging in `pkg/daemon/platform/` (daemon, local_server, ts_server, workspace_watcher) from `github.com/devsy-org/log` to `pkg/log` package-level API
- Remove logger dependency injection (struct fields, function parameters) throughout the daemon platform package
- Remove unused `WithLogger` option and `log` field from `pkg/options/resolver`
- Replace `oldlog.GetLevel()` check with `log.DebugEnabled()` in ts_server
- Use `oldlog.Default.Question()` directly in resolver for interactive prompts (pkg/log has no Question equivalent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated logging infrastructure across daemon and resolver components to use centralized package-level logging instead of per-instance loggers.
  * Updated logging middleware and debug-level detection in server components.
  * Simplified logger initialization and parameter passing throughout the daemon platform layer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->