### PR TITLE
refactor(client): remove old log.Logger from proxyClient

### DIFF
--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -131,7 +131,6 @@ func (cmd *UpCmd) handleInitError(
 			SSHConfigPath:        workspaceInfo.Workspace.SSHConfigPath,
 			SSHConfigIncludePath: workspaceInfo.Workspace.SSHConfigIncludePath,
 		},
-		logger,
 	)
 	if deleteErr != nil {
 		return fmt.Errorf("%s: %w", deleteErr.Error(), err)

--- a/cmd/pro/delete.go
+++ b/cmd/pro/delete.go
@@ -175,7 +175,6 @@ func cleanupLocalWorkspaces(
 						SSHConfigPath:        client.WorkspaceConfig().SSHConfigPath,
 						SSHConfigIncludePath: client.WorkspaceConfig().SSHConfigIncludePath,
 					},
-					log,
 				)
 				if err != nil {
 					log.Errorf("failed to remove workspace: workspaceId=%s, err=%v", w.ID, err)

--- a/pkg/client/clientimplementation/daemonclient/delete.go
+++ b/pkg/client/clientimplementation/daemonclient/delete.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
-	oldlog "github.com/devsy-org/log"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -40,7 +39,6 @@ func (c *client) Delete(ctx context.Context, opt clientpkg.DeleteOptions) error 
 				SSHConfigPath:        c.workspace.SSHConfigPath,
 				SSHConfigIncludePath: c.workspace.SSHConfigIncludePath,
 			},
-			oldlog.Default,
 		)
 		if err != nil {
 			return err
@@ -91,7 +89,6 @@ func (c *client) Delete(ctx context.Context, opt clientpkg.DeleteOptions) error 
 			SSHConfigPath:        c.workspace.SSHConfigPath,
 			SSHConfigIncludePath: c.workspace.SSHConfigIncludePath,
 		},
-		oldlog.Default,
 	)
 	if err != nil {
 		return err

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -23,7 +23,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/terminal"
 	"github.com/devsy-org/devsy/pkg/types"
-	"github.com/devsy-org/log"
 	"github.com/gofrs/flock"
 )
 
@@ -36,13 +35,11 @@ func NewProxyClient(
 	devsyConfig *config.Config,
 	prov *provider.ProviderConfig,
 	workspace *provider.Workspace,
-	log log.Logger,
 ) (client.ProxyClient, error) {
 	pc := &proxyClient{
 		devsyConfig: devsyConfig,
 		config:      prov,
 		workspace:   workspace,
-		log:         log,
 	}
 	pc.executor = &proxyExecutor{client: pc}
 	return pc, nil
@@ -57,7 +54,6 @@ type proxyClient struct {
 	devsyConfig *config.Config
 	config      *provider.ProviderConfig
 	workspace   *provider.Workspace
-	log         log.Logger
 	executor    *proxyExecutor
 }
 
@@ -106,12 +102,12 @@ func (s *proxyClient) Lock(ctx context.Context) error {
 	s.initLock()
 
 	// try to lock workspace
-	s.log.Debugf("Acquire workspace lock...")
-	err := tryLock(ctx, s.workspaceLock, "workspace", s.log)
+	devsylog.Debugf("Acquire workspace lock...")
+	err := tryLock(ctx, s.workspaceLock, "workspace")
 	if err != nil {
 		return fmt.Errorf("error locking workspace: %w", err)
 	}
-	s.log.Debugf("Acquired workspace lock...")
+	devsylog.Debugf("Acquired workspace lock...")
 
 	return nil
 }
@@ -122,11 +118,11 @@ func (s *proxyClient) Unlock() {
 	// try to unlock workspace
 	err := s.workspaceLock.Unlock()
 	if err != nil {
-		s.log.Warnf("Error unlocking workspace: %v", err)
+		devsylog.Warnf("Error unlocking workspace: %v", err)
 	}
 }
 
-func tryLock(ctx context.Context, lock *flock.Flock, name string, log log.Logger) error {
+func tryLock(ctx context.Context, lock *flock.Flock, name string) error {
 	done := scheduleLogMessage(
 		fmt.Sprintf(
 			"Trying to lock %s, seems like another process is running that blocks this %s",
@@ -356,7 +352,7 @@ func (s *proxyClient) Delete(ctx context.Context, opt client.DeleteOptions) erro
 		return fmt.Errorf("error deleting workspace: %w", err)
 	}
 	if err != nil {
-		s.log.Errorf("Error deleting workspace: %v", err)
+		devsylog.Errorf("Error deleting workspace: %v", err)
 	}
 
 	return DeleteWorkspaceFolder(DeleteWorkspaceFolderParams{
@@ -364,7 +360,7 @@ func (s *proxyClient) Delete(ctx context.Context, opt client.DeleteOptions) erro
 		WorkspaceID:          s.workspace.ID,
 		SSHConfigPath:        s.workspace.SSHConfigPath,
 		SSHConfigIncludePath: s.workspace.SSHConfigIncludePath,
-	}, s.log)
+	})
 }
 
 func (s *proxyClient) Status(

--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -281,7 +281,7 @@ func (s *workspaceClient) Lock(ctx context.Context) error {
 
 	// try to lock workspace
 	s.log.Debug("acquire workspace lock")
-	err := tryLock(ctx, s.workspaceLock, "workspace", s.log)
+	err := tryLock(ctx, s.workspaceLock, "workspace")
 	if err != nil {
 		return fmt.Errorf("error locking workspace: %w", err)
 	}
@@ -290,7 +290,7 @@ func (s *workspaceClient) Lock(ctx context.Context) error {
 	// try to lock machine
 	if s.machineLock != nil {
 		s.log.Debug("acquire machine lock")
-		err := tryLock(ctx, s.machineLock, "machine", s.log)
+		err := tryLock(ctx, s.machineLock, "machine")
 		if err != nil {
 			return fmt.Errorf("error locking machine: %w", err)
 		}
@@ -438,7 +438,7 @@ func (s *workspaceClient) Delete(ctx context.Context, opt client.DeleteOptions) 
 		WorkspaceID:          s.workspace.ID,
 		SSHConfigPath:        s.workspace.SSHConfigPath,
 		SSHConfigIncludePath: s.workspace.SSHConfigIncludePath,
-	}, s.log)
+	})
 }
 
 func (s *workspaceClient) isMachineRunning(ctx context.Context) (bool, error) {
@@ -831,7 +831,7 @@ type DeleteWorkspaceFolderParams struct {
 	SSHConfigIncludePath string
 }
 
-func DeleteWorkspaceFolder(params DeleteWorkspaceFolderParams, log log.Logger) error {
+func DeleteWorkspaceFolder(params DeleteWorkspaceFolderParams) error {
 	path, err := ssh.ResolveSSHConfigPath(params.SSHConfigPath)
 	if err != nil {
 		return err
@@ -849,7 +849,7 @@ func DeleteWorkspaceFolder(params DeleteWorkspaceFolderParams, log log.Logger) e
 
 	err = ssh.RemoveFromConfig(params.WorkspaceID, sshConfigPath, sshConfigIncludePath)
 	if err != nil {
-		log.Errorf("Remove workspace '%s' from ssh config: %v", params.WorkspaceID, err)
+		devsylog.Errorf("Remove workspace '%s' from ssh config: %v", params.WorkspaceID, err)
 	}
 
 	workspaceFolder, err := provider.GetWorkspaceDir(params.Context, params.WorkspaceID)

--- a/pkg/workspace/delete.go
+++ b/pkg/workspace/delete.go
@@ -9,7 +9,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
-	oldlog "github.com/devsy-org/log"
 )
 
 // DeleteOptions holds the parameters for deleting a workspace.
@@ -146,7 +145,6 @@ func forceDeleteFolder(opts DeleteOptions, workspaceID string) (string, error) {
 			Context:     opts.DevsyConfig.DefaultContext,
 			WorkspaceID: workspaceID,
 		},
-		oldlog.Default,
 	)
 	if err != nil {
 		return "", err
@@ -176,7 +174,6 @@ func deleteImportedWorkspace(
 			SSHConfigPath:        wsCfg.SSHConfigPath,
 			SSHConfigIncludePath: wsCfg.SSHConfigIncludePath,
 		},
-		oldlog.Default,
 	)
 	if err != nil {
 		return "", true, err
@@ -250,7 +247,6 @@ func deleteSingleMachine(
 			SSHConfigPath:        wsCfg.SSHConfigPath,
 			SSHConfigIncludePath: wsCfg.SSHConfigIncludePath,
 		},
-		oldlog.Default,
 	)
 	if err != nil {
 		return false, err

--- a/pkg/workspace/list.go
+++ b/pkg/workspace/list.go
@@ -20,7 +20,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/platform"
 	providerpkg "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
-	oldlog "github.com/devsy-org/log"
 )
 
 const ProjectLabel = "devsy.sh/project"
@@ -65,7 +64,6 @@ func List(
 							SSHConfigPath:        localWorkspace.SSHConfigPath,
 							SSHConfigIncludePath: localWorkspace.SSHConfigIncludePath,
 						},
-						oldlog.Default,
 					)
 					if err != nil {
 						log.Debugf(

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -140,7 +140,7 @@ func getWorkspaceClient(
 	machine *providerpkg.Machine,
 ) (client.BaseWorkspaceClient, error) {
 	if provider.IsProxyProvider() {
-		return clientimplementation.NewProxyClient(devsyConfig, provider, workspace, oldlog.Default)
+		return clientimplementation.NewProxyClient(devsyConfig, provider, workspace)
 	} else if provider.IsDaemonProvider() {
 		return daemonclient.New(devsyConfig, provider, workspace)
 	} else {
@@ -294,7 +294,6 @@ func resolveWorkspace(
 				SSHConfigPath:        params.SSHConfigPath,
 				SSHConfigIncludePath: params.SSHConfigIncludePath,
 			},
-			oldlog.Default,
 		)
 		return nil, nil, nil, err
 	}


### PR DESCRIPTION
## Summary

- Remove the `log.Logger` field from `proxyClient` struct and the `log` parameter from `NewProxyClient` constructor
- Remove the unused `log` parameter from the `tryLock` function
- Replace all `s.log.Xxx(...)` calls in `proxyClient` with `devsylog.Xxx(...)` package-level functions
- Migrate `DeleteWorkspaceFolder` to use `devsylog` directly instead of accepting a `log.Logger` parameter, updating all callers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal logging infrastructure across workspace and client management operations, including workspace deletion, proxy client setup, and lock handling. Changes consolidate logging patterns for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->