### PR TITLE
fix(lifecycle): accept initializeCommand as a valid waitFor value

### DIFF
--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -406,6 +406,76 @@ var _ = ginkgo.Describe(
 			)
 		}, ginkgo.SpecTimeout(framework.GetTimeout()))
 
+		ginkgo.It(
+			"waitFor initializeCommand defers all container phases to background",
+			func(ctx context.Context) {
+				tempDir, err := setupWorkspace(
+					"tests/up/testdata/docker-waitfor-initializecommand",
+					dtc.initialDir,
+					dtc.f,
+				)
+				framework.ExpectNoError(err)
+
+				err = dtc.f.DevsyUp(ctx, tempDir)
+				framework.ExpectNoError(err)
+
+				// With waitFor=initializeCommand, ALL container lifecycle phases
+				// are deferred to run in the background. Wait for each marker.
+				gomega.Eventually(func() string {
+					out, err := dtc.execSSH(ctx, tempDir, "cat $HOME/on-create.out 2>/dev/null")
+					if err != nil {
+						return ""
+					}
+					return strings.TrimSpace(out)
+				}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(
+					gomega.Equal("onCreateDone"),
+					"deferred onCreateCommand should eventually complete in background",
+				)
+
+				gomega.Eventually(func() string {
+					out, err := dtc.execSSH(
+						ctx,
+						tempDir,
+						"cat $HOME/update-content.out 2>/dev/null",
+					)
+					if err != nil {
+						return ""
+					}
+					return strings.TrimSpace(out)
+				}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(
+					gomega.Equal("updateContentDone"),
+					"deferred updateContentCommand should eventually complete in background",
+				)
+
+				gomega.Eventually(func() string {
+					out, err := dtc.execSSH(ctx, tempDir, "cat $HOME/deferred.marker 2>/dev/null")
+					if err != nil {
+						return ""
+					}
+					return strings.TrimSpace(out)
+				}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(
+					gomega.Equal("postCreateDone"),
+					"deferred postCreateCommand should eventually complete in background",
+				)
+
+				gomega.Eventually(func() string {
+					out, err := dtc.execSSH(
+						ctx,
+						tempDir,
+						"cat $HOME/post-start-deferred.out 2>/dev/null",
+					)
+					if err != nil {
+						return ""
+					}
+					return strings.TrimSpace(out)
+				}).WithTimeout(30*time.Second).WithPolling(2*time.Second).Should(
+					gomega.Equal("postStartDone"),
+					"deferred postStartCommand should eventually complete in background",
+				)
+			},
+			ginkgo.SpecTimeout(framework.GetTimeout()),
+		)
+
 		ginkgo.It("IDE accessible before postAttachCommand completes", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
 				"tests/up/testdata/docker-post-attach-nonblocking",

--- a/e2e/tests/up/testdata/docker-waitfor-initializecommand/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-waitfor-initializecommand/.devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "image": "ghcr.io/devsy-org/test-images/go:1",
+  "waitFor": "initializeCommand",
+  "onCreateCommand": "echo onCreateDone > $HOME/on-create.out",
+  "updateContentCommand": "echo updateContentDone > $HOME/update-content.out",
+  "postCreateCommand": "echo postCreateDone > $HOME/deferred.marker",
+  "postStartCommand": "echo postStartDone > $HOME/post-start-deferred.out"
+}

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -25,11 +25,12 @@ import (
 type LifecyclePhase string
 
 const (
-	PhaseOnCreate      LifecyclePhase = "onCreateCommand"
-	PhaseUpdateContent LifecyclePhase = "updateContentCommand"
-	PhasePostCreate    LifecyclePhase = "postCreateCommand"
-	PhasePostStart     LifecyclePhase = "postStartCommand"
-	PhasePostAttach    LifecyclePhase = "postAttachCommand"
+	PhaseInitializeCommand LifecyclePhase = "initializeCommand"
+	PhaseOnCreate          LifecyclePhase = "onCreateCommand"
+	PhaseUpdateContent     LifecyclePhase = "updateContentCommand"
+	PhasePostCreate        LifecyclePhase = "postCreateCommand"
+	PhasePostStart         LifecyclePhase = "postStartCommand"
+	PhasePostAttach        LifecyclePhase = "postAttachCommand"
 )
 
 // DefaultWaitFor is the spec-defined default for the waitFor property.
@@ -45,8 +46,10 @@ var phaseOrder = []LifecyclePhase{
 }
 
 // validWaitForPhase returns true when phase is an allowed waitFor value.
+// initializeCommand is a valid waitFor value (host-side phase) even though
+// it is not in phaseOrder (which lists only container-side phases).
 func validWaitForPhase(phase LifecyclePhase) bool {
-	return slices.Contains(phaseOrder, phase)
+	return phase == PhaseInitializeCommand || slices.Contains(phaseOrder, phase)
 }
 
 // resolveWaitFor normalises the raw waitFor string from the config,
@@ -188,10 +191,17 @@ func runPrebuildHooks(all []phaseHook) error {
 
 // runWithWaitFor runs hooks up to and including waitFor synchronously
 // and returns the remaining hooks as deferred.
+//
+// When waitFor is initializeCommand (a host-side phase that precedes all
+// container lifecycle phases), every container phase is deferred.
 func runWithWaitFor(
 	all []phaseHook,
 	waitFor LifecyclePhase,
 ) ([]phaseHook, error) {
+	if waitFor == PhaseInitializeCommand {
+		return append([]phaseHook(nil), all...), nil
+	}
+
 	pastWaitFor := false
 	var deferred []phaseHook
 

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -146,11 +146,11 @@ func (s *LifecycleHookTestSuite) TestResolveWaitForValid() {
 	assert.Equal(s.T(), PhaseOnCreate, resolveWaitFor("onCreateCommand"))
 	assert.Equal(s.T(), PhasePostAttach, resolveWaitFor("postAttachCommand"))
 	assert.Equal(s.T(), PhaseUpdateContent, resolveWaitFor("updateContentCommand"))
+	assert.Equal(s.T(), PhaseInitializeCommand, resolveWaitFor("initializeCommand"))
 }
 
 func (s *LifecycleHookTestSuite) TestResolveWaitForInvalid() {
 	assert.Equal(s.T(), DefaultWaitFor, resolveWaitFor("bogus"))
-	assert.Equal(s.T(), DefaultWaitFor, resolveWaitFor("initializeCommand"))
 	assert.Equal(s.T(), DefaultWaitFor, resolveWaitFor("POSTCREATECOMMAND"))
 }
 
@@ -203,6 +203,21 @@ func (s *LifecycleHookTestSuite) TestRunWithWaitForOnCreate() {
 	assert.Equal(t, PhaseUpdateContent, deferred[0].phase)
 	assert.Equal(t, PhasePostCreate, deferred[1].phase)
 	assert.Equal(t, PhasePostStart, deferred[2].phase)
+}
+
+func (s *LifecycleHookTestSuite) TestRunWithWaitForInitializeCommand() {
+	t := s.T()
+	all := makeTestPhaseHooks()
+
+	deferred, err := runWithWaitFor(all, PhaseInitializeCommand)
+	assert.NoError(t, err)
+
+	// initializeCommand is a host-side phase; all container phases are deferred.
+	assert.Len(t, deferred, len(all))
+	assert.Equal(t, PhaseOnCreate, deferred[0].phase)
+	assert.Equal(t, PhaseUpdateContent, deferred[1].phase)
+	assert.Equal(t, PhasePostCreate, deferred[2].phase)
+	assert.Equal(t, PhasePostStart, deferred[3].phase)
 }
 
 func (s *LifecycleHookTestSuite) TestPrebuildIgnoresWaitFor() {


### PR DESCRIPTION
## Summary

- Accept `initializeCommand` as a valid `waitFor` value per the devcontainer spec. Previously it was rejected as invalid and fell back to the default (`updateContentCommand`).
- When `waitFor=initializeCommand`, all container lifecycle phases (onCreateCommand, updateContentCommand, postCreateCommand, postStartCommand) are deferred to run in the background, since the container is considered ready once the host-side initializeCommand completes.
- Added `PhaseInitializeCommand` constant and special-cased it in `resolveWaitFor` (via `validWaitForPhase`) and `runWithWaitFor`.
- Updated the test that previously asserted `initializeCommand` was rejected, and added a new test confirming all container phases are deferred when `waitFor=initializeCommand`.

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new initialization phase for devcontainer setup that enables deferred execution of lifecycle hooks. Hooks can now be queued for later execution instead of running immediately.

* **Tests**
  * Extended test coverage to validate the new initialization phase, verifying proper hook sequencing and deferral behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->