### PR TITLE
ci: remove free-disk-space from lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,8 +11,6 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: jlumbroso/free-disk-space@v1.3.1
-
       - uses: actions/checkout@v6
 
       - name: setup Go


### PR DESCRIPTION
## Summary
- Removes `jlumbroso/free-disk-space@v1.3.1` step from the Lint workflow — golangci-lint doesn't need extra disk space and this step adds significant time to the job.