### PR TITLE
feat(up): add --prebuild flag for devcontainer prebuild lifecycle

### DIFF
--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -50,6 +50,7 @@ type SetupContainerCmd struct {
 	ChownWorkspace         bool
 	StreamMounts           bool
 	InjectGitCredentials   bool
+	Prebuild               bool
 	ContainerWorkspaceInfo string
 	SetupInfo              string
 	AccessKey              string
@@ -72,6 +73,9 @@ func NewSetupContainerCmd(flags *flags.GlobalFlags) *cobra.Command {
 	}
 	setupContainerCmd.Flags().
 		BoolVar(&cmd.StreamMounts, "stream-mounts", false, "If true, will try to stream the bind mounts from the host")
+	setupContainerCmd.Flags().
+		BoolVar(&cmd.Prebuild, "prebuild", false,
+			"If true, only run prebuild lifecycle hooks (onCreateCommand + updateContentCommand)")
 	setupContainerCmd.Flags().
 		BoolVar(&cmd.ChownWorkspace, "chown-workspace", false, "If Devsy should chown the workspace to the remote user")
 	setupContainerCmd.Flags().
@@ -181,26 +185,29 @@ func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
 		ChownProjects:     cmd.ChownWorkspace,
 		PlatformOptions:   &sctx.workspaceInfo.CLIOptions.Platform,
 		TunnelClient:      sctx.tunnelClient,
+		Prebuild:          cmd.Prebuild,
 	}
 
 	if err := setup.SetupContainerPreAttach(sctx.ctx, cfg); err != nil {
 		return err
 	}
 
-	if err := cmd.installIDE(sctx.setupInfo, &sctx.workspaceInfo.IDE); err != nil {
-		return err
-	}
+	if !cmd.Prebuild {
+		if err := cmd.installIDE(sctx.setupInfo, &sctx.workspaceInfo.IDE); err != nil {
+			return err
+		}
 
-	if err := cmd.startContainerDaemon(sctx.workspaceInfo); err != nil {
-		return err
-	}
+		if err := cmd.startContainerDaemon(sctx.workspaceInfo); err != nil {
+			return err
+		}
 
-	// Launch postAttachCommand as a detached background process before sending
-	// the result. Once sendSetupResult returns, the client tears down the SSH
-	// tunnel which kills this process, so postAttach must already be running
-	// independently.
-	if err := cmd.startPostAttachHooks(sctx); err != nil {
-		log.Errorf("failed to start postAttachCommand: %v", err)
+		// Launch postAttachCommand as a detached background process before sending
+		// the result. Once sendSetupResult returns, the client tears down the SSH
+		// tunnel which kills this process, so postAttach must already be running
+		// independently.
+		if err := cmd.startPostAttachHooks(sctx); err != nil {
+			log.Errorf("failed to start postAttachCommand: %v", err)
+		}
 	}
 
 	return cmd.sendSetupResult(sctx.ctx, sctx.setupInfo, sctx.tunnelClient)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -217,6 +217,9 @@ func (cmd *UpCmd) registerWorkspaceFlags(upCmd *cobra.Command) {
 		BoolVar(&cmd.Reconfigure, "reconfigure", false,
 			"Reconfigure the options for this workspace. Only supported in Devsy Pro right now.")
 	upCmd.Flags().
+		BoolVar(&cmd.Prebuild, "prebuild", false,
+			"If true will only run the prebuild lifecycle (onCreateCommand + updateContentCommand) then stop")
+	upCmd.Flags().
 		BoolVar(&cmd.Recreate, "recreate", false, "If true will remove any existing containers and recreate them")
 	upCmd.Flags().
 		BoolVar(&cmd.Reset, "reset", false,
@@ -261,6 +264,10 @@ func (cmd *UpCmd) Run(
 	}
 	if wctx == nil {
 		return nil // Platform mode
+	}
+
+	if cmd.Prebuild {
+		return nil
 	}
 
 	if err := cmd.configureWorkspace(devsyConfig, client, wctx); err != nil {

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -189,6 +189,7 @@ func (r *runner) addSetupFlags(args *[]string) {
 	r.addChownFlag(args, isDockerDriver)
 	r.addDriverFlags(args, isDockerDriver)
 	r.addPlatformFlags(args)
+	r.addPrebuildFlag(args)
 	r.addDebugFlag(args)
 }
 
@@ -217,6 +218,12 @@ func (r *runner) addPlatformFlags(args *[]string) {
 	}
 	if platform.PlatformHost != "" {
 		*args = append(*args, "--platform-host", shellescape.Quote(platform.PlatformHost))
+	}
+}
+
+func (r *runner) addPrebuildFlag(args *[]string) {
+	if r.WorkspaceConfig.CLIOptions.Prebuild {
+		*args = append(*args, "--prebuild")
 	}
 }
 

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -50,7 +50,12 @@ func resolveLifecycleEnv(
 
 // RunPreAttachHooks runs lifecycle hooks up to and including postStartCommand.
 // These must complete before the IDE can be opened.
-func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result) error {
+//
+// When prebuild is true, only onCreateCommand and updateContentCommand are
+// executed (the devcontainer prebuild phase). updateContentCommand always
+// reruns during prebuild — the marker-file check is bypassed so that
+// content changes are picked up.
+func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, prebuild bool) error {
 	env := resolveLifecycleEnv(ctx, setupInfo)
 	containerDetails := setupInfo.ContainerDetails
 	mergedConfig := setupInfo.MergedConfig
@@ -61,16 +66,27 @@ func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result) error {
 		return err
 	}
 
-	// TODO: rerun when contents changed
+	// During prebuild, pass empty content so the marker check is bypassed
+	// and updateContentCommand always reruns (addresses the TODO below).
+	// During normal runs, use containerDetails.Created so it only runs once.
+	updateContentMarker := containerDetails.Created
+	if prebuild {
+		updateContentMarker = ""
+	}
 	if err := run(
 		mergedConfig.UpdateContentCommands,
 		env.remoteUser,
 		env.workspaceFolder,
 		env.remoteEnv,
 		"updateContentCommands",
-		containerDetails.Created,
+		updateContentMarker,
 	); err != nil {
 		return err
+	}
+
+	// Prebuild phase stops after updateContentCommand — skip the user-session hooks.
+	if prebuild {
+		return nil
 	}
 
 	// only run once per container run

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -94,7 +94,7 @@ func (s *LifecycleHookTestSuite) TestLifecycleHooksNoOpWithEmptyConfig() {
 	}
 
 	// Both functions should return nil with empty config (no commands to run)
-	err := RunPreAttachHooks(ctx, result)
+	err := RunPreAttachHooks(ctx, result, false)
 	assert.NoError(s.T(), err)
 
 	err = RunPostAttachHooks(ctx, result)

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -32,6 +32,7 @@ type ContainerSetupConfig struct {
 	SetupInfo         *config.Result
 	ExtraWorkspaceEnv []string
 	ChownProjects     bool
+	Prebuild          bool
 	PlatformOptions   *devsy.PlatformOptions
 	TunnelClient      tunnel.TunnelClient
 }
@@ -56,7 +57,7 @@ func SetupContainerPreAttach(ctx context.Context, cfg *ContainerSetupConfig) err
 	setupOptionalFeatures(ctx, cfg)
 
 	log.Debugf("running pre-attach lifecycle hooks")
-	if err := RunPreAttachHooks(ctx, cfg.SetupInfo); err != nil {
+	if err := RunPreAttachHooks(ctx, cfg.SetupInfo, cfg.Prebuild); err != nil {
 		return fmt.Errorf("lifecycle hooks pre-attach: %w", err)
 	}
 

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -218,6 +218,7 @@ type CLIOptions struct {
 	WorkspaceEnvFile            []string          `json:"workspaceEnvFile,omitempty"`
 	InitEnv                     []string          `json:"initEnv,omitempty"`
 	Recreate                    bool              `json:"recreate,omitempty"`
+	Prebuild                    bool              `json:"prebuild,omitempty"`
 	Reset                       bool              `json:"reset,omitempty"`
 	DisableDaemon               bool              `json:"disableDaemon,omitempty"`
 	DaemonInterval              string            `json:"daemonInterval,omitempty"`


### PR DESCRIPTION
## Summary

- Add `--prebuild` flag to `devsy up` that runs only the prebuild phase of the devcontainer lifecycle (onCreateCommand + updateContentCommand) then stops
- During prebuild, updateContentCommand always reruns (marker-file check is bypassed) so content changes are picked up
- IDE installation, SSH config, dotfiles, container daemon, and postAttach hooks are all skipped in prebuild mode
- The flag flows through the full call chain: `cmd/up.go` → `pkg/devcontainer/setup.go` → `cmd/agent/container/setup.go` → `pkg/devcontainer/setup/setup.go` → `pkg/devcontainer/setup/lifecyclehooks.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--prebuild` flag that skips IDE installation and daemon startup during container setup, running only pre-attach initialization steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->