### PR TITLE
refactor: migrate os.TempDir() callsites to PathManager (Phase 4)

### DIFF
--- a/cmd/profile.go
+++ b/cmd/profile.go
@@ -8,6 +8,9 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"os"
+	"path/filepath"
+
+	"github.com/devsy-org/devsy/pkg/config"
 )
 
 func init() {
@@ -23,12 +26,21 @@ func init() {
 			return
 		}
 
-		f, err := os.OpenFile("/tmp/pprof_ports", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		stateDir, err := config.DefaultPathManager().StateDir()
 		if err == nil {
-			f.Write(
-				[]byte(fmt.Sprintf("%d=%d\n", os.Getpid(), listener.Addr().(*net.TCPAddr).Port)),
+			_ = os.MkdirAll(stateDir, 0o755)
+			f, err := os.OpenFile(
+				filepath.Join(stateDir, "pprof_ports"),
+				os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644,
 			)
-			f.Close()
+			if err == nil {
+				f.Write(
+					[]byte(fmt.Sprintf(
+						"%d=%d\n", os.Getpid(), listener.Addr().(*net.TCPAddr).Port,
+					)),
+				)
+				f.Close()
+			}
 		}
 
 		http.Serve(listener, myMux)

--- a/pkg/agent/binary.go
+++ b/pkg/agent/binary.go
@@ -25,8 +25,12 @@ type BinaryManager struct {
 	sources []BinarySource
 }
 
-func NewBinaryManager(downloadURL string) *BinaryManager {
-	cachePath := filepath.Join(os.TempDir(), config.BinaryName+"-cache")
+func NewBinaryManager(downloadURL string) (*BinaryManager, error) {
+	cachePath, err := config.DefaultPathManager().AgentCacheDir()
+	if err != nil {
+		return nil, fmt.Errorf("agent cache dir: %w", err)
+	}
+
 	cache := &BinaryCache{BaseDir: cachePath}
 
 	return &BinaryManager{
@@ -35,7 +39,7 @@ func NewBinaryManager(downloadURL string) *BinaryManager {
 			&FileCacheSource{Cache: cache},
 			&HTTPDownloadSource{BaseURL: downloadURL, Cache: cache},
 		},
-	}
+	}, nil
 }
 
 func (m *BinaryManager) AcquireBinary(ctx context.Context, arch string) (io.ReadCloser, error) {

--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -172,7 +172,10 @@ func InjectAgent(opts *InjectOptions) error {
 	}
 
 	vc := newVersionChecker(opts)
-	bm := NewBinaryManager(opts.DownloadURL)
+	bm, err := NewBinaryManager(opts.DownloadURL)
+	if err != nil {
+		return fmt.Errorf("create binary manager: %w", err)
+	}
 
 	backoff := wait.Backoff{
 		Steps:    30,

--- a/pkg/command/background.go
+++ b/pkg/command/background.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 
+	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/gofrs/flock"
 )
 
@@ -21,9 +21,18 @@ type CreateCommand func() (*exec.Cmd, error)
 // command already has Stdout/Stderr configured. The PID is recorded in
 // TMPDIR/commandName.pid. These files are not cleaned up on exit.
 func StartBackgroundOnce(commandName string, createCommand CreateCommand) error {
-	lockFile := filepath.Join(os.TempDir(), commandName+".lock")
-	pidFile := filepath.Join(os.TempDir(), commandName+".pid")
-	streamsFile := filepath.Join(os.TempDir(), commandName+".streams")
+	lockFile, err := config.DefaultPathManager().ProcessLockFile(commandName)
+	if err != nil {
+		return fmt.Errorf("process lock file: %w", err)
+	}
+	pidFile, err := config.DefaultPathManager().ProcessPIDFile(commandName)
+	if err != nil {
+		return fmt.Errorf("process pid file: %w", err)
+	}
+	streamsFile, err := config.DefaultPathManager().ProcessStreamsFile(commandName)
+	if err != nil {
+		return fmt.Errorf("process streams file: %w", err)
+	}
 
 	// Create a file-based lock to prevent multiple invocations of this function
 	// before the process is created.

--- a/pkg/daemon/agent/daemon.go
+++ b/pkg/daemon/agent/daemon.go
@@ -329,7 +329,10 @@ func RemoveDaemon() error {
 // identity via /proc/{pid}/exe to avoid killing an unrelated process that
 // reused the PID after a reboot.
 func stopFallbackDaemon() error {
-	pidFile := filepath.Join(os.TempDir(), pkgconfig.DaemonProcessName+".pid")
+	pidFile, err := pkgconfig.DefaultPathManager().DaemonPIDFile()
+	if err != nil {
+		return fmt.Errorf("daemon pid file: %w", err)
+	}
 	pidData, err := os.ReadFile(pidFile) // #nosec G304: not user input
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/pkg/devcontainer/feature/features.go
+++ b/pkg/devcontainer/feature/features.go
@@ -122,9 +122,14 @@ func ProcessFeatureID(
 }
 
 func checkFeatureCache(id string) (string, bool) {
-	featureFolder := getFeaturesTempFolder(id)
+	featureFolder, err := getFeaturesTempFolder(id)
+	if err != nil {
+		log.Debugf("failed to resolve feature cache dir: %v", err)
+		return "", false
+	}
+
 	featureExtractedFolder := filepath.Join(featureFolder, "extracted")
-	_, err := os.Stat(featureExtractedFolder)
+	_, err = os.Stat(featureExtractedFolder)
 	if err == nil {
 		// make sure feature.json is there as well
 		_, err = os.Stat(
@@ -148,7 +153,11 @@ func processOCIFeature(id string) (string, error) {
 		return cached, nil
 	}
 
-	featureFolder := getFeaturesTempFolder(id)
+	featureFolder, err := getFeaturesTempFolder(id)
+	if err != nil {
+		return "", fmt.Errorf("resolve feature cache dir: %w", err)
+	}
+
 	featureExtractedFolder := filepath.Join(featureFolder, "extracted")
 
 	ref, err := name.ParseReference(id)
@@ -291,9 +300,13 @@ func processDirectTarFeature(
 	}
 
 	// feature already exists?
-	featureFolder := getFeaturesTempFolder(id)
+	featureFolder, err := getFeaturesTempFolder(id)
+	if err != nil {
+		return "", fmt.Errorf("resolve feature cache dir: %w", err)
+	}
+
 	featureExtractedFolder := filepath.Join(featureFolder, "extracted")
-	_, err := os.Stat(featureExtractedFolder)
+	_, err = os.Stat(featureExtractedFolder)
 	if err == nil && !forceDownload {
 		log.Debugf("direct tar feature already cached: folder=%s", featureExtractedFolder)
 		return featureExtractedFolder, nil
@@ -407,7 +420,8 @@ func tryDownload(url, destFile string, httpHeaders map[string]string) error {
 	return nil
 }
 
-func getFeaturesTempFolder(id string) string {
+func getFeaturesTempFolder(id string) (string, error) {
 	hashedID := hash.String(id)[:10]
-	return filepath.Join(os.TempDir(), pkgconfig.BinaryName, "features", hashedID)
+
+	return pkgconfig.DefaultPathManager().FeatureCacheDir(hashedID)
 }

--- a/pkg/dockercredentials/helper.go
+++ b/pkg/dockercredentials/helper.go
@@ -163,8 +163,12 @@ func sanitizeServerURL(serverURL string) string {
 }
 
 func (h *Helper) logError(operation string, err error) {
-	logPath := filepath.Join(os.TempDir(), logFileName)
-	// #nosec G304 -- log file path is controlled and in temp directory
+	logDir, lerr := config.DefaultPathManager().LogDir()
+	if lerr != nil {
+		return
+	}
+	logPath := filepath.Join(logDir, logFileName)
+	// #nosec G304 -- log file path is controlled
 	f, ferr := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if ferr != nil {
 		return

--- a/pkg/provider/download.go
+++ b/pkg/provider/download.go
@@ -32,7 +32,6 @@ const (
 	tarSuffix   = ".tar"
 	tgzSuffix   = ".tgz"
 	zipSuffix   = ".zip"
-	cacheDir    = config.BinaryName + "-binaries"
 )
 
 var (
@@ -246,7 +245,12 @@ func toCache(binary *ProviderBinary, binaryPath string) {
 		return
 	}
 
-	cachedBinaryPath := getCachedBinaryPath(binary.Path)
+	cachedBinaryPath, err := getCachedBinaryPath(binary.Path)
+	if err != nil {
+		log.Warnf("error resolving cache path: %v", err)
+		return
+	}
+
 	if err := os.MkdirAll(filepath.Dir(cachedBinaryPath), dirPerms); err != nil {
 		log.Warnf("error creating cache directory: %v", err)
 		return
@@ -263,7 +267,12 @@ func fromCache(binary *ProviderBinary, targetFolder string) bool {
 	}
 
 	binaryPath := getBinaryPath(binary, targetFolder)
-	cachedBinaryPath := getCachedBinaryPath(binary.Path)
+	cachedBinaryPath, err := getCachedBinaryPath(binary.Path)
+	if err != nil {
+		log.Warnf("error resolving cache path: %v", err)
+		return false
+	}
+
 	if !verifyOrRemoveBinary(cachedBinaryPath, binary.Checksum) {
 		return false
 	}
@@ -286,13 +295,15 @@ func fromCache(binary *ProviderBinary, targetFolder string) bool {
 	return true
 }
 
-func getCachedBinaryPath(url string) string {
-	h := hash.String(url)
-	cacheBase := os.TempDir()
-	if userCache, err := os.UserCacheDir(); err == nil {
-		cacheBase = userCache
+func getCachedBinaryPath(url string) (string, error) {
+	cacheDir, err := config.DefaultPathManager().ProviderDownloadCacheDir()
+	if err != nil {
+		return "", fmt.Errorf("provider download cache dir: %w", err)
 	}
-	return filepath.Join(cacheBase, cacheDir, h)
+
+	h := hash.String(url)
+
+	return filepath.Join(cacheDir, h), nil
 }
 
 func verifyOrRemoveBinary(binaryPath, checksum string) bool {

--- a/pkg/ssh/keys.go
+++ b/pkg/ssh/keys.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/provider"
-	"github.com/devsy-org/devsy/pkg/util"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -82,34 +81,42 @@ func GetPrivateKeyRaw(context, workspaceID string) ([]byte, error) {
 	return GetPrivateKeyRawBase(workspaceDir)
 }
 
-func GetDevsyKeysDir() string {
-	dir, err := util.UserHomeDir()
-	if err == nil {
-		tempDir := filepath.Join(dir, config.ConfigDirName, "keys")
-		// #nosec G301 -- TODO Consider using a more secure permission setting and ownership if needed.
-		err = os.MkdirAll(tempDir, 0o755)
-		if err == nil {
-			return tempDir
-		}
+func GetDevsyKeysDir() (string, error) {
+	dir, err := config.DefaultPathManager().SSHKeysDir()
+	if err != nil {
+		return "", fmt.Errorf("ssh keys dir: %w", err)
 	}
 
-	tempDir := os.TempDir()
-	return filepath.Join(tempDir, config.BinaryName+"-ssh")
+	// #nosec G301 -- TODO Consider using a more secure permission setting and ownership if needed.
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("create ssh keys dir: %w", err)
+	}
+
+	return dir, nil
 }
 
 func GetDevsyHostKey() (string, error) {
-	tempDir := GetDevsyKeysDir()
-	return GetHostKeyBase(tempDir)
+	dir, err := GetDevsyKeysDir()
+	if err != nil {
+		return "", err
+	}
+	return GetHostKeyBase(dir)
 }
 
 func GetDevsyPublicKey() (string, error) {
-	tempDir := GetDevsyKeysDir()
-	return GetPublicKeyBase(tempDir)
+	dir, err := GetDevsyKeysDir()
+	if err != nil {
+		return "", err
+	}
+	return GetPublicKeyBase(dir)
 }
 
 func GetDevsyPrivateKeyRaw() ([]byte, error) {
-	tempDir := GetDevsyKeysDir()
-	return GetPrivateKeyRawBase(tempDir)
+	dir, err := GetDevsyKeysDir()
+	if err != nil {
+		return nil, err
+	}
+	return GetPrivateKeyRawBase(dir)
 }
 
 func GetHostKey(context, workspaceID string) (string, error) {

--- a/pkg/ssh/server/agent.go
+++ b/pkg/ssh/server/agent.go
@@ -6,26 +6,32 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/ssh"
 )
 
 func setupAgentListener(reuseSock string) (net.Listener, string, error) {
-	// on some systems (like containers) /tmp may not exists, this ensures
-	// that we have a compliant directory structure
-	err := os.MkdirAll("/tmp", 0o755) // #nosec G301
+	runtimeDir, err := config.DefaultPathManager().RuntimeDir()
 	if err != nil {
-		return nil, "", fmt.Errorf("create /tmp dir: %w", err)
+		return nil, "", fmt.Errorf("runtime dir: %w", err)
+	}
+
+	// Ensure the runtime directory exists (on some systems like containers
+	// it may not exist yet).
+	err = os.MkdirAll(runtimeDir, 0o755) // #nosec G301
+	if err != nil {
+		return nil, "", fmt.Errorf("create runtime dir: %w", err)
 	}
 
 	// Check if we should create a "shared" socket to be reused by clients
 	// used for browser tunnels such as openvscode, since the IDE itself doesn't create an SSH connection it uses a "backhaul" connection and uses the existing socket
 	dir := ""
 	if reuseSock != "" {
-		dir = filepath.Join(os.TempDir(), fmt.Sprintf("auth-agent-%s", reuseSock))
+		dir = filepath.Join(runtimeDir, fmt.Sprintf("auth-agent-%s", reuseSock))
 		// #nosec G301 -- TODO Consider using a more secure permission setting and ownership if needed.
 		err = os.MkdirAll(dir, 0o755)
 		if err != nil {
-			return nil, "", fmt.Errorf("creating SSH_AUTH_SOCK dir in /tmp: %w", err)
+			return nil, "", fmt.Errorf("creating SSH_AUTH_SOCK dir: %w", err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **4d**: Migrated background process PID/lock/streams files (`pkg/command/background.go`) and daemon PID file (`pkg/daemon/agent/daemon.go`) from `os.TempDir()` to `PathManager.ProcessLockFile()`, `ProcessPIDFile()`, `ProcessStreamsFile()`, and `DaemonPIDFile()`
- **4e**: Changed `GetDevsyKeysDir()` in `pkg/ssh/keys.go` from returning `string` to `(string, error)`, using `PathManager.SSHKeysDir()` instead of manual home-dir fallback logic. Updated all callers (`GetDevsyHostKey`, `GetDevsyPublicKey`, `GetDevsyPrivateKeyRaw`)
- **4f**: Replaced hardcoded `/tmp` and `os.TempDir()` in SSH agent socket setup (`pkg/ssh/server/agent.go`) with `PathManager.RuntimeDir()`
- **4g**: Migrated docker credential helper log path (`pkg/dockercredentials/helper.go`) from `os.TempDir()` to `PathManager.LogDir()`
- **4h**: Replaced hardcoded `/tmp/pprof_ports` in `cmd/profile.go` with `PathManager.StateDir()` + `pprof_ports`