### PR TITLE
refactor(log): relocate survey and terminal utility packages

### DIFF
--- a/cmd/pro/add/cluster.go
+++ b/cmd/pro/add/cluster.go
@@ -16,9 +16,9 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
+	"github.com/devsy-org/devsy/pkg/survey"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	oldlog "github.com/devsy-org/log"
-	"github.com/devsy-org/log/survey"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -329,7 +329,7 @@ func ensureHost(devsyConfig *config.Config, host string) (string, error) {
 	for _, pro := range proInstances {
 		options = append(options, pro.Host)
 	}
-	h, err := oldlog.Default.Question(&survey.QuestionOptions{
+	h, err := log.QuestionDefault(&survey.QuestionOptions{
 		Question:     "Select Pro instance to connect your cluster to",
 		Options:      options,
 		DefaultValue: options[0],

--- a/cmd/pro/provider/create/workspace.go
+++ b/cmd/pro/provider/create/workspace.go
@@ -15,7 +15,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform/form"
 	"github.com/devsy-org/devsy/pkg/platform/project"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log/terminal"
+	"github.com/devsy-org/devsy/pkg/terminal"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/cmd/pro/provider/update/workspace.go
+++ b/cmd/pro/provider/update/workspace.go
@@ -13,7 +13,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/form"
 	"github.com/devsy-org/devsy/pkg/platform/project"
-	"github.com/devsy-org/log/terminal"
+	"github.com/devsy-org/devsy/pkg/terminal"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/cmd/pro/reset/password.go
+++ b/cmd/pro/reset/password.go
@@ -11,8 +11,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform/kube"
 	"github.com/devsy-org/devsy/pkg/random"
-	oldlog "github.com/devsy-org/log"
-	"github.com/devsy-org/log/survey"
+	"github.com/devsy-org/devsy/pkg/survey"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -223,7 +222,7 @@ func (cmd *PasswordCmd) resolvePassword() (string, error) {
 	}
 
 	for {
-		password, err := oldlog.Default.Question(&survey.QuestionOptions{
+		password, err := log.QuestionDefault(&survey.QuestionOptions{
 			Question:   "Please enter a new password",
 			IsPassword: true,
 		})

--- a/cmd/pro/start.go
+++ b/cmd/pro/start.go
@@ -31,9 +31,9 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/scanner"
+	"github.com/devsy-org/devsy/pkg/survey"
 	"github.com/devsy-org/devsy/pkg/util"
 	oldlog "github.com/devsy-org/log"
-	"github.com/devsy-org/log/survey"
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -434,7 +434,7 @@ func (cmd *StartCmd) success(ctx context.Context) error {
 			NoOption  = "No, please re-run the DNS check"
 		)
 
-		answer, err := oldlog.Default.Question(&survey.QuestionOptions{
+		answer, err := log.QuestionDefault(&survey.QuestionOptions{
 			Question:     "Unable to reach Devsy at https://" + host + ". Do you want to start port-forwarding instead?",
 			DefaultValue: YesOption,
 			Options: []string{
@@ -998,7 +998,7 @@ func (cmd *StartCmd) resolveKubeConfig(
 	if cmd.Context != "" {
 		contextToLoad = cmd.Context
 	} else if loftConfig.LastInstallContext != "" && loftConfig.LastInstallContext != contextToLoad {
-		contextToLoad, err = oldlog.Default.Question(&survey.QuestionOptions{
+		contextToLoad, err = log.QuestionDefault(&survey.QuestionOptions{
 			Question:     "Seems like you try to use 'devsy pro start' with a different kubernetes context than before. Please choose which kubernetes context you want to use",
 			DefaultValue: contextToLoad,
 			Options:      []string{contextToLoad, loftConfig.LastInstallContext},
@@ -1083,7 +1083,7 @@ func (cmd *StartCmd) handleAlreadyExistingInstallation(ctx context.Context) erro
 					NoOption  = "No, my cluster is running not locally (GKE, EKS, Bare Metal, etc.)"
 				)
 
-				answer, err := oldlog.Default.Question(&survey.QuestionOptions{
+				answer, err := log.QuestionDefault(&survey.QuestionOptions{
 					Question:     "Seems like your cluster is running locally (docker desktop, minikube, kind etc.). Is that correct?",
 					DefaultValue: YesOption,
 					Options: []string{
@@ -1105,7 +1105,7 @@ func (cmd *StartCmd) handleAlreadyExistingInstallation(ctx context.Context) erro
 					NoOption  = "No"
 				)
 
-				answer, err := oldlog.Default.Question(&survey.QuestionOptions{
+				answer, err := log.QuestionDefault(&survey.QuestionOptions{
 					Question:     "Enabling ingress is usually only useful for remote clusters. Do you still want to deploy the ingress to your local cluster?",
 					DefaultValue: NoOption,
 					Options: []string{
@@ -1562,8 +1562,8 @@ func isInstalledLocally(
 	return kerrors.IsNotFound(err)
 }
 
-func enterHostNameQuestion(log oldlog.Logger) (string, error) {
-	return log.Question(&survey.QuestionOptions{
+func enterHostNameQuestion(logger oldlog.Logger) (string, error) {
+	return log.QuestionWith(logger, &survey.QuestionOptions{
 		Question: fmt.Sprintf(
 			"Enter a hostname for your %s instance (e.g. loft.my-domain.tld): \n ",
 			config.ProductNamePro,
@@ -1585,7 +1585,7 @@ func ensureIngressController(
 	ctx context.Context,
 	kubeClient kubernetes.Interface,
 	kubeContext string,
-	log oldlog.Logger,
+	logger oldlog.Logger,
 ) error {
 	// first create an ingress controller
 	const (
@@ -1593,7 +1593,7 @@ func ensureIngressController(
 		NoOption  = "No, I already have an ingress controller installed."
 	)
 
-	answer, err := log.Question(&survey.QuestionOptions{
+	answer, err := log.QuestionWith(logger, &survey.QuestionOptions{
 		Question:     "Ingress controller required. Should the nginx-ingress controller be installed?",
 		DefaultValue: YesOption,
 		Options: []string{
@@ -1622,9 +1622,9 @@ func ensureIngressController(
 			"controller.config.hsts=false",
 			"--wait",
 		}
-		log.WriteString(logrus.InfoLevel, "\n")
-		log.Infof("Executing command: helm %s\n", strings.Join(args, " "))
-		log.Info("Waiting for ingress controller deployment, this can take several minutes...")
+		logger.WriteString(logrus.InfoLevel, "\n")
+		logger.Infof("Executing command: helm %s\n", strings.Join(args, " "))
+		logger.Info("Waiting for ingress controller deployment, this can take several minutes...")
 		helmCmd := exec.CommandContext(
 			ctx,
 			"helm",
@@ -1670,7 +1670,7 @@ func ensureIngressController(
 			}
 		}
 
-		log.Done("installed ingress-nginx to your kubernetes cluster!")
+		logger.Done("installed ingress-nginx to your kubernetes cluster!")
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	al.essio.dev/pkg/shellescape v1.6.0
 	charm.land/huh/v2 v2.0.3
 	charm.land/lipgloss/v2 v2.0.3
+	github.com/AlecAivazis/survey/v2 v2.3.7
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/Microsoft/go-winio v0.6.2
@@ -43,6 +44,7 @@ require (
 	github.com/moby/term v0.5.2
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
+	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.10
 	github.com/sirupsen/logrus v1.9.4
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
@@ -85,7 +87,6 @@ require (
 	code.gitea.io/sdk/gitea v0.22.1 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/42wim/httpsig v1.2.3 // indirect
-	github.com/AlecAivazis/survey/v2 v2.3.7 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 // indirect
@@ -232,7 +233,6 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/pires/go-proxyproto v0.8.1 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus-community/pro-bing v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	github.com/moby/term v0.5.2
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
-	github.com/pkg/errors v0.9.1
 	github.com/pkg/sftp v1.13.10
 	github.com/sirupsen/logrus v1.9.4
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
@@ -233,6 +232,7 @@ require (
 	github.com/opencontainers/runtime-spec v1.3.0 // indirect
 	github.com/pires/go-proxyproto v0.8.1 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus-community/pro-bing v0.4.0 // indirect

--- a/pkg/agent/tunnelserver/logger.go
+++ b/pkg/agent/tunnelserver/logger.go
@@ -12,7 +12,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/agent/tunnel"
 	"github.com/devsy-org/devsy/pkg/scanner"
 	"github.com/devsy-org/log"
-	"github.com/devsy-org/log/survey"
+	oldsurvey "github.com/devsy-org/log/survey"
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 )
@@ -290,7 +290,7 @@ func (s *tunnelLogger) WriteLevel(level logrus.Level, message []byte) (int, erro
 	return len(message), nil
 }
 
-func (s *tunnelLogger) Question(params *survey.QuestionOptions) (string, error) {
+func (s *tunnelLogger) Question(params *oldsurvey.QuestionOptions) (string, error) {
 	return "", fmt.Errorf("not supported")
 }
 

--- a/pkg/client/clientimplementation/daemonclient/create.go
+++ b/pkg/client/clientimplementation/daemonclient/create.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/platform/project"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/log/terminal"
+	"github.com/devsy-org/devsy/pkg/terminal"
 )
 
 func (c *client) Create(

--- a/pkg/client/clientimplementation/daemonclient/update.go
+++ b/pkg/client/clientimplementation/daemonclient/update.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/devsy-org/log/terminal"
+	"github.com/devsy-org/devsy/pkg/terminal"
 )
 
 func (c *client) updateInstance(ctx context.Context) error {

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -21,9 +21,9 @@ import (
 	"github.com/devsy-org/devsy/pkg/options/resolver"
 	platformclient "github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/provider"
+	"github.com/devsy-org/devsy/pkg/terminal"
 	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/devsy-org/log"
-	"github.com/devsy-org/log/terminal"
 	"github.com/gofrs/flock"
 )
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	logLib "github.com/devsy-org/log"
-	"github.com/devsy-org/log/survey"
+	oldsurvey "github.com/devsy-org/log/survey"
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 )
@@ -155,7 +155,7 @@ func (c *CombinedLogger) WriteLevel(level logrus.Level, message []byte) (int, er
 	return len(message), nil
 }
 
-func (c *CombinedLogger) Question(params *survey.QuestionOptions) (string, error) {
+func (c *CombinedLogger) Question(params *oldsurvey.QuestionOptions) (string, error) {
 	return "", errors.New("questions in combined logger not supported")
 }
 

--- a/pkg/log/question.go
+++ b/pkg/log/question.go
@@ -1,0 +1,24 @@
+package log
+
+import (
+	"github.com/devsy-org/devsy/pkg/survey"
+	oldlog "github.com/devsy-org/log"
+	oldsurvey "github.com/devsy-org/log/survey"
+)
+
+// QuestionDefault asks a question using the default logger, bridging the local
+// survey type to the old log module's survey type during the migration.
+func QuestionDefault(opts *survey.QuestionOptions) (string, error) {
+	return oldlog.Default.Question(convertOpts(opts))
+}
+
+// QuestionWith asks a question using the given logger, bridging the local
+// survey type to the old log module's survey type during the migration.
+func QuestionWith(logger oldlog.Logger, opts *survey.QuestionOptions) (string, error) {
+	return logger.Question(convertOpts(opts))
+}
+
+func convertOpts(opts *survey.QuestionOptions) *oldsurvey.QuestionOptions {
+	converted := oldsurvey.QuestionOptions(*opts)
+	return &converted
+}

--- a/pkg/options/resolver/resolve.go
+++ b/pkg/options/resolver/resolve.go
@@ -9,10 +9,9 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/survey"
+	"github.com/devsy-org/devsy/pkg/terminal"
 	"github.com/devsy-org/devsy/pkg/types"
-	oldlog "github.com/devsy-org/log"
-	"github.com/devsy-org/log/survey"
-	"github.com/devsy-org/log/terminal"
 )
 
 func (r *Resolver) resolveOptions(
@@ -154,7 +153,7 @@ func (r *Resolver) resolveOption(
 
 		// check if there is only one option
 		log.Info(option.Description)
-		answer, err := oldlog.Default.Question(&survey.QuestionOptions{
+		answer, err := log.QuestionDefault(&survey.QuestionOptions{
 			Question:               fmt.Sprintf("Please enter a value for %s", optionName),
 			Options:                questionOpts,
 			ValidationRegexPattern: option.ValidationPattern,

--- a/pkg/survey/survey.go
+++ b/pkg/survey/survey.go
@@ -1,11 +1,12 @@
 package survey
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 	"sort"
 
 	surveypkg "github.com/AlecAivazis/survey/v2"
-	"github.com/pkg/errors"
 )
 
 // QuestionOptions defines a question and its options.
@@ -104,7 +105,7 @@ func buildValidator(params *QuestionOptions, compiledRegex *regexp.Regexp) func(
 	return func(val any) error {
 		str, ok := val.(string)
 		if !ok {
-			return errors.New("Input was not a string")
+			return errors.New("input was not a string")
 		}
 
 		if !compiledRegex.MatchString(str) {
@@ -112,7 +113,7 @@ func buildValidator(params *QuestionOptions, compiledRegex *regexp.Regexp) func(
 				return errors.New(params.ValidationMessage)
 			}
 
-			return errors.Errorf("Answer has to match pattern: %s", compiledRegex.String())
+			return fmt.Errorf("answer has to match pattern: %s", compiledRegex.String())
 		}
 
 		if params.ValidationFunc != nil {
@@ -121,7 +122,7 @@ func buildValidator(params *QuestionOptions, compiledRegex *regexp.Regexp) func(
 					return errors.New(params.ValidationMessage)
 				}
 
-				return errors.Errorf("%v", err)
+				return fmt.Errorf("%v", err)
 			}
 		}
 

--- a/pkg/survey/survey.go
+++ b/pkg/survey/survey.go
@@ -1,0 +1,136 @@
+package survey
+
+import (
+	"regexp"
+	"sort"
+
+	surveypkg "github.com/AlecAivazis/survey/v2"
+	"github.com/pkg/errors"
+)
+
+// QuestionOptions defines a question and its options.
+type QuestionOptions struct {
+	Question               string
+	DefaultValue           string
+	DefaultValueSet        bool
+	ValidationRegexPattern string
+	ValidationMessage      string
+	ValidationFunc         func(value string) error
+	Options                []string
+	Sort                   bool
+	IsPassword             bool
+}
+
+// DefaultValidationRegexPattern is the default regex pattern to validate the input.
+var DefaultValidationRegexPattern = regexp.MustCompile("^.*$")
+
+// Survey is the interface for asking questions.
+type Survey interface {
+	Question(params *QuestionOptions) (string, error)
+}
+
+type survey struct{}
+
+// NewSurvey creates a new survey object.
+func NewSurvey() Survey {
+	return &survey{}
+}
+
+// Question asks the user a question and returns the answer.
+func (s *survey) Question(params *QuestionOptions) (string, error) {
+	compiledRegex := DefaultValidationRegexPattern
+	if params.ValidationRegexPattern != "" {
+		compiledRegex = regexp.MustCompile(params.ValidationRegexPattern)
+	}
+
+	prompt := buildPrompt(params)
+	question := []*surveypkg.Question{
+		{
+			Name:   "question",
+			Prompt: prompt,
+		},
+	}
+
+	if params.Options == nil {
+		question[0].Validate = buildValidator(params, compiledRegex)
+	}
+
+	answers := struct {
+		Question string
+	}{}
+
+	err := surveypkg.Ask(question, &answers)
+	if err != nil {
+		return "", err
+	}
+	if answers.Question == "" && len(params.Options) > 0 {
+		answers.Question = params.Options[0]
+	}
+
+	return answers.Question, nil
+}
+
+func buildPrompt(params *QuestionOptions) surveypkg.Prompt {
+	switch {
+	case params.Options != nil:
+		if params.Sort {
+			params.Options = copyStringArray(params.Options)
+			sort.Strings(params.Options)
+		}
+
+		var defaultValue any
+		if params.DefaultValue != "" {
+			defaultValue = params.DefaultValue
+		}
+
+		return &surveypkg.Select{
+			Message: params.Question,
+			Options: params.Options,
+			Default: defaultValue,
+		}
+	case params.IsPassword:
+		return &surveypkg.Password{
+			Message: params.Question,
+		}
+	default:
+		return &surveypkg.Input{
+			Message: params.Question,
+			Default: params.DefaultValue,
+		}
+	}
+}
+
+func buildValidator(params *QuestionOptions, compiledRegex *regexp.Regexp) func(val any) error {
+	return func(val any) error {
+		str, ok := val.(string)
+		if !ok {
+			return errors.New("Input was not a string")
+		}
+
+		if !compiledRegex.MatchString(str) {
+			if params.ValidationMessage != "" {
+				return errors.New(params.ValidationMessage)
+			}
+
+			return errors.Errorf("Answer has to match pattern: %s", compiledRegex.String())
+		}
+
+		if params.ValidationFunc != nil {
+			if err := params.ValidationFunc(str); err != nil {
+				if params.ValidationMessage != "" {
+					return errors.New(params.ValidationMessage)
+				}
+
+				return errors.Errorf("%v", err)
+			}
+		}
+
+		return nil
+	}
+}
+
+func copyStringArray(strings []string) []string {
+	retStrings := []string{}
+	retStrings = append(retStrings, strings...)
+	return retStrings
+}

--- a/pkg/terminal/tty.go
+++ b/pkg/terminal/tty.go
@@ -1,0 +1,16 @@
+package terminal
+
+import (
+	"io"
+	"os"
+
+	dockerterm "github.com/moby/term"
+)
+
+var IsTerminalIn = IsTerminal(os.Stdin)
+
+// IsTerminal returns whether the passed object is a terminal or not.
+func IsTerminal(stdin io.Reader) bool {
+	_, terminal := dockerterm.GetFdInfo(stdin)
+	return terminal
+}

--- a/pkg/workspace/machine.go
+++ b/pkg/workspace/machine.go
@@ -13,10 +13,10 @@ import (
 	"github.com/devsy-org/devsy/pkg/file"
 	"github.com/devsy-org/devsy/pkg/log"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
+	"github.com/devsy-org/devsy/pkg/survey"
+	"github.com/devsy-org/devsy/pkg/terminal"
 	"github.com/devsy-org/devsy/pkg/types"
 	oldlog "github.com/devsy-org/log"
-	"github.com/devsy-org/log/survey"
-	"github.com/devsy-org/log/terminal"
 )
 
 // ListMachines returns all machines configured in the given Devsy context.
@@ -189,7 +189,7 @@ func selectMachine(devsyConfig *config.Config) (client.MachineClient, error) {
 		return nil, errProvideWorkspaceArg
 	}
 
-	answer, err := oldlog.Default.Question(&survey.QuestionOptions{
+	answer, err := log.QuestionDefault(&survey.QuestionOptions{
 		Question:     "Please select a machine from the list below",
 		DefaultValue: machineIDs[0],
 		Options:      machineIDs,

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -22,9 +22,9 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
+	"github.com/devsy-org/devsy/pkg/terminal"
 	"github.com/devsy-org/devsy/pkg/types"
 	oldlog "github.com/devsy-org/log"
-	"github.com/devsy-org/log/terminal"
 )
 
 var errProvideWorkspaceArg = errors.New(


### PR DESCRIPTION
## Summary
- Copies the `survey` and `terminal` utility sub-packages from `github.com/devsy-org/log` into `pkg/survey/` and `pkg/terminal/`
- Updates all import paths to use the new location
- Adds a bridge layer in `pkg/log/question.go` to convert between the new and old survey types (needed because `oldlog.Logger` interface still references the old survey type)
- These packages provide survey/question prompting and terminal detection utilities
- Part of the ongoing migration away from `github.com/devsy-org/log`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated internal packages and dependencies to improve code organization.
  * Reorganized survey, terminal, and logging utilities to centralized package locations.
  * Updated dependency management to promote previously indirect dependencies.

No changes to user-facing functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->