### PR TITLE
ci: gate build and test jobs on pre-commit and lint checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: jlumbroso/free-disk-space@v1.3.1
-
       - uses: actions/checkout@v6
 
       - name: setup Go

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -44,8 +44,6 @@ jobs:
     name: Lint Gate
     runs-on: ubuntu-latest
     steps:
-      - uses: jlumbroso/free-disk-space@v1.3.1
-
       - uses: actions/checkout@v6
 
       - name: setup Go

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -13,32 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: biomejs/setup-biome@v2
-
-      - uses: actions/setup-python@v6
-        with:
-          cache: pip
-          python-version: 3.x
-
-      - run: pip install -r requirements.txt
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - uses: golangci/golangci-lint-action@v9
-        with:
-          version: latest
-          install-only: true
-
-      - run: go install golang.org/x/tools/cmd/goimports@latest
-
-      - uses: actions/cache@v5
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - run: pre-commit run --all-files
+      - uses: j178/prek-action@v2
 
   lint-gate:
     name: Lint Gate

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -7,6 +7,58 @@ on:
   pull_request:
 
 jobs:
+  precommit:
+    name: Pre-commit Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: biomejs/setup-biome@v2
+
+      - uses: actions/setup-python@v6
+        with:
+          cache: pip
+          python-version: 3.x
+
+      - run: pip install -r requirements.txt
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+          install-only: true
+
+      - run: go install golang.org/x/tools/cmd/goimports@latest
+
+      - uses: actions/cache@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - run: pre-commit run --all-files
+
+  lint-gate:
+    name: Lint Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jlumbroso/free-disk-space@v1.3.1
+
+      - uses: actions/checkout@v6
+
+      - name: setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: latest
+          only-new-issues: true
+
   can-read-secret:
     name: Can Read Secret
     runs-on: ubuntu-latest
@@ -24,6 +76,7 @@ jobs:
 
   build-ui:
     name: User Interface Build
+    needs: [precommit, lint-gate]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -55,6 +108,7 @@ jobs:
 
   build-cli:
     name: Build CLI Binary on ${{ matrix.runner }}
+    needs: [precommit, lint-gate]
     strategy:
       matrix:
         include:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,29 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: biomejs/setup-biome@v2
-
-      - uses: actions/setup-python@v6
-        with:
-          cache: pip
-          python-version: 3.x
-
-      - run: pip install -r requirements.txt
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - uses: golangci/golangci-lint-action@v9
-        with:
-          version: latest
-          install-only: true
-
-      - run: go install golang.org/x/tools/cmd/goimports@latest
-
-      - uses: actions/cache@v5
-        with:
-          path: ~/.cache/pre-commit
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-
-      - run: pre-commit run --all-files
+      - uses: j178/prek-action@v2


### PR DESCRIPTION
## Summary

- Add pre-commit and lint as jobs inside `pr-ci.yml` and make `build-cli` and `build-ui` depend on them via `needs`
- This prevents wasting CI runner time on builds and tests when basic quality checks fail
- The standalone `pre-commit.yml` and `lint.yml` workflows are kept for `push` to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline stability by removing unnecessary disk cleanup step.
  * Introduced gated pre-commit and linting checks in PR workflows to enforce code quality standards before building.
  * Simplified pre-commit workflow by consolidating multiple tool setups into a single composite action for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->