### PR TITLE
refactor: remove Log field from ProviderOptionsConfig

### DIFF
--- a/cmd/pro/login.go
+++ b/cmd/pro/login.go
@@ -17,7 +17,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/types"
 	versionpkg "github.com/devsy-org/devsy/pkg/version"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -227,7 +226,6 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string) error {
 			SkipInit:       false,
 			SkipSubOptions: false,
 			SingleMachine:  nil,
-			Log:            oldlog.Default,
 		})
 		if err != nil {
 			return fmt.Errorf("configure provider: %w", err)

--- a/cmd/pro/update_provider.go
+++ b/cmd/pro/update_provider.go
@@ -9,7 +9,6 @@ import (
 	providercmd "github.com/devsy-org/devsy/cmd/provider"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -86,7 +85,6 @@ func (cmd *UpdateProviderCmd) Run(ctx context.Context, args []string) error {
 		SkipInit:       true,
 		SkipSubOptions: false,
 		SingleMachine:  nil,
-		Log:            oldlog.Discard,
 	})
 	if err != nil {
 		return fmt.Errorf(

--- a/cmd/provider/add.go
+++ b/cmd/provider/add.go
@@ -11,7 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -129,7 +128,6 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 			SkipInit:       false,
 			SkipSubOptions: false,
 			SingleMachine:  &cmd.SingleMachine,
-			Log:            oldlog.Default,
 		})
 		if configureErr != nil {
 			devsyConfig, err := config.LoadConfig(cmd.Context, "")

--- a/cmd/provider/set_options.go
+++ b/cmd/provider/set_options.go
@@ -10,7 +10,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -79,11 +78,6 @@ func (cmd *SetOptionsCmd) Run(ctx context.Context, args []string) error {
 	}
 	log.Debugf("Options=%+v", cmd.Options)
 
-	var logger oldlog.Logger = oldlog.Default
-	if cmd.Dry {
-		logger = oldlog.Default.ErrorStreamOnly()
-	}
-
 	providerWithOptions, err := workspace.FindProvider(devsyConfig, providerName)
 	if err != nil {
 		return err
@@ -98,7 +92,6 @@ func (cmd *SetOptionsCmd) Run(ctx context.Context, args []string) error {
 		SkipInit:       cmd.Dry,
 		SkipSubOptions: false,
 		SingleMachine:  &cmd.SingleMachine,
-		Log:            logger,
 	})
 	if err != nil {
 		return err

--- a/cmd/provider/update.go
+++ b/cmd/provider/update.go
@@ -8,7 +8,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -77,7 +76,6 @@ func (cmd *UpdateCmd) Run(ctx context.Context, devsyConfig *config.Config, args 
 			SkipInit:       false,
 			SkipSubOptions: false,
 			SingleMachine:  nil,
-			Log:            oldlog.Default,
 		})
 		if err != nil {
 			log.Errorf(

--- a/cmd/provider/use.go
+++ b/cmd/provider/use.go
@@ -13,8 +13,6 @@ import (
 	options2 "github.com/devsy-org/devsy/pkg/options"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
-	oldlog "github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -100,7 +98,6 @@ func (cmd *UseCmd) Run(ctx context.Context, providerName string) error {
 			SkipInit:       cmd.SkipInit,
 			SkipSubOptions: false,
 			SingleMachine:  &cmd.SingleMachine,
-			Log:            oldlog.Default,
 		})
 	} else {
 		log.Infof(
@@ -133,7 +130,6 @@ type ProviderOptionsConfig struct {
 	SkipInit       bool
 	SkipSubOptions bool
 	SingleMachine  *bool
-	Log            oldlog.Logger
 }
 
 func ConfigureProvider(ctx context.Context, cfg ProviderOptionsConfig) error {
@@ -204,10 +200,10 @@ func configureProviderOptions(
 
 	// run init command
 	if !cfg.SkipInit {
-		stdout := cfg.Log.Writer(logrus.InfoLevel, false)
+		stdout := log.Writer(log.LevelInfo)
 		defer func() { _ = stdout.Close() }()
 
-		stderr := cfg.Log.Writer(logrus.ErrorLevel, false)
+		stderr := log.Writer(log.LevelError)
 		defer func() { _ = stderr.Close() }()
 
 		err = initProvider(ctx, devsyConfig, cfg.Provider, stdout, stderr)


### PR DESCRIPTION
## Summary
- Remove the `Log oldlog.Logger` field from the `ProviderOptionsConfig` struct
- Replace old log writer calls in `configureProviderOptions()` with the new `log.Writer()` API
- Remove all `oldlog "github.com/devsy-org/log"` and `logrus` imports from the 6 affected files
- Remove the dry-run logger variable block in `set_options.go` that was only used for the removed field