### PR TITLE
refactor: reduce complexity of tryOpen

### DIFF
--- a/pkg/open/open.go
+++ b/pkg/open/open.go
@@ -56,8 +56,14 @@ func jlabOpen(url string) error {
 	return exec.Command("jlab", url).Run()
 }
 
-//nolint:cyclop
 func tryOpen(ctx context.Context, url string, fn func(string) error) error {
+	if err := probeURL(ctx, url); err != nil {
+		return err
+	}
+	return openAfterDelay(ctx, url, fn)
+}
+
+func probeURL(ctx context.Context, url string) error {
 	timeoutCtx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
@@ -71,23 +77,30 @@ func tryOpen(ctx context.Context, url string, fn func(string) error) error {
 		return err
 	}
 
-	if resp != nil {
-		defer func() { _ = resp.Body.Close() }()
+	if resp == nil {
+		return fmt.Errorf("not reachable")
+	}
+	defer func() { _ = resp.Body.Close() }()
 
-		if resp.StatusCode != http.StatusBadGateway &&
-			resp.StatusCode != http.StatusServiceUnavailable {
-			select {
-			case <-ctx.Done():
-				return nil
-			case <-time.After(time.Second):
-			}
-			if err := fn(url); err != nil {
-				return fmt.Errorf("open url: %w", err)
-			}
-			log.Infof("opened url: url=%s", url)
-			return nil
-		}
+	if resp.StatusCode == http.StatusBadGateway ||
+		resp.StatusCode == http.StatusServiceUnavailable {
+		return fmt.Errorf("not reachable")
 	}
 
-	return fmt.Errorf("not reachable")
+	return nil
+}
+
+func openAfterDelay(ctx context.Context, url string, fn func(string) error) error {
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-time.After(time.Second):
+	}
+
+	if err := fn(url); err != nil {
+		return fmt.Errorf("open url: %w", err)
+	}
+
+	log.Infof("opened url: url=%s", url)
+	return nil
 }


### PR DESCRIPTION
## Summary
- Extracted `probeURL` and `openAfterDelay` helper functions from `tryOpen` to reduce cyclomatic complexity
- Removed `//nolint:cyclop` directive