### PR TITLE
feat(tunnel): extract PipeBridge and ConnError primitives, fix direct.go race

### DIFF
--- a/pkg/tunnel/connerror.go
+++ b/pkg/tunnel/connerror.go
@@ -1,0 +1,57 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ErrorKind classifies connection errors.
+type ErrorKind int
+
+const (
+	// ErrorTransient indicates a temporary error that may resolve on retry.
+	ErrorTransient ErrorKind = iota
+	// ErrorPermanent indicates an unrecoverable error.
+	ErrorPermanent
+	// ErrorShutdown indicates a graceful or context-driven shutdown.
+	ErrorShutdown
+)
+
+// ClassifyError returns the kind of a connection error.
+func ClassifyError(err error) ErrorKind {
+	if err == nil {
+		return ErrorShutdown
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return ErrorShutdown
+	}
+	if IsEOF(err) {
+		return ErrorTransient
+	}
+	return ErrorPermanent
+}
+
+// IsEOF reports whether err is caused by an EOF condition,
+// including wrapped SSH handshake failures from closed pipes.
+func IsEOF(err error) bool {
+	return errors.Is(err, io.EOF) || strings.Contains(err.Error(), ": EOF")
+}
+
+// ClassifyTunnelErrors determines which error to report when tunnel and/or
+// handler goroutines fail. EOF errors from the handler are suppressed when
+// the tunnel error is the root cause.
+func ClassifyTunnelErrors(tunnelErr, handlerErr error) error {
+	if handlerErr == nil {
+		return nil
+	}
+	if IsEOF(handlerErr) {
+		if tunnelErr != nil {
+			return fmt.Errorf("connect to server: %w", tunnelErr)
+		}
+		return nil
+	}
+	return fmt.Errorf("tunnel to container: %w", handlerErr)
+}

--- a/pkg/tunnel/connerror_test.go
+++ b/pkg/tunnel/connerror_test.go
@@ -1,0 +1,111 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func TestIsEOF(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"bare io.EOF", io.EOF, true},
+		{"wrapped EOF", fmt.Errorf("ssh: handshake failed: %w", io.EOF), true},
+		{"string containing EOF", errors.New("run in container: ssh: handshake failed: EOF"), true},
+		{"non-EOF error", errors.New("connection refused"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsEOF(tt.err); got != tt.want {
+				t.Errorf("IsEOF(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want ErrorKind
+	}{
+		{"nil", nil, ErrorShutdown},
+		{"context.Canceled", context.Canceled, ErrorShutdown},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, ErrorShutdown},
+		{"io.EOF", io.EOF, ErrorTransient},
+		{"wrapped EOF", fmt.Errorf("read: %w", io.EOF), ErrorTransient},
+		{"random error", errors.New("something broke"), ErrorPermanent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ClassifyError(tt.err); got != tt.want {
+				t.Errorf("ClassifyError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyTunnelErrors(t *testing.T) {
+	t.Parallel()
+
+	tunnelErr := errors.New("host unreachable")
+	handlerEOF := fmt.Errorf("ssh: handshake failed: %w", io.EOF)
+	handlerNonEOF := errors.New("permission denied")
+
+	tests := []struct {
+		name      string
+		tunnelErr error
+		handler   error
+		wantNil   bool
+		wantMsg   string
+	}{
+		{"handler nil returns nil", tunnelErr, nil, true, ""},
+		{
+			"handler EOF + tunnel err returns tunnel",
+			tunnelErr,
+			handlerEOF,
+			false,
+			"connect to server: host unreachable",
+		},
+		{"handler EOF + no tunnel returns nil", nil, handlerEOF, true, ""},
+		{
+			"handler non-EOF returns handler error",
+			nil,
+			handlerNonEOF,
+			false,
+			"tunnel to container: permission denied",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClassifyTunnelErrors(tt.tunnelErr, tt.handler)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("ClassifyTunnelErrors() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("ClassifyTunnelErrors() = nil, want error")
+			}
+			if got.Error() != tt.wantMsg {
+				t.Errorf("ClassifyTunnelErrors() = %q, want %q", got.Error(), tt.wantMsg)
+			}
+		})
+	}
+}

--- a/pkg/tunnel/container.go
+++ b/pkg/tunnel/container.go
@@ -6,11 +6,9 @@ package tunnel
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/devsy-org/devsy/pkg/agent"
@@ -22,22 +20,20 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// ContainerTunnel manages the state of the tunnel to the container.
+type ContainerTunnel struct {
+	client               client.WorkspaceClient
+	updateConfigInterval time.Duration
+}
+
 // NewContainerTunnel constructs a ContainerTunnel using the workspace client, if proxy is True then
 // the workspace's agent config is not periodically updated.
-//
-//nolint:funcorder
 func NewContainerTunnel(client client.WorkspaceClient) *ContainerTunnel {
 	updateConfigInterval := time.Second * 30
 	return &ContainerTunnel{
 		client:               client,
 		updateConfigInterval: updateConfigInterval,
 	}
-}
-
-// ContainerTunnel manages the state of the tunnel to the container.
-type ContainerTunnel struct {
-	client               client.WorkspaceClient
-	updateConfigInterval time.Duration
 }
 
 // Handler defines what to do once the tunnel has a client established.
@@ -55,56 +51,36 @@ func (c *ContainerTunnel) Run(
 		return nil
 	}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	stdoutReader, stdoutWriter, err := os.Pipe()
+	pb, err := NewPipeBridge()
 	if err != nil {
 		return err
 	}
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = stdoutWriter.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
+	defer pb.Close()
 
 	timeout := config.ParseTimeOption(cfg, config.ContextOptionAgentInjectTimeout)
 
-	// tunnel to host
-	tunnelChan := make(chan error, 1)
-	go func() {
-		tunnelChan <- c.runHostTunnel(cancelCtx, stdinReader, stdoutWriter, timeout)
-	}()
+	return pb.RunPair(ctx,
+		func(ctx context.Context, stdin *os.File, stdout *os.File) error {
+			return c.runHostTunnel(ctx, stdin, stdout, timeout)
+		},
+		func(ctx context.Context, stdout *os.File, stdin *os.File) error {
+			sshClient, err := devssh.StdioClient(stdout, stdin, false)
+			if err != nil {
+				return fmt.Errorf("create ssh client: %w", err)
+			}
+			defer func() { _ = sshClient.Close() }()
+			log.Debugf("connected to host")
 
-	// connect to container
-	containerChan := make(chan error, 1)
-	go func() {
-		sshClient, err := devssh.StdioClient(stdoutReader, stdinWriter, false)
-		if err != nil {
-			containerChan <- fmt.Errorf("create ssh client: %w", err)
-			return
-		}
+			if c.updateConfigInterval > 0 {
+				go func() { c.updateConfig(ctx, sshClient) }()
+			}
 
-		defer func() { _ = sshClient.Close() }()
-		defer cancel()
-		defer log.Debugf("connection to container closed")
-		log.Debugf("connected to host")
-
-		if c.updateConfigInterval > 0 {
-			go func() {
-				c.updateConfig(cancelCtx, sshClient)
-			}()
-		}
-
-		if err := c.runInContainer(cancelCtx, sshClient, handler, envVars); err != nil {
-			containerChan <- fmt.Errorf("run in container: %w", err)
-		} else {
-			containerChan <- nil
-		}
-	}()
-
-	return awaitGoroutines(tunnelChan, containerChan, stdoutWriter, stdinWriter)
+			if err := c.runInContainer(ctx, sshClient, handler, envVars); err != nil {
+				return fmt.Errorf("run in container: %w", err)
+			}
+			return nil
+		},
+	)
 }
 
 // runHostTunnel injects the devsy agent onto the host and starts the SSH server,
@@ -141,54 +117,6 @@ func (c *ContainerTunnel) runHostTunnel(
 		Stderr:          writer,
 		Timeout:         timeout,
 	})
-}
-
-// awaitGoroutines waits for both the container and tunnel goroutines to report
-// and returns the appropriate error. The container result is the primary result;
-// the tunnel result provides root-cause context when the container gets EOF.
-func awaitGoroutines(
-	tunnelChan, containerChan <-chan error,
-	stdoutWriter, stdinWriter *os.File,
-) error {
-	var tunnelErr, containerErr error
-
-	select {
-	case containerErr = <-containerChan:
-		select {
-		case tunnelErr = <-tunnelChan:
-		default:
-		}
-	case tunnelErr = <-tunnelChan:
-		// Host tunnel exited before container finished. Close pipes to unblock
-		// the container goroutine (may be blocked in SSH handshake).
-		_ = stdoutWriter.Close()
-		_ = stdinWriter.Close()
-		containerErr = <-containerChan
-	}
-
-	return classifyTunnelErrors(tunnelErr, containerErr)
-}
-
-// classifyTunnelErrors determines which error to report when the tunnel and/or
-// container goroutines fail. EOF errors from the container are suppressed when
-// the tunnel error is the root cause.
-func classifyTunnelErrors(tunnelErr, containerErr error) error {
-	if containerErr == nil {
-		return nil
-	}
-	if isEOFError(containerErr) {
-		if tunnelErr != nil {
-			return fmt.Errorf("connect to server: %w", tunnelErr)
-		}
-		return nil
-	}
-	return fmt.Errorf("tunnel to container: %w", containerErr)
-}
-
-// isEOFError reports whether an error is caused by an EOF condition,
-// including wrapped SSH handshake failures from closed pipes.
-func isEOFError(err error) bool {
-	return errors.Is(err, io.EOF) || strings.Contains(err.Error(), ": EOF")
 }
 
 // updateConfig is called periodically to keep the workspace agent config up to date.
@@ -253,36 +181,25 @@ func (c *ContainerTunnel) runInContainer(
 		return err
 	}
 
-	stdoutReader, stdoutWriter, err := os.Pipe()
+	pb, err := NewPipeBridge()
 	if err != nil {
 		return err
 	}
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = stdoutWriter.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
+	defer pb.Close()
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// tunnel to container
 	tunnelDone := make(chan error, 1)
 	go func() {
-		tunnelDone <- c.runContainerTunnel(cancelCtx, containerTunnelOpts{
+		tunnelDone <- c.runContainerTunnel(ctx, containerTunnelOpts{
 			sshClient:     sshClient,
 			workspaceInfo: workspaceInfo,
-			stdinReader:   stdinReader,
-			stdoutWriter:  stdoutWriter,
+			stdinReader:   pb.StdinReader,
+			stdoutWriter:  pb.StdoutWriter,
 			envVars:       envVars,
 		})
 	}()
 
-	containerClient, err := devssh.StdioClient(stdoutReader, stdinWriter, false)
+	containerClient, err := devssh.StdioClient(pb.StdoutReader, pb.StdinWriter, false)
 	if err != nil {
-		// StdioClient failed — check if the tunnel goroutine already exited
-		// with an error. If so, the tunnel error is the root cause.
 		select {
 		case tunnelErr := <-tunnelDone:
 			if tunnelErr != nil {
@@ -295,7 +212,7 @@ func (c *ContainerTunnel) runInContainer(
 	defer func() { _ = containerClient.Close() }()
 	log.Debugf("connected to container")
 
-	return handler(cancelCtx, containerClient)
+	return handler(ctx, containerClient)
 }
 
 type containerTunnelOpts struct {

--- a/pkg/tunnel/direct.go
+++ b/pkg/tunnel/direct.go
@@ -2,7 +2,6 @@ package tunnel
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 
@@ -16,48 +15,23 @@ type Tunnel func(ctx context.Context, stdin io.Reader, stdout io.Writer) error
 // Here the tunnel will be an SSH connection with it's STDIO as arguments and the handler will be the function to execute the command
 // using the connected SSH client.
 func NewTunnel(ctx context.Context, tunnel Tunnel, handler Handler) error {
-	// create context
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// create readers
-	stdoutReader, stdoutWriter, err := os.Pipe()
+	pb, err := NewPipeBridge()
 	if err != nil {
 		return err
 	}
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = stdoutWriter.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
+	defer pb.Close()
 
-	// start ssh proxy
-	outerTunnelChan := make(chan error, 1)
-	go func() {
-		outerTunnelChan <- tunnel(ctx, stdinReader, stdoutWriter)
-	}()
-
-	// start ssh client as root / default user
-	innerTunnelChan := make(chan error, 1)
-	go func() {
-		sshClient, err := devssh.StdioClient(stdoutReader, stdinWriter, false)
-		if err != nil {
-			innerTunnelChan <- err
-			return
-		}
-		defer func() { _ = sshClient.Close() }()
-		defer cancel()
-
-		// start ssh tunnel
-		innerTunnelChan <- handler(cancelCtx, sshClient)
-	}()
-
-	// wait for result
-	select {
-	case err := <-innerTunnelChan:
-		return fmt.Errorf("inner tunnel: %w", err)
-	case err := <-outerTunnelChan:
-		return fmt.Errorf("outer tunnel: %w", err)
-	}
+	return pb.RunPair(ctx,
+		func(ctx context.Context, stdin *os.File, stdout *os.File) error {
+			return tunnel(ctx, stdin, stdout)
+		},
+		func(ctx context.Context, stdout *os.File, stdin *os.File) error {
+			sshClient, err := devssh.StdioClient(stdout, stdin, false)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = sshClient.Close() }()
+			return handler(ctx, sshClient)
+		},
+	)
 }

--- a/pkg/tunnel/direct.go
+++ b/pkg/tunnel/direct.go
@@ -11,9 +11,10 @@ import (
 // Tunnel defines the function to create an "outer" tunnel.
 type Tunnel func(ctx context.Context, stdin io.Reader, stdout io.Writer) error
 
-// NewTunnel creates a tunnel to the devcontainer using generic functions to establish the "outer" and "inner" tunnel, used by proxy clients
-// Here the tunnel will be an SSH connection with it's STDIO as arguments and the handler will be the function to execute the command
-// using the connected SSH client.
+// NewTunnel creates a tunnel to the devcontainer using generic functions
+// to establish the "outer" and "inner" tunnel, used by proxy clients.
+// The tunnel is an SSH connection with stdio as arguments and the handler
+// executes the command using the connected SSH client.
 func NewTunnel(ctx context.Context, tunnel Tunnel, handler Handler) error {
 	pb, err := NewPipeBridge()
 	if err != nil {

--- a/pkg/tunnel/pipebridge.go
+++ b/pkg/tunnel/pipebridge.go
@@ -1,0 +1,98 @@
+package tunnel
+
+import (
+	"context"
+	"os"
+)
+
+// PipeBridge manages two os.Pipe pairs (stdin + stdout) for bidirectional
+// communication between a tunnel function and a handler function.
+type PipeBridge struct {
+	StdoutReader *os.File // handler reads tunnel's stdout
+	StdoutWriter *os.File // tunnel writes its stdout
+	StdinReader  *os.File // tunnel reads handler's stdin
+	StdinWriter  *os.File // handler writes to tunnel's stdin
+}
+
+// NewPipeBridge creates two os.Pipe pairs for bidirectional stdio bridging.
+func NewPipeBridge() (*PipeBridge, error) {
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		_ = stdoutReader.Close()
+		_ = stdoutWriter.Close()
+		return nil, err
+	}
+	return &PipeBridge{
+		StdoutReader: stdoutReader,
+		StdoutWriter: stdoutWriter,
+		StdinReader:  stdinReader,
+		StdinWriter:  stdinWriter,
+	}, nil
+}
+
+// Close closes all pipe file descriptors. Safe to call multiple times.
+func (pb *PipeBridge) Close() {
+	_ = pb.StdoutReader.Close()
+	_ = pb.StdoutWriter.Close()
+	_ = pb.StdinReader.Close()
+	_ = pb.StdinWriter.Close()
+}
+
+// TunnelFunc is called in a goroutine with the tunnel-side pipe ends.
+type TunnelFunc func(ctx context.Context, stdin *os.File, stdout *os.File) error
+
+// HandlerFunc is called in a goroutine with the handler-side pipe ends.
+type HandlerFunc func(ctx context.Context, stdout *os.File, stdin *os.File) error
+
+// RunPair launches tunnelFn and handlerFn in goroutines, coordinating shutdown
+// using the awaitGoroutines pattern from container.go.
+// On tunnel-first-exit: closes pipes to unblock handler, waits for handler result.
+// On handler-first-exit: non-blocking check on tunnel channel.
+// Returns the classified error via ClassifyTunnelErrors.
+func (pb *PipeBridge) RunPair(
+	ctx context.Context,
+	tunnelFn TunnelFunc,
+	handlerFn HandlerFunc,
+) error {
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	tunnelChan := make(chan error, 1)
+	go func() {
+		tunnelChan <- tunnelFn(cancelCtx, pb.StdinReader, pb.StdoutWriter)
+	}()
+
+	handlerChan := make(chan error, 1)
+	go func() {
+		defer cancel()
+		handlerChan <- handlerFn(cancelCtx, pb.StdoutReader, pb.StdinWriter)
+	}()
+
+	return awaitPair(tunnelChan, handlerChan, pb.StdoutWriter, pb.StdinWriter)
+}
+
+// awaitPair waits for both goroutines and returns the classified error.
+func awaitPair(
+	tunnelChan, handlerChan <-chan error,
+	stdoutWriter, stdinWriter *os.File,
+) error {
+	var tunnelErr, handlerErr error
+
+	select {
+	case handlerErr = <-handlerChan:
+		select {
+		case tunnelErr = <-tunnelChan:
+		default:
+		}
+	case tunnelErr = <-tunnelChan:
+		_ = stdoutWriter.Close()
+		_ = stdinWriter.Close()
+		handlerErr = <-handlerChan
+	}
+
+	return ClassifyTunnelErrors(tunnelErr, handlerErr)
+}

--- a/pkg/tunnel/pipebridge_test.go
+++ b/pkg/tunnel/pipebridge_test.go
@@ -1,0 +1,220 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestNewPipeBridge(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	msg := []byte("hello")
+	buf := make([]byte, len(msg))
+
+	t.Run("stdout pipe", func(t *testing.T) {
+		if _, writeErr := pb.StdoutWriter.Write(msg); writeErr != nil {
+			t.Fatalf("StdoutWriter.Write() error = %v", writeErr)
+		}
+		n, readErr := pb.StdoutReader.Read(buf)
+		if readErr != nil {
+			t.Fatalf("StdoutReader.Read() error = %v", readErr)
+		}
+		if string(buf[:n]) != "hello" {
+			t.Errorf("StdoutReader.Read() = %q, want %q", string(buf[:n]), "hello")
+		}
+	})
+
+	t.Run("stdin pipe", func(t *testing.T) {
+		if _, writeErr := pb.StdinWriter.Write(msg); writeErr != nil {
+			t.Fatalf("StdinWriter.Write() error = %v", writeErr)
+		}
+		n, readErr := pb.StdinReader.Read(buf)
+		if readErr != nil {
+			t.Fatalf("StdinReader.Read() error = %v", readErr)
+		}
+		if string(buf[:n]) != "hello" {
+			t.Errorf("StdinReader.Read() = %q, want %q", string(buf[:n]), "hello")
+		}
+	})
+}
+
+func TestRunPairBothSucceed(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	tunnel := func(_ context.Context, stdin *os.File, stdout *os.File) error {
+		buf := make([]byte, 5)
+		n, readErr := stdin.Read(buf)
+		if readErr != nil {
+			return readErr
+		}
+		_, writeErr := stdout.Write(buf[:n])
+		return writeErr
+	}
+
+	handler := func(_ context.Context, stdout *os.File, stdin *os.File) error {
+		if _, writeErr := stdin.Write([]byte("ping!")); writeErr != nil {
+			return writeErr
+		}
+		buf := make([]byte, 5)
+		n, readErr := stdout.Read(buf)
+		if readErr != nil {
+			return readErr
+		}
+		if string(buf[:n]) != "ping!" {
+			t.Errorf("handler got %q, want %q", string(buf[:n]), "ping!")
+		}
+		return nil
+	}
+
+	if runErr := pb.RunPair(context.Background(), tunnel, handler); runErr != nil {
+		t.Errorf("RunPair() error = %v, want nil", runErr)
+	}
+}
+
+func TestRunPairTunnelError(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	tunnelErr := errors.New("host unreachable")
+
+	tunnel := func(_ context.Context, _ *os.File, _ *os.File) error {
+		return tunnelErr
+	}
+
+	handler := func(_ context.Context, stdout *os.File, _ *os.File) error {
+		// Block on read until pipes are closed by awaitPair
+		buf := make([]byte, 1)
+		_, readErr := stdout.Read(buf)
+		return readErr
+	}
+
+	got := pb.RunPair(context.Background(), tunnel, handler)
+	if got == nil {
+		t.Fatal("RunPair() = nil, want error")
+	}
+	want := "connect to server: host unreachable"
+	if got.Error() != want {
+		t.Errorf("RunPair() = %q, want %q", got.Error(), want)
+	}
+}
+
+func TestRunPairHandlerError(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	handlerErr := errors.New("permission denied")
+
+	tunnel := func(ctx context.Context, _ *os.File, _ *os.File) error {
+		<-ctx.Done()
+		return nil
+	}
+
+	handler := func(_ context.Context, _ *os.File, _ *os.File) error {
+		return handlerErr
+	}
+
+	got := pb.RunPair(context.Background(), tunnel, handler)
+	if got == nil {
+		t.Fatal("RunPair() = nil, want error")
+	}
+	want := "tunnel to container: permission denied"
+	if got.Error() != want {
+		t.Errorf("RunPair() = %q, want %q", got.Error(), want)
+	}
+}
+
+func TestRunPairContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	tunnel := func(ctx context.Context, _ *os.File, _ *os.File) error {
+		<-ctx.Done()
+		return nil
+	}
+
+	handler := func(ctx context.Context, _ *os.File, _ *os.File) error {
+		cancel()
+		return nil
+	}
+
+	if runErr := pb.RunPair(ctx, tunnel, handler); runErr != nil {
+		t.Errorf("RunPair() error = %v, want nil", runErr)
+	}
+}
+
+func TestRunPairPipesClosedAfterReturn(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+
+	tunnel := func(_ context.Context, stdin *os.File, stdout *os.File) error {
+		buf := make([]byte, 1)
+		n, readErr := stdin.Read(buf)
+		if readErr != nil {
+			return readErr
+		}
+		_, writeErr := stdout.Write(buf[:n])
+		return writeErr
+	}
+
+	handler := func(_ context.Context, stdout *os.File, stdin *os.File) error {
+		if _, writeErr := stdin.Write([]byte("x")); writeErr != nil {
+			return writeErr
+		}
+		buf := make([]byte, 1)
+		_, readErr := stdout.Read(buf)
+		return readErr
+	}
+
+	if runErr := pb.RunPair(context.Background(), tunnel, handler); runErr != nil {
+		t.Fatalf("RunPair() error = %v", runErr)
+	}
+
+	// After RunPair, the write-end pipes should be closed by awaitPair
+	// (in the tunnel-first-exit path) or were never explicitly closed
+	// (handler-first-exit). Close all and verify writes fail.
+	pb.Close()
+
+	_, err = pb.StdoutWriter.Write([]byte("x"))
+	if err == nil {
+		t.Error("write to StdoutWriter after Close should fail")
+	}
+	_, err = pb.StdinWriter.Write([]byte("x"))
+	if err == nil {
+		t.Error("write to StdinWriter after Close should fail")
+	}
+}


### PR DESCRIPTION
## Summary

- Extracted the pipe-bridge-goroutine coordination pattern into `PipeBridge` (`NewPipeBridge()`, `Close()`, `RunPair()`) and the EOF/error classification logic into `ConnError` (`ClassifyTunnelErrors()`, `IsEOF()`, `ClassifyError()`)
- Refactored `container.go` `Run()` to use `PipeBridge.RunPair()` for outer tunnel coordination, and `runInContainer()` to use `PipeBridge` for pipe lifecycle management — removed inlined `awaitGoroutines`, `classifyTunnelErrors`, and `isEOFError` (net -109 lines)
- Fixed a **critical race condition** in `direct.go` `NewTunnel()`: the outer goroutine received the original `ctx` instead of `cancelCtx` (not notified on handler return), pipes were never closed on first-exit, and EOF classification was entirely absent. Replaced with `PipeBridge.RunPair()` which handles all three correctly