### PR TITLE
refactor: migrate opener and provider/env away from old logger

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -399,7 +399,6 @@ func (cmd *UpCmd) openIDE(
 		Client:             client,
 		User:               wctx.user,
 		Result:             wctx.result,
-		Log:                log,
 	})
 }
 

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -25,7 +25,6 @@ import (
 	open2 "github.com/devsy-org/devsy/pkg/open"
 	"github.com/devsy-org/devsy/pkg/port"
 	"github.com/devsy-org/devsy/pkg/tunnel"
-	"github.com/devsy-org/log"
 )
 
 // Params holds the parameters needed to open an IDE.
@@ -37,7 +36,6 @@ type Params struct {
 	Client             client2.BaseWorkspaceClient
 	User               string
 	Result             *config2.Result
-	Log                log.Logger
 }
 
 // Open dispatches to the correct IDE opener based on ideName.

--- a/pkg/log/levels.go
+++ b/pkg/log/levels.go
@@ -17,6 +17,24 @@ func DebugEnabled() bool {
 	return sugar.Desugar().Core().Enabled(zapcore.DebugLevel)
 }
 
+// LevelString returns the lowest enabled log level as a lowercase string
+// (e.g. "debug", "info", "warn", "error", "fatal").
+func LevelString() string {
+	core := sugar.Desugar().Core()
+	for _, l := range []zapcore.Level{
+		zapcore.DebugLevel,
+		zapcore.InfoLevel,
+		zapcore.WarnLevel,
+		zapcore.ErrorLevel,
+		zapcore.FatalLevel,
+	} {
+		if core.Enabled(l) {
+			return l.String()
+		}
+	}
+	return "info"
+}
+
 // VerbosityToLevel converts a -v count (0-3) to a zapcore.Level.
 // 0 = error+fatal only, 1 = +warn+info, 2 = +debug, 3 = trace (mapped to zap Debug-1).
 func VerbosityToLevel(verbosity int) zapcore.Level {

--- a/pkg/provider/env.go
+++ b/pkg/provider/env.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/devsy-org/devsy/pkg/config"
-	oldlog "github.com/devsy-org/log"
+	devsylog "github.com/devsy-org/devsy/pkg/log"
 )
 
 func combineOptions(
@@ -160,7 +160,7 @@ func GetBaseEnvironment(context, provider string) map[string]string {
 	retVars[config.EnvProviderContext] = context
 	providerFolder, _ := GetProviderDir(context, provider)
 	retVars[config.EnvProviderFolder] = filepath.ToSlash(providerFolder)
-	retVars[config.EnvLogLevel] = oldlog.Default.GetLevel().String()
+	retVars[config.EnvLogLevel] = devsylog.LevelString()
 	return retVars
 }
 


### PR DESCRIPTION
## Summary
- Remove dead `Log log.Logger` field from `opener.Params` — it was set by callers but never read
- Replace `oldlog.Default.GetLevel().String()` in `pkg/provider/env.go` with new `devsylog.LevelString()`
- Add `LevelString()` function to `pkg/log/levels.go` for subprocess env propagation
- Remove `Log: log,` from the `opener.Params` literal in `cmd/up.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed logging dependency from IDE opener module, simplifying the codebase.
  * Updated logging level configuration handling for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->