### PR TITLE
fix(config): handle remoteEnv null values to unset variables

### DIFF
--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -480,11 +480,12 @@ func (cmd *SetupContainerCmd) sendSetupResult(
 func fillContainerEnv(setupInfo *config.Result) error {
 	// set remote-env
 	if setupInfo.MergedConfig.RemoteEnv == nil {
-		setupInfo.MergedConfig.RemoteEnv = make(map[string]string)
+		setupInfo.MergedConfig.RemoteEnv = make(map[string]*string)
 	}
 
 	if _, ok := setupInfo.MergedConfig.RemoteEnv["PATH"]; !ok {
-		setupInfo.MergedConfig.RemoteEnv["PATH"] = "${containerEnv:PATH}"
+		pathVal := "${containerEnv:PATH}"
+		setupInfo.MergedConfig.RemoteEnv["PATH"] = &pathVal
 	}
 
 	// merge config

--- a/cmd/agent/container/setup_internal_test.go
+++ b/cmd/agent/container/setup_internal_test.go
@@ -13,15 +13,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func ptr(s string) *string { return &s }
+
 func TestCompressSetupInfoPreservesSubstitutedValues(t *testing.T) {
 	// Simulate post-substitution state: PATH is a real value, not a
 	// ${containerEnv:PATH} literal.
 	info := &config.Result{
 		MergedConfig: &config.MergedDevContainerConfig{
 			DevContainerConfigBase: config.DevContainerConfigBase{
-				RemoteEnv: map[string]string{
-					"PATH": "/usr/local/bin:/usr/bin:/bin",
-					"HOME": "/home/testuser",
+				RemoteEnv: map[string]*string{
+					"PATH": ptr("/usr/local/bin:/usr/bin:/bin"),
+					"HOME": ptr("/home/testuser"),
 				},
 			},
 		},
@@ -46,8 +48,11 @@ func TestCompressSetupInfoPreservesSubstitutedValues(t *testing.T) {
 
 	// The resolved PATH must come through, not a literal variable reference.
 	gotPath := roundTripped.MergedConfig.RemoteEnv["PATH"]
-	assert.Equal(t, "/usr/local/bin:/usr/bin:/bin", gotPath)
-	assert.False(t, strings.Contains(gotPath, "${containerEnv:"),
+	require.NotNil(t, gotPath)
+	assert.Equal(t, "/usr/local/bin:/usr/bin:/bin", *gotPath)
+	assert.False(t, strings.Contains(*gotPath, "${containerEnv:"),
 		"PATH should be resolved, not contain ${containerEnv:} literals")
-	assert.Equal(t, "/home/testuser", roundTripped.MergedConfig.RemoteEnv["HOME"])
+	gotHome := roundTripped.MergedConfig.RemoteEnv["HOME"]
+	require.NotNil(t, gotHome)
+	assert.Equal(t, "/home/testuser", *gotHome)
 }

--- a/e2e/tests/up-docker-compose/config.go
+++ b/e2e/tests/up-docker-compose/config.go
@@ -407,6 +407,55 @@ var _ = ginkgo.Describe(
 			framework.ExpectNoError(err)
 		}, ginkgo.SpecTimeout(framework.GetTimeout()))
 
+		ginkgo.It("remote env null unsets variable", func(ctx context.Context) {
+			_, workspace, err := tc.setupAndStartWorkspace(
+				ctx,
+				"tests/up-docker-compose/testdata/docker-compose-remote-env-null",
+			)
+			framework.ExpectNoError(err)
+
+			ids, err := findComposeContainer(
+				ctx,
+				tc.dockerHelper,
+				tc.composeHelper,
+				workspace.UID,
+				"app",
+			)
+			framework.ExpectNoError(err)
+			gomega.Expect(ids).To(
+				gomega.HaveLen(1),
+				"1 compose container to be created",
+			)
+
+			// Verify SET_VAR is set
+			err = tc.f.ExecCommand(
+				ctx,
+				true,
+				true,
+				"SET=hello",
+				[]string{
+					"ssh", "--command",
+					"head -1 $HOME/remote-env-null.out",
+					workspace.ID,
+				},
+			)
+			framework.ExpectNoError(err)
+
+			// Verify UNSET_VAR was unset (not just empty)
+			err = tc.f.ExecCommand(
+				ctx,
+				true,
+				true,
+				"UNSET=true",
+				[]string{
+					"ssh", "--command",
+					"tail -1 $HOME/remote-env-null.out",
+					workspace.ID,
+				},
+			)
+			framework.ExpectNoError(err)
+		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+
 		ginkgo.It("remote user", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
 				ctx,

--- a/e2e/tests/up-docker-compose/testdata/docker-compose-remote-env-null/.devcontainer.json
+++ b/e2e/tests/up-docker-compose/testdata/docker-compose-remote-env-null/.devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "remote-env-null-test",
+  "dockerComposeFile": "./docker-compose.yaml",
+  "service": "app",
+  "workspaceFolder": "/workspaces",
+  "remoteEnv": {
+    "SET_VAR": "hello",
+    "UNSET_VAR": null
+  },
+  "postCreateCommand": [
+    "sh",
+    "-c",
+    "echo SET=$SET_VAR > $HOME/remote-env-null.out && if [ -z \"${UNSET_VAR+x}\" ]; then echo UNSET=true >> $HOME/remote-env-null.out; else echo UNSET=false >> $HOME/remote-env-null.out; fi"
+  ]
+}

--- a/e2e/tests/up-docker-compose/testdata/docker-compose-remote-env-null/Dockerfile
+++ b/e2e/tests/up-docker-compose/testdata/docker-compose-remote-env-null/Dockerfile
@@ -1,0 +1,2 @@
+FROM ghcr.io/devsy-org/test-images/go:1
+ENV UNSET_VAR=should_be_gone

--- a/e2e/tests/up-docker-compose/testdata/docker-compose-remote-env-null/docker-compose.yaml
+++ b/e2e/tests/up-docker-compose/testdata/docker-compose-remote-env-null/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  app:
+    build: .
+    command: sleep infinity
+    volumes:
+      - .:/workspaces:cached

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -288,10 +288,12 @@ func (r *runner) runDockerCompose(
 
 	// expose the compose project name inside the container
 	if mergedConfig.RemoteEnv == nil {
-		mergedConfig.RemoteEnv = map[string]string{}
+		mergedConfig.RemoteEnv = map[string]*string{}
 	}
-	mergedConfig.RemoteEnv["DEVSY_COMPOSE_PROJECT_NAME"] = project.Name
-	mergedConfig.RemoteEnv["COMPOSE_PROJECT_NAME"] = project.Name
+	composeName := project.Name
+	mergedConfig.RemoteEnv["DEVSY_COMPOSE_PROJECT_NAME"] = &composeName
+	composeAlias := project.Name
+	mergedConfig.RemoteEnv["COMPOSE_PROJECT_NAME"] = &composeAlias
 
 	// setup container
 	return r.setupContainer(ctx, &setupContainerParams{

--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -66,7 +66,7 @@ type DevContainerConfigBase struct {
 	UpdateRemoteUserUID *bool `json:"updateRemoteUserUID,omitempty"`
 
 	// Remote environment variables to set for processes spawned in the container including lifecycle scripts and any remote editor/IDE server process.
-	RemoteEnv map[string]string `json:"remoteEnv,omitempty"`
+	RemoteEnv map[string]*string `json:"remoteEnv,omitempty"`
 
 	// The username to use for spawning processes in the container including lifecycle scripts and any remote editor/IDE server process. The default is the same user as the container.
 	RemoteUser string `json:"remoteUser,omitempty"`

--- a/pkg/devcontainer/config/merge.go
+++ b/pkg/devcontainer/config/merge.go
@@ -90,7 +90,7 @@ func MergeConfiguration(
 	)
 	mergedConfig.RemoteEnv = mergeMaps(
 		reversed,
-		func(entry *ImageMetadata) map[string]string { return entry.RemoteEnv },
+		func(entry *ImageMetadata) map[string]*string { return entry.RemoteEnv },
 	)
 	mergedConfig.ContainerEnv = mergeMaps(
 		reversed,

--- a/pkg/devcontainer/config_test.go
+++ b/pkg/devcontainer/config_test.go
@@ -130,8 +130,8 @@ func (s *SubstituteTestSuite) TestSubstitute_InitEnvInRemoteEnv() {
 			Image: "alpine:latest",
 		},
 		DevContainerConfigBase: config.DevContainerConfigBase{
-			RemoteEnv: map[string]string{
-				"MY_VAR": "${localEnv:CUSTOM_VAR}",
+			RemoteEnv: map[string]*string{
+				"MY_VAR": ptr("${localEnv:CUSTOM_VAR}"),
 			},
 		},
 	}
@@ -142,7 +142,8 @@ func (s *SubstituteTestSuite) TestSubstitute_InitEnvInRemoteEnv() {
 	result, ctx, err := s.runner.substitute(options, rawConfig)
 
 	s.NoError(err)
-	s.Equal("test_value", result.Config.RemoteEnv["MY_VAR"])
+	s.Require().NotNil(result.Config.RemoteEnv["MY_VAR"])
+	s.Equal("test_value", *result.Config.RemoteEnv["MY_VAR"])
 	s.Equal("test_value", ctx.Env["CUSTOM_VAR"])
 }
 
@@ -245,3 +246,5 @@ func (s *SubstituteTestSuite) TestSubstitute_AdditionalFeaturesEmpty() {
 	s.NoError(err)
 	s.Nil(result.Config.Features)
 }
+
+func ptr(s string) *string { return &s }

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -390,40 +390,59 @@ func containsError(line string) bool {
 }
 
 func mergeRemoteEnv(
-	remoteEnv map[string]string,
+	remoteEnv map[string]*string,
 	probedEnv map[string]string,
 	remoteUser string,
 ) map[string]string {
 	retEnv := map[string]string{}
-
-	// Order matters here
-	// remoteEnv should always override probedEnv as it has been specified explicitly by the devcontainer author
 	maps.Copy(retEnv, probedEnv)
-	maps.Copy(retEnv, remoteEnv)
-	probedPath, probeOk := probedEnv["PATH"]
-	remotePath, remoteOk := remoteEnv["PATH"]
-	if probeOk && remoteOk {
-		// merge probed PATH and remote PATH
-		sbinRegex := regexp.MustCompile(`/sbin(/|$)`)
-		probedTokens := strings.Split(probedPath, ":")
-		insertAt := 0
-		for e := range strings.SplitSeq(remotePath, ":") {
-			// check if remotePath entry is in probed tokens
-			i := slices.Index(probedTokens, e)
-			if i == -1 {
-				// only include /sbin paths for root users
-				if remoteUser == "root" || !sbinRegex.MatchString(e) {
-					probedTokens = slices.Insert(probedTokens, insertAt, e)
-				}
-			} else {
-				insertAt = i + 1
-			}
-		}
 
-		retEnv["PATH"] = strings.Join(probedTokens, ":")
+	// Apply remoteEnv: nil means unset, non-nil means override.
+	for k, v := range remoteEnv {
+		if v == nil {
+			delete(retEnv, k)
+		} else {
+			retEnv[k] = *v
+		}
 	}
 
+	mergePATH(retEnv, remoteEnv, probedEnv, remoteUser)
+
 	return retEnv
+}
+
+func mergePATH(
+	retEnv map[string]string,
+	remoteEnv map[string]*string,
+	probedEnv map[string]string,
+	remoteUser string,
+) {
+	remotePath, remoteOk := remoteEnv["PATH"]
+	if !remoteOk {
+		return
+	}
+	// nil PATH means unset — already handled by the delete above.
+	if remotePath == nil {
+		return
+	}
+	probedPath, probeOk := probedEnv["PATH"]
+	if !probeOk {
+		return
+	}
+	sbinRegex := regexp.MustCompile(`/sbin(/|$)`)
+	probedTokens := strings.Split(probedPath, ":")
+	insertAt := 0
+	for e := range strings.SplitSeq(*remotePath, ":") {
+		i := slices.Index(probedTokens, e)
+		if i == -1 {
+			if remoteUser == "root" || !sbinRegex.MatchString(e) {
+				probedTokens = slices.Insert(probedTokens, insertAt, e)
+			}
+		} else {
+			insertAt = i + 1
+		}
+	}
+	retEnv["PATH"] = strings.Join(probedTokens, ":")
 }
 
 func buildCommandArgs(c []string, remoteUser, currentUsername string) []string {

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -242,6 +242,53 @@ func makeTestPhaseHooks() []phaseHook {
 	}
 }
 
+func ptr(s string) *string { return &s }
+
+func (s *LifecycleHookTestSuite) TestMergeRemoteEnvNilUnsetsKey() {
+	probedEnv := map[string]string{"KEEP": "yes", "DROP": "bye"}
+	remoteEnv := map[string]*string{"DROP": nil}
+
+	result := mergeRemoteEnv(remoteEnv, probedEnv, "vscode")
+
+	assert.Equal(s.T(), "yes", result["KEEP"])
+	_, found := result["DROP"]
+	assert.False(s.T(), found, "nil value should unset key")
+}
+
+func (s *LifecycleHookTestSuite) TestMergeRemoteEnvNonNilOverrides() {
+	probedEnv := map[string]string{"VAR": "old"}
+	remoteEnv := map[string]*string{"VAR": ptr("new")}
+
+	result := mergeRemoteEnv(remoteEnv, probedEnv, "vscode")
+
+	assert.Equal(s.T(), "new", result["VAR"])
+}
+
+func (s *LifecycleHookTestSuite) TestMergeRemoteEnvNilMissingKeyNoop() {
+	probedEnv := map[string]string{"OTHER": "val"}
+	remoteEnv := map[string]*string{"ABSENT": nil}
+
+	result := mergeRemoteEnv(remoteEnv, probedEnv, "vscode")
+
+	assert.Equal(s.T(), "val", result["OTHER"])
+	_, found := result["ABSENT"]
+	assert.False(s.T(), found)
+}
+
+func (s *LifecycleHookTestSuite) TestMergeRemoteEnvNilPATHRemoves() {
+	probedEnv := map[string]string{
+		"PATH": "/usr/bin:/bin",
+		"HOME": "/home/dev",
+	}
+	remoteEnv := map[string]*string{"PATH": nil}
+
+	result := mergeRemoteEnv(remoteEnv, probedEnv, "vscode")
+
+	_, found := result["PATH"]
+	assert.False(s.T(), found, "nil PATH should remove PATH")
+	assert.Equal(s.T(), "/home/dev", result["HOME"])
+}
+
 func TestLifecycleHookTestSuite(t *testing.T) {
 	suite.Run(t, new(LifecycleHookTestSuite))
 }

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -280,24 +280,54 @@ func patchEtcEnvironment(mergedConfig *config.MergedDevContainerConfig) error {
 		return nil
 	}
 
-	// build remote env
-	remoteEnvs := []string{}
-	for k, v := range mergedConfig.RemoteEnv {
-		remoteEnvs = append(remoteEnvs, k+"=\""+v+"\"")
-	}
-	sort.Strings(remoteEnvs)
+	setEnvs, unsetKeys := splitRemoteEnv(mergedConfig.RemoteEnv)
+	marker := buildEnvMarker(setEnvs, unsetKeys)
 
-	// check if we need to update env
-	exists, err := markerFileExists("patchEtcEnvironment", strings.Join(remoteEnvs, "\n"))
+	exists, err := markerFileExists("patchEtcEnvironment", marker)
 	if err != nil {
 		return err
 	} else if exists {
 		return nil
 	}
 
-	// update env
-	envfile.MergeAndApply(mergedConfig.RemoteEnv)
+	envfile.MergeAndApply(setEnvs)
+	for _, k := range unsetKeys {
+		if err := os.Unsetenv(k); err != nil {
+			return fmt.Errorf("unset env %s: %w", k, err)
+		}
+	}
+
 	return nil
+}
+
+func splitRemoteEnv(
+	remoteEnv map[string]*string,
+) (map[string]string, []string) {
+	setEnvs := map[string]string{}
+	unsetKeys := []string{}
+	for k, v := range remoteEnv {
+		if v == nil {
+			unsetKeys = append(unsetKeys, k)
+		} else {
+			setEnvs[k] = *v
+		}
+	}
+	return setEnvs, unsetKeys
+}
+
+func buildEnvMarker(
+	setEnvs map[string]string,
+	unsetKeys []string,
+) string {
+	lines := make([]string, 0, len(setEnvs))
+	for k, v := range setEnvs {
+		lines = append(lines, k+"=\""+v+"\"")
+	}
+	sort.Strings(lines)
+	sort.Strings(unsetKeys)
+	return strings.Join(lines, "\n") +
+		"\n---unset---\n" +
+		strings.Join(unsetKeys, "\n")
 }
 
 func chownAgentSock(setupInfo *config.Result) error {


### PR DESCRIPTION
## Summary

- Change `RemoteEnv` type from `map[string]string` to `map[string]*string` so JSON `null` values are preserved as `nil` pointers instead of silently becoming empty strings
- Update `mergeRemoteEnv()` to delete environment variables when the remoteEnv value is `nil`, implementing the devcontainer spec's "unset" semantics
- Update `patchEtcEnvironment()` to call `os.Unsetenv` for nil entries and only pass non-nil values to `envfile.MergeAndApply`
- Update all consumers (`compose.go`, `fillContainerEnv`, merge accessor) to use `*string` pointer semantics
- Add unit tests for null unset behavior in `mergeRemoteEnv` (nil removes key, nil on missing key is no-op, nil PATH removes PATH)
- Add e2e test with a container image that sets `UNSET_VAR` to verify it gets fully unset when `remoteEnv` has it as `null`

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for null environment variables in devcontainer remote environment configuration, enabling explicit removal of environment variables inherited from container images rather than only overriding them.

* **Tests**
  * Added comprehensive end-to-end test coverage for environment variable propagation and explicit unset behavior in docker-compose configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->