### PR TITLE
fix(desktop): fix 5 broken features in Electron app

### DIFF
--- a/desktop-electron/src/main/ipc.ts
+++ b/desktop-electron/src/main/ipc.ts
@@ -141,6 +141,14 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
     await cli.runRaw(cliArgs)
   })
 
+  ipcMain.handle("context_create", async (_event, args: { name: string }) => {
+    await cli.runRaw(["context", "create", args.name])
+  })
+
+  ipcMain.handle("context_delete", async (_event, args: { name: string }) => {
+    await cli.runRaw(["context", "delete", args.name])
+  })
+
   // ── System ──
   ipcMain.handle("devpod_version", async () => {
     return cli.runRaw(["version"])

--- a/desktop-electron/src/renderer/src/lib/components/context/ContextSheet.svelte
+++ b/desktop-electron/src/renderer/src/lib/components/context/ContextSheet.svelte
@@ -11,12 +11,14 @@ import * as Sheet from "$lib/components/ui/sheet/index.js"
 import {
   contextOptions as fetchContextOptions,
   contextSetOptions,
+  contextDelete,
 } from "$lib/ipc/commands.js"
 import {
   parseContextOptions,
   CONTEXT_OPTION_KEYS,
 } from "$lib/stores/settings.js"
 import type { ContextOptions } from "$lib/stores/settings.js"
+import { refreshContexts } from "$lib/stores/contexts.js"
 import { toasts } from "$lib/stores/toasts.js"
 import type { Context } from "$lib/types/index.js"
 
@@ -51,6 +53,21 @@ let opts = $state<ContextOptions>({
 
 let loading = $state(true)
 let saving = $state(false)
+let deleting = $state(false)
+
+async function handleDelete() {
+  deleting = true
+  try {
+    await contextDelete(context.name)
+    await refreshContexts()
+    toasts.success(`Context "${context.name}" deleted`)
+    open = false
+  } catch (err) {
+    toasts.error(`Failed to delete context: ${err}`)
+  } finally {
+    deleting = false
+  }
+}
 
 async function loadOptions() {
   loading = true
@@ -303,6 +320,16 @@ function toggleOption(key: keyof ContextOptions) {
             <Switch checked={opts.gpgAgentForwarding} onCheckedChange={() => toggleOption("gpgAgentForwarding")} disabled={saving} />
           </div>
         </div>
+
+        {#if !isActive}
+          <Separator />
+          <div class="space-y-2">
+            <h3 class="text-sm font-semibold text-destructive uppercase tracking-wider">Danger Zone</h3>
+            <Button variant="destructive" class="w-full" disabled={deleting} onclick={handleDelete}>
+              {deleting ? "Deleting..." : `Delete Context "${context.name}"`}
+            </Button>
+          </div>
+        {/if}
       {/if}
     </div>
   </Sheet.ResizableContent>

--- a/desktop-electron/src/renderer/src/lib/components/workspace/CreateWorkspaceSheet.svelte
+++ b/desktop-electron/src/renderer/src/lib/components/workspace/CreateWorkspaceSheet.svelte
@@ -13,6 +13,7 @@ import LanguageIcon from "$lib/components/workspace/LanguageIcon.svelte"
 import LogTable from "$lib/components/log/LogTable.svelte"
 import { workspaceUp } from "$lib/ipc/commands.js"
 import { onCommandProgress } from "$lib/ipc/events.js"
+import type { CommandProgress } from "$lib/types/index.js"
 import { providers } from "$lib/stores/providers.js"
 import { workspaces } from "$lib/stores/workspaces.js"
 import { toasts } from "$lib/stores/toasts.js"
@@ -174,6 +175,27 @@ onDestroy(() => {
   unlisten?.()
 })
 
+function handleProgress(progress: CommandProgress, wsId: string | undefined) {
+  if (progress.message) {
+    outputLines = [...outputLines, progress.message]
+    requestAnimationFrame(() => {
+      outputEl?.scrollIntoView({ block: "end", behavior: "smooth" })
+    })
+  }
+  if (progress.done) {
+    submitting = false
+    if (stripAnsi(progress.message).includes("Exit code: 0")) {
+      createdId = wsId ?? null
+      toasts.success(`Workspace ${wsId ?? "created"} is ready`)
+      requestAnimationFrame(() => {
+        openBtnEl?.scrollIntoView({ block: "center", behavior: "smooth" })
+      })
+    } else {
+      toasts.error("Workspace creation failed. Check output for details.")
+    }
+  }
+}
+
 async function handleSubmit() {
   if (!source.trim()) {
     error = "Source is required"
@@ -202,35 +224,37 @@ async function handleSubmit() {
   outputLines = []
 
   try {
+    // Buffer events arriving before commandId is known to avoid the race
+    // where streaming events arrive before workspaceUp() resolves.
+    const pendingEvents: CommandProgress[] = []
+    let resolvedCommandId: string | null = null
+
     unlisten = await onCommandProgress((progress) => {
-      if (commandId && progress.commandId === commandId) {
-        if (progress.message) {
-          outputLines = [...outputLines, progress.message]
-          requestAnimationFrame(() => {
-            outputEl?.scrollIntoView({ block: "end", behavior: "smooth" })
-          })
+      if (resolvedCommandId) {
+        if (progress.commandId === resolvedCommandId) {
+          handleProgress(progress, workspaceId)
         }
-        if (progress.done) {
-          submitting = false
-          if (stripAnsi(progress.message).includes("Exit code: 0")) {
-            createdId = workspaceId ?? null
-            toasts.success(`Workspace ${workspaceId ?? "created"} is ready`)
-            requestAnimationFrame(() => {
-              openBtnEl?.scrollIntoView({ block: "center", behavior: "smooth" })
-            })
-          } else {
-            toasts.error("Workspace creation failed. Check output for details.")
-          }
-        }
+      } else {
+        pendingEvents.push(progress)
       }
     })
 
-    commandId = await workspaceUp({
+    const cmdId = await workspaceUp({
       source: source.trim(),
       workspaceId,
       provider: selectedProvider || undefined,
       ide: selectedIde || undefined,
     })
+
+    commandId = cmdId
+    resolvedCommandId = cmdId
+
+    // Replay any events that arrived before the commandId was known
+    for (const event of pendingEvents) {
+      if (event.commandId === cmdId) {
+        handleProgress(event, workspaceId)
+      }
+    }
   } catch (err) {
     toasts.error(`Failed to create workspace: ${err}`)
     submitting = false

--- a/desktop-electron/src/renderer/src/lib/ipc/bridge.ts
+++ b/desktop-electron/src/renderer/src/lib/ipc/bridge.ts
@@ -44,14 +44,18 @@ if (isElectron()) {
     })
     return Promise.resolve(unlisten)
   }
-} else {
+} else if (import.meta.env.DEV) {
   console.info(
-    "%c[DevPod] Running in browser mock mode",
+    "%c[Devsy] Running in browser mock mode",
     "color: #f59e0b; font-weight: bold",
   )
   const mock = await import("./mock.js")
   _invoke = mock.invoke as InvokeFn
   _listen = mock.listen as ListenFn
+} else {
+  throw new Error(
+    "electronAPI not found. The preload script failed to expose the Electron API.",
+  )
 }
 
 export const invoke = _invoke

--- a/desktop-electron/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop-electron/src/renderer/src/lib/ipc/commands.ts
@@ -149,6 +149,14 @@ export async function contextSetOptions(
   return invoke("context_set_options", { options, context })
 }
 
+export async function contextCreate(name: string): Promise<void> {
+  return invoke("context_create", { name })
+}
+
+export async function contextDelete(name: string): Promise<void> {
+  return invoke("context_delete", { name })
+}
+
 // Audit commands
 export async function auditRecent(limit?: number): Promise<AuditEntry[]> {
   return invoke<AuditEntry[]>("audit_recent", { limit })

--- a/desktop-electron/src/renderer/src/lib/ipc/mock.ts
+++ b/desktop-electron/src/renderer/src/lib/ipc/mock.ts
@@ -223,6 +223,13 @@ const COMMANDS: Record<string, Handler> = {
     SSH_CONFIG_INCLUDE_PATH: { value: "" },
   }),
   context_set_options: () => undefined,
+  context_create: (args) => {
+    CONTEXTS.push({ name: args.name as string })
+  },
+  context_delete: (args) => {
+    const idx = CONTEXTS.findIndex((c) => c.name === args.name)
+    if (idx !== -1) CONTEXTS.splice(idx, 1)
+  },
 
   // System
   devpod_version: () => "v0.6.0-mock",

--- a/desktop-electron/src/renderer/src/lib/ipc/terminal.ts
+++ b/desktop-electron/src/renderer/src/lib/ipc/terminal.ts
@@ -40,19 +40,19 @@ export async function terminalListSessions(): Promise<string[]> {
 }
 
 interface TerminalOutputPayload {
-  session_id: string
+  sessionId: string
   data: number[]
 }
 
 interface TerminalExitPayload {
-  session_id: string
+  sessionId: string
 }
 
 export function onTerminalOutput(
   callback: (sessionId: string, data: Uint8Array) => void,
 ): Promise<UnlistenFn> {
   return listen<TerminalOutputPayload>("terminal:output", (event) => {
-    callback(event.payload.session_id, new Uint8Array(event.payload.data))
+    callback(event.payload.sessionId, new Uint8Array(event.payload.data))
   })
 }
 
@@ -60,6 +60,6 @@ export function onTerminalExit(
   callback: (sessionId: string) => void,
 ): Promise<UnlistenFn> {
   return listen<TerminalExitPayload>("terminal:exit", (event) => {
-    callback(event.payload.session_id)
+    callback(event.payload.sessionId)
   })
 }

--- a/desktop-electron/src/renderer/src/lib/stores/contexts.ts
+++ b/desktop-electron/src/renderer/src/lib/stores/contexts.ts
@@ -10,6 +10,16 @@ export const contextsLoading = writable(true)
 
 let unlisten: UnlistenFn | null = null
 
+export async function refreshContexts() {
+  try {
+    const result = await contextList()
+    contexts.set(result.contexts)
+    activeContext.set(result.activeContext)
+  } catch {
+    // IPC not available
+  }
+}
+
 export async function initContexts() {
   contextsLoading.set(true)
   try {

--- a/desktop-electron/src/renderer/src/pages/ContextsPage.svelte
+++ b/desktop-electron/src/renderer/src/pages/ContextsPage.svelte
@@ -1,19 +1,27 @@
 <script lang="ts">
-import { Layers, Settings2 } from "@lucide/svelte"
+import { Layers, Plus, Settings2 } from "@lucide/svelte"
 import { Button } from "$lib/components/ui/button/index.js"
+import { Input } from "$lib/components/ui/input/index.js"
+import { Label } from "$lib/components/ui/label/index.js"
 import { badgeVariants } from "$lib/components/ui/badge/index.js"
+import * as Dialog from "$lib/components/ui/dialog/index.js"
 import CardSkeleton from "$lib/components/ui/skeleton/CardSkeleton.svelte"
 import ContextSheet from "$lib/components/context/ContextSheet.svelte"
 import {
   contexts,
   activeContext,
   contextsLoading,
+  refreshContexts,
 } from "$lib/stores/contexts.js"
-import { contextUse } from "$lib/ipc/commands.js"
+import { contextUse, contextCreate } from "$lib/ipc/commands.js"
 import { toasts } from "$lib/stores/toasts.js"
 
 let selectedContext = $state<string | null>(null)
 let sheetOpen = $state(false)
+
+let createDialogOpen = $state(false)
+let newContextName = $state("")
+let creating = $state(false)
 
 let selectedCtx = $derived(
   selectedContext
@@ -35,11 +43,61 @@ async function handleUse(e: Event, name: string) {
     toasts.error(`Failed to switch context: ${err}`)
   }
 }
+
+async function handleCreate() {
+  const name = newContextName.trim()
+  if (!name) return
+  creating = true
+  try {
+    await contextCreate(name)
+    await refreshContexts()
+    toasts.success(`Context "${name}" created`)
+    createDialogOpen = false
+    newContextName = ""
+  } catch (err) {
+    toasts.error(`Failed to create context: ${err}`)
+  } finally {
+    creating = false
+  }
+}
 </script>
 
 <div class="space-y-6">
   <div class="flex items-center justify-between">
     <h1 class="text-2xl font-bold">Contexts</h1>
+    <Dialog.Root bind:open={createDialogOpen}>
+      <Dialog.Trigger>
+        {#snippet child({ props })}
+          <Button size="sm" {...props}>
+            <Plus class="mr-2 h-4 w-4" />
+            Create Context
+          </Button>
+        {/snippet}
+      </Dialog.Trigger>
+      <Dialog.Content class="sm:max-w-md">
+        <Dialog.Header>
+          <Dialog.Title>Create Context</Dialog.Title>
+          <Dialog.Description>Create a new context to organize your workspace configurations.</Dialog.Description>
+        </Dialog.Header>
+        <form onsubmit={(e) => { e.preventDefault(); handleCreate() }} class="space-y-4">
+          <div class="space-y-1.5">
+            <Label>Name</Label>
+            <Input
+              placeholder="e.g. staging, production"
+              value={newContextName}
+              oninput={(e) => (newContextName = e.currentTarget.value)}
+              disabled={creating}
+            />
+          </div>
+          <Dialog.Footer>
+            <Button type="button" variant="outline" onclick={() => (createDialogOpen = false)} disabled={creating}>Cancel</Button>
+            <Button type="submit" disabled={creating || !newContextName.trim()}>
+              {creating ? "Creating..." : "Create"}
+            </Button>
+          </Dialog.Footer>
+        </form>
+      </Dialog.Content>
+    </Dialog.Root>
   </div>
 
   {#if $contextsLoading}

--- a/desktop-electron/src/renderer/tsconfig.json
+++ b/desktop-electron/src/renderer/tsconfig.json
@@ -11,6 +11,7 @@
     "moduleResolution": "bundler",
     "module": "ESNext",
     "target": "ESNext",
+    "types": ["vite/client"],
     "paths": {
       "$lib/*": ["./src/lib/*"]
     }


### PR DESCRIPTION
## Summary
- **Issues 1 & 4 (mock data leaking):** Bridge.ts unconditionally fell back to mock data (hardcoded workspaces, dummy SSH keys) in production builds. Fixed by gating mock import behind `import.meta.env.DEV` so Vite tree-shakes it from production. Production without electronAPI now throws an explicit error.
- **Issue 5 (terminal broken):** PtyManager sent `{ sessionId }` (camelCase) but renderer expected `{ session_id }` (snake_case). Fixed field names in renderer `TerminalOutputPayload` and `TerminalExitPayload` interfaces.
- **Issue 2 (create workspace broken):** Race condition where `commandId` was null when early `command-progress` events arrived. Fixed by buffering events until `workspaceUp()` resolves, then replaying matching events.
- **Issue 3 (context management broken):** No UI for adding/removing contexts. Added `context_create` and `context_delete` IPC handlers, renderer commands, mock handlers, Create Context dialog on ContextsPage, and Delete button in ContextSheet.

All changes verified: `svelte-check` 0 errors, `vitest` 112/112 tests passing.