### PR TITLE
fix(config): correct portsAttributes JSON struct tag typo

### DIFF
--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -57,7 +57,7 @@ type DevContainerConfigBase struct {
 	ForwardPorts types.StrIntArray `json:"forwardPorts,omitempty"`
 
 	// Set default properties that are applied when a specific port number is forwarded.
-	PortsAttributes map[string]PortAttribute `json:"portAttributes,omitempty"`
+	PortsAttributes map[string]PortAttribute `json:"portsAttributes,omitempty"`
 
 	// Set default properties that are applied to all ports that don't get properties from the setting `remote.portsAttributes`.
 	OtherPortsAttributes *PortAttribute `json:"otherPortsAttributes,omitempty"`


### PR DESCRIPTION
## Summary

The `PortsAttributes` field in `DevContainerConfigBase` had an incorrect JSON struct tag — `portAttributes` instead of `portsAttributes` (missing the 's'). This caused the devcontainer spec's `portsAttributes` property to be silently ignored during JSON unmarshaling, meaning all port attribute configuration from devcontainer.json was dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed port attributes configuration serialization to use the correct key format for configuration file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->