### PR TITLE
refactor: migrate cmd/pro/login, cmd/logs, container_tunnel, update_workspace to pkg/log

### DIFF
--- a/cmd/agent/container_tunnel.go
+++ b/cmd/agent/container_tunnel.go
@@ -17,7 +17,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/encoding"
 	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -53,8 +52,6 @@ func NewContainerTunnelCmd(flags *flags.GlobalFlags) *cobra.Command {
 
 // Run runs the command logic.
 func (cmd *ContainerTunnelCmd) Run(ctx context.Context) error {
-	logger := oldlog.Default.ErrorStreamOnly()
-
 	// write workspace info
 	shouldExit, workspaceInfo, err := agent.WriteWorkspaceInfo(cmd.WorkspaceInfo)
 	if err != nil {
@@ -76,7 +73,7 @@ func (cmd *ContainerTunnelCmd) Run(ctx context.Context) error {
 	}
 
 	// wait until devcontainer is started
-	err = startDevContainer(ctx, workspaceInfo, runner, logger)
+	err = startDevContainer(ctx, workspaceInfo, runner)
 	if err != nil {
 		return err
 	}
@@ -112,7 +109,6 @@ func startDevContainer(
 	ctx context.Context,
 	workspaceConfig *provider2.AgentWorkspaceInfo,
 	runner devcontainer.Runner,
-	logger oldlog.Logger,
 ) error {
 	containerDetails, err := runner.Find(ctx)
 	if err != nil {
@@ -122,7 +118,7 @@ func startDevContainer(
 	// start container if necessary
 	if containerDetails == nil || containerDetails.State.Status != "running" {
 		// start container
-		_, err = StartContainer(ctx, runner, logger, workspaceConfig)
+		_, err = StartContainer(ctx, runner, workspaceConfig)
 		if err != nil {
 			return err
 		}
@@ -132,7 +128,7 @@ func startDevContainer(
 		err = runner.Command(ctx, "root", "cat "+pkgconfig.DevContainerResultPath, nil, buf, buf)
 		if err != nil {
 			// start container
-			_, err = StartContainer(ctx, runner, logger, workspaceConfig)
+			_, err = StartContainer(ctx, runner, workspaceConfig)
 			if err != nil {
 				return err
 			}
@@ -145,7 +141,6 @@ func startDevContainer(
 func StartContainer(
 	ctx context.Context,
 	runner devcontainer.Runner,
-	logger oldlog.Logger,
 	workspaceConfig *provider2.AgentWorkspaceInfo,
 ) (*config.Result, error) {
 	log.Debugf("starting Devsy container")

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -11,10 +11,9 @@ import (
 	"github.com/devsy-org/devsy/pkg/agent"
 	clientpkg "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
+	devsylog "github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/ssh"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -71,8 +70,6 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 	if !ok {
 		return fmt.Errorf("this command is not supported for proxy providers")
 	}
-	log := oldlog.Default
-
 	// create readers
 	stdoutReader, stdoutWriter, err := os.Pipe()
 	if err != nil {
@@ -86,7 +83,7 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 	defer func() { _ = stdinWriter.Close() }()
 	// ssh tunnel command
 	sshServerCmd := fmt.Sprintf("'%s' helper ssh-server --stdio", client.AgentPath())
-	if log.GetLevel() == logrus.DebugLevel {
+	if devsylog.DebugEnabled() {
 		sshServerCmd += " --debug"
 	}
 
@@ -96,7 +93,7 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 	// start ssh server in background
 	errChan := make(chan error, 1)
 	go func() {
-		stderr := log.Writer(logrus.DebugLevel, false)
+		stderr := devsylog.Writer(devsylog.LevelDebug)
 		defer func() { _ = stderr.Close() }()
 
 		errChan <- agent.InjectAgent(&agent.InjectOptions{
@@ -127,7 +124,7 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 		client.Context(),
 		client.Workspace(),
 	)
-	if log.GetLevel() == logrus.DebugLevel {
+	if devsylog.DebugEnabled() {
 		agentCommand += " --debug"
 	}
 

--- a/cmd/pro/login.go
+++ b/cmd/pro/login.go
@@ -10,6 +10,7 @@ import (
 	proflags "github.com/devsy-org/devsy/cmd/pro/flags"
 	providercmd "github.com/devsy-org/devsy/cmd/provider"
 	"github.com/devsy-org/devsy/pkg/config"
+	devsylog "github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/provider"
@@ -55,7 +56,7 @@ func NewLoginCmd(flags *proflags.GlobalFlags) *cobra.Command {
 				)
 			}
 
-			return cmd.Run(cobraCmd.Context(), args[0], oldlog.Default)
+			return cmd.Run(cobraCmd.Context(), args[0])
 		},
 	}
 
@@ -81,7 +82,7 @@ func NewLoginCmd(flags *proflags.GlobalFlags) *cobra.Command {
 }
 
 //nolint:cyclop,funlen // pre-existing complexity
-func (cmd *LoginCmd) Run(ctx context.Context, fullURL string, log oldlog.Logger) error {
+func (cmd *LoginCmd) Run(ctx context.Context, fullURL string) error {
 	if strings.HasPrefix(fullURL, "http://") {
 		return fmt.Errorf("http is not supported for Devsy Pro, please use https:// instead")
 	} else if !strings.HasPrefix(fullURL, "https://") {
@@ -165,10 +166,10 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string, log oldlog.Logger)
 		}
 		if rv.LT(semver.Version{Major: 0, Minor: 6, Patch: 999}) &&
 			remoteVersion != versionpkg.DevVersion {
-			log.Debug("remote version < 0.7.0, installing proxy provider")
+			devsylog.Debug("remote version < 0.7.0, installing proxy provider")
 			// proxy providers are deprecated and shouldn't be used
 			// unless explicitly the server version is below 0.7.0
-			err = cmd.addLoftProvider(devsyConfig, fullURL, log)
+			err = cmd.addLoftProvider(devsyConfig, fullURL)
 			if err != nil {
 				return err
 			}
@@ -212,7 +213,7 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string, log oldlog.Logger)
 		if err != nil {
 			return err
 		}
-		log.Donef("logged into Devsy Pro instance: url=%s", fullURL)
+		devsylog.Infof("logged into Devsy Pro instance: url=%s", fullURL)
 	}
 
 	// 3. Configure provider
@@ -226,21 +227,20 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string, log oldlog.Logger)
 			SkipInit:       false,
 			SkipSubOptions: false,
 			SingleMachine:  nil,
-			Log:            log,
+			Log:            oldlog.Default,
 		})
 		if err != nil {
 			return fmt.Errorf("configure provider: %w", err)
 		}
 	}
 
-	log.Done("configured Devsy Pro")
+	devsylog.Info("configured Devsy Pro")
 	return nil
 }
 
 func (cmd *LoginCmd) addLoftProvider(
 	devsyConfig *config.Config,
 	url string,
-	log oldlog.Logger,
 ) error {
 	// find out loft version
 	err := cmd.resolveProviderSource(url)
@@ -249,11 +249,11 @@ func (cmd *LoginCmd) addLoftProvider(
 	}
 
 	// add the provider
-	log.Infof("Add Devsy Pro provider...")
+	devsylog.Infof("Add Devsy Pro provider...")
 
 	// is development?
 	if cmd.ProviderSource == config.RepoSlug+"@v0.0.0" {
-		log.Debugf("Add development provider")
+		devsylog.Debugf("Add development provider")
 		_, err = workspace.AddProviderRaw(workspace.ProviderParams{
 			DevsyConfig:  devsyConfig,
 			ProviderName: cmd.Provider,

--- a/cmd/pro/update_workspace.go
+++ b/cmd/pro/update_workspace.go
@@ -8,10 +8,9 @@ import (
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
+	devsylog "github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
-	oldlog "github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -73,7 +72,7 @@ func (cmd *UpdateWorkspaceCmd) Run(
 		Options: opts,
 		Config:  provider,
 		Stdout:  &buf,
-		Stderr:  oldlog.Default.ErrorStreamOnly().Writer(logrus.ErrorLevel, true),
+		Stderr:  devsylog.Writer(devsylog.LevelError),
 	})
 	if err != nil {
 		return fmt.Errorf("update workspace with provider \"%s\": %w", provider.Name, err)


### PR DESCRIPTION
## Summary

- Migrate 4 files from old `github.com/devsy-org/log` to `github.com/devsy-org/devsy/pkg/log` (zap-based)
- Files: `cmd/pro/login.go`, `cmd/logs.go`, `cmd/agent/container_tunnel.go`, `cmd/pro/update_workspace.go`
- Remove dead `logger oldlog.Logger` params from `startDevContainer` and `StartContainer` in container_tunnel.go (logger was passed through but never used)
- Remove `log oldlog.Logger` param from `LoginCmd.Run` and `addLoftProvider` in login.go
- Replace `log.GetLevel() == logrus.DebugLevel` with `devsylog.DebugEnabled()` in logs.go
- Note: login.go retains `oldlog` import for `ProviderOptionsConfig.Log` field (coupled to provider config system, migrated separately)