### PR TITLE
feat(desktop): add stateful mock CLI and integration e2e tests

### DIFF
--- a/desktop-electron/e2e/electron-app.ts
+++ b/desktop-electron/e2e/electron-app.ts
@@ -1,8 +1,9 @@
 import { _electron as electron } from "@playwright/test"
 import type { ElectronApplication, Page } from "@playwright/test"
-import { resolve, dirname } from "node:path"
+import { resolve, dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
-import { chmodSync } from "node:fs"
+import { chmodSync, unlinkSync } from "node:fs"
+import { tmpdir } from "node:os"
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 
@@ -36,4 +37,12 @@ export async function launchApp(): Promise<{
   await page.waitForTimeout(4000)
 
   return { app, page }
+}
+
+export function resetMockState(): void {
+  try {
+    unlinkSync(join(tmpdir(), "devsy-mock-state.json"))
+  } catch {
+    // File doesn't exist, that's fine
+  }
 }

--- a/desktop-electron/e2e/fixtures/mock-devpod.cjs
+++ b/desktop-electron/e2e/fixtures/mock-devpod.cjs
@@ -118,6 +118,7 @@ while (i < args.length) {
 const cmd = positional[0] || ""
 const sub = positional[1] || ""
 const extra = positional[2] || ""
+const extra2 = positional[3] || ""
 
 function out(data) {
   process.stdout.write(typeof data === "string" ? data + "\n" : JSON.stringify(data, null, 2) + "\n")
@@ -185,7 +186,7 @@ switch (cmd) {
       }
       case "rename": {
         const oldName = extra
-        const newName = nameFlag
+        const newName = nameFlag || extra2
         if (oldName && newName && state.providers[oldName]) {
           const entry = state.providers[oldName]
           entry.config.name = newName

--- a/desktop-electron/e2e/fixtures/mock-devpod.cjs
+++ b/desktop-electron/e2e/fixtures/mock-devpod.cjs
@@ -3,34 +3,52 @@
 // Mock devpod binary for e2e tests (cross-platform Node.js version)
 // Returns canned JSON responses for each subcommand
 // Handles --output json, --skip-pro, and other flags the app sends
+// Persists state to a JSON file so provider/workspace CRUD works across calls
 
-const args = process.argv.slice(2)
+const fs = require("fs")
+const path = require("path")
+const os = require("os")
 
-// Collect positional args, skipping flags
-const positional = []
-let i = 0
-while (i < args.length) {
-  const arg = args[i]
-  if (arg === "--output") { i += 2; continue }
-  if (arg === "--skip-pro" || arg === "--force" || arg.startsWith("--use=")) { i++; continue }
-  if (arg === "-o" || arg === "--option") { i += 2; continue }
-  if (["--id", "--provider", "--ide", "--name", "--version", "--timeout"].includes(arg)) { i += 2; continue }
-  if (arg === "--recreate" || arg === "--reset" || arg === "--dry-run") { i++; continue }
-  if (arg.startsWith("-")) { i++; continue }
-  positional.push(arg)
-  i++
-}
+const STATE_FILE = path.join(os.tmpdir(), "devsy-mock-state.json")
 
-const cmd = positional[0] || ""
-const sub = positional[1] || ""
-
-function out(data) {
-  process.stdout.write(typeof data === "string" ? data + "\n" : JSON.stringify(data, null, 2) + "\n")
-}
-
-switch (cmd) {
-  case "list":
-    out([
+function defaultState() {
+  return {
+    providers: {
+      docker: {
+        config: {
+          name: "docker",
+          version: "v0.5.0",
+          icon: "https://devsy.sh/icons/docker.svg",
+          description: "Devsy on Docker",
+          source: { github: "devsy-org/devpod-provider-docker" },
+          options: {
+            DOCKER_HOST: {
+              displayName: "Docker Host",
+              description: "Docker daemon socket to connect to",
+              default: "unix:///var/run/docker.sock",
+              type: "string",
+            },
+          },
+          optionGroups: [],
+        },
+        state: { initialized: true },
+        default: true,
+      },
+      kubernetes: {
+        config: {
+          name: "kubernetes",
+          version: "v0.3.0",
+          icon: "https://devsy.sh/icons/k8s.svg",
+          description: "Devsy on Kubernetes",
+          source: { github: "devsy-org/devpod-provider-kubernetes" },
+          options: {},
+          optionGroups: [],
+        },
+        state: { initialized: false },
+        default: false,
+      },
+    },
+    workspaces: [
       {
         id: "test-workspace",
         uid: "ws-001",
@@ -53,47 +71,67 @@ switch (cmd) {
         creationTimestamp: "2026-04-19T09:00:00Z",
         context: "default",
       },
-    ])
+    ],
+  }
+}
+
+function loadState() {
+  try {
+    const data = fs.readFileSync(STATE_FILE, "utf8")
+    return JSON.parse(data)
+  } catch {
+    return defaultState()
+  }
+}
+
+function saveState(state) {
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), "utf8")
+}
+
+const state = loadState()
+
+const args = process.argv.slice(2)
+
+// Collect positional args and named flag values
+const positional = []
+let idFlag = ""
+let providerFlag = ""
+let ideFlag = ""
+let nameFlag = ""
+let i = 0
+while (i < args.length) {
+  const arg = args[i]
+  if (arg === "--output") { i += 2; continue }
+  if (arg === "--skip-pro" || arg === "--force" || arg.startsWith("--use=")) { i++; continue }
+  if (arg === "-o" || arg === "--option") { i += 2; continue }
+  if (arg === "--id") { idFlag = args[i + 1] || ""; i += 2; continue }
+  if (arg === "--provider") { providerFlag = args[i + 1] || ""; i += 2; continue }
+  if (arg === "--ide") { ideFlag = args[i + 1] || ""; i += 2; continue }
+  if (arg === "--name") { nameFlag = args[i + 1] || ""; i += 2; continue }
+  if (["--version", "--timeout"].includes(arg)) { i += 2; continue }
+  if (arg === "--recreate" || arg === "--reset" || arg === "--dry-run") { i++; continue }
+  if (arg.startsWith("-")) { i++; continue }
+  positional.push(arg)
+  i++
+}
+
+const cmd = positional[0] || ""
+const sub = positional[1] || ""
+const extra = positional[2] || ""
+
+function out(data) {
+  process.stdout.write(typeof data === "string" ? data + "\n" : JSON.stringify(data, null, 2) + "\n")
+}
+
+switch (cmd) {
+  case "list":
+    out(state.workspaces)
     break
 
   case "provider":
     switch (sub) {
       case "list":
-        out({
-          docker: {
-            config: {
-              name: "docker",
-              version: "v0.5.0",
-              icon: "https://devsy.sh/icons/docker.svg",
-              description: "Devsy on Docker",
-              source: { github: "devsy-org/devpod-provider-docker" },
-              options: {
-                DOCKER_HOST: {
-                  displayName: "Docker Host",
-                  description: "Docker daemon socket to connect to",
-                  default: "unix:///var/run/docker.sock",
-                  type: "string",
-                },
-              },
-              optionGroups: [],
-            },
-            state: { initialized: true },
-            default: true,
-          },
-          kubernetes: {
-            config: {
-              name: "kubernetes",
-              version: "v0.3.0",
-              icon: "https://devsy.sh/icons/k8s.svg",
-              description: "Devsy on Kubernetes",
-              source: { github: "devsy-org/devpod-provider-kubernetes" },
-              options: {},
-              optionGroups: [],
-            },
-            state: { initialized: false },
-            default: false,
-          },
-        })
+        out(state.providers)
         break
       case "options":
         out({
@@ -115,12 +153,64 @@ switch (cmd) {
           },
         })
         break
-      case "add":
-      case "delete":
-      case "use":
-      case "update":
+      case "add": {
+        const provName = extra
+        if (provName) {
+          state.providers[provName] = {
+            config: {
+              name: provName,
+              version: "v0.1.0",
+              icon: "",
+              description: "",
+              source: {},
+              options: {},
+              optionGroups: [],
+            },
+            state: { initialized: false },
+            default: false,
+          }
+          saveState(state)
+        }
+        out("")
+        break
+      }
+      case "delete": {
+        const provName = extra
+        if (provName && state.providers[provName]) {
+          delete state.providers[provName]
+          saveState(state)
+        }
+        out("")
+        break
+      }
+      case "rename": {
+        const oldName = extra
+        const newName = nameFlag
+        if (oldName && newName && state.providers[oldName]) {
+          const entry = state.providers[oldName]
+          entry.config.name = newName
+          state.providers[newName] = entry
+          delete state.providers[oldName]
+          saveState(state)
+        }
+        out("")
+        break
+      }
+      case "use": {
+        const provName = extra
+        if (provName && state.providers[provName]) {
+          for (const key of Object.keys(state.providers)) {
+            state.providers[key].default = false
+          }
+          state.providers[provName].state.initialized = true
+          state.providers[provName].default = true
+          saveState(state)
+        }
+        out("")
+        break
+      }
       case "set-options":
-      case "rename":
+      case "update":
         out("")
         break
       default:
@@ -189,17 +279,15 @@ switch (cmd) {
     }
     break
 
-  case "status":
-    // Return per-workspace status based on workspace ID
-    switch (sub) {
-      case "dev-env":
-        out({ state: "Stopped" })
-        break
-      default:
-        out({ state: "Running" })
-        break
+  case "status": {
+    const ws = state.workspaces.find((w) => w.id === sub)
+    if (ws) {
+      out({ state: ws.status })
+    } else {
+      out({ state: "NotFound" })
     }
     break
+  }
 
   case "version":
     out("v0.1.0-test")
@@ -210,25 +298,54 @@ switch (cmd) {
     process.exit(0)
     break
 
-  case "up":
+  case "up": {
+    const source = sub
     out("Resolving source...")
     out("Pulling image...")
     out("Starting workspace...")
     out("Workspace ready.")
+    const wsId = idFlag || (source ? source.split("/").pop().replace(".git", "") : "") || "workspace"
+    state.workspaces.push({
+      id: wsId,
+      uid: "ws-" + Date.now(),
+      source: { gitRepository: source },
+      provider: { name: providerFlag || "docker" },
+      ide: { name: ideFlag || "none" },
+      status: "Running",
+      lastUsedTimestamp: new Date().toISOString(),
+      creationTimestamp: new Date().toISOString(),
+      context: "default",
+    })
+    saveState(state)
     process.exit(0)
     break
+  }
 
-  case "stop":
+  case "stop": {
+    const wsId = sub
     out("Stopping workspace...")
     out("Workspace stopped.")
+    const ws = state.workspaces.find((w) => w.id === wsId)
+    if (ws) {
+      ws.status = "Stopped"
+      saveState(state)
+    }
     process.exit(0)
     break
+  }
 
-  case "delete":
+  case "delete": {
+    const wsId = sub
     out("Deleting workspace...")
     out("Workspace deleted.")
+    const idx = state.workspaces.findIndex((w) => w.id === wsId)
+    if (idx !== -1) {
+      state.workspaces.splice(idx, 1)
+      saveState(state)
+    }
     process.exit(0)
     break
+  }
 
   case "upgrade":
     out("Already up to date.")

--- a/desktop-electron/e2e/integration.e2e.ts
+++ b/desktop-electron/e2e/integration.e2e.ts
@@ -1,0 +1,399 @@
+import { test, expect } from "@playwright/test"
+import type { ElectronApplication, Page } from "@playwright/test"
+import { launchApp, resetMockState } from "./electron-app.js"
+
+// ---------------------------------------------------------------------------
+// Flow 1 — Provider CRUD
+// ---------------------------------------------------------------------------
+test.describe.serial("Provider CRUD", () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async () => {
+    resetMockState()
+    ;({ app, page } = await launchApp())
+  })
+
+  test.afterAll(async () => {
+    await app.close()
+  })
+
+  test("should show default providers", async () => {
+    await page.click('[data-sidebar="sidebar"] a[href="#/providers"]')
+    await page
+      .locator('[data-slot="sidebar-inset"] h1')
+      .first()
+      .waitFor({ timeout: 5000 })
+    await page
+      .locator('[data-slot="sidebar-inset"] main button')
+      .first()
+      .waitFor({ timeout: 10000 })
+
+    const main = page.locator('[data-slot="sidebar-inset"] main')
+    await expect(main).toContainText("docker", { timeout: 10000 })
+    await expect(main).toContainText("kubernetes", { timeout: 10000 })
+  })
+
+  test("should delete docker provider", async () => {
+    const main = page.locator('[data-slot="sidebar-inset"] main')
+    await main.locator("button", { hasText: "docker" }).first().click()
+
+    // Wait for the ProviderSheet to open (use data-slot to target it specifically)
+    const sheet = page.locator('[data-slot="sheet-content"]')
+    await sheet.waitFor({ timeout: 5000 })
+
+    // Click Delete in the sheet
+    await sheet.getByRole("button", { name: "Delete" }).click()
+
+    // ConfirmDialog appears — click its destructive Delete button
+    const confirmDialog = page.locator('[data-slot="dialog-content"]')
+    await confirmDialog.waitFor({ timeout: 5000 })
+    await confirmDialog.getByRole("button", { name: "Delete" }).click()
+
+    // Wait for both dialogs to close
+    await sheet.waitFor({ state: "hidden", timeout: 10000 })
+
+    // Wait for watcher to poll updated state
+    await page.waitForTimeout(4000)
+
+    // Verify docker is gone
+    await expect(main).not.toContainText("docker", { timeout: 10000 })
+    await expect(main).toContainText("kubernetes", { timeout: 10000 })
+  })
+
+  test("should delete kubernetes provider", async () => {
+    const main = page.locator('[data-slot="sidebar-inset"] main')
+    await main.locator("button", { hasText: "kubernetes" }).first().click()
+
+    const sheet = page.locator('[data-slot="sheet-content"]')
+    await sheet.waitFor({ timeout: 5000 })
+
+    await sheet.getByRole("button", { name: "Delete" }).click()
+
+    const confirmDialog = page.locator('[data-slot="dialog-content"]')
+    await confirmDialog.waitFor({ timeout: 5000 })
+    await confirmDialog.getByRole("button", { name: "Delete" }).click()
+
+    await sheet.waitFor({ state: "hidden", timeout: 10000 })
+    await page.waitForTimeout(4000)
+
+    // Empty state should appear
+    await expect(
+      page.locator('[data-slot="sidebar-inset"]'),
+    ).toContainText("No providers configured yet", { timeout: 10000 })
+  })
+
+  test("should add docker provider from preset", async () => {
+    // Click the empty-state "Add your first provider" button
+    await page
+      .getByRole("button", { name: /add your first provider/i })
+      .click()
+
+    // Wait for the Add Provider page heading
+    await page.locator("h1", { hasText: "Add Provider" }).waitFor({ timeout: 5000 })
+
+    // Click docker preset card
+    await page
+      .locator("button", { hasText: "docker" })
+      .filter({ hasText: "Local Docker containers" })
+      .click()
+
+    // doAdd() calls providerAdd, providerUse, then goto('/providers?setup=docker')
+    // Wait for redirect back to providers page
+    await page
+      .locator('[data-slot="sidebar-inset"] h1', { hasText: /providers/i })
+      .waitFor({ timeout: 10000 })
+
+    // Wait for the watcher to pick up the new provider
+    await page.waitForTimeout(4000)
+
+    // Verify docker appears in provider cards
+    const main = page.locator('[data-slot="sidebar-inset"] main')
+    await expect(main).toContainText("docker", { timeout: 10000 })
+
+    // The setup flow auto-opens the ProviderSheet — close it if open
+    const setupSheet = page.locator('[data-slot="sheet-content"]')
+    if (await setupSheet.isVisible()) {
+      await page.keyboard.press("Escape")
+      await setupSheet.waitFor({ state: "hidden", timeout: 5000 })
+    }
+  })
+
+  test("should rename docker provider to my-docker", async () => {
+    const main = page.locator('[data-slot="sidebar-inset"] main')
+    await main.locator("button", { hasText: "docker" }).first().click()
+
+    const sheet = page.locator('[data-slot="sheet-content"]')
+    await sheet.waitFor({ timeout: 5000 })
+
+    // Click Rename button in the sheet header
+    await sheet.getByRole("button", { name: "Rename" }).click()
+
+    // Fill the rename input
+    const renameInput = sheet.locator("input").first()
+    await renameInput.fill("my-docker")
+
+    // Click Save in the rename form (the first Save button in the sheet header)
+    await sheet.getByRole("button", { name: "Save" }).first().click()
+
+    // Sheet closes after successful rename
+    await sheet.waitFor({ state: "hidden", timeout: 10000 })
+
+    // Wait for watcher
+    await page.waitForTimeout(4000)
+
+    // Verify 'my-docker' appears
+    await expect(main).toContainText("my-docker", { timeout: 10000 })
+  })
+
+  test("should delete renamed provider", async () => {
+    const main = page.locator('[data-slot="sidebar-inset"] main')
+    await main.locator("button", { hasText: "my-docker" }).first().click()
+
+    const sheet = page.locator('[data-slot="sheet-content"]')
+    await sheet.waitFor({ timeout: 5000 })
+
+    await sheet.getByRole("button", { name: "Delete" }).click()
+
+    const confirmDialog = page.locator('[data-slot="dialog-content"]')
+    await confirmDialog.waitFor({ timeout: 5000 })
+    await confirmDialog.getByRole("button", { name: "Delete" }).click()
+
+    await sheet.waitFor({ state: "hidden", timeout: 10000 })
+    await page.waitForTimeout(4000)
+
+    await expect(main).not.toContainText("my-docker", { timeout: 10000 })
+  })
+
+  test("should re-add docker provider", async () => {
+    // After deleting all, empty state should show
+    await page
+      .getByRole("button", { name: /add your first provider/i })
+      .click()
+
+    await page.locator("h1", { hasText: "Add Provider" }).waitFor({ timeout: 5000 })
+
+    await page
+      .locator("button", { hasText: "docker" })
+      .filter({ hasText: "Local Docker containers" })
+      .click()
+
+    await page
+      .locator('[data-slot="sidebar-inset"] h1', { hasText: /providers/i })
+      .waitFor({ timeout: 10000 })
+
+    await page.waitForTimeout(4000)
+
+    const main = page.locator('[data-slot="sidebar-inset"] main')
+    await expect(main).toContainText("docker", { timeout: 10000 })
+
+    // Close setup sheet if it auto-opened
+    const setupSheet = page.locator('[data-slot="sheet-content"]')
+    if (await setupSheet.isVisible()) {
+      await page.keyboard.press("Escape")
+      await setupSheet.waitFor({ state: "hidden", timeout: 5000 })
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Flow 2 — Workspace lifecycle (Node.js)
+// ---------------------------------------------------------------------------
+test.describe.serial("Workspace lifecycle - Node.js", () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async () => {
+    resetMockState()
+    ;({ app, page } = await launchApp())
+  })
+
+  test.afterAll(async () => {
+    await app.close()
+  })
+
+  test("should show default workspaces", async () => {
+    await page.click('[data-sidebar="sidebar"] a[href="#/workspaces"]')
+    await page.locator("table").waitFor({ timeout: 10000 })
+
+    const table = page.locator("table")
+    await expect(table).toContainText("test-workspace", { timeout: 10000 })
+    await expect(table).toContainText("dev-env", { timeout: 10000 })
+  })
+
+  test("should create Node.js workspace", async () => {
+    await page.getByRole("button", { name: /create workspace/i }).click()
+
+    const sheet = page.locator('[role="dialog"]')
+    await sheet.waitFor({ timeout: 5000 })
+
+    // Click Node.js template
+    await sheet.locator("button", { hasText: "Node.js" }).click()
+
+    // Verify source input is populated
+    const sourceInput = sheet.locator('input[placeholder*="github"]')
+    await expect(sourceInput).toHaveValue(
+      "https://github.com/microsoft/vscode-remote-try-node",
+      { timeout: 5000 },
+    )
+
+    // Select IDE = None
+    await sheet.getByRole("button", { name: /select an ide/i }).click()
+    await page.locator('[role="option"]', { hasText: "None" }).click()
+
+    // Submit
+    await sheet.getByRole("button", { name: /create workspace/i }).click()
+
+    // Wait for output
+    await expect(sheet).toContainText("Output", { timeout: 15000 })
+    await expect(sheet).toContainText(/resolving|pulling|starting|ready/i, {
+      timeout: 15000,
+    })
+
+    // Wait for "Open Workspace" success button
+    await sheet
+      .getByRole("button", { name: /open workspace/i })
+      .waitFor({ timeout: 15000 })
+
+    // Close the sheet
+    await page.keyboard.press("Escape")
+    await sheet.waitFor({ state: "hidden", timeout: 5000 })
+
+    // Wait for watcher to pick up the new workspace
+    await page.waitForTimeout(4000)
+  })
+
+  test("should show new workspace in table", async () => {
+    // Workspace ID from template name: 'Node.js' → 'node-js'
+    await expect(page.locator("table")).toContainText("node-js", {
+      timeout: 10000,
+    })
+  })
+
+  test("should navigate to workspace detail and stop it", async () => {
+    // Click the workspace row
+    await page.locator("table tr", { hasText: "node-js" }).click()
+
+    // Wait for detail page
+    await page
+      .locator("h1", { hasText: "node-js" })
+      .waitFor({ timeout: 10000 })
+
+    // Click Stop
+    await page.getByRole("button", { name: "Stop" }).click()
+
+    // Wait for stop operation to complete
+    await page.waitForTimeout(5000)
+
+    // Verify the status badge in the header shows "Stopped"
+    // The header has: h1, provider badge, status badge — target the status badge near h1
+    const headerArea = page.locator("h1", { hasText: "node-js" }).locator("..")
+    await expect(headerArea).toContainText("Stopped", { timeout: 10000 })
+  })
+
+  test("should delete workspace from detail page", async () => {
+    // Click Delete button (the destructive one in the action bar)
+    await page.getByRole("button", { name: "Delete" }).click()
+
+    // ConfirmDialog appears — click the confirm Delete in the dialog
+    const confirmDialog = page.locator('[data-slot="dialog-content"]')
+    await confirmDialog.waitFor({ timeout: 5000 })
+    await confirmDialog.getByRole("button", { name: "Delete" }).click()
+
+    // Navigates to /workspaces on success — wait for table
+    await page.locator("table").waitFor({ timeout: 15000 })
+
+    // Verify node-js is gone
+    await expect(page.locator("table")).not.toContainText("node-js", {
+      timeout: 10000,
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Flow 3 — Workspace lifecycle (Python)
+// ---------------------------------------------------------------------------
+test.describe.serial("Workspace lifecycle - Python", () => {
+  let app: ElectronApplication
+  let page: Page
+
+  test.beforeAll(async () => {
+    resetMockState()
+    ;({ app, page } = await launchApp())
+  })
+
+  test.afterAll(async () => {
+    await app.close()
+  })
+
+  test("should create Python workspace", async () => {
+    await page.click('[data-sidebar="sidebar"] a[href="#/workspaces"]')
+    await page.locator("table").waitFor({ timeout: 10000 })
+
+    await page.getByRole("button", { name: /create workspace/i }).click()
+
+    const sheet = page.locator('[role="dialog"]')
+    await sheet.waitFor({ timeout: 5000 })
+
+    // Click Python template
+    await sheet.locator("button", { hasText: "Python" }).click()
+
+    // Verify source populated
+    const sourceInput = sheet.locator('input[placeholder*="github"]')
+    await expect(sourceInput).toHaveValue(
+      "https://github.com/microsoft/vscode-remote-try-python",
+      { timeout: 5000 },
+    )
+
+    // Select IDE = None
+    await sheet.getByRole("button", { name: /select an ide/i }).click()
+    await page.locator('[role="option"]', { hasText: "None" }).click()
+
+    // Submit
+    await sheet.getByRole("button", { name: /create workspace/i }).click()
+
+    // Wait for success
+    await sheet
+      .getByRole("button", { name: /open workspace/i })
+      .waitFor({ timeout: 15000 })
+
+    // Close sheet
+    await page.keyboard.press("Escape")
+    await sheet.waitFor({ state: "hidden", timeout: 5000 })
+
+    await page.waitForTimeout(4000)
+  })
+
+  test("should show python workspace in table", async () => {
+    // Template name 'Python' → workspace id 'python'
+    await expect(page.locator("table")).toContainText("python", {
+      timeout: 10000,
+    })
+  })
+
+  test("should delete python workspace", async () => {
+    // Click workspace row
+    await page.locator("table tr", { hasText: "python" }).click()
+
+    // Wait for detail page
+    await page
+      .locator("h1", { hasText: "python" })
+      .waitFor({ timeout: 10000 })
+
+    // Click Delete
+    await page.getByRole("button", { name: "Delete" }).click()
+
+    // Confirm in the dialog
+    const confirmDialog = page.locator('[data-slot="dialog-content"]')
+    await confirmDialog.waitFor({ timeout: 5000 })
+    await confirmDialog.getByRole("button", { name: "Delete" }).click()
+
+    // Wait for redirect to workspaces list
+    await page.locator("table").waitFor({ timeout: 15000 })
+
+    // Verify python workspace is gone
+    await expect(page.locator("table")).not.toContainText("python", {
+      timeout: 10000,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Makes the e2e mock CLI (`mock-devpod.cjs`) stateful by persisting provider and workspace data to a JSON file (`/tmp/devsy-mock-state.json`) between invocations, enabling realistic CRUD test flows
- Adds `resetMockState()` helper to `electron-app.ts` for clearing state between test runs
- Adds 15 new integration e2e tests in `integration.e2e.ts` covering three serial flows:
  - **Provider CRUD** (7 tests): show defaults, delete docker, delete kubernetes, add from preset, rename to my-docker, delete renamed, re-add docker
  - **Workspace lifecycle — Node.js** (5 tests): show defaults, create from template, verify in table, stop from detail page, delete from detail page
  - **Workspace lifecycle — Python** (3 tests): create from template, verify in table, delete from detail page

All 15 integration tests + 14 existing e2e tests + 113 unit tests pass.