### PR TITLE
refactor: remove redundant EnvDebug case from agent.go

### DIFF
--- a/cmd/agent/agent.go
+++ b/cmd/agent/agent.go
@@ -63,8 +63,6 @@ func AgentPersistentPreRunE(
 		log.Default.SetLevel(logrus.FatalLevel)
 	case globalFlags.Debug:
 		log.Default.SetLevel(logrus.DebugLevel)
-	case os.Getenv(config.EnvDebug) == config.BoolTrue:
-		log.Default.SetLevel(logrus.DebugLevel)
 	}
 
 	if globalFlags.DevsyHome != "" {


### PR DESCRIPTION
## Summary

- Remove redundant `os.Getenv(config.EnvDebug)` case from the old logger level switch in `cmd/agent/agent.go` `AgentPersistentPreRunE` — this condition is already handled by root command's `PersistentPreRunE` which sets `globalFlags.Debug` from the environment variable before agent code runs