### PR TITLE
feat(desktop): improve provider/workspace creation UX

### DIFF
--- a/desktop-electron/package-lock.json
+++ b/desktop-electron/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "devpod-desktop",
+  "name": "devsy-desktop",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "devpod-desktop",
+      "name": "devsy-desktop",
       "version": "0.1.0",
       "dependencies": {
         "chokidar": "^4.0.0",

--- a/desktop-electron/src/renderer/src/lib/components/provider/ProviderSheet.svelte
+++ b/desktop-electron/src/renderer/src/lib/components/provider/ProviderSheet.svelte
@@ -198,16 +198,7 @@ async function handleSaveOptions() {
 }
 </script>
 
-<Sheet.Root bind:open onOpenChange={async (isOpen) => {
-  if (!isOpen && setup && !setupCompleted) {
-    try {
-      await providerDelete(provider.name)
-      ondeleted?.()
-    } catch {
-      // Provider may already be gone
-    }
-  }
-}}>
+<Sheet.Root bind:open>
   <Sheet.ResizableContent>
     <Sheet.Header class="p-6">
       <Sheet.Title class="flex items-center gap-2">

--- a/desktop-electron/src/renderer/src/lib/components/workspace/CreateWorkspaceSheet.svelte
+++ b/desktop-electron/src/renderer/src/lib/components/workspace/CreateWorkspaceSheet.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { onDestroy } from "svelte"
 import { goto } from "$lib/router.js"
-import { Check, ChevronsUpDown } from "@lucide/svelte"
+import { Check, ChevronsUpDown, TriangleAlert } from "@lucide/svelte"
 import { Button } from "$lib/components/ui/button/index.js"
 import * as Command from "$lib/components/ui/command/index.js"
 import { Input } from "$lib/components/ui/input/index.js"
@@ -293,6 +293,18 @@ async function handleSubmit() {
         </div>
       {/if}
 
+      {#if $providers.length === 0}
+        <div class="flex items-start gap-3 rounded-md border border-destructive bg-destructive/10 p-3 text-sm text-destructive">
+          <TriangleAlert class="mt-0.5 h-4 w-4 shrink-0" />
+          <div class="flex flex-col gap-2">
+            <span>No providers configured. You need at least one provider to create a workspace.</span>
+            <Button variant="outline" size="sm" onclick={() => { open = false; goto('/providers/add') }}>
+              Add Provider
+            </Button>
+          </div>
+        </div>
+      {/if}
+
       <form class="space-y-4" onsubmit={(e) => { e.preventDefault(); handleSubmit() }}>
         <div class="space-y-1.5">
           <Label class="text-sm">Source *</Label>
@@ -344,6 +356,14 @@ async function handleSubmit() {
                       </Command.Item>
                     {/each}
                   </Command.Group>
+                  <Command.Separator />
+                  <Command.Item
+                    value="__add_provider__"
+                    class="justify-start text-muted-foreground"
+                    onSelect={() => { providerComboOpen = false; providerSearch = ""; open = false; goto('/providers/add') }}
+                  >
+                    + Add Provider
+                  </Command.Item>
                 </Command.List>
               </Command.Root>
             </Popover.Content>
@@ -385,7 +405,7 @@ async function handleSubmit() {
         </div>
 
         <Sheet.Footer class="px-0 pt-2">
-          <Button type="submit" disabled={submitting} class="w-full">
+          <Button type="submit" disabled={submitting || $providers.length === 0} class="w-full">
             {#if submitting}<Spinner />{/if}
             {submitting ? "Creating..." : "Create Workspace"}
           </Button>

--- a/desktop-electron/src/renderer/src/pages/ProviderAddPage.svelte
+++ b/desktop-electron/src/renderer/src/pages/ProviderAddPage.svelte
@@ -5,7 +5,7 @@ import { Button } from "$lib/components/ui/button/index.js"
 import { Input } from "$lib/components/ui/input/index.js"
 import { Label } from "$lib/components/ui/label/index.js"
 import ProviderIcon from "$lib/components/provider/ProviderIcon.svelte"
-import { providerAdd } from "$lib/ipc/commands.js"
+import { providerAdd, providerUse } from "$lib/ipc/commands.js"
 import { providers } from "$lib/stores/providers.js"
 import { toasts } from "$lib/stores/toasts.js"
 
@@ -61,6 +61,7 @@ async function doAdd(name: string, source?: string) {
   submitting = true
   try {
     await providerAdd(name, source !== name ? source : undefined)
+    await providerUse(name)
     toasts.success(`Added provider ${name}`)
     goto(`/providers?setup=${name}`)
   } catch (err) {


### PR DESCRIPTION
## Summary

- **Empty-provider banner**: When no providers are configured, the Create Workspace sheet shows a warning banner with a TriangleAlert icon and an "Add Provider" button that navigates to `/providers/add`. The "Create Workspace" submit button is also disabled when no providers exist.
- **Add-provider link in dropdown**: A `+ Add Provider` option at the bottom of the provider combo dropdown allows quick navigation to add a provider from within the workspace creation flow.
- **Auto-initialize provider on add**: `providerUse()` is now called automatically after `providerAdd()` in `ProviderAddPage`, so newly added providers are initialized immediately without requiring the user to complete the setup sheet.
- **Remove aggressive setup deletion**: Dismissing the provider setup sheet no longer deletes the newly added provider, since it's already initialized from the add flow.