### PR TITLE
chore: remove stale migration comments, FIXMEs, and duplicate constant

### DIFF
--- a/cmd/pro/provider/up.go
+++ b/cmd/pro/provider/up.go
@@ -151,12 +151,9 @@ func templateUpdateRequired(instance *managementv1.DevsyWorkspaceInstance) bool 
 
 func printInstanceInfo(instance *managementv1.DevsyWorkspaceInstance) {
 	workspaceConfig, _ := json.Marshal(struct {
-		// Cluster    storagev1.WorkspaceTargetNamespace
 		Template   *storagev1.TemplateRef
 		Parameters string
 	}{
-		// Cluster:    cluster,
-		// FIXME: Bring back runner ref
 		Template:   instance.Spec.TemplateRef,
 		Parameters: instance.Spec.Parameters,
 	})

--- a/pkg/loftconfig/server.go
+++ b/pkg/loftconfig/server.go
@@ -5,12 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/platform/client"
 	"github.com/devsy-org/devsy/pkg/provider"
-)
-
-const (
-	LoftPlatformConfigFileName = "devsy-config.json" // TODO: move somewhere else, replace hardoced strings with usage of this const
 )
 
 type DevsyConfigRequest struct {
@@ -48,7 +45,7 @@ func readConfig(contextName string, providerName string) (*client.Config, error)
 		return nil, err
 	}
 
-	configPath := filepath.Join(providerDir, LoftPlatformConfigFileName)
+	configPath := filepath.Join(providerDir, platform.LoftPlatformConfigFileName)
 
 	// Check if given context and provider have Loft Platform configuration
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {

--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -12,8 +12,7 @@ import (
 var sugar *zap.SugaredLogger
 
 func init() {
-	// Default: silent until Init() is called. This avoids double-logging
-	// during the migration period when the old logger is still active.
+	// Default: silent until Init() is called.
 	sugar = zap.NewNop().Sugar()
 }
 

--- a/pkg/platform/config.go
+++ b/pkg/platform/config.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	defaultTimeout                    = 10 * time.Minute
-	LoftPlatformConfigFileName string = "devsy-config.json" // TODO: replace hardcoded strings with this
+	LoftPlatformConfigFileName string = "devsy-config.json"
 )
 
 func Timeout() time.Duration {

--- a/pkg/platform/form/form.go
+++ b/pkg/platform/form/form.go
@@ -114,10 +114,6 @@ func CreateInstance(
 					Name:    selectedTemplate.GetName(),
 					Version: selectedTemplateVersion,
 				},
-				// FIXME: Bring back runner ref
-				// ClusterRef: storagev1.ClusterRef{
-				// 	Cluster: selectedCluster.GetName(),
-				// },
 				Parameters: renderedParameters,
 			},
 		},


### PR DESCRIPTION
## Summary
- Removed stale migration comment from `pkg/log/logger.go`
- Removed FIXME comments and commented-out Cluster/ClusterRef code from `cmd/pro/provider/up.go` and `pkg/platform/form/form.go`
- Consolidated duplicate `LoftPlatformConfigFileName` constant — `pkg/loftconfig/server.go` now imports from `pkg/platform`
- Removed TODO comments from `pkg/platform/config.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed commented-out code and unused references.
  * Cleaned up inline TODO comments.
  * Updated initialization comment for clarity.

* **Refactor**
  * Consolidated configuration filename handling to use a shared platform constant across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->