### PR TITLE
refactor: reduce complexity of envfile MergeAndApply

### DIFF
--- a/pkg/envfile/envfile.go
+++ b/pkg/envfile/envfile.go
@@ -37,25 +37,34 @@ func Apply() {
 	}
 }
 
-//nolint:cyclop // pre-existing complexity
+// readEnvFile reads and parses the envfile from disk.
+// Returns an empty EnvFile if the file does not exist, or nil on read/parse errors.
+func readEnvFile() *EnvFile {
+	out, err := os.ReadFile(location)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Debugf("Error reading envfile: %v", err)
+			return nil
+		}
+		return &EnvFile{}
+	}
+
+	envFile := &EnvFile{}
+	if err := json.Unmarshal(out, envFile); err != nil {
+		log.Debugf("Error parsing envfile: %v", err)
+		return nil
+	}
+	return envFile
+}
+
 func MergeAndApply(env map[string]string) {
 	if len(env) == 0 {
 		return
 	}
 
-	envFile := &EnvFile{}
-	out, err := os.ReadFile(location)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			log.Debugf("Error reading envfile: %v", err)
-			return
-		}
-	} else {
-		err = json.Unmarshal(out, envFile)
-		if err != nil {
-			log.Debugf("Error parsing envfile: %v", err)
-			return
-		}
+	envFile := readEnvFile()
+	if envFile == nil {
+		return
 	}
 
 	if envFile.Env == nil {
@@ -63,20 +72,18 @@ func MergeAndApply(env map[string]string) {
 	}
 	maps.Copy(envFile.Env, env)
 
-	out, err = json.Marshal(envFile)
+	out, err := json.Marshal(envFile)
 	if err != nil {
 		log.Debugf("Error marshalling envfile: %v", err)
 		return
 	}
 
 	// #nosec G306 -- TODO Consider using a more secure permission setting and ownership if needed.
-	err = os.WriteFile(location, out, 0o666)
-	if err != nil {
+	if err := os.WriteFile(location, out, 0o666); err != nil {
 		log.Debugf("Error writing envfile: %v", err)
 		return
 	}
 
-	// apply
 	for k, v := range envFile.Env {
 		_ = os.Setenv(k, v)
 	}


### PR DESCRIPTION
## Summary
- Extract `readEnvFile()` helper from `MergeAndApply()` in `pkg/envfile/envfile.go` to reduce cyclomatic complexity from 9 to 7 (threshold is 8)
- Remove the `//nolint:cyclop` directive that was added during the logging migration
- Pure refactor — no behavior change