### PR TITLE
refactor(client): remove Log field from command option structs

### DIFF
--- a/cmd/pro/check_health.go
+++ b/cmd/pro/check_health.go
@@ -79,7 +79,6 @@ func (cmd *CheckHealthCmd) Run(
 		Config:  provider,
 		Stdout:  &buf,
 		Stderr:  oldlog.Default.Writer(logrus.ErrorLevel, true),
-		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("check health with provider \"%s\": %w", provider.Name, err)

--- a/cmd/pro/create_workspace.go
+++ b/cmd/pro/create_workspace.go
@@ -74,7 +74,6 @@ func (cmd *CreateWorkspaceCmd) Run(
 		Config:  provider,
 		Stdout:  &buf,
 		Stderr:  oldlog.Default.ErrorStreamOnly().Writer(logrus.ErrorLevel, true),
-		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("create workspace: %w", err)

--- a/cmd/pro/list_clusters.go
+++ b/cmd/pro/list_clusters.go
@@ -10,7 +10,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -71,7 +70,6 @@ func (cmd *ListClustersCmd) Run(
 		Options: opts,
 		Config:  provider,
 		Stdout:  &buf,
-		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("list clusters with provider \"%s\": %w", provider.Name, err)

--- a/cmd/pro/list_projects.go
+++ b/cmd/pro/list_projects.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -65,7 +64,6 @@ func (cmd *ListProjectsCmd) Run(
 		Options: devsyConfig.ProviderOptions(provider.Name),
 		Config:  provider,
 		Stdout:  &buf,
-		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("watch workspaces with provider \"%s\": %w", provider.Name, err)

--- a/cmd/pro/list_templates.go
+++ b/cmd/pro/list_templates.go
@@ -10,7 +10,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -71,7 +70,6 @@ func (cmd *ListTemplatesCmd) Run(
 		Options: opts,
 		Config:  provider,
 		Stdout:  &buf,
-		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("list templates with provider \"%s\": %w", provider.Name, err)

--- a/cmd/pro/list_workspaces.go
+++ b/cmd/pro/list_workspaces.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -65,7 +64,6 @@ func (cmd *ListWorkspacesCmd) Run(
 		Options: devsyConfig.ProviderOptions(provider.Name),
 		Config:  provider,
 		Stdout:  &buf,
-		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("list workspaces: %w", err)

--- a/cmd/pro/self.go
+++ b/cmd/pro/self.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -65,7 +64,6 @@ func (cmd *SelfCmd) Run(
 		Options: devsyConfig.ProviderOptions(provider.Name),
 		Config:  provider,
 		Stdout:  &buf,
-		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("get self: %w", err)

--- a/cmd/pro/update_workspace.go
+++ b/cmd/pro/update_workspace.go
@@ -74,7 +74,6 @@ func (cmd *UpdateWorkspaceCmd) Run(
 		Config:  provider,
 		Stdout:  &buf,
 		Stderr:  oldlog.Default.ErrorStreamOnly().Writer(logrus.ErrorLevel, true),
-		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("update workspace with provider \"%s\": %w", provider.Name, err)

--- a/cmd/pro/version.go
+++ b/cmd/pro/version.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -69,7 +68,6 @@ func (cmd *VersionCmd) Run(
 		Options: opts,
 		Config:  providerConfig,
 		Stdout:  &buf,
-		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("get version: %w", err)

--- a/cmd/pro/watch_workspaces.go
+++ b/cmd/pro/watch_workspaces.go
@@ -90,7 +90,6 @@ func (cmd *WatchWorkspacesCmd) Run(
 		Config:  providerConfig,
 		Stdout:  os.Stdout,
 		Stderr:  oldlog.Default.ErrorStreamOnly().Writer(logrus.ErrorLevel, false),
-		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("watch workspaces with provider \"%s\": %w", providerConfig.Name, err)

--- a/cmd/provider/use.go
+++ b/cmd/provider/use.go
@@ -234,7 +234,6 @@ func initProvider(
 		Config:  provider,
 		Stdout:  stdout,
 		Stderr:  stderr,
-		Log:     oldlog.Default,
 	})
 	if err != nil {
 		return fmt.Errorf("init: %w", err)

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -90,7 +90,6 @@ func (e *proxyExecutor) execute(ctx context.Context, params execParams) error {
 		Stdin:     params.stdin,
 		Stdout:    params.stdout,
 		Stderr:    params.stderr,
-		Log:       e.client.log.ErrorStreamOnly(),
 	})
 }
 
@@ -390,7 +389,6 @@ func (s *proxyClient) Status(
 		Stdin:     nil,
 		Stdout:    io.MultiWriter(stdout, buf),
 		Stderr:    buf,
-		Log:       s.log.ErrorStreamOnly(),
 	})
 	if err != nil {
 		return client.StatusNotFound, fmt.Errorf(

--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/compress"
 	"github.com/devsy-org/devsy/pkg/config"
 	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
+	devsylog "github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/options"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/shell"
@@ -406,7 +407,6 @@ func (s *workspaceClient) Delete(ctx context.Context, opt client.DeleteOptions) 
 				Stdin:  nil,
 				Stdout: writer,
 				Stderr: writer,
-				Log:    s.log.ErrorStreamOnly(),
 			})
 			if err != nil {
 				if !opt.Force {
@@ -512,7 +512,6 @@ func (s *workspaceClient) Stop(ctx context.Context, opt client.StopOptions) erro
 			Stdin:  nil,
 			Stdout: writer,
 			Stderr: writer,
-			Log:    s.log.ErrorStreamOnly(),
 		})
 		if err != nil {
 			return err
@@ -546,7 +545,6 @@ func (s *workspaceClient) Command(
 		Stdin:   commandOptions.Stdin,
 		Stdout:  commandOptions.Stdout,
 		Stderr:  commandOptions.Stderr,
-		Log:     s.log.ErrorStreamOnly(),
 	})
 }
 
@@ -682,7 +680,6 @@ func (s *workspaceClient) getContainerStatus(ctx context.Context) (client.Status
 		Stdin:  nil,
 		Stdout: io.MultiWriter(stdout, buf),
 		Stderr: buf,
-		Log:    s.log.ErrorStreamOnly(),
 	})
 	if err != nil {
 		return client.StatusNotFound, fmt.Errorf(
@@ -727,7 +724,6 @@ type CommandOptions struct {
 	Stdin     io.Reader
 	Stdout    io.Writer
 	Stderr    io.Writer
-	Log       log.Logger
 }
 
 func (s *workspaceClient) buildEnvironment(command string) ([]string, error) {
@@ -766,7 +762,6 @@ func RunCommandWithBinaries(opts CommandOptions) error {
 		Stdin:   opts.Stdin,
 		Stdout:  opts.Stdout,
 		Stderr:  opts.Stderr,
-		Log:     opts.Log,
 	})
 }
 
@@ -777,7 +772,6 @@ type RunCommandOptions struct {
 	Stdin   io.Reader
 	Stdout  io.Writer
 	Stderr  io.Writer
-	Log     log.Logger // Optional: for debug mode env var
 }
 
 func RunCommand(opts RunCommandOptions) error {
@@ -785,8 +779,7 @@ func RunCommand(opts RunCommandOptions) error {
 		return nil
 	}
 
-	// Add debug env var if logger provided and in debug mode
-	if opts.Log != nil && opts.Log.GetLevel() == logrus.DebugLevel {
+	if devsylog.DebugEnabled() {
 		opts.Environ = append(opts.Environ, config.EnvDebug+"="+config.BoolTrue)
 	}
 

--- a/pkg/workspace/list.go
+++ b/pkg/workspace/list.go
@@ -366,7 +366,6 @@ func listInstancesProxyProvider(
 		Config:  providerConfig,
 		Stdout:  &stdout,
 		Stderr:  &stderr,
-		Log:     oldlog.Default,
 	}); err != nil {
 		return nil, fmt.Errorf("failed to list pro workspaces: %s: %w", stderr.String(), err)
 	}


### PR DESCRIPTION
## Summary

- Remove `Log log.Logger` field from `CommandOptions` and `RunCommandOptions` structs in `workspace_client.go`
- Replace logrus-based debug level check in `RunCommand` with `pkg/log.DebugEnabled()` package-level function
- Remove all `Log:` field assignments from callers across `cmd/pro/`, `cmd/provider/use.go`, `pkg/workspace/list.go`, and `proxy_client.go`
- Clean up unused `oldlog` imports where no other usage remains

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined logging configuration across workspace, cluster, project, template, and provider operations to consolidate how logging is managed during command execution throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->