### PR TITLE
fix(lifecycle): enforce waitFor property in lifecycle hook execution

### DIFF
--- a/cmd/agent/container/container.go
+++ b/cmd/agent/container/container.go
@@ -13,6 +13,7 @@ func NewContainerCmd(flags *flags.GlobalFlags) *cobra.Command {
 	}
 
 	containerCmd.AddCommand(NewSetupContainerCmd(flags))
+	containerCmd.AddCommand(NewDeferredHooksCmd(flags))
 	containerCmd.AddCommand(NewPostAttachCmd(flags))
 	containerCmd.AddCommand(NewDaemonCmd())
 	containerCmd.AddCommand(NewVSCodeAsyncCmd())

--- a/cmd/agent/container/deferred_hooks.go
+++ b/cmd/agent/container/deferred_hooks.go
@@ -1,0 +1,69 @@
+//go:build !windows
+
+package container
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/devsy-org/devsy/pkg/compress"
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/devcontainer/setup"
+	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/spf13/cobra"
+)
+
+// DeferredHooksCmd runs deferred lifecycle hooks as a detached background process.
+type DeferredHooksCmd struct {
+	*flags.GlobalFlags
+	SetupInfo string
+	Prebuild  bool
+}
+
+// NewDeferredHooksCmd creates a new command.
+func NewDeferredHooksCmd(flags *flags.GlobalFlags) *cobra.Command {
+	cmd := &DeferredHooksCmd{
+		GlobalFlags: flags,
+	}
+	deferredCmd := &cobra.Command{
+		Use:   "deferred-hooks",
+		Short: "Runs deferred lifecycle hooks (phases after waitFor)",
+		Args:  cobra.NoArgs,
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			return cmd.Run(cobraCmd.Context())
+		},
+	}
+	deferredCmd.Flags().
+		StringVar(&cmd.SetupInfo, "setup-info", "", "The container setup info")
+	deferredCmd.Flags().
+		BoolVar(&cmd.Prebuild, "prebuild", false, "If true, prebuild lifecycle mode")
+	_ = deferredCmd.MarkFlagRequired("setup-info")
+	return deferredCmd
+}
+
+// Run executes the deferred lifecycle hooks.
+func (cmd *DeferredHooksCmd) Run(ctx context.Context) error {
+	decompressed, err := compress.Decompress(cmd.SetupInfo)
+	if err != nil {
+		return err
+	}
+
+	setupInfo := &config.Result{}
+	if err := json.Unmarshal([]byte(decompressed), setupInfo); err != nil {
+		return err
+	}
+
+	log.Debugf("running deferred lifecycle hooks")
+	deferred, err := setup.RunPreAttachHooks(ctx, setupInfo, cmd.Prebuild)
+	if err != nil {
+		log.Errorf("deferred hooks setup failed: %v", err)
+		return nil
+	}
+
+	if err := deferred.Run(); err != nil {
+		log.Errorf("deferred lifecycle hooks failed: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/agent/container/deferred_hooks_windows.go
+++ b/cmd/agent/container/deferred_hooks_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package container
+
+import (
+	"fmt"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/spf13/cobra"
+)
+
+func NewDeferredHooksCmd(_ *flags.GlobalFlags) *cobra.Command {
+	return &cobra.Command{
+		Use:   "deferred-hooks",
+		Short: "Runs deferred lifecycle hooks (phases after waitFor)",
+		Args:  cobra.NoArgs,
+		RunE: func(_ *cobra.Command, _ []string) error {
+			return fmt.Errorf("Windows Containers are not supported")
+		},
+	}
+}

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -188,29 +188,67 @@ func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
 		Prebuild:          cmd.Prebuild,
 	}
 
-	if err := setup.SetupContainerPreAttach(sctx.ctx, cfg); err != nil {
+	deferred, err := setup.SetupContainerPreAttach(sctx.ctx, cfg)
+	if err != nil {
 		return err
 	}
 
 	if !cmd.Prebuild {
-		if err := cmd.installIDE(sctx.setupInfo, &sctx.workspaceInfo.IDE); err != nil {
+		if err := cmd.setupPostAttach(sctx, deferred); err != nil {
 			return err
-		}
-
-		if err := cmd.startContainerDaemon(sctx.workspaceInfo); err != nil {
-			return err
-		}
-
-		// Launch postAttachCommand as a detached background process before sending
-		// the result. Once sendSetupResult returns, the client tears down the SSH
-		// tunnel which kills this process, so postAttach must already be running
-		// independently.
-		if err := cmd.startPostAttachHooks(sctx); err != nil {
-			log.Errorf("failed to start postAttachCommand: %v", err)
 		}
 	}
 
 	return cmd.sendSetupResult(sctx.ctx, sctx.setupInfo, sctx.tunnelClient)
+}
+
+func (cmd *SetupContainerCmd) setupPostAttach(
+	sctx *setupContext,
+	deferred setup.DeferredHooks,
+) error {
+	if err := cmd.installIDE(sctx.setupInfo, &sctx.workspaceInfo.IDE); err != nil {
+		return err
+	}
+
+	if err := cmd.startContainerDaemon(sctx.workspaceInfo); err != nil {
+		return err
+	}
+
+	if !deferred.Empty() {
+		if err := cmd.startDeferredHooks(); err != nil {
+			log.Errorf("failed to start deferred lifecycle hooks: %v", err)
+		}
+	}
+
+	if err := cmd.startPostAttachHooks(sctx); err != nil {
+		log.Errorf("failed to start postAttachCommand: %v", err)
+	}
+
+	return nil
+}
+
+func (cmd *SetupContainerCmd) startDeferredHooks() error {
+	return command.StartBackgroundOnce("devsy.deferred-hooks", func() (*exec.Cmd, error) {
+		log.Debugf("starting deferred lifecycle hooks as background process")
+		return cmd.buildDeferredHooksCmd()
+	})
+}
+
+func (cmd *SetupContainerCmd) buildDeferredHooksCmd() (*exec.Cmd, error) {
+	binaryPath, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+
+	args := []string{
+		"agent", "container", "deferred-hooks",
+		"--setup-info", cmd.SetupInfo,
+	}
+	if cmd.Prebuild {
+		args = append(args, "--prebuild")
+	}
+
+	return exec.Command(binaryPath, args...), nil
 }
 
 func (cmd *SetupContainerCmd) initializeTunnelClient(

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -214,8 +214,17 @@ func (cmd *SetupContainerCmd) setupPostAttach(
 		return err
 	}
 
+	// Re-serialize the post-substitution setupInfo for background processes.
+	// fillContainerEnv() modifies sctx.setupInfo after initial parsing, so
+	// cmd.SetupInfo (the original CLI arg) has unresolved variables like
+	// ${containerEnv:PATH}. Background hooks need the resolved values.
+	resolvedSetupInfo, err := compressSetupInfo(sctx.setupInfo)
+	if err != nil {
+		return fmt.Errorf("re-serialize setup info: %w", err)
+	}
+
 	if !deferred.Empty() {
-		if err := cmd.startDeferredHooks(); err != nil {
+		if err := cmd.startDeferredHooks(resolvedSetupInfo); err != nil {
 			log.Errorf("failed to start deferred lifecycle hooks: %v", err)
 		}
 	}
@@ -227,14 +236,24 @@ func (cmd *SetupContainerCmd) setupPostAttach(
 	return nil
 }
 
-func (cmd *SetupContainerCmd) startDeferredHooks() error {
+// compressSetupInfo marshals and compresses a config.Result for passing
+// to background subprocesses.
+func compressSetupInfo(setupInfo *config.Result) (string, error) {
+	raw, err := json.Marshal(setupInfo)
+	if err != nil {
+		return "", fmt.Errorf("marshal setup info: %w", err)
+	}
+	return compress.Compress(string(raw))
+}
+
+func (cmd *SetupContainerCmd) startDeferredHooks(setupInfo string) error {
 	return command.StartBackgroundOnce("devsy.deferred-hooks", func() (*exec.Cmd, error) {
 		log.Debugf("starting deferred lifecycle hooks as background process")
-		return cmd.buildDeferredHooksCmd()
+		return buildDeferredHooksCmd(setupInfo, cmd.Prebuild)
 	})
 }
 
-func (cmd *SetupContainerCmd) buildDeferredHooksCmd() (*exec.Cmd, error) {
+func buildDeferredHooksCmd(setupInfo string, prebuild bool) (*exec.Cmd, error) {
 	binaryPath, err := os.Executable()
 	if err != nil {
 		return nil, err
@@ -242,9 +261,9 @@ func (cmd *SetupContainerCmd) buildDeferredHooksCmd() (*exec.Cmd, error) {
 
 	args := []string{
 		"agent", "container", "deferred-hooks",
-		"--setup-info", cmd.SetupInfo,
+		"--setup-info", setupInfo,
 	}
-	if cmd.Prebuild {
+	if prebuild {
 		args = append(args, "--prebuild")
 	}
 

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -248,7 +248,10 @@ func (cmd *SetupContainerCmd) buildDeferredHooksCmd() (*exec.Cmd, error) {
 		args = append(args, "--prebuild")
 	}
 
-	return exec.Command(binaryPath, args...), nil
+	return &exec.Cmd{
+		Path: binaryPath,
+		Args: append([]string{binaryPath}, args...),
+	}, nil
 }
 
 func (cmd *SetupContainerCmd) initializeTunnelClient(

--- a/cmd/agent/container/setup_internal_test.go
+++ b/cmd/agent/container/setup_internal_test.go
@@ -1,0 +1,53 @@
+//go:build !windows
+
+package container
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/compress"
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompressSetupInfoPreservesSubstitutedValues(t *testing.T) {
+	// Simulate post-substitution state: PATH is a real value, not a
+	// ${containerEnv:PATH} literal.
+	info := &config.Result{
+		MergedConfig: &config.MergedDevContainerConfig{
+			DevContainerConfigBase: config.DevContainerConfigBase{
+				RemoteEnv: map[string]string{
+					"PATH": "/usr/local/bin:/usr/bin:/bin",
+					"HOME": "/home/testuser",
+				},
+			},
+		},
+		ContainerDetails: &config.ContainerDetails{
+			State: config.ContainerDetailsState{},
+		},
+		SubstitutionContext: &config.SubstitutionContext{
+			ContainerWorkspaceFolder: "/workspaces/test",
+		},
+	}
+
+	compressed, err := compressSetupInfo(info)
+	require.NoError(t, err)
+	require.NotEmpty(t, compressed)
+
+	// Round-trip: decompress and unmarshal.
+	decompressed, err := compress.Decompress(compressed)
+	require.NoError(t, err)
+
+	var roundTripped config.Result
+	require.NoError(t, json.Unmarshal([]byte(decompressed), &roundTripped))
+
+	// The resolved PATH must come through, not a literal variable reference.
+	gotPath := roundTripped.MergedConfig.RemoteEnv["PATH"]
+	assert.Equal(t, "/usr/local/bin:/usr/bin:/bin", gotPath)
+	assert.False(t, strings.Contains(gotPath, "${containerEnv:"),
+		"PATH should be resolved, not contain ${containerEnv:} literals")
+	assert.Equal(t, "/home/testuser", roundTripped.MergedConfig.RemoteEnv["HOME"])
+}

--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -304,6 +304,64 @@ var _ = ginkgo.Describe(
 				"postStartCommand should have run again after restart")
 		}, ginkgo.SpecTimeout(framework.GetTimeout()))
 
+		ginkgo.It("waitFor defers postCreateCommand to background", func(ctx context.Context) {
+			tempDir, err := setupWorkspace(
+				"tests/up/testdata/docker-waitfor",
+				dtc.initialDir,
+				dtc.f,
+			)
+			framework.ExpectNoError(err)
+
+			err = dtc.f.DevsyUp(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			// onCreateCommand and updateContentCommand should have run (foreground).
+			out, err := dtc.execSSH(ctx, tempDir, "cat $HOME/on-create.out")
+			framework.ExpectNoError(err)
+			gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("onCreateDone"))
+
+			out, err = dtc.execSSH(ctx, tempDir, "cat $HOME/update-content.out")
+			framework.ExpectNoError(err)
+			gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("updateContentDone"))
+
+			// postCreateCommand runs as a deferred hook in the background.
+			// Wait for it to complete and verify the marker file + env substitution.
+			gomega.Eventually(func() string {
+				out, err := dtc.execSSH(ctx, tempDir, "cat $HOME/deferred.marker 2>/dev/null")
+				if err != nil {
+					return ""
+				}
+				return strings.TrimSpace(out)
+			}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(
+				gomega.Equal("postCreateDone"),
+				"deferred postCreateCommand should eventually complete in background",
+			)
+
+			// Verify the deferred hook received substituted env vars, not literals.
+			envPath, err := dtc.execSSH(ctx, tempDir, "cat $HOME/deferred-env-path.out")
+			framework.ExpectNoError(err)
+			gomega.Expect(envPath).To(gomega.ContainSubstring("/usr/local/bin"),
+				"deferred hook should receive resolved PATH, not ${containerEnv:PATH}")
+			gomega.Expect(envPath).NotTo(gomega.ContainSubstring("${containerEnv:"),
+				"deferred hook should not contain literal variable references")
+
+			// postStartCommand also deferred — verify it ran.
+			gomega.Eventually(func() string {
+				out, err := dtc.execSSH(
+					ctx,
+					tempDir,
+					"cat $HOME/post-start-deferred.out 2>/dev/null",
+				)
+				if err != nil {
+					return ""
+				}
+				return strings.TrimSpace(out)
+			}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(
+				gomega.Equal("postStartDone"),
+				"deferred postStartCommand should eventually complete in background",
+			)
+		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+
 		ginkgo.It("IDE accessible before postAttachCommand completes", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
 				"tests/up/testdata/docker-post-attach-nonblocking",

--- a/e2e/tests/up/testdata/docker-waitfor/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-waitfor/.devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "image": "ghcr.io/devsy-org/test-images/go:1",
+  "waitFor": "updateContentCommand",
+  "remoteEnv": {
+    "CONTAINER_ENV_PATH": "${containerEnv:PATH}"
+  },
+  "onCreateCommand": "echo onCreateDone > $HOME/on-create.out",
+  "updateContentCommand": "echo updateContentDone > $HOME/update-content.out",
+  "postCreateCommand": "echo -n ${CONTAINER_ENV_PATH} > $HOME/deferred-env-path.out && echo postCreateDone > $HOME/deferred.marker",
+  "postStartCommand": "echo postStartDone > $HOME/post-start-deferred.out"
+}

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -20,6 +20,55 @@ import (
 	"github.com/devsy-org/devsy/pkg/types"
 )
 
+// LifecyclePhase identifies a devcontainer lifecycle command.
+type LifecyclePhase string
+
+const (
+	PhaseOnCreate      LifecyclePhase = "onCreateCommand"
+	PhaseUpdateContent LifecyclePhase = "updateContentCommand"
+	PhasePostCreate    LifecyclePhase = "postCreateCommand"
+	PhasePostStart     LifecyclePhase = "postStartCommand"
+	PhasePostAttach    LifecyclePhase = "postAttachCommand"
+)
+
+// DefaultWaitFor is the spec-defined default for the waitFor property.
+const DefaultWaitFor = PhaseUpdateContent
+
+// phaseOrder defines the canonical lifecycle ordering per the devcontainer spec.
+var phaseOrder = []LifecyclePhase{
+	PhaseOnCreate,
+	PhaseUpdateContent,
+	PhasePostCreate,
+	PhasePostStart,
+	PhasePostAttach,
+}
+
+// validWaitForPhase returns true when phase is an allowed waitFor value.
+func validWaitForPhase(phase LifecyclePhase) bool {
+	return slices.Contains(phaseOrder, phase)
+}
+
+// resolveWaitFor normalises the raw waitFor string from the config,
+// falling back to the spec default for empty or invalid values.
+func resolveWaitFor(raw string) LifecyclePhase {
+	if raw == "" {
+		return DefaultWaitFor
+	}
+	p := LifecyclePhase(raw)
+	if !validWaitForPhase(p) {
+		return DefaultWaitFor
+	}
+	return p
+}
+
+// hookRunParams groups the arguments for running a single lifecycle phase.
+type hookRunParams struct {
+	commands []types.LifecycleHook
+	env      lifecycleEnv
+	name     string
+	content  string
+}
+
 // lifecycleEnv holds the resolved environment for running lifecycle hooks.
 type lifecycleEnv struct {
 	remoteUser      string
@@ -57,71 +106,133 @@ func resolveLifecycleEnv(
 	}
 }
 
-// RunPreAttachHooks runs lifecycle hooks up to and including postStartCommand.
-// These must complete before the IDE can be opened.
-//
-// When prebuild is true, only onCreateCommand and updateContentCommand are
-// executed (the devcontainer prebuild phase). updateContentCommand always
-// reruns during prebuild — the marker-file check is bypassed so that
-// content changes are picked up.
-func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, prebuild bool) error {
-	env := resolveLifecycleEnv(ctx, setupInfo)
-	containerDetails := setupInfo.ContainerDetails
-	mergedConfig := setupInfo.MergedConfig
+// preAttachPhaseParams returns the hookRunParams for each pre-attach
+// lifecycle phase in spec order.
+func preAttachPhaseParams(
+	setupInfo *config.Result,
+	env lifecycleEnv,
+	prebuild bool,
+) []phaseHook {
+	cd := setupInfo.ContainerDetails
+	mc := setupInfo.MergedConfig
 
-	// only run once per container run
-	if err := run(mergedConfig.OnCreateCommands, env.remoteUser, env.workspaceFolder, env.remoteEnv,
-		"onCreateCommands", containerDetails.Created); err != nil {
-		return err
-	}
-
-	// During prebuild, pass empty content so the marker check is bypassed
-	// and updateContentCommand always reruns (addresses the TODO below).
-	// During normal runs, use containerDetails.Created so it only runs once.
-	updateContentMarker := containerDetails.Created
+	updateContentMarker := cd.Created
 	if prebuild {
 		updateContentMarker = ""
 	}
-	if err := run(
-		mergedConfig.UpdateContentCommands,
-		env.remoteUser,
-		env.workspaceFolder,
-		env.remoteEnv,
-		"updateContentCommands",
-		updateContentMarker,
-	); err != nil {
-		return err
-	}
 
-	// Prebuild phase stops after updateContentCommand — skip the user-session hooks.
+	return []phaseHook{
+		{PhaseOnCreate, hookRunParams{mc.OnCreateCommands, env, "onCreateCommands", cd.Created}},
+		{
+			PhaseUpdateContent,
+			hookRunParams{
+				mc.UpdateContentCommands,
+				env,
+				"updateContentCommands",
+				updateContentMarker,
+			},
+		},
+		{
+			PhasePostCreate,
+			hookRunParams{mc.PostCreateCommands, env, "postCreateCommands", cd.Created},
+		},
+		{
+			PhasePostStart,
+			hookRunParams{mc.PostStartCommands, env, "postStartCommands", cd.State.StartedAt},
+		},
+	}
+}
+
+// phaseHook pairs a lifecycle phase with the parameters needed to run it.
+type phaseHook struct {
+	phase  LifecyclePhase
+	params hookRunParams
+}
+
+// RunPreAttachHooks runs lifecycle hooks up to and including the waitFor phase
+// synchronously and returns a slice of deferred phases that should run in the
+// background.
+//
+// When prebuild is true, only onCreateCommand and updateContentCommand are
+// executed and waitFor is ignored.
+func RunPreAttachHooks(
+	ctx context.Context,
+	setupInfo *config.Result,
+	prebuild bool,
+) (DeferredHooks, error) {
+	env := resolveLifecycleEnv(ctx, setupInfo)
+	all := preAttachPhaseParams(setupInfo, env, prebuild)
+
 	if prebuild {
-		return nil
+		return DeferredHooks{}, runPrebuildHooks(all)
 	}
 
-	// only run once per container run
-	if err := run(
-		mergedConfig.PostCreateCommands,
-		env.remoteUser,
-		env.workspaceFolder,
-		env.remoteEnv,
-		"postCreateCommands",
-		containerDetails.Created,
-	); err != nil {
-		return err
+	waitFor := resolveWaitFor(setupInfo.MergedConfig.WaitFor)
+	deferred, err := runWithWaitFor(all, waitFor)
+	return DeferredHooks{hooks: deferred}, err
+}
+
+// runPrebuildHooks runs only onCreateCommand and updateContentCommand.
+func runPrebuildHooks(all []phaseHook) error {
+	for _, ph := range all {
+		if ph.phase != PhaseOnCreate && ph.phase != PhaseUpdateContent {
+			continue
+		}
+		if err := runHook(ph.params); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// runWithWaitFor runs hooks up to and including waitFor synchronously
+// and returns the remaining hooks as deferred.
+func runWithWaitFor(
+	all []phaseHook,
+	waitFor LifecyclePhase,
+) ([]phaseHook, error) {
+	pastWaitFor := false
+	var deferred []phaseHook
+
+	for _, ph := range all {
+		if pastWaitFor {
+			deferred = append(deferred, ph)
+			continue
+		}
+		if err := runHook(ph.params); err != nil {
+			return nil, err
+		}
+		if ph.phase == waitFor {
+			pastWaitFor = true
+		}
 	}
 
-	// run when the container was restarted
-	if err := run(
-		mergedConfig.PostStartCommands,
-		env.remoteUser,
-		env.workspaceFolder,
-		env.remoteEnv,
-		"postStartCommands",
-		containerDetails.State.StartedAt,
-	); err != nil {
-		return err
-	}
+	return deferred, nil
+}
 
+// DeferredHooks holds lifecycle hooks that should run in the background
+// after the foreground (waitFor) hooks have completed.
+type DeferredHooks struct {
+	hooks []phaseHook
+}
+
+// Empty returns true when there are no deferred hooks with commands to run.
+func (d DeferredHooks) Empty() bool {
+	for _, ph := range d.hooks {
+		if len(ph.params.commands) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// Run executes all deferred hooks sequentially.
+func (d DeferredHooks) Run() error {
+	for _, ph := range d.hooks {
+		if err := runHook(ph.params); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -130,112 +241,121 @@ func RunPreAttachHooks(ctx context.Context, setupInfo *config.Result, prebuild b
 func RunPostAttachHooks(ctx context.Context, setupInfo *config.Result) error {
 	env := resolveLifecycleEnv(ctx, setupInfo)
 
-	// run always when attaching to the container
-	return run(
-		setupInfo.MergedConfig.PostAttachCommands,
-		env.remoteUser,
-		env.workspaceFolder,
-		env.remoteEnv,
-		"postAttachCommands",
-		"",
-	)
+	return runHook(hookRunParams{
+		commands: setupInfo.MergedConfig.PostAttachCommands,
+		env:      env,
+		name:     "postAttachCommands",
+		content:  "",
+	})
 }
 
-func run(
-	commands []types.LifecycleHook,
-	remoteUser, dir string,
-	remoteEnv map[string]string,
-	name, content string,
-) error {
-	if len(commands) == 0 {
+func runHook(p hookRunParams) error {
+	if len(p.commands) == 0 {
 		return nil
 	}
 
-	// check marker file
-	if content != "" {
-		exists, err := markerFileExists(name, content)
-		if err != nil {
-			return err
-		} else if exists {
-			return nil
-		}
+	if skip, err := shouldSkipHook(p.name, p.content); err != nil || skip {
+		return err
 	}
 
-	remoteEnvArr := []string{}
+	envArr := buildEnvArr(p.env.remoteEnv)
+	return executeHookCommands(p, envArr)
+}
+
+func shouldSkipHook(name, content string) (bool, error) {
+	if content == "" {
+		return false, nil
+	}
+	return markerFileExists(name, content)
+}
+
+func buildEnvArr(remoteEnv map[string]string) []string {
+	arr := make([]string, 0, len(remoteEnv))
 	for k, v := range remoteEnv {
-		remoteEnvArr = append(remoteEnvArr, k+"="+v)
+		arr = append(arr, k+"="+v)
 	}
+	return arr
+}
 
-	for _, cmd := range commands {
+func executeHookCommands(p hookRunParams, envArr []string) error {
+	for _, cmd := range p.commands {
 		if len(cmd) == 0 {
 			continue
 		}
-
 		for k, c := range cmd {
-			log.Infof("running %s lifecycle hook: %s %s", name, k, strings.Join(c, " "))
-			currentUser, err := user.Current()
-			if err != nil {
+			if err := runSingleHookCommand(p, envArr, k, c); err != nil {
 				return err
 			}
-
-			if len(c) == 0 {
-				log.Debugf("skipping empty command for lifecycle hook %s", name)
-				continue
-			}
-			args := buildCommandArgs(c, remoteUser, currentUser.Username)
-
-			// create command
-			cmd := exec.Command(args[0], args[1:]...)
-			cmd.Dir = dir
-			cmd.Env = os.Environ()
-			cmd.Env = append(cmd.Env, remoteEnvArr...)
-
-			// Create pipes for stdout and stderr
-			stdoutPipe, err := cmd.StdoutPipe()
-			if err != nil {
-				return fmt.Errorf("failed to get stdout pipe: %w", err)
-			}
-			stderrPipe, err := cmd.StderrPipe()
-			if err != nil {
-				return fmt.Errorf("failed to get stderr pipe: %w", err)
-			}
-
-			// Start the command
-			if err := cmd.Start(); err != nil {
-				return fmt.Errorf("failed to start command: %w", err)
-			}
-
-			// Use WaitGroup to wait for both stdout and stderr processing
-			var wg sync.WaitGroup
-			wg.Add(2)
-
-			go func() {
-				defer wg.Done()
-				logPipeOutput(stdoutPipe, true)
-			}()
-
-			go func() {
-				defer wg.Done()
-				logPipeOutput(stderrPipe, false)
-			}()
-
-			// Wait for command to finish
-			wg.Wait()
-			err = cmd.Wait()
-			if err != nil {
-				log.Debugf(
-					"failed running %s lifecycle script: command=%v, error=%v",
-					k,
-					cmd.Args,
-					err,
-				)
-				return fmt.Errorf("failed to run: %s, error: %w", strings.Join(c, " "), err)
-			}
-
-			log.Infof("ran command: command=%s, args=%s", k, strings.Join(c, " "))
 		}
 	}
+	return nil
+}
 
+func runSingleHookCommand(
+	p hookRunParams,
+	remoteEnvArr []string,
+	key string, c []string,
+) error {
+	log.Infof("running %s lifecycle hook: %s %s", p.name, key, strings.Join(c, " "))
+	currentUser, err := user.Current()
+	if err != nil {
+		return err
+	}
+
+	if len(c) == 0 {
+		log.Debugf("skipping empty command for lifecycle hook %s", p.name)
+		return nil
+	}
+	args := buildCommandArgs(c, p.env.remoteUser, currentUser.Username)
+
+	// create command
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Dir = p.env.workspaceFolder
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, remoteEnvArr...)
+
+	return executeAndLog(cmd, key, c)
+}
+
+func executeAndLog(cmd *exec.Cmd, key string, c []string) error {
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("failed to get stdout pipe: %w", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("failed to get stderr pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start command: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		logPipeOutput(stdoutPipe, true)
+	}()
+
+	go func() {
+		defer wg.Done()
+		logPipeOutput(stderrPipe, false)
+	}()
+
+	wg.Wait()
+	if err := cmd.Wait(); err != nil {
+		log.Debugf(
+			"failed running %s lifecycle script: command=%v, error=%v",
+			key,
+			cmd.Args,
+			err,
+		)
+		return fmt.Errorf("failed to run: %s, error: %w", strings.Join(c, " "), err)
+	}
+
+	log.Infof("ran command: command=%s, args=%s", key, strings.Join(c, " "))
 	return nil
 }
 

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -308,11 +308,17 @@ func runSingleHookCommand(
 	}
 	args := buildCommandArgs(c, p.env.remoteUser, currentUser.Username)
 
-	// create command
-	cmd := exec.Command(args[0], args[1:]...)
-	cmd.Dir = p.env.workspaceFolder
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, remoteEnvArr...)
+	resolvedPath, err := exec.LookPath(args[0])
+	if err != nil {
+		return fmt.Errorf("command not found: %s: %w", args[0], err)
+	}
+
+	cmd := &exec.Cmd{
+		Path: resolvedPath,
+		Args: args,
+		Dir:  p.env.workspaceFolder,
+		Env:  append(os.Environ(), remoteEnvArr...),
+	}
 
 	return executeAndLog(cmd, key, c)
 }

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -94,8 +94,9 @@ func (s *LifecycleHookTestSuite) TestLifecycleHooksNoOpWithEmptyConfig() {
 	}
 
 	// Both functions should return nil with empty config (no commands to run)
-	err := RunPreAttachHooks(ctx, result, false)
+	deferred, err := RunPreAttachHooks(ctx, result, false)
 	assert.NoError(s.T(), err)
+	assert.True(s.T(), deferred.Empty())
 
 	err = RunPostAttachHooks(ctx, result)
 	assert.NoError(s.T(), err)
@@ -129,6 +130,116 @@ func (s *LifecycleHookTestSuite) TestResolveLifecycleEnvIncludesSecrets() {
 	assert.Equal(t, "s3cret", env.remoteEnv["SECRET_PRESENT"])
 	_, found := env.remoteEnv["SECRET_ABSENT"]
 	assert.False(t, found, "SECRET_ABSENT should not be in remoteEnv when not set in environment")
+}
+
+func (s *LifecycleHookTestSuite) TestResolveWaitForDefault() {
+	assert.Equal(s.T(), DefaultWaitFor, resolveWaitFor(""))
+}
+
+func (s *LifecycleHookTestSuite) TestResolveWaitForValid() {
+	assert.Equal(s.T(), PhasePostCreate, resolveWaitFor("postCreateCommand"))
+	assert.Equal(s.T(), PhasePostStart, resolveWaitFor("postStartCommand"))
+	assert.Equal(s.T(), PhaseOnCreate, resolveWaitFor("onCreateCommand"))
+	assert.Equal(s.T(), PhasePostAttach, resolveWaitFor("postAttachCommand"))
+	assert.Equal(s.T(), PhaseUpdateContent, resolveWaitFor("updateContentCommand"))
+}
+
+func (s *LifecycleHookTestSuite) TestResolveWaitForInvalid() {
+	assert.Equal(s.T(), DefaultWaitFor, resolveWaitFor("bogus"))
+	assert.Equal(s.T(), DefaultWaitFor, resolveWaitFor("initializeCommand"))
+	assert.Equal(s.T(), DefaultWaitFor, resolveWaitFor("POSTCREATECOMMAND"))
+}
+
+func (s *LifecycleHookTestSuite) TestRunWithWaitForDefaultSplit() {
+	t := s.T()
+	all := makeTestPhaseHooks()
+
+	deferred, err := runWithWaitFor(all, DefaultWaitFor)
+	assert.NoError(t, err)
+
+	// Default waitFor is updateContentCommand.
+	// Deferred should be postCreateCommand and postStartCommand.
+	assert.Len(t, deferred, 2)
+	assert.Equal(t, PhasePostCreate, deferred[0].phase)
+	assert.Equal(t, PhasePostStart, deferred[1].phase)
+}
+
+func (s *LifecycleHookTestSuite) TestRunWithWaitForPostCreate() {
+	t := s.T()
+	all := makeTestPhaseHooks()
+
+	deferred, err := runWithWaitFor(all, PhasePostCreate)
+	assert.NoError(t, err)
+
+	// Only postStartCommand should be deferred.
+	assert.Len(t, deferred, 1)
+	assert.Equal(t, PhasePostStart, deferred[0].phase)
+}
+
+func (s *LifecycleHookTestSuite) TestRunWithWaitForPostStart() {
+	t := s.T()
+	all := makeTestPhaseHooks()
+
+	deferred, err := runWithWaitFor(all, PhasePostStart)
+	assert.NoError(t, err)
+
+	// All pre-attach hooks run in foreground, nothing deferred.
+	assert.Empty(t, deferred)
+}
+
+func (s *LifecycleHookTestSuite) TestRunWithWaitForOnCreate() {
+	t := s.T()
+	all := makeTestPhaseHooks()
+
+	deferred, err := runWithWaitFor(all, PhaseOnCreate)
+	assert.NoError(t, err)
+
+	// updateContentCommand, postCreateCommand, postStartCommand deferred.
+	assert.Len(t, deferred, 3)
+	assert.Equal(t, PhaseUpdateContent, deferred[0].phase)
+	assert.Equal(t, PhasePostCreate, deferred[1].phase)
+	assert.Equal(t, PhasePostStart, deferred[2].phase)
+}
+
+func (s *LifecycleHookTestSuite) TestPrebuildIgnoresWaitFor() {
+	ctx := context.Background()
+	result := &config.Result{
+		MergedConfig: &config.MergedDevContainerConfig{
+			DevContainerConfigBase: config.DevContainerConfigBase{
+				// Set waitFor to onCreateCommand — prebuild should ignore this.
+				WaitFor: "onCreateCommand",
+			},
+		},
+		ContainerDetails: &config.ContainerDetails{
+			State: config.ContainerDetailsState{},
+		},
+		SubstitutionContext: &config.SubstitutionContext{
+			ContainerWorkspaceFolder: "/workspaces/test",
+		},
+	}
+
+	// In prebuild mode, no deferred hooks are returned regardless of waitFor.
+	deferred, err := RunPreAttachHooks(ctx, result, true)
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), deferred.Empty())
+}
+
+func (s *LifecycleHookTestSuite) TestDeferredHooksEmpty() {
+	d := DeferredHooks{}
+	assert.True(s.T(), d.Empty())
+	assert.NoError(s.T(), d.Run())
+}
+
+// makeTestPhaseHooks creates a phaseHook slice with no commands so that
+// runHook is a no-op. This lets us test the split logic without executing
+// real processes.
+func makeTestPhaseHooks() []phaseHook {
+	return []phaseHook{
+		{phase: PhaseOnCreate, params: hookRunParams{name: "onCreateCommands"}},
+		{phase: PhaseUpdateContent, params: hookRunParams{name: "updateContentCommands"}},
+		{phase: PhasePostCreate, params: hookRunParams{name: "postCreateCommands"}},
+		{phase: PhasePostStart, params: hookRunParams{name: "postStartCommands"}},
+	}
 }
 
 func TestLifecycleHookTestSuite(t *testing.T) {

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -37,32 +37,37 @@ type ContainerSetupConfig struct {
 	TunnelClient      tunnel.TunnelClient
 }
 
-// SetupContainerPreAttach runs container setup up to and including postStartCommand.
-// After this returns, the workspace is ready for IDE access.
-func SetupContainerPreAttach(ctx context.Context, cfg *ContainerSetupConfig) error {
+// SetupContainerPreAttach runs container setup up to and including the waitFor
+// lifecycle phase. Hooks after waitFor are returned as DeferredHooks for the
+// caller to launch in the background.
+func SetupContainerPreAttach(
+	ctx context.Context,
+	cfg *ContainerSetupConfig,
+) (DeferredHooks, error) {
 	if err := validateContainerSetupConfig(cfg); err != nil {
-		return err
+		return DeferredHooks{}, err
 	}
 
 	writeResultFile(cfg)
 
 	if err := setupWorkspaceOwnership(cfg); err != nil {
-		return err
+		return DeferredHooks{}, err
 	}
 
 	if err := setupEnvironment(cfg); err != nil {
-		return err
+		return DeferredHooks{}, err
 	}
 
 	setupOptionalFeatures(ctx, cfg)
 
 	log.Debugf("running pre-attach lifecycle hooks")
-	if err := RunPreAttachHooks(ctx, cfg.SetupInfo, cfg.Prebuild); err != nil {
-		return fmt.Errorf("lifecycle hooks pre-attach: %w", err)
+	deferred, err := RunPreAttachHooks(ctx, cfg.SetupInfo, cfg.Prebuild)
+	if err != nil {
+		return DeferredHooks{}, fmt.Errorf("lifecycle hooks pre-attach: %w", err)
 	}
 
 	log.Debugf("pre-attach setup completed")
-	return nil
+	return deferred, nil
 }
 
 // SetupContainerPostAttach runs postAttachCommand only.


### PR DESCRIPTION
## Summary

- Enforces the devcontainer `waitFor` property which was parsed but never applied at runtime. Previously all pre-attach lifecycle hooks ran synchronously (equivalent to `waitFor: "postStartCommand"`). Now hooks up to and including the `waitFor` phase run in the foreground, while remaining hooks are launched as a background process via a new `deferred-hooks` subcommand.
- Default `waitFor` is `"updateContentCommand"` per spec — only `onCreateCommand` and `updateContentCommand` block; `postCreateCommand` and `postStartCommand` run in background alongside `postAttachCommand`.
- Invalid or empty `waitFor` values fall back to the spec default. Prebuild mode is unaffected (always runs only `onCreateCommand` + `updateContentCommand`).
- Refactors the 6-argument `run()` function into a `hookRunParams` struct to satisfy the `revive/argument-limit` linter rule, and splits complex functions to stay within cyclomatic complexity limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `deferred-hooks` CLI subcommand for managing background lifecycle hook execution with `waitFor` phase support.

* **Refactor**
  * Improved setup flow to separate foreground and deferred post-attach operations, allowing lifecycle hooks to run both synchronously and in the background for optimized container initialization.
  * Lifecycle hooks now respect devcontainer `waitFor` phases for granular control over execution timing.

* **Tests**
  * Expanded test coverage for deferred hook logic and `waitFor` phase resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->