### PR TITLE
refactor: remove devsylog import alias

### DIFF
--- a/cmd/helper/ssh_server.go
+++ b/cmd/helper/ssh_server.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	helperssh "github.com/devsy-org/devsy/pkg/ssh/server"
 	"github.com/devsy-org/devsy/pkg/ssh/server/port"
 	"github.com/devsy-org/devsy/pkg/stdio"
@@ -151,7 +151,7 @@ func (cmd *SSHServerCmd) Run(_ *cobra.Command, _ []string) error {
 			return fmt.Errorf("address %s already in use: %w", cmd.Address, err)
 		}
 
-		devsylog.Infof("address %s already in use", cmd.Address)
+		log.Infof("address %s already in use", cmd.Address)
 		return nil
 	}
 

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -11,7 +11,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/extract"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
@@ -161,7 +161,7 @@ func (cmd *ImportCmd) importWorkspace(
 		return fmt.Errorf("save workspace config: %w", err)
 	}
 
-	devsylog.Infof("imported workspace: workspaceId=%s", cmd.WorkspaceID)
+	log.Infof("imported workspace: workspaceId=%s", cmd.WorkspaceID)
 	return nil
 }
 
@@ -175,7 +175,7 @@ func (cmd *ImportCmd) importMachine(
 
 	// if machine already exists we skip
 	if cmd.MachineReuse && provider.MachineExists(devsyConfig.DefaultContext, cmd.MachineID) {
-		devsylog.Infof("Reusing existing machine %s", cmd.MachineID)
+		log.Infof("Reusing existing machine %s", cmd.MachineID)
 		return nil
 	}
 
@@ -215,7 +215,7 @@ func (cmd *ImportCmd) importMachine(
 		return fmt.Errorf("save machine config: %w", err)
 	}
 
-	devsylog.Infof("imported machine: machineId=%s", cmd.MachineID)
+	log.Infof("imported machine: machineId=%s", cmd.MachineID)
 	return nil
 }
 
@@ -225,7 +225,7 @@ func (cmd *ImportCmd) importProvider(
 ) error {
 	// if provider already exists we skip
 	if cmd.ProviderReuse && provider.ProviderExists(devsyConfig.DefaultContext, cmd.ProviderID) {
-		devsylog.Infof("Reusing existing provider %s", cmd.ProviderID)
+		log.Infof("Reusing existing provider %s", cmd.ProviderID)
 		return nil
 	}
 
@@ -276,7 +276,7 @@ func (cmd *ImportCmd) importProvider(
 		}
 	}
 
-	devsylog.Infof("imported provider: providerId=%s", cmd.ProviderID)
+	log.Infof("imported provider: providerId=%s", cmd.ProviderID)
 	return nil
 }
 

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -11,7 +11,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/agent"
 	clientpkg "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/ssh"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
@@ -83,7 +83,7 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 	defer func() { _ = stdinWriter.Close() }()
 	// ssh tunnel command
 	sshServerCmd := fmt.Sprintf("'%s' helper ssh-server --stdio", client.AgentPath())
-	if devsylog.DebugEnabled() {
+	if log.DebugEnabled() {
 		sshServerCmd += " --debug"
 	}
 
@@ -93,7 +93,7 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 	// start ssh server in background
 	errChan := make(chan error, 1)
 	go func() {
-		stderr := devsylog.Writer(devsylog.LevelDebug)
+		stderr := log.Writer(log.LevelDebug)
 		defer func() { _ = stderr.Close() }()
 
 		errChan <- agent.InjectAgent(&agent.InjectOptions{
@@ -124,7 +124,7 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 		client.Context(),
 		client.Workspace(),
 	)
-	if devsylog.DebugEnabled() {
+	if log.DebugEnabled() {
 		agentCommand += " --debug"
 	}
 

--- a/cmd/machine/ssh.go
+++ b/cmd/machine/ssh.go
@@ -14,7 +14,7 @@ import (
 	devagent "github.com/devsy-org/devsy/pkg/agent"
 	"github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/pty"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
 	devsshagent "github.com/devsy-org/devsy/pkg/ssh/agent"
@@ -124,7 +124,7 @@ func (cmd *SSHCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	writer := devsylog.Writer(devsylog.LevelInfo)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	// Get the timeout from the context options

--- a/cmd/pro/check_health.go
+++ b/cmd/pro/check_health.go
@@ -9,7 +9,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/spf13/cobra"
 )
@@ -77,7 +77,7 @@ func (cmd *CheckHealthCmd) Run(
 		Options: devsyConfig.ProviderOptions(provider.Name),
 		Config:  provider,
 		Stdout:  &buf,
-		Stderr:  devsylog.Writer(devsylog.LevelError),
+		Stderr:  log.Writer(log.LevelError),
 	})
 	if err != nil {
 		return fmt.Errorf("check health with provider \"%s\": %w", provider.Name, err)

--- a/cmd/pro/create_workspace.go
+++ b/cmd/pro/create_workspace.go
@@ -8,7 +8,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/spf13/cobra"
@@ -72,7 +72,7 @@ func (cmd *CreateWorkspaceCmd) Run(
 		Options: opts,
 		Config:  provider,
 		Stdout:  &buf,
-		Stderr:  devsylog.Writer(devsylog.LevelError),
+		Stderr:  log.Writer(log.LevelError),
 	})
 	if err != nil {
 		return fmt.Errorf("create workspace: %w", err)

--- a/cmd/pro/login.go
+++ b/cmd/pro/login.go
@@ -10,7 +10,7 @@ import (
 	proflags "github.com/devsy-org/devsy/cmd/pro/flags"
 	providercmd "github.com/devsy-org/devsy/cmd/provider"
 	"github.com/devsy-org/devsy/pkg/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/provider"
@@ -165,7 +165,7 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string) error {
 		}
 		if rv.LT(semver.Version{Major: 0, Minor: 6, Patch: 999}) &&
 			remoteVersion != versionpkg.DevVersion {
-			devsylog.Debug("remote version < 0.7.0, installing proxy provider")
+			log.Debug("remote version < 0.7.0, installing proxy provider")
 			// proxy providers are deprecated and shouldn't be used
 			// unless explicitly the server version is below 0.7.0
 			err = cmd.addLoftProvider(devsyConfig, fullURL)
@@ -212,7 +212,7 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string) error {
 		if err != nil {
 			return err
 		}
-		devsylog.Infof("logged into Devsy Pro instance: url=%s", fullURL)
+		log.Infof("logged into Devsy Pro instance: url=%s", fullURL)
 	}
 
 	// 3. Configure provider
@@ -232,7 +232,7 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string) error {
 		}
 	}
 
-	devsylog.Info("configured Devsy Pro")
+	log.Info("configured Devsy Pro")
 	return nil
 }
 
@@ -247,11 +247,11 @@ func (cmd *LoginCmd) addLoftProvider(
 	}
 
 	// add the provider
-	devsylog.Infof("Add Devsy Pro provider...")
+	log.Infof("Add Devsy Pro provider...")
 
 	// is development?
 	if cmd.ProviderSource == config.RepoSlug+"@v0.0.0" {
-		devsylog.Debugf("Add development provider")
+		log.Debugf("Add development provider")
 		_, err = workspace.AddProviderRaw(workspace.ProviderParams{
 			DevsyConfig:  devsyConfig,
 			ProviderName: cmd.Provider,

--- a/cmd/pro/update_workspace.go
+++ b/cmd/pro/update_workspace.go
@@ -8,7 +8,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/spf13/cobra"
@@ -72,7 +72,7 @@ func (cmd *UpdateWorkspaceCmd) Run(
 		Options: opts,
 		Config:  provider,
 		Stdout:  &buf,
-		Stderr:  devsylog.Writer(devsylog.LevelError),
+		Stderr:  log.Writer(log.LevelError),
 	})
 	if err != nil {
 		return fmt.Errorf("update workspace with provider \"%s\": %w", provider.Name, err)

--- a/cmd/pro/watch_workspaces.go
+++ b/cmd/pro/watch_workspaces.go
@@ -10,7 +10,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/pro/flags"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/spf13/cobra"
 )
@@ -88,7 +88,7 @@ func (cmd *WatchWorkspacesCmd) Run(
 		Options: opts,
 		Config:  providerConfig,
 		Stdout:  os.Stdout,
-		Stderr:  devsylog.Writer(devsylog.LevelError),
+		Stderr:  log.Writer(log.LevelError),
 	})
 	if err != nil {
 		return fmt.Errorf("watch workspaces with provider \"%s\": %w", providerConfig.Name, err)

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -21,7 +21,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/gpg"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/port"
 	"github.com/devsy-org/devsy/pkg/provider"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
@@ -173,12 +173,12 @@ func (cmd *SSHCmd) Run(
 	// add ssh keys to agent
 	if devsyConfig.ContextOption(config.ContextOptionSSHAgentForwarding) == config.BoolTrue &&
 		devsyConfig.ContextOption(config.ContextOptionSSHAddPrivateKeys) == config.BoolTrue {
-		devsylog.Debug(
+		log.Debug(
 			"adding ssh keys to agent, disable via 'devsy context set-options -o SSH_ADD_PRIVATE_KEYS=false'",
 		)
 		err := devssh.AddPrivateKeysToAgent(ctx)
 		if err != nil {
-			devsylog.Debugf("Error adding private keys to ssh-agent: %v", err)
+			log.Debugf("Error adding private keys to ssh-agent: %v", err)
 		}
 	}
 
@@ -221,7 +221,7 @@ func (cmd *SSHCmd) jumpContainerTailscale(
 	devsyConfig *config.Config,
 	client client2.DaemonClient,
 ) error {
-	devsylog.Debugf("Starting tailscale connection")
+	log.Debugf("Starting tailscale connection")
 
 	err := client.CheckWorkspaceReachable(ctx)
 	if err != nil {
@@ -259,7 +259,7 @@ func (cmd *SSHCmd) jumpContainerTailscale(
 				},
 			)
 			if err != nil {
-				devsylog.Errorf("Error starting services: %v", err)
+				log.Errorf("Error starting services: %v", err)
 			}
 		}()
 	}
@@ -268,7 +268,7 @@ func (cmd *SSHCmd) jumpContainerTailscale(
 	if cmd.GPGAgentForwarding ||
 		devsyConfig.ContextOption(config.ContextOptionGPGAgentForwarding) == config.BoolTrue {
 		if gpg.IsGpgTunnelRunning(ctx, cmd.User, toolSSHClient) {
-			devsylog.Debugf("[GPG] exporting already running, skipping")
+			log.Debugf("[GPG] exporting already running, skipping")
 		} else if err := cmd.setupGPGAgent(ctx, toolSSHClient); err != nil {
 			return err
 		}
@@ -304,7 +304,7 @@ func (cmd *SSHCmd) startProxyTunnel(
 	devsyConfig *config.Config,
 	client client2.ProxyClient,
 ) error {
-	devsylog.Debugf("Start proxy tunnel")
+	log.Debugf("Start proxy tunnel")
 	return tunnel.NewTunnel(
 		ctx,
 		func(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
@@ -381,7 +381,7 @@ func (cmd *SSHCmd) forwardTimeout() (time.Duration, error) {
 			return timeout, fmt.Errorf("parse forward ports timeout: %w", err)
 		}
 
-		devsylog.Infof("Using port forwarding timeout of %s", cmd.ForwardPortsTimeout)
+		log.Infof("Using port forwarding timeout of %s", cmd.ForwardPortsTimeout)
 	}
 
 	return timeout, nil
@@ -404,7 +404,7 @@ func (cmd *SSHCmd) reverseForwardPorts(
 		}
 
 		// start the forwarding
-		devsylog.Infof(
+		log.Infof(
 			"Reverse forwarding local %s/%s to remote %s/%s",
 			mapping.Host.Protocol,
 			mapping.Host.Address,
@@ -447,7 +447,7 @@ func (cmd *SSHCmd) forwardPorts(
 		}
 
 		// start the forwarding
-		devsylog.Infof(
+		log.Infof(
 			"Forwarding local %s/%s to remote %s/%s",
 			mapping.Host.Protocol,
 			mapping.Host.Address,
@@ -512,7 +512,7 @@ func (cmd *SSHCmd) startTunnel(
 		)
 	}
 	// start ssh
-	writer := devsylog.Writer(devsylog.LevelInfo)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
 	// check if we should do gpg agent forwarding
@@ -521,7 +521,7 @@ func (cmd *SSHCmd) startTunnel(
 		// Check if a forwarding is already enabled and running, in that case
 		// we skip the forwarding and keep using the original one
 		if gpg.IsGpgTunnelRunning(ctx, cmd.User, containerClient) {
-			devsylog.Debugf("[GPG] exporting already running, skipping")
+			log.Debugf("[GPG] exporting already running, skipping")
 		} else {
 			err := cmd.setupGPGAgent(ctx, containerClient)
 			if err != nil {
@@ -532,7 +532,7 @@ func (cmd *SSHCmd) startTunnel(
 
 	workdir := resolveWorkdir(cmd.WorkDir, workspaceClient)
 
-	devsylog.Debugf("Run outer container tunnel")
+	log.Debugf("Run outer container tunnel")
 	commandArgs := []string{
 		agent.ContainerDevsyHelperLocation,
 		"helper",
@@ -543,7 +543,7 @@ func (cmd *SSHCmd) startTunnel(
 		workdir,
 	}
 	if cmd.ReuseSSHAuthSock != "" {
-		devsylog.Debug("Reusing SSH_AUTH_SOCK")
+		log.Debug("Reusing SSH_AUTH_SOCK")
 		commandArgs = append(commandArgs, "--reuse-ssh-auth-sock", cmd.ReuseSSHAuthSock)
 	}
 	if cmd.Debug {
@@ -624,7 +624,7 @@ func resolveMergedWorkspaceFolder(
 
 	result, err := provider.LoadWorkspaceResult(workspaceConfig.Context, workspaceConfig.ID)
 	if err != nil {
-		devsylog.Debugf("Error loading workspace result for workdir resolution: %v", err)
+		log.Debugf("Error loading workspace result for workdir resolution: %v", err)
 		return ""
 	}
 	if result == nil || result.MergedConfig == nil {
@@ -660,7 +660,7 @@ func (cmd *SSHCmd) startServices(
 			},
 		)
 		if err != nil {
-			devsylog.Debugf("Error running credential server: %v", err)
+			log.Debugf("Error running credential server: %v", err)
 		}
 	}
 }
@@ -671,14 +671,14 @@ func (cmd *SSHCmd) setupGPGAgent(
 	ctx context.Context,
 	containerClient *ssh.Client,
 ) error {
-	devsylog.Debugf("[GPG] exporting gpg owner trust from host")
+	log.Debugf("[GPG] exporting gpg owner trust from host")
 	ownerTrustExport, err := gpg.GetHostOwnerTrust()
 	if err != nil {
 		return fmt.Errorf("export local ownertrust from GPG: %w", err)
 	}
 	ownerTrustArgument := base64.StdEncoding.EncodeToString(ownerTrustExport)
 
-	devsylog.Debugf("[GPG] detecting gpg-agent socket path on host")
+	log.Debugf("[GPG] detecting gpg-agent socket path on host")
 	// Detect local agent extra socket, this will be forwarded to the remote and
 	// symlinked in multiple paths
 	gpgExtraSocketBytes, err := exec.Command("gpgconf", []string{"--list-dir", "agent-extra-socket"}...).
@@ -688,7 +688,7 @@ func (cmd *SSHCmd) setupGPGAgent(
 	}
 
 	gpgExtraSocketPath := strings.TrimSpace(string(gpgExtraSocketBytes))
-	devsylog.Debugf("[GPG] detected gpg-agent socket path %s", gpgExtraSocketPath)
+	log.Debugf("[GPG] detected gpg-agent socket path %s", gpgExtraSocketPath)
 
 	gitKey := gpgSigningKey()
 
@@ -706,7 +706,7 @@ func (cmd *SSHCmd) setupGPGAgent(
 		gpgExtraSocketPath,
 	}
 
-	if devsylog.DebugEnabled() {
+	if log.DebugEnabled() {
 		forwardAgent = append(forwardAgent, "--debug")
 	}
 
@@ -720,16 +720,16 @@ func (cmd *SSHCmd) setupGPGAgent(
 		command = shellescape.QuoteCommand([]string{"su", "-c", command, cmd.User})
 	}
 
-	devsylog.Debugf(
+	log.Debugf(
 		"[GPG] start reverse forward of gpg-agent socket %s, keeping connection open",
 		gpgExtraSocketPath,
 	)
 
 	go func() {
-		devsylog.Error(cmd.reverseForwardPorts(ctx, containerClient))
+		log.Error(cmd.reverseForwardPorts(ctx, containerClient))
 	}()
 
-	writer := devsylog.Writer(devsylog.LevelInfo)
+	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 	err = devssh.Run(ctx, devssh.RunOptions{
 		Client:  containerClient,
@@ -754,7 +754,7 @@ func gpgSigningKey() string {
 		formatStr = strings.TrimSpace(string(format))
 	}
 	if formatStr == "ssh" {
-		devsylog.Debugf(
+		log.Debugf(
 			"[GPG] gpg.format is ssh, skipping GPG signing key (handled by SSH signing helper)",
 		)
 		return ""
@@ -762,7 +762,7 @@ func gpgSigningKey() string {
 
 	key, err := exec.Command("git", "config", "--get", "user.signingKey").Output()
 	if err != nil {
-		devsylog.Debugf("[GPG] no git signkey detected, skipping")
+		log.Debugf("[GPG] no git signkey detected, skipping")
 		return ""
 	}
 
@@ -772,14 +772,14 @@ func gpgSigningKey() string {
 	// looks like a file path and the format isn't x509 (which legitimately
 	// uses certificate file paths via gpgsm), it's an SSH key.
 	if (strings.HasPrefix(result, "/") || strings.HasPrefix(result, "~")) && formatStr != "x509" {
-		devsylog.Debugf(
+		log.Debugf(
 			"[GPG] signing key %s looks like a file path, skipping (not a GPG key ID)",
 			result,
 		)
 		return ""
 	}
 
-	devsylog.Debugf("[GPG] detected git sign key %s", result)
+	log.Debugf("[GPG] detected git sign key %s", result)
 	return result
 }
 
@@ -798,7 +798,7 @@ func startSSHKeepAlive(
 		case <-ticker.C:
 			_, _, err := client.SendRequest("keepalive@openssh.com", true, nil)
 			if err != nil {
-				devsylog.Errorf("Failed to send keepalive: %w", err)
+				log.Errorf("Failed to send keepalive: %w", err)
 			}
 		}
 	}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -11,7 +11,7 @@ import (
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
 )
@@ -106,28 +106,28 @@ func (cmd *StatusCmd) Run(
 	case "plain":
 		switch instanceStatus {
 		case client2.StatusStopped:
-			devsylog.Infof(
+			log.Infof(
 				"Workspace '%s' is '%s', you can start it via 'devsy up %s'",
 				client.Workspace(),
 				instanceStatus,
 				client.Workspace(),
 			)
 		case client2.StatusBusy:
-			devsylog.Infof(
+			log.Infof(
 				"Workspace '%s' is '%s', which means its currently unaccessible. "+
 					"This is usually resolved by waiting a couple of minutes",
 				client.Workspace(),
 				instanceStatus,
 			)
 		case client2.StatusNotFound:
-			devsylog.Infof(
+			log.Infof(
 				"Workspace '%s' is '%s', you can create it via 'devsy up %s'",
 				client.Workspace(),
 				instanceStatus,
 				client.Workspace(),
 			)
 		default:
-			devsylog.Infof("Workspace '%s' is '%s'", client.Workspace(), instanceStatus)
+			log.Infof("Workspace '%s' is '%s'", client.Workspace(), instanceStatus)
 		}
 	case "json":
 		out, err := json.Marshal(&client2.WorkspaceStatus{

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -22,7 +22,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/dotfiles"
 	"github.com/devsy-org/devsy/pkg/ide"
 	"github.com/devsy-org/devsy/pkg/ide/opener"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	options2 "github.com/devsy-org/devsy/pkg/options"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
@@ -290,9 +290,9 @@ func (cmd *UpCmd) prepareWorkspace(client client2.BaseWorkspaceClient) {
 
 	if !cmd.Platform.Enabled && ide.ReusesAuthSock(targetIDE) {
 		cmd.SSHAuthSockID = util.RandStringBytes(10)
-		devsylog.Debug("Reusing SSH_AUTH_SOCK", cmd.SSHAuthSockID)
+		log.Debug("Reusing SSH_AUTH_SOCK", cmd.SSHAuthSockID)
 	} else if cmd.Platform.Enabled && ide.ReusesAuthSock(targetIDE) {
-		devsylog.Debug(
+		log.Debug(
 			"Reusing SSH_AUTH_SOCK is not supported with platform mode, consider launching the IDE from the platform UI",
 		)
 	}
@@ -357,7 +357,7 @@ func (cmd *UpCmd) configureWorkspace(
 			return err
 		}
 
-		devsylog.Info("SSH configuration completed in workspace")
+		log.Info("SSH configuration completed in workspace")
 	}
 
 	if err := dotfiles.Setup(dotfiles.SetupParams{
@@ -468,7 +468,7 @@ func (cmd *UpCmd) devsyUpProxy(
 	// create up command
 	errChan := make(chan error, 1)
 	go func() {
-		defer devsylog.Debug("done executing up command")
+		defer log.Debug("done executing up command")
 		defer cancel()
 
 		// build devsy up options
@@ -563,8 +563,8 @@ func (cmd *UpCmd) devsyUpMachine(
 	}
 
 	// create container etc.
-	devsylog.Info("creating devcontainer")
-	defer devsylog.Debug("done creating devcontainer")
+	log.Info("creating devcontainer")
+	defer log.Debug("done creating devcontainer")
 
 	// if we run on a platform, we need to pass the platform options
 	if cmd.Platform.Enabled {
@@ -583,7 +583,7 @@ func (cmd *UpCmd) devsyUpMachine(
 
 	// ssh tunnel command
 	sshTunnelCmd := fmt.Sprintf("'%s' helper ssh-server --stdio", client.AgentPath())
-	if devsylog.DebugEnabled() {
+	if log.DebugEnabled() {
 		sshTunnelCmd += " --debug"
 	}
 
@@ -594,7 +594,7 @@ func (cmd *UpCmd) devsyUpMachine(
 		workspaceInfo,
 	)
 
-	if devsylog.DebugEnabled() {
+	if log.DebugEnabled() {
 		agentCommand += " --debug"
 	}
 
@@ -746,8 +746,8 @@ func (cmd *UpCmd) prepareClient(
 	}
 
 	if cmd.Platform.Enabled {
-		devsylog.Debug("Running in platform mode")
-		devsylog.Debug("Using error output stream")
+		log.Debug("Running in platform mode")
+		log.Debug("Using error output stream")
 
 		// merge context options from env
 		config.MergeContextOptions(devsyConfig.Current(), os.Environ())

--- a/pkg/agent/tunnelserver/stream.go
+++ b/pkg/agent/tunnelserver/stream.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/devsy-org/devsy/pkg/agent/tunnel"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 func NewStreamReader(stream tunnel.Tunnel_StreamWorkspaceClient) io.Reader {
@@ -20,14 +20,14 @@ func NewStreamReader(stream tunnel.Tunnel_StreamWorkspaceClient) io.Reader {
 			if resp != nil && len(resp.Content) > 0 {
 				_, err = writer.Write(resp.Content)
 				if err != nil {
-					devsylog.Debugf("Error writing to pipe: %v", err)
+					log.Debugf("Error writing to pipe: %v", err)
 					return
 				}
 			}
 			if errors.Is(err, io.EOF) {
 				return
 			} else if err != nil {
-				devsylog.Debugf("Error receiving from stream: %v", err)
+				log.Debugf("Error receiving from stream: %v", err)
 				return
 			}
 		}
@@ -55,7 +55,7 @@ func (s *streamWriter) Write(p []byte) (int, error) {
 
 	s.bytesWritten += int64(len(p))
 	if time.Since(s.lastMessage) > time.Second*2 {
-		devsylog.Infof("Uploaded %.2f MB", float64(s.bytesWritten)/1024/1024)
+		log.Infof("Uploaded %.2f MB", float64(s.bytesWritten)/1024/1024)
 		s.lastMessage = time.Now()
 	}
 

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -21,7 +21,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/gitsshsigning"
 	"github.com/devsy-org/devsy/pkg/gpg"
 	devsyconfig "github.com/devsy-org/devsy/pkg/loftconfig"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/netstat"
 	"github.com/devsy-org/devsy/pkg/platform"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
@@ -237,7 +237,7 @@ func (t *tunnelServer) GitCredentials(
 	ctx context.Context,
 	message *tunnel.Message,
 ) (*tunnel.Message, error) {
-	devsylog.Debugf(
+	log.Debugf(
 		"getting git credentials: allowGitCredentials=%v, workspaceIsNil=%v",
 		t.allowGitCredentials,
 		t.workspace == nil,
@@ -287,7 +287,7 @@ func (t *tunnelServer) GitCredentials(
 			// This allows downstream credential helpers to figure out which passwords needs to be fetched
 			credentials.Path = path
 		} else {
-			devsylog.Warn("workspace is not available for git credentials")
+			log.Warn("workspace is not available for git credentials")
 		}
 
 		response, err := gitcredentials.GetCredentials(credentials)
@@ -404,22 +404,22 @@ func (t *tunnelServer) SendResult(
 }
 
 func (t *tunnelServer) Ping(context.Context, *tunnel.Empty) (*tunnel.Empty, error) {
-	devsylog.Debug("received ping from agent")
+	log.Debug("received ping from agent")
 	return &tunnel.Empty{}, nil
 }
 
 func (t *tunnelServer) Log(ctx context.Context, message *tunnel.LogMessage) (*tunnel.Empty, error) {
 	switch message.LogLevel {
 	case tunnel.LogLevel_DEBUG:
-		devsylog.Debug(strings.TrimSpace(message.Message))
+		log.Debug(strings.TrimSpace(message.Message))
 	case tunnel.LogLevel_INFO:
-		devsylog.Info(strings.TrimSpace(message.Message))
+		log.Info(strings.TrimSpace(message.Message))
 	case tunnel.LogLevel_WARNING:
-		devsylog.Warn(strings.TrimSpace(message.Message))
+		log.Warn(strings.TrimSpace(message.Message))
 	case tunnel.LogLevel_ERROR:
-		devsylog.Error(strings.TrimSpace(message.Message))
+		log.Error(strings.TrimSpace(message.Message))
 	case tunnel.LogLevel_DONE:
-		devsylog.Info(strings.TrimSpace(message.Message))
+		log.Info(strings.TrimSpace(message.Message))
 	}
 
 	return &tunnel.Empty{}, nil
@@ -445,7 +445,7 @@ func (t *tunnelServer) StreamWorkspace(
 	if err == nil {
 		excludes, err = ignorefile.ReadAll(f)
 		if err != nil {
-			devsylog.Warnf("error reading %s file: error=%v", pkgconfig.IgnoreFileName, err)
+			log.Warnf("error reading %s file: error=%v", pkgconfig.IgnoreFileName, err)
 		}
 	}
 
@@ -488,7 +488,7 @@ func (t *tunnelServer) StreamMount(
 		if err == nil {
 			excludes, err = ignorefile.ReadAll(f)
 			if err != nil {
-				devsylog.Warnf("error reading %s file: error=%v", pkgconfig.IgnoreFileName, err)
+				log.Warnf("error reading %s file: error=%v", pkgconfig.IgnoreFileName, err)
 			}
 		}
 	}

--- a/pkg/client/clientimplementation/daemonclient/up.go
+++ b/pkg/client/clientimplementation/daemonclient/up.go
@@ -16,7 +16,7 @@ import (
 	clientpkg "github.com/devsy-org/devsy/pkg/client"
 	devsyconfig "github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/kube"
 	corev1 "k8s.io/api/core/v1"
@@ -65,7 +65,7 @@ func (c *client) Up(ctx context.Context, opt clientpkg.UpOptions) (*config.Resul
 	printInstanceInfo(instance)
 
 	if instance.Spec.TemplateRef != nil && templateUpdateRequired(instance) {
-		devsylog.Info("Template update required")
+		log.Info("Template update required")
 		oldInstance := instance.DeepCopy()
 		instance.Spec.TemplateRef.SyncOnce = true
 
@@ -73,7 +73,7 @@ func (c *client) Up(ctx context.Context, opt clientpkg.UpOptions) (*config.Resul
 		if err != nil {
 			return nil, fmt.Errorf("update instance: %w", err)
 		}
-		devsylog.Info("updated template")
+		log.Info("updated template")
 	}
 
 	// encode options
@@ -84,7 +84,7 @@ func (c *client) Up(ctx context.Context, opt clientpkg.UpOptions) (*config.Resul
 	}
 
 	// prompt user to attach to active task or start new one
-	devsylog.Debug("Check active up task")
+	log.Debug("Check active up task")
 	activeUpTask, err := findActiveUpTask(ctx, managementClient, instance)
 	if err != nil {
 		return nil, fmt.Errorf("find active up task: %w", err)
@@ -92,7 +92,7 @@ func (c *client) Up(ctx context.Context, opt clientpkg.UpOptions) (*config.Resul
 
 	// if we have an active up task, cancel it before creating a new one
 	if activeUpTask != nil {
-		devsylog.Warnf("Found active up task %s, attempting to cancel it", activeUpTask.ID)
+		log.Warnf("Found active up task %s, attempting to cancel it", activeUpTask.ID)
 		_, err = managementClient.Loft().
 			ManagementV1().
 			DevsyWorkspaceInstances(instance.Namespace).
@@ -195,7 +195,7 @@ func printInstanceInfo(instance *managementv1.DevsyWorkspaceInstance) {
 		Template:   instance.Spec.TemplateRef,
 		Parameters: instance.Spec.Parameters,
 	})
-	devsylog.Debug("Starting pro workspace with configuration", string(workspaceConfig))
+	log.Debug("Starting pro workspace with configuration", string(workspaceConfig))
 }
 
 func observeTask(
@@ -265,7 +265,7 @@ func printLogs(
 	taskID string,
 ) (int, error) {
 	// get logs reader
-	devsylog.Debugf("printing logs of task: %s", taskID)
+	log.Debugf("printing logs of task: %s", taskID)
 	logsReader, err := managementClient.Loft().ManagementV1().RESTClient().Get().
 		Namespace(workspace.Namespace).
 		Resource("devsyworkspaceinstances").
@@ -291,8 +291,8 @@ func printLogs(
 	scanner.Buffer(buf, maxCapacity)
 
 	// create json streamer
-	stdoutStreamer, stdoutDone := devsylog.PipeJSONStream()
-	stderrStreamer, stderrDone := devsylog.PipeJSONStream()
+	stdoutStreamer, stdoutDone := log.PipeJSONStream()
+	stderrStreamer, stderrDone := log.PipeJSONStream()
 	defer func() {
 		// close the streams
 		_ = stdoutStreamer.Close()
@@ -317,16 +317,16 @@ func printLogs(
 		switch message.Type {
 		case StdoutData:
 			if _, err := stdoutStreamer.Write(message.Bytes); err != nil {
-				devsylog.Debugf("error read stdout: %v", err)
+				log.Debugf("error read stdout: %v", err)
 				return 1, err
 			}
 		case StderrData:
 			if _, err := stderrStreamer.Write(message.Bytes); err != nil {
-				devsylog.Debugf("error read stderr: %v", err)
+				log.Debugf("error read stderr: %v", err)
 				return 1, err
 			}
 		case ExitCode:
-			devsylog.Debugf("exit code: %d", message.ExitCode)
+			log.Debugf("exit code: %d", message.ExitCode)
 			return message.ExitCode, nil
 		}
 	}

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/devsy-org/api/pkg/devsy"
 	"github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/options"
 	"github.com/devsy-org/devsy/pkg/options/resolver"
 	platformclient "github.com/devsy-org/devsy/pkg/platform/client"
@@ -91,7 +91,7 @@ func (e *proxyExecutor) execute(ctx context.Context, params execParams) error {
 
 // executeWithJSONLog runs a command with JSON log streaming.
 func (e *proxyExecutor) executeWithJSONLog(ctx context.Context, params execParams) error {
-	writer, _ := devsylog.PipeJSONStream()
+	writer, _ := log.PipeJSONStream()
 	defer func() { _ = writer.Close() }()
 
 	params.stderr = writer
@@ -102,12 +102,12 @@ func (s *proxyClient) Lock(ctx context.Context) error {
 	s.initLock()
 
 	// try to lock workspace
-	devsylog.Debugf("Acquire workspace lock...")
+	log.Debugf("Acquire workspace lock...")
 	err := tryLock(ctx, s.workspaceLock, "workspace")
 	if err != nil {
 		return fmt.Errorf("error locking workspace: %w", err)
 	}
-	devsylog.Debugf("Acquired workspace lock...")
+	log.Debugf("Acquired workspace lock...")
 
 	return nil
 }
@@ -118,7 +118,7 @@ func (s *proxyClient) Unlock() {
 	// try to unlock workspace
 	err := s.workspaceLock.Unlock()
 	if err != nil {
-		devsylog.Warnf("Error unlocking workspace: %v", err)
+		log.Warnf("Error unlocking workspace: %v", err)
 	}
 }
 
@@ -352,7 +352,7 @@ func (s *proxyClient) Delete(ctx context.Context, opt client.DeleteOptions) erro
 		return fmt.Errorf("error deleting workspace: %w", err)
 	}
 	if err != nil {
-		devsylog.Errorf("Error deleting workspace: %v", err)
+		log.Errorf("Error deleting workspace: %v", err)
 	}
 
 	return DeleteWorkspaceFolder(DeleteWorkspaceFolderParams{
@@ -394,7 +394,7 @@ func (s *proxyClient) Status(
 		)
 	}
 
-	devsylog.ReadJSONStream(bytes.NewReader(buf.Bytes()))
+	log.ReadJSONStream(bytes.NewReader(buf.Bytes()))
 	status := &client.WorkspaceStatus{}
 	err = json.Unmarshal(stdout.Bytes(), status)
 	if err != nil {

--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -19,7 +19,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/compress"
 	"github.com/devsy-org/devsy/pkg/config"
 	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/options"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/shell"
@@ -151,15 +151,15 @@ func (s *workspaceClient) RefreshOptions(
 		userOptions,
 	)
 	if err != nil {
-		devsylog.Errorf("failed to resolve and save options workspace: error=%v", err)
+		log.Errorf("failed to resolve and save options workspace: error=%v", err)
 		return err
 	}
 
 	if workspace != nil {
 		s.workspace = workspace
-		devsylog.Debugf("refreshed workspace options: workspaceId=%s", s.workspace.ID)
+		log.Debugf("refreshed workspace options: workspaceId=%s", s.workspace.ID)
 	} else {
-		devsylog.Debug("workspace is nil; not updating workspace options")
+		log.Debug("workspace is nil; not updating workspace options")
 	}
 	return nil
 }
@@ -213,7 +213,7 @@ func (s *workspaceClient) agentInfo(cliOptions provider.CLIOptions) *provider.Ag
 	if s.workspace != nil {
 		result, err := provider.LoadWorkspaceResult(s.workspace.Context, s.workspace.ID)
 		if err != nil {
-			devsylog.Debugf("error loading workspace result: error=%v", err)
+			log.Debugf("error loading workspace result: error=%v", err)
 		} else if result != nil {
 			lastDevContainerConfig = result.DevContainerConfigWithPath
 		}
@@ -275,21 +275,21 @@ func (s *workspaceClient) Lock(ctx context.Context) error {
 	}
 
 	// try to lock workspace
-	devsylog.Debug("acquire workspace lock")
+	log.Debug("acquire workspace lock")
 	err := tryLock(ctx, s.workspaceLock, "workspace")
 	if err != nil {
 		return fmt.Errorf("error locking workspace: %w", err)
 	}
-	devsylog.Debug("acquired workspace lock")
+	log.Debug("acquired workspace lock")
 
 	// try to lock machine
 	if s.machineLock != nil {
-		devsylog.Debug("acquire machine lock")
+		log.Debug("acquire machine lock")
 		err := tryLock(ctx, s.machineLock, "machine")
 		if err != nil {
 			return fmt.Errorf("error locking machine: %w", err)
 		}
-		devsylog.Debug("acquired machine lock")
+		log.Debug("acquired machine lock")
 	}
 
 	return nil
@@ -297,19 +297,19 @@ func (s *workspaceClient) Lock(ctx context.Context) error {
 
 func (s *workspaceClient) Unlock() {
 	if err := s.initLock(); err != nil {
-		devsylog.Warnf("initializing lock: %v", err)
+		log.Warnf("initializing lock: %v", err)
 		return
 	}
 
 	if s.machineLock != nil {
 		if err := s.machineLock.Unlock(); err != nil {
-			devsylog.Warnf("error unlocking machine: %v", err)
+			log.Warnf("error unlocking machine: %v", err)
 		}
 	}
 
 	if s.workspaceLock != nil {
 		if err := s.workspaceLock.Unlock(); err != nil {
-			devsylog.Warnf("error unlocking workspace: %v", err)
+			log.Warnf("error unlocking workspace: %v", err)
 		}
 	}
 }
@@ -374,10 +374,10 @@ func (s *workspaceClient) Delete(ctx context.Context, opt client.DeleteOptions) 
 				return err
 			}
 		} else if isRunning {
-			writer := devsylog.Writer(devsylog.LevelInfo)
+			writer := log.Writer(log.LevelInfo)
 			defer func() { _ = writer.Close() }()
 
-			devsylog.Info("deleting workspace container")
+			log.Info("deleting workspace container")
 			compressed, info, err := s.compressedAgentInfo(provider.CLIOptions{})
 			if err != nil {
 				return fmt.Errorf("agent info")
@@ -409,7 +409,7 @@ func (s *workspaceClient) Delete(ctx context.Context, opt client.DeleteOptions) 
 				}
 
 				if !errors.Is(err, context.DeadlineExceeded) {
-					devsylog.Errorf("error deleting container: error=%v", err)
+					log.Errorf("error deleting container: error=%v", err)
 				}
 			}
 		}
@@ -479,10 +479,10 @@ func (s *workspaceClient) Stop(ctx context.Context, opt client.StopOptions) erro
 	defer s.m.Unlock()
 
 	if !s.isMachineProvider() || !s.workspace.Machine.AutoDelete {
-		writer := devsylog.Writer(devsylog.LevelInfo)
+		writer := log.Writer(log.LevelInfo)
 		defer func() { _ = writer.Close() }()
 
-		devsylog.Info("stopping container")
+		log.Info("stopping container")
 		compressed, info, err := s.compressedAgentInfo(provider.CLIOptions{})
 		if err != nil {
 			return fmt.Errorf("agent info")
@@ -511,7 +511,7 @@ func (s *workspaceClient) Stop(ctx context.Context, opt client.StopOptions) erro
 		if err != nil {
 			return err
 		}
-		devsylog.Info("stopped container")
+		log.Info("stopped container")
 
 		return nil
 	}
@@ -693,7 +693,7 @@ func (s *workspaceClient) getContainerStatus(ctx context.Context) (client.Status
 		)
 	}
 
-	devsylog.Debugf(
+	log.Debugf(
 		"container status command output: stdout=%s, stderr=%s, parsed=%v",
 		stdout.String(),
 		buf.String(),
@@ -774,7 +774,7 @@ func RunCommand(opts RunCommandOptions) error {
 		return nil
 	}
 
-	if devsylog.DebugEnabled() {
+	if log.DebugEnabled() {
 		opts.Environ = append(opts.Environ, config.EnvDebug+"="+config.BoolTrue)
 	}
 
@@ -844,7 +844,7 @@ func DeleteWorkspaceFolder(params DeleteWorkspaceFolderParams) error {
 
 	err = ssh.RemoveFromConfig(params.WorkspaceID, sshConfigPath, sshConfigIncludePath)
 	if err != nil {
-		devsylog.Errorf("Remove workspace '%s' from ssh config: %v", params.WorkspaceID, err)
+		log.Errorf("Remove workspace '%s' from ssh config: %v", params.WorkspaceID, err)
 	}
 
 	workspaceFolder, err := provider.GetWorkspaceDir(params.Context, params.WorkspaceID)
@@ -901,7 +901,7 @@ func StartWait(
 
 func handleBusyStatus(startWaiting *time.Time) bool {
 	if time.Since(*startWaiting) > logThreshold {
-		devsylog.Info("workspace is busy, waiting for workspace to become ready")
+		log.Info("workspace is busy, waiting for workspace to become ready")
 		*startWaiting = time.Now()
 	}
 	return true
@@ -992,7 +992,7 @@ func buildAgentCommand(
 		agentCommand,
 		workspaceInfo,
 	)
-	if devsylog.DebugEnabled() {
+	if log.DebugEnabled() {
 		command += " --debug"
 	}
 	return command
@@ -1025,10 +1025,10 @@ type agentInjectionOptions struct {
 func runAgentInjection(opts agentInjectionOptions) chan error {
 	errChan := make(chan error, 1)
 	go func() {
-		defer devsylog.Debugf("up command completed")
+		defer log.Debugf("up command completed")
 		defer opts.cancel()
 
-		writer := devsylog.Writer(devsylog.LevelInfo)
+		writer := log.Writer(log.LevelInfo)
 		defer func() { _ = writer.Close() }()
 
 		errChan <- agent.InjectAgent(&agent.InjectOptions{

--- a/pkg/provider/env.go
+++ b/pkg/provider/env.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/devsy-org/devsy/pkg/config"
-	devsylog "github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 func combineOptions(
@@ -160,7 +160,7 @@ func GetBaseEnvironment(context, provider string) map[string]string {
 	retVars[config.EnvProviderContext] = context
 	providerFolder, _ := GetProviderDir(context, provider)
 	retVars[config.EnvProviderFolder] = filepath.ToSlash(providerFolder)
-	retVars[config.EnvLogLevel] = devsylog.LevelString()
+	retVars[config.EnvLogLevel] = log.LevelString()
 	return retVars
 }
 


### PR DESCRIPTION
## Summary
Remove the `devsylog` import alias from 18 files. This alias was needed during the logging migration when both old (logrus) and new (pkg/log) loggers coexisted. Now that the migration is complete, the alias is unnecessary — none of these files import stdlib `log`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal logging package references for improved code consistency and maintainability across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->