### PR TITLE
fix(lifecycle): install dotfiles between postCreate and postStart

### DIFF
--- a/cmd/agent/container/deferred_hooks.go
+++ b/cmd/agent/container/deferred_hooks.go
@@ -55,7 +55,7 @@ func (cmd *DeferredHooksCmd) Run(ctx context.Context) error {
 	}
 
 	log.Debugf("running deferred lifecycle hooks")
-	deferred, err := setup.RunPreAttachHooks(ctx, setupInfo, cmd.Prebuild)
+	deferred, err := setup.RunPreAttachHooks(ctx, setupInfo, cmd.Prebuild, setup.DotfilesConfig{})
 	if err != nil {
 		log.Errorf("deferred hooks setup failed: %v", err)
 		return nil

--- a/cmd/agent/container/deferred_hooks.go
+++ b/cmd/agent/container/deferred_hooks.go
@@ -17,8 +17,10 @@ import (
 // DeferredHooksCmd runs deferred lifecycle hooks as a detached background process.
 type DeferredHooksCmd struct {
 	*flags.GlobalFlags
-	SetupInfo string
-	Prebuild  bool
+	SetupInfo      string
+	Prebuild       bool
+	DotfilesRepo   string
+	DotfilesScript string
 }
 
 // NewDeferredHooksCmd creates a new command.
@@ -38,6 +40,10 @@ func NewDeferredHooksCmd(flags *flags.GlobalFlags) *cobra.Command {
 		StringVar(&cmd.SetupInfo, "setup-info", "", "The container setup info")
 	deferredCmd.Flags().
 		BoolVar(&cmd.Prebuild, "prebuild", false, "If true, prebuild lifecycle mode")
+	deferredCmd.Flags().
+		StringVar(&cmd.DotfilesRepo, "dotfiles-repo", "", "Dotfiles repository URL")
+	deferredCmd.Flags().
+		StringVar(&cmd.DotfilesScript, "dotfiles-script", "", "Dotfiles install script path")
 	_ = deferredCmd.MarkFlagRequired("setup-info")
 	return deferredCmd
 }
@@ -55,7 +61,10 @@ func (cmd *DeferredHooksCmd) Run(ctx context.Context) error {
 	}
 
 	log.Debugf("running deferred lifecycle hooks")
-	deferred, err := setup.RunPreAttachHooks(ctx, setupInfo, cmd.Prebuild, setup.DotfilesConfig{})
+	deferred, err := setup.RunPreAttachHooks(ctx, setupInfo, cmd.Prebuild, setup.DotfilesConfig{
+		Repository:    cmd.DotfilesRepo,
+		InstallScript: cmd.DotfilesScript,
+	})
 	if err != nil {
 		log.Errorf("deferred hooks setup failed: %v", err)
 		return nil

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -56,6 +56,8 @@ type SetupContainerCmd struct {
 	AccessKey              string
 	PlatformHost           string
 	WorkspaceHost          string
+	DotfilesRepo           string
+	DotfilesScript         string
 }
 
 // NewSetupContainerCmd creates a new command.
@@ -89,6 +91,10 @@ func NewSetupContainerCmd(flags *flags.GlobalFlags) *cobra.Command {
 	setupContainerCmd.Flags().
 		StringVar(&cmd.WorkspaceHost, "workspace-host", "", "Workspace hostname to use")
 	setupContainerCmd.Flags().StringVar(&cmd.PlatformHost, "platform-host", "", "Platform host")
+	setupContainerCmd.Flags().
+		StringVar(&cmd.DotfilesRepo, "dotfiles-repo", "", "Dotfiles repository URL")
+	setupContainerCmd.Flags().
+		StringVar(&cmd.DotfilesScript, "dotfiles-script", "", "Dotfiles install script path")
 	_ = setupContainerCmd.MarkFlagRequired("setup-info")
 	return setupContainerCmd
 }
@@ -186,6 +192,10 @@ func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
 		PlatformOptions:   &sctx.workspaceInfo.CLIOptions.Platform,
 		TunnelClient:      sctx.tunnelClient,
 		Prebuild:          cmd.Prebuild,
+		Dotfiles: setup.DotfilesConfig{
+			Repository:    cmd.DotfilesRepo,
+			InstallScript: cmd.DotfilesScript,
+		},
 	}
 
 	deferred, err := setup.SetupContainerPreAttach(sctx.ctx, cfg)

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -235,7 +235,10 @@ func (cmd *SetupContainerCmd) setupPostAttach(
 	}
 
 	if !deferred.Empty() {
-		if err := cmd.startDeferredHooks(resolvedSetupInfo); err != nil {
+		err = cmd.startDeferredHooks(
+			resolvedSetupInfo, cmd.DotfilesRepo, cmd.DotfilesScript,
+		)
+		if err != nil {
 			log.Errorf("failed to start deferred lifecycle hooks: %v", err)
 		}
 	}
@@ -257,14 +260,18 @@ func compressSetupInfo(setupInfo *config.Result) (string, error) {
 	return compress.Compress(string(raw))
 }
 
-func (cmd *SetupContainerCmd) startDeferredHooks(setupInfo string) error {
+func (cmd *SetupContainerCmd) startDeferredHooks(
+	setupInfo, dotfilesRepo, dotfilesScript string,
+) error {
 	return command.StartBackgroundOnce("devsy.deferred-hooks", func() (*exec.Cmd, error) {
 		log.Debugf("starting deferred lifecycle hooks as background process")
-		return buildDeferredHooksCmd(setupInfo, cmd.Prebuild)
+		return buildDeferredHooksCmd(setupInfo, cmd.Prebuild, dotfilesRepo, dotfilesScript)
 	})
 }
 
-func buildDeferredHooksCmd(setupInfo string, prebuild bool) (*exec.Cmd, error) {
+func buildDeferredHooksCmd(
+	setupInfo string, prebuild bool, dotfilesRepo, dotfilesScript string,
+) (*exec.Cmd, error) {
 	binaryPath, err := os.Executable()
 	if err != nil {
 		return nil, err
@@ -276,6 +283,12 @@ func buildDeferredHooksCmd(setupInfo string, prebuild bool) (*exec.Cmd, error) {
 	}
 	if prebuild {
 		args = append(args, "--prebuild")
+	}
+	if dotfilesRepo != "" {
+		args = append(args, "--dotfiles-repo", dotfilesRepo)
+	}
+	if dotfilesScript != "" {
+		args = append(args, "--dotfiles-script", dotfilesScript)
 	}
 
 	return &exec.Cmd{

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -286,20 +286,20 @@ type workspaceContext struct {
 	workdir string
 }
 
-// resolveDotfilesOptions populates CLIOptions.DotfilesRepo and DotfilesScript
+// resolveDotfilesOptions populates DotfilesRepo and DotfilesScript
 // from the CLI flags and config context options so they flow to the container.
 func (cmd *UpCmd) resolveDotfilesOptions(devsyConfig *config.Config) {
 	repo := devsyConfig.ContextOption(config.ContextOptionDotfilesURL)
 	if cmd.DotfilesSource != "" {
 		repo = cmd.DotfilesSource
 	}
-	cmd.CLIOptions.DotfilesRepo = repo
+	cmd.DotfilesRepo = repo
 
 	script := devsyConfig.ContextOption(config.ContextOptionDotfilesScript)
 	if cmd.DotfilesScript != "" {
 		script = cmd.DotfilesScript
 	}
-	cmd.CLIOptions.DotfilesScript = script
+	cmd.DotfilesScript = script
 }
 
 // prepareWorkspace handles initial setup and validation.
@@ -389,7 +389,7 @@ func (cmd *UpCmd) configureWorkspace(
 	// (between postCreateCommand and postStartCommand). The host-side
 	// SSH-based installation is only used as a fallback when the
 	// container-side path was not configured.
-	if cmd.CLIOptions.DotfilesRepo == "" {
+	if cmd.DotfilesRepo == "" {
 		if err := dotfiles.Setup(dotfiles.SetupParams{
 			Source:       cmd.DotfilesSource,
 			Script:       cmd.DotfilesScript,

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -78,6 +78,8 @@ func (cmd *UpCmd) execute(cobraCmd *cobra.Command, args []string) error {
 		cmd.StrictHostKeyChecking = true
 	}
 
+	cmd.resolveDotfilesOptions(devsyConfig)
+
 	ctx, cancel := WithSignals(cobraCmd.Context())
 	defer cancel()
 
@@ -284,6 +286,22 @@ type workspaceContext struct {
 	workdir string
 }
 
+// resolveDotfilesOptions populates CLIOptions.DotfilesRepo and DotfilesScript
+// from the CLI flags and config context options so they flow to the container.
+func (cmd *UpCmd) resolveDotfilesOptions(devsyConfig *config.Config) {
+	repo := devsyConfig.ContextOption(config.ContextOptionDotfilesURL)
+	if cmd.DotfilesSource != "" {
+		repo = cmd.DotfilesSource
+	}
+	cmd.CLIOptions.DotfilesRepo = repo
+
+	script := devsyConfig.ContextOption(config.ContextOptionDotfilesScript)
+	if cmd.DotfilesScript != "" {
+		script = cmd.DotfilesScript
+	}
+	cmd.CLIOptions.DotfilesScript = script
+}
+
 // prepareWorkspace handles initial setup and validation.
 func (cmd *UpCmd) prepareWorkspace(client client2.BaseWorkspaceClient) {
 	if cmd.Reset {
@@ -367,15 +385,21 @@ func (cmd *UpCmd) configureWorkspace(
 		log.Info("SSH configuration completed in workspace")
 	}
 
-	if err := dotfiles.Setup(dotfiles.SetupParams{
-		Source:       cmd.DotfilesSource,
-		Script:       cmd.DotfilesScript,
-		EnvFiles:     cmd.DotfilesScriptEnvFile,
-		EnvKeyValues: cmd.DotfilesScriptEnv,
-		Client:       client,
-		DevsyConfig:  devsyConfig,
-	}); err != nil {
-		return err
+	// Dotfiles are now installed in-container during the lifecycle
+	// (between postCreateCommand and postStartCommand). The host-side
+	// SSH-based installation is only used as a fallback when the
+	// container-side path was not configured.
+	if cmd.CLIOptions.DotfilesRepo == "" {
+		if err := dotfiles.Setup(dotfiles.SetupParams{
+			Source:       cmd.DotfilesSource,
+			Script:       cmd.DotfilesScript,
+			EnvFiles:     cmd.DotfilesScriptEnvFile,
+			EnvKeyValues: cmd.DotfilesScriptEnv,
+			Client:       client,
+			DevsyConfig:  devsyConfig,
+		}); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -299,7 +299,7 @@ func (cmd *UpCmd) resolveDotfilesOptions(devsyConfig *config.Config) {
 	if cmd.DotfilesScript != "" {
 		script = cmd.DotfilesScript
 	}
-	cmd.DotfilesScript = script
+	cmd.CLIOptions.DotfilesScript = script
 }
 
 // prepareWorkspace handles initial setup and validation.

--- a/e2e/tests/up/dotfiles.go
+++ b/e2e/tests/up/dotfiles.go
@@ -3,10 +3,12 @@ package up
 import (
 	"context"
 	"os"
+	"strings"
 
 	"github.com/devsy-org/devsy/e2e/framework"
 	docker "github.com/devsy-org/devsy/pkg/docker"
 	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
 )
 
 var _ = ginkgo.Describe(
@@ -88,6 +90,39 @@ var _ = ginkgo.Describe(
 			out, err := dtc.execSSH(ctx, tempDir, "cat ~/.branch_test")
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(out, "test\n")
+		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+
+		ginkgo.It("dotfiles installed between postCreate and postStart", func(ctx context.Context) {
+			tempDir, err := dtc.setupAndUp(
+				ctx,
+				"tests/up/testdata/docker-dotfiles-lifecycle-order",
+				"--dotfiles",
+				"https://github.com/loft-sh/example-dotfiles",
+				"--dotfiles-script",
+				"install-example",
+			)
+			framework.ExpectNoError(err)
+
+			// Verify dotfiles install-example ran (creates /tmp/worked).
+			_, err = dtc.execSSH(ctx, tempDir, "test -f /tmp/worked")
+			framework.ExpectNoError(err)
+
+			// The devcontainer.json commands probe /tmp/worked at runtime:
+			//   postCreateCommand checks if /tmp/worked exists (it should NOT yet)
+			//   postStartCommand checks if /tmp/worked exists (it SHOULD by now)
+			// Correct ordering (postCreate → dotfiles → postStart) produces:
+			//   postCreate
+			//   dotfiles-before-postStart
+			//   postStart
+			out, err := dtc.execSSH(ctx, tempDir, "cat /tmp/lifecycle-order.log")
+			framework.ExpectNoError(err)
+
+			lines := strings.Split(strings.TrimSpace(out), "\n")
+			gomega.Expect(lines).To(gomega.Equal([]string{
+				"postCreate",
+				"dotfiles-before-postStart",
+				"postStart",
+			}), "lifecycle ordering should be: postCreate → dotfiles → postStart")
 		}, ginkgo.SpecTimeout(framework.GetTimeout()))
 	},
 )

--- a/e2e/tests/up/testdata/docker-dotfiles-lifecycle-order/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-dotfiles-lifecycle-order/.devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "image": "ghcr.io/devsy-org/test-images/go:1",
+  "postCreateCommand": "if [ -f /tmp/worked ]; then echo dotfiles-before-postCreate >> /tmp/lifecycle-order.log; fi && echo postCreate >> /tmp/lifecycle-order.log",
+  "postStartCommand": "if [ -f /tmp/worked ]; then echo dotfiles-before-postStart >> /tmp/lifecycle-order.log; fi && echo postStart >> /tmp/lifecycle-order.log"
+}

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -189,6 +189,7 @@ func (r *runner) addSetupFlags(args *[]string) {
 	r.addChownFlag(args, isDockerDriver)
 	r.addDriverFlags(args, isDockerDriver)
 	r.addPlatformFlags(args)
+	r.addDotfilesFlags(args)
 	r.addPrebuildFlag(args)
 	r.addDebugFlag(args)
 }
@@ -218,6 +219,16 @@ func (r *runner) addPlatformFlags(args *[]string) {
 	}
 	if platform.PlatformHost != "" {
 		*args = append(*args, "--platform-host", shellescape.Quote(platform.PlatformHost))
+	}
+}
+
+func (r *runner) addDotfilesFlags(args *[]string) {
+	cli := r.WorkspaceConfig.CLIOptions
+	if cli.DotfilesRepo != "" {
+		*args = append(*args, "--dotfiles-repo", shellescape.Quote(cli.DotfilesRepo))
+	}
+	if cli.DotfilesScript != "" {
+		*args = append(*args, "--dotfiles-script", shellescape.Quote(cli.DotfilesScript))
 	}
 }
 

--- a/pkg/devcontainer/setup/dotfiles.go
+++ b/pkg/devcontainer/setup/dotfiles.go
@@ -1,0 +1,184 @@
+package setup
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/devsy-org/devsy/pkg/git"
+	"github.com/devsy-org/devsy/pkg/log"
+)
+
+// PhaseDotfiles is a synthetic lifecycle phase for dotfiles installation.
+// Per the devcontainer spec, dotfiles run after postCreateCommand and
+// before postStartCommand.
+const PhaseDotfiles LifecyclePhase = "dotfilesInstall"
+
+// RunDotfiles clones the dotfiles repository and runs the install script
+// inside the container. It is a no-op when repo is empty. The caller is
+// responsible for marker-file checks.
+func RunDotfiles(ctx context.Context, cfg DotfilesConfig) error {
+	if cfg.Repository == "" {
+		return nil
+	}
+
+	log.Infof("Installing dotfiles from %s", cfg.Repository)
+
+	targetDir, err := dotfilesTargetDir()
+	if err != nil {
+		return err
+	}
+
+	if err := cloneDotfiles(ctx, cfg.Repository, targetDir); err != nil {
+		return err
+	}
+
+	return installDotfiles(ctx, cfg.InstallScript, targetDir)
+}
+
+func dotfilesTargetDir() (string, error) {
+	home := os.Getenv("HOME")
+	if home == "" {
+		return "", fmt.Errorf("HOME environment variable not set")
+	}
+	return filepath.Join(home, "dotfiles"), nil
+}
+
+func cloneDotfiles(ctx context.Context, repo, targetDir string) error {
+	if _, err := os.Stat(targetDir); err == nil {
+		log.Info("dotfiles already cloned, skipping")
+		return nil
+	}
+
+	log.Infof("Cloning dotfiles %s", repo)
+	gitInfo := git.NormalizeRepositoryGitInfo(repo)
+	return git.CloneRepository(ctx, gitInfo, targetDir, "", false)
+}
+
+func installDotfiles(
+	ctx context.Context,
+	script, targetDir string,
+) error {
+	if err := os.Chdir(targetDir); err != nil {
+		return fmt.Errorf("enter dotfiles directory: %w", err)
+	}
+
+	if script != "" {
+		return runDotfilesScript(ctx, script)
+	}
+
+	return runKnownDotfilesScripts(ctx)
+}
+
+func runDotfilesScript(ctx context.Context, script string) error {
+	log.Infof("Executing dotfiles install script %s", script)
+	p := "./" + strings.TrimPrefix(script, "./")
+
+	if err := ensureDotfileExecutable(ctx, p); err != nil {
+		return err
+	}
+
+	return execDotfilesCmd(ctx, p)
+}
+
+var knownInstallScripts = []string{
+	"./install.sh",
+	"./install",
+	"./bootstrap.sh",
+	"./bootstrap",
+	"./script/bootstrap",
+	"./setup.sh",
+	"./setup",
+	"./setup/setup",
+}
+
+func runKnownDotfilesScripts(ctx context.Context) error {
+	scripts := slices.DeleteFunc(
+		slices.Clone(knownInstallScripts),
+		func(p string) bool {
+			_, err := os.Stat(p)
+			return os.IsNotExist(err)
+		},
+	)
+
+	for _, s := range scripts {
+		if err := ensureDotfileExecutable(ctx, s); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			continue
+		}
+		if err := execDotfilesCmd(ctx, s); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			continue
+		}
+		log.Debug("dotfiles install script executed")
+		return nil
+	}
+
+	log.Info("No install script found, linking dotfiles")
+	return linkAllDotfiles()
+}
+
+func linkAllDotfiles() error {
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	files, err := os.ReadDir(".")
+	if err != nil {
+		return err
+	}
+
+	home := os.Getenv("HOME")
+	for _, f := range files {
+		if !strings.HasPrefix(f.Name(), ".") || f.IsDir() {
+			continue
+		}
+		src := filepath.Join(pwd, f.Name())
+		dest := filepath.Join(home, f.Name())
+		if err := linkDotfile(src, dest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func linkDotfile(src, dest string) error {
+	log.Debugf("linking %s in home", filepath.Base(dest))
+	cleanDest := filepath.Clean(dest)
+	if _, err := os.Lstat(cleanDest); err == nil {
+		_ = os.Remove(cleanDest) // #nosec G703 -- user dotfile path
+	}
+	return os.Symlink(src, cleanDest)
+}
+
+func ensureDotfileExecutable(ctx context.Context, path string) error {
+	// #nosec G204 -- user-provided dotfile install script path
+	checkCmd := exec.CommandContext(ctx, "test", "-f", path)
+	if err := checkCmd.Run(); err != nil {
+		return fmt.Errorf("install script %s not found: %w", path, err)
+	}
+
+	// #nosec G204 -- user-provided dotfile install script path
+	chmodCmd := exec.CommandContext(ctx, "chmod", "+x", path)
+	if err := chmodCmd.Run(); err != nil {
+		return fmt.Errorf("chmod +x %s: %w", path, err)
+	}
+	return nil
+}
+
+func execDotfilesCmd(ctx context.Context, script string) error {
+	writer := log.Writer(log.LevelInfo)
+	cmd := exec.CommandContext(ctx, script)
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	return cmd.Run()
+}

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -231,7 +231,7 @@ func runPrebuildHooks(all []phaseHook) error {
 		if ph.phase != PhaseOnCreate && ph.phase != PhaseUpdateContent {
 			continue
 		}
-		if err := runHook(ph.params); err != nil {
+		if err := runPhaseHook(ph); err != nil {
 			return err
 		}
 	}

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -123,36 +123,41 @@ func preAttachPhaseParams(
 	}
 
 	return []phaseHook{
-		{PhaseOnCreate, hookRunParams{mc.OnCreateCommands, env, "onCreateCommands", cd.Created}},
 		{
-			PhaseUpdateContent,
-			hookRunParams{
-				mc.UpdateContentCommands,
-				env,
-				"updateContentCommands",
-				updateContentMarker,
+			phase:  PhaseOnCreate,
+			params: hookRunParams{mc.OnCreateCommands, env, "onCreateCommands", cd.Created},
+		},
+		{
+			phase: PhaseUpdateContent,
+			params: hookRunParams{
+				mc.UpdateContentCommands, env, "updateContentCommands", updateContentMarker,
 			},
 		},
 		{
-			PhasePostCreate,
-			hookRunParams{mc.PostCreateCommands, env, "postCreateCommands", cd.Created},
+			phase:  PhasePostCreate,
+			params: hookRunParams{mc.PostCreateCommands, env, "postCreateCommands", cd.Created},
 		},
 		{
-			PhasePostStart,
-			hookRunParams{mc.PostStartCommands, env, "postStartCommands", cd.State.StartedAt},
+			phase: PhasePostStart,
+			params: hookRunParams{
+				mc.PostStartCommands, env, "postStartCommands", cd.State.StartedAt,
+			},
 		},
 	}
 }
 
 // phaseHook pairs a lifecycle phase with the parameters needed to run it.
+// When runFunc is set it is called instead of runHook (used for dotfiles).
 type phaseHook struct {
-	phase  LifecyclePhase
-	params hookRunParams
+	phase   LifecyclePhase
+	params  hookRunParams
+	runFunc func() error
 }
 
 // RunPreAttachHooks runs lifecycle hooks up to and including the waitFor phase
 // synchronously and returns a slice of deferred phases that should run in the
-// background.
+// background. Dotfiles are installed between postCreateCommand and
+// postStartCommand per the devcontainer spec.
 //
 // When prebuild is true, only onCreateCommand and updateContentCommand are
 // executed and waitFor is ignored.
@@ -160,9 +165,14 @@ func RunPreAttachHooks(
 	ctx context.Context,
 	setupInfo *config.Result,
 	prebuild bool,
+	dotfiles DotfilesConfig,
 ) (DeferredHooks, error) {
 	env := resolveLifecycleEnv(ctx, setupInfo)
 	all := preAttachPhaseParams(setupInfo, env, prebuild)
+
+	// Insert the dotfiles phase between postCreate and postStart.
+	created := setupInfo.ContainerDetails.Created
+	all = insertDotfilesPhase(ctx, all, dotfiles, created)
 
 	if prebuild {
 		return DeferredHooks{}, runPrebuildHooks(all)
@@ -171,6 +181,48 @@ func RunPreAttachHooks(
 	waitFor := resolveWaitFor(setupInfo.MergedConfig.WaitFor)
 	deferred, err := runWithWaitFor(all, waitFor)
 	return DeferredHooks{hooks: deferred}, err
+}
+
+// insertDotfilesPhase splices a dotfiles phaseHook after postCreateCommand
+// when a dotfiles repository is configured.
+func insertDotfilesPhase(
+	ctx context.Context,
+	all []phaseHook,
+	dotfiles DotfilesConfig,
+	created string,
+) []phaseHook {
+	if dotfiles.Repository == "" {
+		return all
+	}
+
+	idx := -1
+	for i, ph := range all {
+		if ph.phase == PhasePostCreate {
+			idx = i + 1
+			break
+		}
+	}
+	if idx == -1 {
+		idx = len(all)
+	}
+
+	cfg := dotfiles
+	dotfilesHook := phaseHook{
+		phase: PhaseDotfiles,
+		params: hookRunParams{
+			name:    "dotfilesInstall",
+			content: created,
+		},
+		runFunc: func() error {
+			skip, err := shouldSkipHook("dotfilesInstall", created)
+			if err != nil || skip {
+				return err
+			}
+			return RunDotfiles(ctx, cfg)
+		},
+	}
+
+	return slices.Insert(all, idx, dotfilesHook)
 }
 
 // runPrebuildHooks runs only onCreateCommand and updateContentCommand.
@@ -200,7 +252,7 @@ func runWithWaitFor(
 			deferred = append(deferred, ph)
 			continue
 		}
-		if err := runHook(ph.params); err != nil {
+		if err := runPhaseHook(ph); err != nil {
 			return nil, err
 		}
 		if ph.phase == waitFor {
@@ -211,16 +263,25 @@ func runWithWaitFor(
 	return deferred, nil
 }
 
+// runPhaseHook dispatches to either the custom runFunc or the standard
+// runHook depending on the phaseHook configuration.
+func runPhaseHook(ph phaseHook) error {
+	if ph.runFunc != nil {
+		return ph.runFunc()
+	}
+	return runHook(ph.params)
+}
+
 // DeferredHooks holds lifecycle hooks that should run in the background
 // after the foreground (waitFor) hooks have completed.
 type DeferredHooks struct {
 	hooks []phaseHook
 }
 
-// Empty returns true when there are no deferred hooks with commands to run.
+// Empty returns true when there are no deferred hooks with work to run.
 func (d DeferredHooks) Empty() bool {
 	for _, ph := range d.hooks {
-		if len(ph.params.commands) > 0 {
+		if ph.runFunc != nil || len(ph.params.commands) > 0 {
 			return false
 		}
 	}
@@ -230,7 +291,7 @@ func (d DeferredHooks) Empty() bool {
 // Run executes all deferred hooks sequentially.
 func (d DeferredHooks) Run() error {
 	for _, ph := range d.hooks {
-		if err := runHook(ph.params); err != nil {
+		if err := runPhaseHook(ph); err != nil {
 			return err
 		}
 	}

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -98,7 +98,7 @@ func (s *LifecycleHookTestSuite) TestLifecycleHooksNoOpWithEmptyConfig() {
 	}
 
 	// Both functions should return nil with empty config (no commands to run)
-	deferred, err := RunPreAttachHooks(ctx, result, false)
+	deferred, err := RunPreAttachHooks(ctx, result, false, DotfilesConfig{})
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), deferred.Empty())
 
@@ -223,7 +223,7 @@ func (s *LifecycleHookTestSuite) TestPrebuildIgnoresWaitFor() {
 	}
 
 	// In prebuild mode, no deferred hooks are returned regardless of waitFor.
-	deferred, err := RunPreAttachHooks(ctx, result, true)
+	deferred, err := RunPreAttachHooks(ctx, result, true, DotfilesConfig{})
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), deferred.Empty())
 }
@@ -432,6 +432,97 @@ func assertFileContains(
 	)
 	assert.NoError(t, err)
 	assert.Contains(t, string(content), expected)
+}
+
+func (s *LifecycleHookTestSuite) TestInsertDotfilesPhaseOrdering() {
+	t := s.T()
+	all := makeTestPhaseHooks()
+	ctx := context.Background()
+
+	cfg := DotfilesConfig{Repository: "https://github.com/user/dotfiles"}
+	result := insertDotfilesPhase(ctx, all, cfg, "test-created")
+
+	// Should have 5 phases: onCreate, updateContent, postCreate, dotfiles, postStart
+	assert.Len(t, result, 5)
+	assert.Equal(t, PhaseOnCreate, result[0].phase)
+	assert.Equal(t, PhaseUpdateContent, result[1].phase)
+	assert.Equal(t, PhasePostCreate, result[2].phase)
+	assert.Equal(t, PhaseDotfiles, result[3].phase)
+	assert.Equal(t, PhasePostStart, result[4].phase)
+}
+
+func (s *LifecycleHookTestSuite) TestInsertDotfilesPhaseSkippedWhenEmpty() {
+	t := s.T()
+	all := makeTestPhaseHooks()
+	ctx := context.Background()
+
+	result := insertDotfilesPhase(ctx, all, DotfilesConfig{}, "test-created")
+
+	// No dotfiles repo — phase list unchanged.
+	assert.Len(t, result, 4)
+	for i, ph := range result {
+		assert.Equal(t, all[i].phase, ph.phase)
+	}
+}
+
+func (s *LifecycleHookTestSuite) TestDotfilesPhaseHasRunFunc() {
+	t := s.T()
+	all := makeTestPhaseHooks()
+	ctx := context.Background()
+
+	cfg := DotfilesConfig{Repository: "https://github.com/user/dotfiles"}
+	result := insertDotfilesPhase(ctx, all, cfg, "")
+
+	dotfilesHook := result[3]
+	assert.Equal(t, PhaseDotfiles, dotfilesHook.phase)
+	assert.NotNil(t, dotfilesHook.runFunc, "dotfiles phase should have a runFunc")
+}
+
+func (s *LifecycleHookTestSuite) TestRunWithWaitForDefaultSplitWithDotfiles() {
+	t := s.T()
+	all := makeTestPhaseHooks()
+	ctx := context.Background()
+
+	cfg := DotfilesConfig{Repository: "https://github.com/user/dotfiles"}
+	all = insertDotfilesPhase(ctx, all, cfg, "")
+
+	deferred, err := runWithWaitFor(all, DefaultWaitFor)
+	assert.NoError(t, err)
+
+	// Default waitFor is updateContentCommand.
+	// Deferred: postCreate, dotfiles, postStart.
+	assert.Len(t, deferred, 3)
+	assert.Equal(t, PhasePostCreate, deferred[0].phase)
+	assert.Equal(t, PhaseDotfiles, deferred[1].phase)
+	assert.Equal(t, PhasePostStart, deferred[2].phase)
+}
+
+func (s *LifecycleHookTestSuite) TestRunWithWaitForPostCreateWithDotfiles() {
+	t := s.T()
+	all := makeTestPhaseHooks()
+	ctx := context.Background()
+
+	cfg := DotfilesConfig{Repository: "https://github.com/user/dotfiles"}
+	all = insertDotfilesPhase(ctx, all, cfg, "")
+
+	deferred, err := runWithWaitFor(all, PhasePostCreate)
+	assert.NoError(t, err)
+
+	// Deferred: dotfiles, postStart.
+	assert.Len(t, deferred, 2)
+	assert.Equal(t, PhaseDotfiles, deferred[0].phase)
+	assert.Equal(t, PhasePostStart, deferred[1].phase)
+}
+
+func (s *LifecycleHookTestSuite) TestDeferredHooksNotEmptyWithDotfiles() {
+	t := s.T()
+	ctx := context.Background()
+
+	cfg := DotfilesConfig{Repository: "https://github.com/user/dotfiles"}
+	all := insertDotfilesPhase(ctx, nil, cfg, "")
+
+	d := DeferredHooks{hooks: all}
+	assert.False(t, d.Empty(), "should not be empty when dotfiles runFunc is set")
 }
 
 func TestLifecycleHookTestSuite(t *testing.T) {

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -28,6 +28,13 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+// DotfilesConfig holds the parameters needed to install dotfiles inside
+// the container as part of the lifecycle.
+type DotfilesConfig struct {
+	Repository    string
+	InstallScript string
+}
+
 type ContainerSetupConfig struct {
 	SetupInfo         *config.Result
 	ExtraWorkspaceEnv []string
@@ -35,6 +42,7 @@ type ContainerSetupConfig struct {
 	Prebuild          bool
 	PlatformOptions   *devsy.PlatformOptions
 	TunnelClient      tunnel.TunnelClient
+	Dotfiles          DotfilesConfig
 }
 
 // SetupContainerPreAttach runs container setup up to and including the waitFor
@@ -61,7 +69,7 @@ func SetupContainerPreAttach(
 	setupOptionalFeatures(ctx, cfg)
 
 	log.Debugf("running pre-attach lifecycle hooks")
-	deferred, err := RunPreAttachHooks(ctx, cfg.SetupInfo, cfg.Prebuild)
+	deferred, err := RunPreAttachHooks(ctx, cfg.SetupInfo, cfg.Prebuild, cfg.Dotfiles)
 	if err != nil {
 		return DeferredHooks{}, fmt.Errorf("lifecycle hooks pre-attach: %w", err)
 	}

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -235,6 +235,10 @@ type CLIOptions struct {
 	UidMap                      []string          `json:"uidMap,omitempty"`
 	GidMap                      []string          `json:"gidMap,omitempty"`
 
+	// dotfiles options
+	DotfilesRepo   string `json:"dotfilesRepo,omitempty"`
+	DotfilesScript string `json:"dotfilesScript,omitempty"`
+
 	// build options
 	// Repository specifies the container registry repository to push the built image to (e.g., ghcr.io/user/image).
 	// When set, the image will be tagged and pushed to this repository after building.


### PR DESCRIPTION
## Summary

- Moves dotfiles installation from host-side SSH into the container-side lifecycle, running after `postCreateCommand` and before `postStartCommand` per the devcontainer spec
- Adds `DotfilesConfig` (repo URL + install script) to `ContainerSetupConfig` and passes it through `CLIOptions` → container setup command flags → lifecycle hook ordering
- Uses marker files so dotfiles only install once on container creation, not on restart
- Host-side SSH dotfiles (`pkg/dotfiles/dotfiles.go`) is skipped when container-side handles it, preserved as fallback for non-devcontainer paths
- Adds 7 unit tests verifying phase ordering (dotfiles between postCreate/postStart), waitFor split correctness with dotfiles phase, and `DeferredHooks.Empty()` awareness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI options to specify a dotfiles repository and install script.
  * Dotfiles can be installed as part of container setup (in-container or host-conditional).
  * Installer auto-detects known install scripts and falls back to symlinking dotfiles when none found.
* **Tests**
  * New end-to-end test verifying dotfiles install ordering with lifecycle hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->