### PR TITLE
refactor(log): migrate client package constructors to pkg/log (batch 1)

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -257,7 +257,6 @@ func (cmd *SSHCmd) jumpContainerTailscale(
 					Client:       client,
 					SSHClient:    toolSSHClient,
 					User:         cmd.User,
-					Log:          log,
 					ForwardPorts: false,
 					ExtraPorts:   nil,
 				},

--- a/pkg/client/clientimplementation/daemonclient/client.go
+++ b/pkg/client/clientimplementation/daemonclient/client.go
@@ -16,6 +16,7 @@ import (
 	clientpkg "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
 	daemon "github.com/devsy-org/devsy/pkg/daemon/platform"
+	"github.com/devsy-org/devsy/pkg/log"
 	devsyopen "github.com/devsy-org/devsy/pkg/open"
 	"github.com/devsy-org/devsy/pkg/options"
 	"github.com/devsy-org/devsy/pkg/options/resolver"
@@ -24,7 +25,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/provider"
 	sshServer "github.com/devsy-org/devsy/pkg/ssh/server"
 	"github.com/devsy-org/devsy/pkg/ts"
-	"github.com/devsy-org/log"
 	"golang.org/x/crypto/ssh"
 	"tailscale.com/client/local"
 	"tailscale.com/tailcfg"
@@ -34,7 +34,6 @@ func New(
 	devsyConfig *config.Config,
 	prov *provider.ProviderConfig,
 	workspace *provider.Workspace,
-	log log.Logger,
 ) (clientpkg.DaemonClient, error) {
 	tsClient := &local.Client{
 		Socket:        daemon.GetSocketAddr(workspace.Provider.Name),
@@ -45,7 +44,6 @@ func New(
 		devsyConfig: devsyConfig,
 		config:      prov,
 		workspace:   workspace,
-		log:         log,
 		tsClient:    tsClient,
 		localClient: daemon.NewLocalClient(prov.Name),
 	}, nil
@@ -57,7 +55,6 @@ type client struct {
 	devsyConfig *config.Config
 	config      *provider.ProviderConfig
 	workspace   *provider.Workspace
-	log         log.Logger
 	tsClient    *local.Client
 	localClient *daemon.LocalClient
 }
@@ -181,7 +178,7 @@ func (c *client) CheckWorkspaceReachable(ctx context.Context) error {
 		return fmt.Errorf("reach host: %w", err)
 	}
 
-	c.log.Debugf("Host %s is reachable. Proceeding with SSH session...", wAddr.Host())
+	log.Debugf("Host %s is reachable. Proceeding with SSH session...", wAddr.Host())
 	return nil
 }
 

--- a/pkg/client/clientimplementation/daemonclient/create.go
+++ b/pkg/client/clientimplementation/daemonclient/create.go
@@ -40,7 +40,6 @@ func (c *client) Create(
 		c.workspace.UID,
 		c.workspace.Source.String(),
 		c.workspace.Picture,
-		c.log,
 	)
 	if err != nil {
 		return err

--- a/pkg/client/clientimplementation/daemonclient/delete.go
+++ b/pkg/client/clientimplementation/daemonclient/delete.go
@@ -7,7 +7,9 @@ import (
 
 	clientpkg "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
+	oldlog "github.com/devsy-org/log"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -38,7 +40,7 @@ func (c *client) Delete(ctx context.Context, opt clientpkg.DeleteOptions) error 
 				SSHConfigPath:        c.workspace.SSHConfigPath,
 				SSHConfigIncludePath: c.workspace.SSHConfigIncludePath,
 			},
-			c.log,
+			oldlog.Default,
 		)
 		if err != nil {
 			return err
@@ -77,7 +79,7 @@ func (c *client) Delete(ctx context.Context, opt clientpkg.DeleteOptions) error 
 		}
 
 		if !kerrors.IsNotFound(err) {
-			c.log.Errorf("Error deleting workspace: %v", err)
+			log.Errorf("Error deleting workspace: %v", err)
 		}
 	}
 
@@ -89,7 +91,7 @@ func (c *client) Delete(ctx context.Context, opt clientpkg.DeleteOptions) error 
 			SSHConfigPath:        c.workspace.SSHConfigPath,
 			SSHConfigIncludePath: c.workspace.SSHConfigIncludePath,
 		},
-		c.log,
+		oldlog.Default,
 	)
 	if err != nil {
 		return err
@@ -102,7 +104,7 @@ func (c *client) Delete(ctx context.Context, opt clientpkg.DeleteOptions) error 
 	}
 
 	// wait until the workspace is deleted
-	c.log.Debugf("Waiting for workspace to get deleted...")
+	log.Debugf("Waiting for workspace to get deleted...")
 	err = wait.PollUntilContextTimeout(
 		ctx,
 		time.Second,
@@ -122,7 +124,7 @@ func (c *client) Delete(ctx context.Context, opt clientpkg.DeleteOptions) error 
 				return true, nil
 			}
 
-			c.log.Debugf("Workspace is not deleted yet, waiting again...")
+			log.Debugf("Workspace is not deleted yet, waiting again...")
 			return false, nil
 		},
 	)

--- a/pkg/client/clientimplementation/daemonclient/form.go
+++ b/pkg/client/clientimplementation/daemonclient/form.go
@@ -12,11 +12,11 @@ import (
 	storagev1 "github.com/devsy-org/api/pkg/apis/storage/v1"
 	"github.com/devsy-org/devsy/cmd/pro/provider/list"
 	"github.com/devsy-org/devsy/pkg/encoding"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	platformclient "github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/platform/labels"
 	"github.com/devsy-org/devsy/pkg/platform/project"
-	"github.com/devsy-org/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
@@ -25,7 +25,6 @@ func createInstanceInteractive(
 	ctx context.Context,
 	baseClient platformclient.Client,
 	id, uid, source, picture string,
-	log log.Logger,
 ) (*managementv1.DevsyWorkspaceInstance, error) {
 	formCtx, cancelForm := context.WithCancel(ctx)
 	defer cancelForm()
@@ -47,14 +46,14 @@ func createInstanceInteractive(
 			huh.NewSelect[*managementv1.Cluster]().
 				Title("Cluster").
 				OptionsFunc(func() []huh.Option[*managementv1.Cluster] {
-					return getClusterOptions(ctx, baseClient, selectedProject, cancelForm, log)
+					return getClusterOptions(ctx, baseClient, selectedProject, cancelForm)
 				}, &selectedProject).
 				Value(&selectedCluster).
 				WithHeight(5),
 			huh.NewSelect[*managementv1.DevsyWorkspaceTemplate]().
 				Title("Template").
 				OptionsFunc(func() []huh.Option[*managementv1.DevsyWorkspaceTemplate] {
-					return getTemplateOptions(ctx, baseClient, selectedProject, cancelForm, log)
+					return getTemplateOptions(ctx, baseClient, selectedProject, cancelForm)
 				}, &selectedProject).
 				Value(&selectedTemplate),
 			huh.NewSelect[string]().
@@ -293,7 +292,6 @@ func getClusterOptions(
 	client platformclient.Client,
 	project *managementv1.Project,
 	cancel CancelFunc,
-	log log.Logger,
 ) []huh.Option[*managementv1.Cluster] {
 	opts := []huh.Option[*managementv1.Cluster]{}
 	if project == nil {
@@ -323,7 +321,6 @@ func getTemplateOptions(
 	client platformclient.Client,
 	project *managementv1.Project,
 	cancel CancelFunc,
-	log log.Logger,
 ) []huh.Option[*managementv1.DevsyWorkspaceTemplate] {
 	opts := []huh.Option[*managementv1.DevsyWorkspaceTemplate]{}
 	if project == nil {

--- a/pkg/client/clientimplementation/daemonclient/stop.go
+++ b/pkg/client/clientimplementation/daemonclient/stop.go
@@ -8,6 +8,7 @@ import (
 	managementv1 "github.com/devsy-org/api/pkg/apis/management/v1"
 	clientpkg "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/platform"
+	oldlog "github.com/devsy-org/log"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,7 +48,7 @@ func (c *client) Stop(ctx context.Context, opt clientpkg.StopOptions) error {
 		return fmt.Errorf("no stop task id returned from server")
 	}
 
-	_, err = observeTask(ctx, managementClient, workspace, retStop.Status.TaskID, c.log)
+	_, err = observeTask(ctx, managementClient, workspace, retStop.Status.TaskID, oldlog.Default)
 	if err != nil {
 		return fmt.Errorf("stop: %w", err)
 	}

--- a/pkg/client/clientimplementation/daemonclient/up.go
+++ b/pkg/client/clientimplementation/daemonclient/up.go
@@ -19,7 +19,7 @@ import (
 	devsylog "github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/kube"
-	"github.com/devsy-org/log"
+	oldlog "github.com/devsy-org/log"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -63,10 +63,10 @@ func (c *client) Up(ctx context.Context, opt clientpkg.UpOptions) (*config.Resul
 
 	// Log current workspace information. This is both useful to the user to understand the workspace configuration
 	// and to us when we receive troubleshooting logs
-	printInstanceInfo(instance, c.log)
+	printInstanceInfo(instance, oldlog.Default)
 
 	if instance.Spec.TemplateRef != nil && templateUpdateRequired(instance) {
-		c.log.Info("Template update required")
+		devsylog.Info("Template update required")
 		oldInstance := instance.DeepCopy()
 		instance.Spec.TemplateRef.SyncOnce = true
 
@@ -74,7 +74,7 @@ func (c *client) Up(ctx context.Context, opt clientpkg.UpOptions) (*config.Resul
 		if err != nil {
 			return nil, fmt.Errorf("update instance: %w", err)
 		}
-		c.log.Info("updated template")
+		devsylog.Info("updated template")
 	}
 
 	// encode options
@@ -85,7 +85,7 @@ func (c *client) Up(ctx context.Context, opt clientpkg.UpOptions) (*config.Resul
 	}
 
 	// prompt user to attach to active task or start new one
-	c.log.Debug("Check active up task")
+	devsylog.Debug("Check active up task")
 	activeUpTask, err := findActiveUpTask(ctx, managementClient, instance)
 	if err != nil {
 		return nil, fmt.Errorf("find active up task: %w", err)
@@ -93,7 +93,7 @@ func (c *client) Up(ctx context.Context, opt clientpkg.UpOptions) (*config.Resul
 
 	// if we have an active up task, cancel it before creating a new one
 	if activeUpTask != nil {
-		c.log.Warnf("Found active up task %s, attempting to cancel it", activeUpTask.ID)
+		devsylog.Warnf("Found active up task %s, attempting to cancel it", activeUpTask.ID)
 		_, err = managementClient.Loft().
 			ManagementV1().
 			DevsyWorkspaceInstances(instance.Namespace).
@@ -121,7 +121,7 @@ func (c *client) Up(ctx context.Context, opt clientpkg.UpOptions) (*config.Resul
 		return nil, fmt.Errorf("no up task id returned from server")
 	}
 
-	return waitTaskDone(ctx, managementClient, instance, task.Status.TaskID, c.log)
+	return waitTaskDone(ctx, managementClient, instance, task.Status.TaskID, oldlog.Default)
 }
 
 func waitTaskDone(
@@ -129,7 +129,7 @@ func waitTaskDone(
 	managementClient kube.Interface,
 	instance *managementv1.DevsyWorkspaceInstance,
 	taskID string,
-	log log.Logger,
+	log oldlog.Logger,
 ) (*config.Result, error) {
 	exitCode, err := observeTask(ctx, managementClient, instance, taskID, log)
 	if err != nil {
@@ -187,7 +187,7 @@ func templateUpdateRequired(instance *managementv1.DevsyWorkspaceInstance) bool 
 	return !templateResolved || templateChangesAvailable
 }
 
-func printInstanceInfo(instance *managementv1.DevsyWorkspaceInstance, log log.Logger) {
+func printInstanceInfo(instance *managementv1.DevsyWorkspaceInstance, log oldlog.Logger) {
 	workspaceConfig, _ := json.Marshal(struct {
 		Target     storagev1.WorkspaceTarget
 		Template   *storagev1.TemplateRef
@@ -205,7 +205,7 @@ func observeTask(
 	managementClient kube.Interface,
 	instance *managementv1.DevsyWorkspaceInstance,
 	taskID string,
-	log log.Logger,
+	log oldlog.Logger,
 ) (int, error) {
 	var (
 		exitCode int
@@ -266,7 +266,7 @@ func printLogs(
 	managementClient kube.Interface,
 	workspace *managementv1.DevsyWorkspaceInstance,
 	taskID string,
-	logger log.Logger,
+	logger oldlog.Logger,
 ) (int, error) {
 	// get logs reader
 	logger.Debugf("printing logs of task: %s", taskID)

--- a/pkg/client/clientimplementation/machine_client.go
+++ b/pkg/client/clientimplementation/machine_client.go
@@ -10,18 +10,16 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/options"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 )
 
 func NewMachineClient(
 	devsyConfig *config.Config,
 	provider *provider.ProviderConfig,
 	machine *provider.Machine,
-	log log.Logger,
 ) (client.MachineClient, error) {
 	if !provider.IsMachineProvider() {
 		log.Error("provider is not a machine provider")
@@ -36,7 +34,6 @@ func NewMachineClient(
 		devsyConfig: devsyConfig,
 		config:      provider,
 		machine:     machine,
-		log:         log,
 	}
 	mc.executor = &machineExecutor{client: mc}
 
@@ -47,7 +44,6 @@ type machineClient struct {
 	devsyConfig *config.Config
 	config      *provider.ProviderConfig
 	machine     *provider.Machine
-	log         log.Logger
 	executor    *machineExecutor
 }
 
@@ -64,7 +60,6 @@ type execConfig struct {
 	stderr       io.Writer
 	extraEnv     map[string]string
 	stdin        io.Reader
-	log          log.Logger
 	withProgress bool
 	startMsg     string
 	doneMsg      string
@@ -73,15 +68,15 @@ type execConfig struct {
 func (e *machineExecutor) execute(ctx context.Context, cfg execConfig) error {
 	var done chan struct{}
 	if cfg.withProgress {
-		done = scheduleLogMessage("Devsy "+cfg.name+" operation is in progress", e.client.log)
+		done = scheduleLogMessage("Devsy " + cfg.name + " operation is in progress")
 		defer close(done)
 	}
 
 	if cfg.startMsg != "" {
-		e.client.log.Infof(cfg.startMsg)
+		log.Infof(cfg.startMsg)
 	}
 
-	opts := CommandOptions{
+	err := RunCommandWithBinaries(CommandOptions{
 		Ctx:      ctx,
 		Name:     cfg.name,
 		Command:  cfg.command,
@@ -93,20 +88,13 @@ func (e *machineExecutor) execute(ctx context.Context, cfg execConfig) error {
 		Stderr:   cfg.stderr,
 		ExtraEnv: cfg.extraEnv,
 		Stdin:    cfg.stdin,
-		Log:      cfg.log,
-	}
-
-	if opts.Log == nil {
-		opts.Log = e.client.log
-	}
-
-	err := RunCommandWithBinaries(opts)
+	})
 	if err != nil {
 		return err
 	}
 
 	if cfg.doneMsg != "" {
-		e.client.log.Done(cfg.doneMsg)
+		log.Infof(cfg.doneMsg)
 	}
 
 	return nil
@@ -119,7 +107,7 @@ func (e *machineExecutor) lifecycleCommand(
 	command types.StrArray,
 	verb, pastVerb string,
 ) error {
-	writer := e.client.log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	return e.execute(ctx, execConfig{
@@ -213,7 +201,6 @@ func (s *machineClient) Command(ctx context.Context, commandOptions client.Comma
 		extraEnv: map[string]string{
 			provider.CommandEnv: commandOptions.Command,
 		},
-		log: s.log.ErrorStreamOnly(),
 	})
 }
 
@@ -228,7 +215,7 @@ func (s *machineClient) Status(
 		name:    "status",
 		command: s.config.Exec.Status,
 		stdout:  stdout,
-		stderr:  io.MultiWriter(stderr, s.log.Writer(logrus.InfoLevel, true)),
+		stderr:  io.MultiWriter(stderr, log.Writer(log.LevelInfo)),
 	})
 	if err != nil {
 		return client.StatusNotFound, fmt.Errorf(
@@ -254,7 +241,7 @@ func (s *machineClient) Describe(ctx context.Context) (string, error) {
 		name:    "describe",
 		command: s.config.Exec.Describe,
 		stdout:  stdout,
-		stderr:  io.MultiWriter(stderr, s.log.Writer(logrus.InfoLevel, true)),
+		stderr:  io.MultiWriter(stderr, log.Writer(log.LevelInfo)),
 	})
 	if err != nil {
 		return client.DescriptionNotFound, fmt.Errorf(
@@ -276,7 +263,7 @@ func (s *machineClient) Delete(ctx context.Context, options client.DeleteOptions
 		}
 	}
 
-	writer := s.log.Writer(logrus.InfoLevel, false)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	err := s.executor.execute(ctx, execConfig{
@@ -293,13 +280,13 @@ func (s *machineClient) Delete(ctx context.Context, options client.DeleteOptions
 		return err
 	}
 	if err != nil {
-		s.log.Errorf("failed to delete machine: machineId=%s, err=%v", s.machine.ID, err)
+		log.Errorf("failed to delete machine: machineId=%s, err=%v", s.machine.ID, err)
 	}
 
 	return DeleteMachineFolder(s.machine.Context, s.machine.ID)
 }
 
-func scheduleLogMessage(msg string, log log.Logger) chan struct{} {
+func scheduleLogMessage(msg string) chan struct{} {
 	done := make(chan struct{})
 	go func() {
 		for {

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -134,7 +134,6 @@ func tryLock(ctx context.Context, lock *flock.Flock, name string, log log.Logger
 			name,
 			name,
 		),
-		log,
 	)
 	defer close(done)
 

--- a/pkg/client/clientimplementation/services.go
+++ b/pkg/client/clientimplementation/services.go
@@ -8,7 +8,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	daemon "github.com/devsy-org/devsy/pkg/daemon/platform"
 	"github.com/devsy-org/devsy/pkg/tunnel"
-	"github.com/devsy-org/log"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -17,7 +16,6 @@ type StartServicesDaemonOptions struct {
 	Client           client.DaemonClient
 	SSHClient        *ssh.Client
 	User             string
-	Log              log.Logger
 	ForwardPorts     bool
 	ExtraPorts       []string
 	GitSSHSigningKey string

--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -333,7 +333,7 @@ func (s *workspaceClient) Create(ctx context.Context) error {
 	}
 
 	// create machine client
-	machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine, s.log)
+	machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine)
 	if err != nil {
 		return err
 	}
@@ -420,7 +420,7 @@ func (s *workspaceClient) Delete(ctx context.Context, opt client.DeleteOptions) 
 		}
 	} else if s.machine != nil && s.workspace.Machine.ID != "" && len(s.config.Exec.Delete) > 0 {
 		// delete machine if config was found
-		machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine, s.log)
+		machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine)
 		if err != nil {
 			if !opt.Force {
 				return err
@@ -447,7 +447,7 @@ func (s *workspaceClient) isMachineRunning(ctx context.Context) (bool, error) {
 	}
 
 	// delete machine if config was found
-	machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine, s.log)
+	machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine)
 	if err != nil {
 		return false, err
 	}
@@ -471,7 +471,7 @@ func (s *workspaceClient) Start(ctx context.Context) error {
 		return nil
 	}
 
-	machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine, s.log)
+	machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine)
 	if err != nil {
 		return err
 	}
@@ -522,7 +522,7 @@ func (s *workspaceClient) Stop(ctx context.Context, opt client.StopOptions) erro
 		return nil
 	}
 
-	machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine, s.log)
+	machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine)
 	if err != nil {
 		return err
 	}
@@ -563,7 +563,7 @@ func (s *workspaceClient) Status(
 			return client.StatusNotFound, nil
 		}
 
-		machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine, s.log)
+		machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine)
 		if err != nil {
 			return client.StatusNotFound, err
 		}
@@ -613,7 +613,7 @@ func (s *workspaceClient) Describe(ctx context.Context) (string, error) {
 			return client.DescriptionNotFound, nil
 		}
 
-		machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine, s.log)
+		machineClient, err := NewMachineClient(s.devsyConfig, s.config, s.machine)
 		if err != nil {
 			return client.DescriptionNotFound, err
 		}

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -237,7 +237,6 @@ func makeDaemonStartFunc(
 				Client:           daemonClient,
 				SSHClient:        toolClient,
 				User:             params.User,
-				Log:              params.Log,
 				ForwardPorts:     forwardPorts,
 				ExtraPorts:       extraPorts,
 				GitSSHSigningKey: params.GitSSHSigningKey,

--- a/pkg/workspace/machine.go
+++ b/pkg/workspace/machine.go
@@ -16,7 +16,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/survey"
 	"github.com/devsy-org/devsy/pkg/terminal"
 	"github.com/devsy-org/devsy/pkg/types"
-	oldlog "github.com/devsy-org/log"
 )
 
 // ListMachines returns all machines configured in the given Devsy context.
@@ -110,7 +109,6 @@ func resolveMachine(
 		devsyConfig,
 		defaultProvider.Config,
 		machineObj,
-		oldlog.Default,
 	)
 	if err != nil {
 		_ = os.RemoveAll(filepath.Dir(machineObj.Origin))
@@ -221,7 +219,6 @@ func loadExistingMachine(
 		devsyConfig,
 		providerWithOptions.Config,
 		machineConfig,
-		oldlog.Default,
 	)
 }
 

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -142,7 +142,7 @@ func getWorkspaceClient(
 	if provider.IsProxyProvider() {
 		return clientimplementation.NewProxyClient(devsyConfig, provider, workspace, oldlog.Default)
 	} else if provider.IsDaemonProvider() {
-		return daemonclient.New(devsyConfig, provider, workspace, oldlog.Default)
+		return daemonclient.New(devsyConfig, provider, workspace)
 	} else {
 		return clientimplementation.NewWorkspaceClient(
 			devsyConfig,
@@ -408,7 +408,6 @@ func createWorkspace(
 				devsyConfig,
 				provider.Config,
 				machineConfig,
-				oldlog.Default,
 			)
 			if err != nil {
 				_ = clientimplementation.DeleteMachineFolder(


### PR DESCRIPTION
## Summary
- Remove `log.Logger` parameter from `NewMachineClient`, `daemonclient.New`, and related functions
- Remove `Log` field from `StartServicesDaemonOptions` struct
- Replace instance logger calls with `pkg/log` package-level functions
- Update all callers to match new signatures
- Part of the ongoing migration away from `github.com/devsy-org/log`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated logging implementation across daemon, machine, and workspace client components for improved code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->