### PR TITLE
refactor(log): migrate JSON stream functions to package-level logging

### DIFF
--- a/pkg/client/clientimplementation/daemonclient/up.go
+++ b/pkg/client/clientimplementation/daemonclient/up.go
@@ -19,7 +19,6 @@ import (
 	devsylog "github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/kube"
-	oldlog "github.com/devsy-org/log"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -292,8 +291,8 @@ func printLogs(
 	scanner.Buffer(buf, maxCapacity)
 
 	// create json streamer
-	stdoutStreamer, stdoutDone := devsylog.PipeJSONStream(oldlog.Default)
-	stderrStreamer, stderrDone := devsylog.PipeJSONStream(oldlog.Default.ErrorStreamOnly())
+	stdoutStreamer, stdoutDone := devsylog.PipeJSONStream()
+	stderrStreamer, stderrDone := devsylog.PipeJSONStream()
 	defer func() {
 		// close the streams
 		_ = stdoutStreamer.Close()

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -95,7 +95,7 @@ func (e *proxyExecutor) execute(ctx context.Context, params execParams) error {
 
 // executeWithJSONLog runs a command with JSON log streaming.
 func (e *proxyExecutor) executeWithJSONLog(ctx context.Context, params execParams) error {
-	writer, _ := devsylog.PipeJSONStream(e.client.log.ErrorStreamOnly())
+	writer, _ := devsylog.PipeJSONStream()
 	defer func() { _ = writer.Close() }()
 
 	params.stderr = writer
@@ -398,7 +398,7 @@ func (s *proxyClient) Status(
 		)
 	}
 
-	devsylog.ReadJSONStream(bytes.NewReader(buf.Bytes()), s.log.ErrorStreamOnly())
+	devsylog.ReadJSONStream(bytes.NewReader(buf.Bytes()))
 	status := &client.WorkspaceStatus{}
 	err = json.Unmarshal(stdout.Bytes(), status)
 	if err != nil {

--- a/pkg/log/jsonstream.go
+++ b/pkg/log/jsonstream.go
@@ -9,37 +9,34 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func PipeJSONStream(logger log.Logger) (io.WriteCloser, chan struct{}) {
+func PipeJSONStream() (io.WriteCloser, chan struct{}) {
 	done := make(chan struct{})
 	reader, writer := io.Pipe()
 	go func() {
-		ReadJSONStream(reader, logger)
+		ReadJSONStream(reader)
 		close(done)
 	}()
 
 	return writer, done
 }
 
-func ReadJSONStream(reader io.Reader, logger log.Logger) {
+var levelFuncs = map[logrus.Level]func(...any){
+	logrus.TraceLevel: Debug,
+	logrus.DebugLevel: Debug,
+	logrus.InfoLevel:  Info,
+	logrus.WarnLevel:  Warn,
+	logrus.ErrorLevel: Error,
+	logrus.PanicLevel: Error,
+	logrus.FatalLevel: Error,
+}
+
+func ReadJSONStream(reader io.Reader) {
 	scan := scanner.NewScanner(reader)
 	for scan.Scan() {
 		lineObject, err := Unmarshal(scan.Bytes())
 		if err == nil && lineObject.Message != "" {
-			switch lineObject.Level {
-			case logrus.TraceLevel:
-				logger.Debug(lineObject.Message)
-			case logrus.DebugLevel:
-				logger.Debug(lineObject.Message)
-			case logrus.InfoLevel:
-				logger.Info(lineObject.Message)
-			case logrus.WarnLevel:
-				logger.Warn(lineObject.Message)
-			case logrus.ErrorLevel:
-				logger.Error(lineObject.Message)
-			case logrus.PanicLevel:
-				logger.Error(lineObject.Message)
-			case logrus.FatalLevel:
-				logger.Error(lineObject.Message)
+			if fn, ok := levelFuncs[lineObject.Level]; ok {
+				fn(lineObject.Message)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- Remove the `log.Logger` parameter from `PipeJSONStream` and `ReadJSONStream` in `pkg/log/jsonstream.go`, replacing logger method calls with package-level `Debug`/`Info`/`Warn`/`Error` functions from the new zap-based `pkg/log` package.
- Update all call sites in `proxy_client.go` and `daemonclient/up.go` to use the new parameterless signatures.
- Remove the now-unused `oldlog "github.com/devsy-org/log"` import from `up.go`.
- Refactor the level-dispatch switch to a map to satisfy the `cyclop` complexity lint.