### PR TITLE
fix: prevent stdout corruption in container agent logging

### DIFF
--- a/pkg/driver/kubernetes/throttledlogger/throttled_logger.go
+++ b/pkg/driver/kubernetes/throttledlogger/throttled_logger.go
@@ -3,37 +3,35 @@ package throttledlogger
 import (
 	"time"
 
-	"github.com/devsy-org/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 // ThrottledLogger is a logger that throttles the output,
 // i.e. it only logs a message if a certain amount of time has passed since the last log message.
 type ThrottledLogger struct {
-	logger log.Logger
-	timer  *Timer
+	timer *Timer
 }
 
-func NewThrottledLogger(logger log.Logger, throttlingInterval time.Duration) *ThrottledLogger {
+func NewThrottledLogger(throttlingInterval time.Duration) *ThrottledLogger {
 	return &ThrottledLogger{
-		logger: logger,
-		timer:  NewTimer(throttlingInterval),
+		timer: NewTimer(throttlingInterval),
 	}
 }
 
 func (t *ThrottledLogger) Infof(format string, args ...any) {
-	t.log(t.logger.Infof, format, args...)
+	t.logf(log.Infof, format, args...)
 }
 
 func (t *ThrottledLogger) Debugf(format string, args ...any) {
-	t.log(t.logger.Debugf, format, args...)
+	t.logf(log.Debugf, format, args...)
 }
 
-type LoggingFunc func(string, ...any)
+type loggingFunc func(string, ...any)
 
-func (t *ThrottledLogger) log(loggingFunc LoggingFunc, format string, args ...any) {
+func (t *ThrottledLogger) logf(fn loggingFunc, format string, args ...any) {
 	now := time.Now()
 	if t.timer.IntervalPassed(now) {
-		loggingFunc(format, args...)
+		fn(format, args...)
 		t.timer.Tick(now)
 	}
 }

--- a/pkg/driver/kubernetes/wait.go
+++ b/pkg/driver/kubernetes/wait.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/driver/kubernetes/throttledlogger"
 	"github.com/devsy-org/devsy/pkg/log"
-	oldlog "github.com/devsy-org/log"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +16,7 @@ import (
 )
 
 func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*corev1.Pod, error) {
-	throttledLogger := throttledlogger.NewThrottledLogger(oldlog.GetInstance(), time.Second*5)
+	throttledLogger := throttledlogger.NewThrottledLogger(time.Second * 5)
 
 	timeoutDuration, err := time.ParseDuration(k.options.PodTimeout)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fix regression from PR #20 where `ThrottledLogger` in `pkg/driver/kubernetes/wait.go` used `oldlog.GetInstance()` which writes Info-level messages to stdout
- In the agent process, stdout is the gRPC/tunnel protocol channel — these log messages corrupted the binary protocol causing "did not receive a result back from agent" failures in kubernetes and build e2e tests
- Migrated `ThrottledLogger` to use `pkg/log` package-level functions (which write to stderr), removing the old log library dependency