### PR TITLE
refactor: migrate cmd/ simple batch 1 to pkg/log

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -13,7 +13,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -179,13 +178,12 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 func (cmd *BuildCmd) Run(ctx context.Context, client client.WorkspaceClient) error {
-	return cmd.build(ctx, client, oldlog.Default)
+	return cmd.build(ctx, client)
 }
 
 func (cmd *BuildCmd) build(
 	ctx context.Context,
 	workspaceClient client.WorkspaceClient,
-	log oldlog.Logger,
 ) error {
 	err := workspaceClient.Lock(ctx)
 	if err != nil {

--- a/cmd/helper/ssh_server.go
+++ b/cmd/helper/ssh_server.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
+	devsylog "github.com/devsy-org/devsy/pkg/log"
 	helperssh "github.com/devsy-org/devsy/pkg/ssh/server"
 	"github.com/devsy-org/devsy/pkg/ssh/server/port"
 	"github.com/devsy-org/devsy/pkg/stdio"
 	"github.com/devsy-org/devsy/pkg/token"
-	oldlog "github.com/devsy-org/log"
 	"github.com/devsy-org/ssh"
 	"github.com/spf13/cobra"
 )
@@ -151,7 +151,7 @@ func (cmd *SSHServerCmd) Run(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("address %s already in use: %w", cmd.Address, err)
 		}
 
-		oldlog.Default.ErrorStreamOnly().Infof("address %s already in use", cmd.Address)
+		devsylog.Infof("address %s already in use", cmd.Address)
 		return nil
 	}
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -11,9 +11,9 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/extract"
+	devsylog "github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +48,7 @@ func NewImportCmd(flags *flags.GlobalFlags) *cobra.Command {
 				return err
 			}
 
-			return cmd.Run(cobraCmd.Context(), devsyConfig, oldlog.Default)
+			return cmd.Run(cobraCmd.Context(), devsyConfig)
 		},
 	}
 
@@ -68,7 +68,6 @@ func NewImportCmd(flags *flags.GlobalFlags) *cobra.Command {
 func (cmd *ImportCmd) Run(
 	ctx context.Context,
 	devsyConfig *config.Config,
-	log oldlog.Logger,
 ) error {
 	exportConfig := &provider.ExportConfig{}
 	err := json.Unmarshal([]byte(cmd.Data), exportConfig)
@@ -92,25 +91,25 @@ func (cmd *ImportCmd) Run(
 	}
 
 	// check if conflicting ids
-	err = cmd.checkForConflictingIDs(ctx, exportConfig, devsyConfig, log)
+	err = cmd.checkForConflictingIDs(ctx, exportConfig, devsyConfig)
 	if err != nil {
 		return err
 	}
 
 	// import provider
-	err = cmd.importProvider(devsyConfig, exportConfig, log)
+	err = cmd.importProvider(devsyConfig, exportConfig)
 	if err != nil {
 		return err
 	}
 
 	// import machine
-	err = cmd.importMachine(devsyConfig, exportConfig, log)
+	err = cmd.importMachine(devsyConfig, exportConfig)
 	if err != nil {
 		return err
 	}
 
 	// import workspace
-	err = cmd.importWorkspace(devsyConfig, exportConfig, log)
+	err = cmd.importWorkspace(devsyConfig, exportConfig)
 	if err != nil {
 		return err
 	}
@@ -121,7 +120,6 @@ func (cmd *ImportCmd) Run(
 func (cmd *ImportCmd) importWorkspace(
 	devsyConfig *config.Config,
 	exportConfig *provider.ExportConfig,
-	log oldlog.Logger,
 ) error {
 	workspaceDir, err := provider.GetWorkspaceDir(devsyConfig.DefaultContext, cmd.WorkspaceID)
 	if err != nil {
@@ -163,14 +161,13 @@ func (cmd *ImportCmd) importWorkspace(
 		return fmt.Errorf("save workspace config: %w", err)
 	}
 
-	log.Donef("imported workspace: workspaceId=%s", cmd.WorkspaceID)
+	devsylog.Infof("imported workspace: workspaceId=%s", cmd.WorkspaceID)
 	return nil
 }
 
 func (cmd *ImportCmd) importMachine(
 	devsyConfig *config.Config,
 	exportConfig *provider.ExportConfig,
-	log oldlog.Logger,
 ) error {
 	if exportConfig.Machine == nil {
 		return nil
@@ -178,7 +175,7 @@ func (cmd *ImportCmd) importMachine(
 
 	// if machine already exists we skip
 	if cmd.MachineReuse && provider.MachineExists(devsyConfig.DefaultContext, cmd.MachineID) {
-		log.Infof("Reusing existing machine %s", cmd.MachineID)
+		devsylog.Infof("Reusing existing machine %s", cmd.MachineID)
 		return nil
 	}
 
@@ -218,18 +215,17 @@ func (cmd *ImportCmd) importMachine(
 		return fmt.Errorf("save machine config: %w", err)
 	}
 
-	log.Donef("imported machine: machineId=%s", cmd.MachineID)
+	devsylog.Infof("imported machine: machineId=%s", cmd.MachineID)
 	return nil
 }
 
 func (cmd *ImportCmd) importProvider(
 	devsyConfig *config.Config,
 	exportConfig *provider.ExportConfig,
-	log oldlog.Logger,
 ) error {
 	// if provider already exists we skip
 	if cmd.ProviderReuse && provider.ProviderExists(devsyConfig.DefaultContext, cmd.ProviderID) {
-		log.Infof("Reusing existing provider %s", cmd.ProviderID)
+		devsylog.Infof("Reusing existing provider %s", cmd.ProviderID)
 		return nil
 	}
 
@@ -280,7 +276,7 @@ func (cmd *ImportCmd) importProvider(
 		}
 	}
 
-	log.Donef("imported provider: providerId=%s", cmd.ProviderID)
+	devsylog.Infof("imported provider: providerId=%s", cmd.ProviderID)
 	return nil
 }
 
@@ -288,7 +284,6 @@ func (cmd *ImportCmd) checkForConflictingIDs(
 	ctx context.Context,
 	exportConfig *provider.ExportConfig,
 	devsyConfig *config.Config,
-	log oldlog.Logger,
 ) error {
 	workspaces, err := workspace.List(ctx, devsyConfig, false, cmd.Owner)
 	if err != nil {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -11,8 +11,8 @@ import (
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
+	devsylog "github.com/devsy-org/devsy/pkg/log"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +48,6 @@ func NewStatusCmd(flags *flags.GlobalFlags) *cobra.Command {
 				return err
 			}
 
-			logger := oldlog.Default.ErrorStreamOnly()
 			client, err := workspace2.Get(ctx, workspace2.GetOptions{
 				DevsyConfig: devsyConfig,
 				Args:        args,
@@ -58,7 +57,7 @@ func NewStatusCmd(flags *flags.GlobalFlags) *cobra.Command {
 				return err
 			}
 
-			return cmd.Run(ctx, client, logger)
+			return cmd.Run(ctx, client)
 		},
 		ValidArgsFunction: func(rootCmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			return completion.GetWorkspaceSuggestions(
@@ -84,7 +83,6 @@ func NewStatusCmd(flags *flags.GlobalFlags) *cobra.Command {
 func (cmd *StatusCmd) Run(
 	ctx context.Context,
 	client client2.BaseWorkspaceClient,
-	log oldlog.Logger,
 ) error {
 	// parse timeout
 	if cmd.Timeout != "" {
@@ -108,28 +106,28 @@ func (cmd *StatusCmd) Run(
 	case "plain":
 		switch instanceStatus {
 		case client2.StatusStopped:
-			log.Infof(
+			devsylog.Infof(
 				"Workspace '%s' is '%s', you can start it via 'devsy up %s'",
 				client.Workspace(),
 				instanceStatus,
 				client.Workspace(),
 			)
 		case client2.StatusBusy:
-			log.Infof(
+			devsylog.Infof(
 				"Workspace '%s' is '%s', which means its currently unaccessible. "+
 					"This is usually resolved by waiting a couple of minutes",
 				client.Workspace(),
 				instanceStatus,
 			)
 		case client2.StatusNotFound:
-			log.Infof(
+			devsylog.Infof(
 				"Workspace '%s' is '%s', you can create it via 'devsy up %s'",
 				client.Workspace(),
 				instanceStatus,
 				client.Workspace(),
 			)
 		default:
-			log.Infof("Workspace '%s' is '%s'", client.Workspace(), instanceStatus)
+			devsylog.Infof("Workspace '%s' is '%s'", client.Workspace(), instanceStatus)
 		}
 	case "json":
 		out, err := json.Marshal(&client2.WorkspaceStatus{

--- a/cmd/troubleshoot.go
+++ b/cmd/troubleshoot.go
@@ -17,7 +17,6 @@ import (
 	pkgprovider "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/version"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -95,13 +94,12 @@ func (cmd *TroubleshootCmd) Run(ctx context.Context, args []string) {
 		return
 	}
 
-	logger := oldlog.Default.ErrorStreamOnly()
-	info.Providers, err = collectProviders(info.Config, logger)
+	info.Providers, err = collectProviders(info.Config)
 	if err != nil {
 		info.Errors = append(info.Errors, PrintableError{fmt.Errorf("collect providers: %w", err)})
 	}
 
-	info.DevsyProInstances, err = collectPlatformInfo(info.Config, logger)
+	info.DevsyProInstances, err = collectPlatformInfo(info.Config)
 	if err != nil {
 		info.Errors = append(
 			info.Errors,
@@ -141,7 +139,6 @@ func (cmd *TroubleshootCmd) Run(ctx context.Context, args []string) {
 					ctx,
 					info.Config,
 					proInstance.Host,
-					logger,
 					info.Workspace.UID,
 					info.Workspace.Pro.Project,
 				)
@@ -178,7 +175,6 @@ func collectProWorkspaceInfo(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	host string,
-	logger oldlog.Logger,
 	workspaceUID string,
 	project string,
 ) (*managementv1.DevsyWorkspaceInstanceTroubleshoot, error) {
@@ -216,7 +212,6 @@ func collectProWorkspaceInfo(
 // It returns a map of providers with their default settings and an error if any occurs.
 func collectProviders(
 	devsyConfig *config.Config,
-	logger oldlog.Logger,
 ) (map[string]provider.ProviderWithDefault, error) {
 	providers, err := workspace.LoadAllProviders(devsyConfig)
 	if err != nil {
@@ -260,7 +255,6 @@ type DevsyProInstance struct {
 // This means that even when an error value is returned, the pro instance slice will contain valid values.
 func collectPlatformInfo(
 	devsyConfig *config.Config,
-	logger oldlog.Logger,
 ) ([]DevsyProInstance, error) {
 	proInstanceList, err := workspace.ListProInstances(devsyConfig)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Migrate 5 cmd/ files from old logger to `pkg/log` (zap-based)
- Remove dead `log`/`logger` parameters from functions where logger was passed but never used externally
- Replace `Donef()` → `Infof()` (no Done equivalent in new logger)
- Remove `ErrorStreamOnly()` calls (no-op — new logger always writes to stderr)
- Files: `cmd/build.go`, `cmd/status.go`, `cmd/import.go`, `cmd/troubleshoot.go`, `cmd/helper/ssh_server.go`