### PR TITLE
fix(build): bake devcontainer.metadata LABEL into built images

### DIFF
--- a/pkg/driver/docker/build.go
+++ b/pkg/driver/docker/build.go
@@ -97,6 +97,7 @@ func buildDockerBuildxArgs(options *build.BuildOptions, platform string) []strin
 	args = appendBuildFlags(args, options.Load, options.Push)
 	args = appendImageTags(args, options.Images)
 	args = appendBuildArgsAndContexts(args, options.BuildArgs, options.Contexts)
+	args = appendLabels(args, options.Labels)
 	args = appendTargetAndPlatform(args, options.Target, platform)
 	args = appendCacheOptions(args, options.CacheFrom, options.CacheTo)
 	args = append(args, options.CliOpts...)
@@ -141,6 +142,19 @@ func appendBuildArgsAndContexts(args []string, buildArgs, contexts map[string]st
 
 	for _, k := range contextKeys {
 		args = append(args, "--build-context", k+"="+contexts[k])
+	}
+	return args
+}
+
+func appendLabels(args []string, labels map[string]string) []string {
+	keys := make([]string, 0, len(labels))
+	for k := range labels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		args = append(args, "--label", k+"="+labels[k])
 	}
 	return args
 }


### PR DESCRIPTION
## Summary

- `BuildOptions.Labels` was correctly populated with the `devcontainer.metadata` label but never passed as `--label` flags to the `docker buildx build` command
- Added `appendLabels` helper (with sorted keys for deterministic output) and wired it into `buildDockerBuildxArgs`, matching the existing pattern used by `appendBuildArgsAndContexts`
- The buildkit code paths already handled labels correctly; this fix closes the gap for the docker buildx path