### PR TITLE
refactor: migrate provider.go and get_workspace_config.go to pkg/log

### DIFF
--- a/cmd/helper/get_workspace_config.go
+++ b/cmd/helper/get_workspace_config.go
@@ -11,8 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer"
 	"github.com/devsy-org/devsy/pkg/log"
-	oldlog "github.com/devsy-org/log"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -70,15 +68,7 @@ func (cmd *GetWorkspaceConfigCommand) Run(
 	}
 	rawSource := args[0]
 
-	level := oldlog.Default.GetLevel()
-	if cmd.Debug {
-		level = logrus.DebugLevel
-	}
-	var logger oldlog.Logger = oldlog.NewStdoutLogger(os.Stdin, os.Stdout, os.Stderr, level)
-	if os.Getenv(config.EnvUI) == config.BoolTrue {
-		logger = oldlog.Discard
-	}
-	logger.Debugf("Resolving devcontainer config for source: %s", rawSource)
+	log.Debugf("Resolving devcontainer config for source: %s", rawSource)
 
 	ctx, cancel := context.WithTimeout(context.Background(), cmd.timeout)
 	defer cancel()

--- a/cmd/pro/provider/provider.go
+++ b/cmd/pro/provider/provider.go
@@ -13,7 +13,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
-	oldlog "github.com/devsy-org/log"
 	"github.com/spf13/cobra"
 )
 
@@ -29,8 +28,6 @@ func NewProProviderCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 				os.Getenv("DEVSY_CONFIG") != "" {
 				globalFlags.Config = os.Getenv(platform.ConfigEnv)
 			}
-
-			oldlog.Default.SetFormat(oldlog.JSONFormat)
 
 			if os.Getenv(config.EnvDebug) == config.BoolTrue {
 				globalFlags.Debug = true


### PR DESCRIPTION
## Summary

- Remove `oldlog.Default.SetFormat(oldlog.JSONFormat)` from `cmd/pro/provider/provider.go` and drop the `oldlog` import — all subcommands have already been migrated
- Replace old logger setup block in `cmd/helper/get_workspace_config.go` with a single `log.Debugf` call using `pkg/log`, removing `oldlog` and `logrus` imports

Part of the logging migration series (#38, #39, #40, #41, #42).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified logging configuration in workspace and provider commands by removing redundant logger initialization and setup code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->