### PR TITLE
fix(lifecycle): run named sub-commands in parallel within lifecycle hooks

### DIFF
--- a/e2e/tests/up-docker-compose/testdata/docker-compose-lifecycle-parallel-object/.devcontainer.json
+++ b/e2e/tests/up-docker-compose/testdata/docker-compose-lifecycle-parallel-object/.devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "Go",
+  "dockerComposeFile": "./docker-compose.yaml",
+  "service": "app",
+  "workspaceFolder": "/workspaces",
+  "postCreateCommand": {
+    "marker-a": "echo -n parallelA > $HOME/parallel-a.out",
+    "marker-b": "echo -n parallelB > $HOME/parallel-b.out"
+  }
+}

--- a/e2e/tests/up-docker-compose/testdata/docker-compose-lifecycle-parallel-object/docker-compose.yaml
+++ b/e2e/tests/up-docker-compose/testdata/docker-compose-lifecycle-parallel-object/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  app:
+    image: ghcr.io/devsy-org/test-images/go:1
+    command: sleep infinity
+    volumes:
+      - .:/workspaces:cached

--- a/e2e/tests/up-docker-compose/up_docker_compose.go
+++ b/e2e/tests/up-docker-compose/up_docker_compose.go
@@ -348,6 +348,40 @@ var _ = ginkgo.Describe(
 			gomega.Expect(postAttachCommand).To(gomega.Equal("postAttachCommand"))
 		}, ginkgo.SpecTimeout(framework.GetTimeout()))
 
+		ginkgo.It("parallel object based commands", func(ctx context.Context) {
+			tempDir, err := setupWorkspace(
+				"tests/up-docker-compose/testdata/docker-compose-lifecycle-parallel-object",
+				tc.initialDir,
+				tc.f,
+			)
+			framework.ExpectNoError(err)
+
+			err = tc.f.DevsyUp(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			workspace, err := tc.f.FindWorkspace(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			ids, err := tc.dockerHelper.FindContainer(ctx, []string{
+				fmt.Sprintf(
+					"%s=%s",
+					compose.ProjectLabel,
+					tc.composeHelper.GetProjectName(workspace.UID),
+				),
+				fmt.Sprintf("%s=%s", compose.ServiceLabel, "app"),
+			})
+			framework.ExpectNoError(err)
+			gomega.Expect(ids).To(gomega.HaveLen(1), "1 compose container to be created")
+
+			parallelA, err := tc.execSSH(ctx, tempDir, "cat $HOME/parallel-a.out")
+			framework.ExpectNoError(err)
+			gomega.Expect(parallelA).To(gomega.Equal("parallelA"))
+
+			parallelB, err := tc.execSSH(ctx, tempDir, "cat $HOME/parallel-b.out")
+			framework.ExpectNoError(err)
+			gomega.Expect(parallelB).To(gomega.Equal("parallelB"))
+		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+
 		ginkgo.It("commands with quotes", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
 				"tests/up-docker-compose/testdata/docker-compose-lifecycle-quotes",

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -282,13 +283,47 @@ func executeHookCommands(p hookRunParams, envArr []string) error {
 		if len(cmd) == 0 {
 			continue
 		}
-		for k, c := range cmd {
-			if err := runSingleHookCommand(p, envArr, k, c); err != nil {
-				return err
-			}
+		if err := executeLifecycleHook(p, envArr, cmd); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// executeLifecycleHook runs the sub-commands within a single LifecycleHook.
+// When the hook has multiple named keys (object syntax), the sub-commands run
+// concurrently per the devcontainer spec. Single-key hooks run directly.
+func executeLifecycleHook(
+	p hookRunParams,
+	envArr []string,
+	hook types.LifecycleHook,
+) error {
+	if len(hook) <= 1 {
+		for k, c := range hook {
+			return runSingleHookCommand(p, envArr, k, c)
+		}
+	}
+
+	var (
+		wg   sync.WaitGroup
+		mu   sync.Mutex
+		errs []error
+	)
+
+	wg.Add(len(hook))
+	for k, c := range hook {
+		go func() {
+			defer wg.Done()
+			if err := runSingleHookCommand(p, envArr, k, c); err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("named command %q failed: %w", k, err))
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+	return errors.Join(errs...)
 }
 
 func runSingleHookCommand(

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -2,12 +2,16 @@ package setup
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"os/user"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -287,6 +291,147 @@ func (s *LifecycleHookTestSuite) TestMergeRemoteEnvNilPATHRemoves() {
 	_, found := result["PATH"]
 	assert.False(s.T(), found, "nil PATH should remove PATH")
 	assert.Equal(s.T(), "/home/dev", result["HOME"])
+}
+
+func (s *LifecycleHookTestSuite) TestParallelNamedCommandsTiming() {
+	t := s.T()
+	currentUser, err := user.Current()
+	assert.NoError(t, err)
+
+	// Two "sleep 0.5" commands that, if run in parallel, complete in ~0.5s.
+	hook := types.LifecycleHook{
+		"sleep-a": {"sleep", "0.5"},
+		"sleep-b": {"sleep", "0.5"},
+	}
+
+	p := hookRunParams{
+		commands: []types.LifecycleHook{hook},
+		env: lifecycleEnv{
+			remoteUser:      currentUser.Username,
+			workspaceFolder: t.TempDir(),
+		},
+		name: "testParallel",
+	}
+
+	envArr := buildEnvArr(p.env.remoteEnv)
+
+	start := time.Now()
+	err = executeHookCommands(p, envArr)
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.Less(t, elapsed, 900*time.Millisecond,
+		"two 0.5s commands should complete in ~0.5s when parallel, not ~1s")
+}
+
+func (s *LifecycleHookTestSuite) TestParallelNamedCommandsErrorIsolation() {
+	t := s.T()
+	currentUser, err := user.Current()
+	assert.NoError(t, err)
+
+	dir := t.TempDir()
+	markerFile := filepath.Join(dir, "ran.txt")
+
+	// "fail" exits immediately; "succeed" sleeps briefly then writes a marker.
+	hook := types.LifecycleHook{
+		"fail":    {"sh", "-c", "exit 1"},
+		"succeed": {"sh", "-c", fmt.Sprintf("sleep 0.1 && echo done > %s", markerFile)},
+	}
+
+	p := hookRunParams{
+		commands: []types.LifecycleHook{hook},
+		env: lifecycleEnv{
+			remoteUser:      currentUser.Username,
+			workspaceFolder: dir,
+		},
+		name: "testErrorIsolation",
+	}
+
+	envArr := buildEnvArr(p.env.remoteEnv)
+	err = executeHookCommands(p, envArr)
+
+	// The combined error should mention which named command failed.
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), `named command "fail" failed`)
+
+	// The succeed command should have run to completion despite the failure.
+	_, statErr := os.Stat(markerFile)
+	assert.NoError(t, statErr, "succeed command should run even when fail command errors")
+}
+
+func (s *LifecycleHookTestSuite) TestSingleStringCommandBackwardCompat() {
+	t := s.T()
+	currentUser, err := user.Current()
+	assert.NoError(t, err)
+
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "out.txt")
+
+	// Anonymous string command uses key "".
+	hook := types.LifecycleHook{
+		"": {"sh", "-c", fmt.Sprintf("echo hello > %s", outFile)},
+	}
+
+	p := hookRunParams{
+		commands: []types.LifecycleHook{hook},
+		env: lifecycleEnv{
+			remoteUser:      currentUser.Username,
+			workspaceFolder: dir,
+		},
+		name: "testBackwardCompat",
+	}
+
+	envArr := buildEnvArr(p.env.remoteEnv)
+	err = executeHookCommands(p, envArr)
+
+	assert.NoError(t, err)
+	assertFileContains(t, dir, "out.txt", "hello")
+}
+
+func (s *LifecycleHookTestSuite) TestSingleNamedCommandNoGoroutine() {
+	t := s.T()
+	currentUser, err := user.Current()
+	assert.NoError(t, err)
+
+	dir := t.TempDir()
+	outFile := filepath.Join(dir, "named.txt")
+
+	hook := types.LifecycleHook{
+		"setup": {
+			"sh", "-c",
+			fmt.Sprintf("echo setup > %s", outFile),
+		},
+	}
+
+	p := hookRunParams{
+		commands: []types.LifecycleHook{hook},
+		env: lifecycleEnv{
+			remoteUser:      currentUser.Username,
+			workspaceFolder: dir,
+		},
+		name: "testSingleNamed",
+	}
+
+	envArr := buildEnvArr(p.env.remoteEnv)
+	err = executeHookCommands(p, envArr)
+
+	assert.NoError(t, err)
+	assertFileContains(t, dir, "named.txt", "setup")
+}
+
+// assertFileContains reads a file under dir by name and checks it
+// contains the expected substring. Using filepath.Join with a
+// known-safe base directory satisfies gosec G304.
+func assertFileContains(
+	t *testing.T,
+	dir, name, expected string,
+) {
+	t.Helper()
+	content, err := os.ReadFile(
+		filepath.Clean(filepath.Join(dir, name)),
+	)
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), expected)
 }
 
 func TestLifecycleHookTestSuite(t *testing.T) {


### PR DESCRIPTION
## Summary

- Object-syntax lifecycle commands (e.g. `{"install": "npm install", "build": "npm run build"}`) now run their named sub-commands concurrently via goroutines, matching the devcontainer spec
- Single-key hooks (including anonymous string/array commands) continue to run directly without goroutines
- When multiple sub-commands fail, all errors are collected with `errors.Join` and each identifies which named command failed
- Adds unit tests covering parallel timing verification, error isolation, and backward compatibility
- Adds e2e testdata and test case for parallel object-based lifecycle commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lifecycle hooks in devcontainers now support parallel execution, improving setup performance when multiple commands are defined.

* **Tests**
  * Added end-to-end tests validating parallel command execution in devcontainer lifecycle hooks.
  * Extended unit tests to verify parallel execution timing and error handling across multiple concurrent commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->