### PR TITLE
refactor(tunnel): migrate workspace_client.go to PipeBridge.RunPair()

### DIFF
--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/shell"
 	"github.com/devsy-org/devsy/pkg/ssh"
+	"github.com/devsy-org/devsy/pkg/tunnel"
 	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/gofrs/flock"
 )
@@ -953,33 +954,48 @@ func BuildAgentClient(ctx context.Context, opts BuildAgentClientOptions) (*confi
 	}
 
 	command := buildAgentCommand(opts.WorkspaceClient, opts.AgentCommand, workspaceInfo)
-	stdoutReader, stdoutWriter, stdinReader, stdinWriter, err := createPipes()
+
+	pb, err := tunnel.NewPipeBridge()
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = stdoutWriter.Close() }()
-	defer func() { _ = stdoutReader.Close() }()
-	defer func() { _ = stdinReader.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
+	defer pb.Close()
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	var result *config2.Result
+	err = pb.RunPair(ctx,
+		func(ctx context.Context, stdin *os.File, stdout *os.File) error {
+			defer log.Debugf("up command completed")
 
-	errChan := runAgentInjection(agentInjectionOptions{
-		ctx:             cancelCtx,
-		workspaceClient: opts.WorkspaceClient,
-		command:         command,
-		stdin:           stdinReader,
-		stdout:          stdoutWriter,
-		timeout:         wInfo.InjectTimeout,
-		cancel:          cancel,
-	})
-	result, err := runTunnelServer(cancelCtx, opts, stdoutReader, stdinWriter)
-	if err != nil {
-		return nil, err
-	}
+			writer := log.Writer(log.LevelInfo)
+			defer func() { _ = writer.Close() }()
 
-	return result, <-errChan
+			return agent.InjectAgent(&agent.InjectOptions{
+				Ctx: ctx,
+				Exec: func(ctx context.Context, command string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
+					return opts.WorkspaceClient.Command(ctx, client.CommandOptions{
+						Command: command,
+						Stdin:   stdin,
+						Stdout:  stdout,
+						Stderr:  stderr,
+					})
+				},
+				IsLocal:         opts.WorkspaceClient.AgentLocal(),
+				RemoteAgentPath: opts.WorkspaceClient.AgentPath(),
+				DownloadURL:     opts.WorkspaceClient.AgentURL(),
+				Command:         command,
+				Stdin:           stdin,
+				Stdout:          stdout,
+				Stderr:          writer,
+				Timeout:         wInfo.InjectTimeout,
+			})
+		},
+		func(ctx context.Context, stdout *os.File, stdin *os.File) error {
+			var handlerErr error
+			result, handlerErr = runTunnelServer(ctx, opts, stdout, stdin)
+			return handlerErr
+		},
+	)
+	return result, err
 }
 
 func buildAgentCommand(
@@ -996,62 +1012,6 @@ func buildAgentCommand(
 		command += " --debug"
 	}
 	return command
-}
-
-func createPipes() (stdoutReader, stdoutWriter, stdinReader, stdinWriter *os.File, err error) {
-	stdoutReader, stdoutWriter, err = os.Pipe()
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-	stdinReader, stdinWriter, err = os.Pipe()
-	if err != nil {
-		func() { _ = stdoutReader.Close() }()
-		func() { _ = stdoutWriter.Close() }()
-		return nil, nil, nil, nil, err
-	}
-	return stdoutReader, stdoutWriter, stdinReader, stdinWriter, nil
-}
-
-type agentInjectionOptions struct {
-	ctx             context.Context
-	workspaceClient client.WorkspaceClient
-	command         string
-	stdin           *os.File
-	stdout          *os.File
-	timeout         time.Duration
-	cancel          context.CancelFunc
-}
-
-func runAgentInjection(opts agentInjectionOptions) chan error {
-	errChan := make(chan error, 1)
-	go func() {
-		defer log.Debugf("up command completed")
-		defer opts.cancel()
-
-		writer := log.Writer(log.LevelInfo)
-		defer func() { _ = writer.Close() }()
-
-		errChan <- agent.InjectAgent(&agent.InjectOptions{
-			Ctx: opts.ctx,
-			Exec: func(ctx context.Context, command string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
-				return opts.workspaceClient.Command(ctx, client.CommandOptions{
-					Command: command,
-					Stdin:   stdin,
-					Stdout:  stdout,
-					Stderr:  stderr,
-				})
-			},
-			IsLocal:         opts.workspaceClient.AgentLocal(),
-			RemoteAgentPath: opts.workspaceClient.AgentPath(),
-			DownloadURL:     opts.workspaceClient.AgentURL(),
-			Command:         opts.command,
-			Stdin:           opts.stdin,
-			Stdout:          opts.stdout,
-			Stderr:          writer,
-			Timeout:         opts.timeout,
-		})
-	}()
-	return errChan
 }
 
 func runTunnelServer(

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -329,8 +329,5 @@ func pipe(
 	_ = toStdin.Close()
 	_ = fromStdout.Close()
 
-	// Drain the second result so neither goroutine outlives the caller.
-	<-errChan
-
 	return first
 }

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -329,5 +329,8 @@ func pipe(
 	_ = toStdin.Close()
 	_ = fromStdout.Close()
 
+	// Drain the second result so neither goroutine outlives the caller.
+	<-errChan
+
 	return first
 }

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -28,53 +28,71 @@ func TestPipeSuite(t *testing.T) {
 }
 
 func (s *PipeTestSuite) TestPipe_NormalBidirectionalCopy() {
-	toStdinReader, toStdinWriter, err := os.Pipe()
-	s.Require().NoError(err)
+	// Test that pipe() copies data in both directions. pipe() returns after
+	// the first direction completes and closes both endpoints, so we test
+	// each direction independently to avoid non-deterministic races.
 
-	// Use a thread-safe wrapper around bytes.Buffer for toStdout so the
-	// race detector doesn't flag the concurrent write (from the copy
-	// goroutine) and read (from the assertion below).
-	toStdout := &syncBuffer{}
+	// --- Test stdout direction (fromStdout → toStdout) ---
+	s.Run("stdout direction", func() {
+		toStdinWriter := nopWriteCloser{}
+		toStdout := &syncBuffer{}
 
-	// Use io.Pipe for feeders — synchronous semantics ensure data is
-	// fully consumed before the feeder moves on.
-	fromStdinReader, fromStdinWriter := io.Pipe()
-	fromStdoutReader, fromStdoutWriter := io.Pipe()
-	defer func() { _ = fromStdinWriter.Close() }()
-	defer func() { _ = fromStdoutWriter.Close() }()
+		// fromStdin: keep open so stdin direction doesn't finish first.
+		fromStdinReader, fromStdinWriter, err := os.Pipe()
+		s.Require().NoError(err)
 
-	stdinPayload := "hello from stdin"
-	stdoutPayload := "hello from stdout"
+		fromStdoutReader, fromStdoutWriter, err := os.Pipe()
+		s.Require().NoError(err)
 
-	go func() {
-		_, _ = fromStdoutWriter.Write([]byte(stdoutPayload))
-		_, _ = fromStdinWriter.Write([]byte(stdinPayload))
+		stdoutPayload := "hello from stdout"
+		_, err = fromStdoutWriter.Write([]byte(stdoutPayload))
+		s.Require().NoError(err)
 		_ = fromStdoutWriter.Close()
+
+		pipeErr := pipe(toStdinWriter, fromStdinReader, toStdout, fromStdoutReader)
+		s.NoError(pipeErr)
+		s.Equal(stdoutPayload, toStdout.String())
+
 		_ = fromStdinWriter.Close()
-	}()
+	})
 
-	// Read from toStdin consumer in the background — unblocks when pipe()
-	// closes toStdinWriter.
-	var gotStdin []byte
-	stdinDone := make(chan struct{})
-	go func() {
-		defer close(stdinDone)
-		gotStdin, _ = io.ReadAll(toStdinReader)
-	}()
+	// --- Test stdin direction (fromStdin → toStdin) ---
+	s.Run("stdin direction", func() {
+		toStdinReader, toStdinWriter, err := os.Pipe()
+		s.Require().NoError(err)
 
-	pipeErr := pipe(toStdinWriter, fromStdinReader, toStdout, fromStdoutReader)
+		var toStdoutBuf bytes.Buffer
 
-	<-stdinDone
-	_ = toStdinReader.Close()
+		fromStdinReader, fromStdinWriter, err := os.Pipe()
+		s.Require().NoError(err)
 
-	s.NoError(pipeErr)
-	s.Equal(stdinPayload, string(gotStdin))
-	// Allow a brief moment for the stdout goroutine to finish its last
-	// write (pipe() returns after the first direction completes; the
-	// stdout goroutine may still be flushing).
-	s.Eventually(func() bool {
-		return toStdout.String() == stdoutPayload
-	}, time.Second, 5*time.Millisecond, "expected stdout payload %q", stdoutPayload)
+		// fromStdout: keep open so stdout direction doesn't finish first.
+		fromStdoutReader, fromStdoutWriter, err := os.Pipe()
+		s.Require().NoError(err)
+
+		stdinPayload := "hello from stdin"
+		_, err = fromStdinWriter.Write([]byte(stdinPayload))
+		s.Require().NoError(err)
+		_ = fromStdinWriter.Close()
+
+		// Read toStdin in background.
+		var gotStdin []byte
+		stdinDone := make(chan struct{})
+		go func() {
+			defer close(stdinDone)
+			gotStdin, _ = io.ReadAll(toStdinReader)
+		}()
+
+		pipeErr := pipe(toStdinWriter, fromStdinReader, &toStdoutBuf, fromStdoutReader)
+
+		<-stdinDone
+		_ = toStdinReader.Close()
+
+		s.NoError(pipeErr)
+		s.Equal(stdinPayload, string(gotStdin))
+
+		_ = fromStdoutWriter.Close()
+	})
 }
 
 func (s *PipeTestSuite) TestPipe_WriterSideClosesFirst() {

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,17 +31,13 @@ func (s *PipeTestSuite) TestPipe_NormalBidirectionalCopy() {
 	toStdinReader, toStdinWriter, err := os.Pipe()
 	s.Require().NoError(err)
 
-	// Use bytes.Buffer for toStdout — pipe() doesn't close it (just io.Writer),
-	// and the io.Pipe feeder below guarantees the stdout copy goroutine writes
-	// to the buffer before sending on errChan, giving a happens-before with
-	// pipe()'s return.
-	var toStdoutBuf bytes.Buffer
+	// Use a thread-safe wrapper around bytes.Buffer for toStdout so the
+	// race detector doesn't flag the concurrent write (from the copy
+	// goroutine) and read (from the assertion below).
+	toStdout := &syncBuffer{}
 
-	// Use io.Pipe for feeders — synchronous Write blocks until the copy
-	// goroutine Reads, ensuring both goroutines have consumed and written
-	// their data before either signals completion. The sequential close
-	// order (stdout first, then stdin) makes the stdout direction always
-	// win the race to errChan.
+	// Use io.Pipe for feeders — synchronous semantics ensure data is
+	// fully consumed before the feeder moves on.
 	fromStdinReader, fromStdinWriter := io.Pipe()
 	fromStdoutReader, fromStdoutWriter := io.Pipe()
 	defer func() { _ = fromStdinWriter.Close() }()
@@ -65,14 +62,19 @@ func (s *PipeTestSuite) TestPipe_NormalBidirectionalCopy() {
 		gotStdin, _ = io.ReadAll(toStdinReader)
 	}()
 
-	pipeErr := pipe(toStdinWriter, fromStdinReader, &toStdoutBuf, fromStdoutReader)
+	pipeErr := pipe(toStdinWriter, fromStdinReader, toStdout, fromStdoutReader)
 
 	<-stdinDone
 	_ = toStdinReader.Close()
 
 	s.NoError(pipeErr)
 	s.Equal(stdinPayload, string(gotStdin))
-	s.Equal(stdoutPayload, toStdoutBuf.String())
+	// Allow a brief moment for the stdout goroutine to finish its last
+	// write (pipe() returns after the first direction completes; the
+	// stdout goroutine may still be flushing).
+	s.Eventually(func() bool {
+		return toStdout.String() == stdoutPayload
+	}, time.Second, 5*time.Millisecond, "expected stdout payload %q", stdoutPayload)
 }
 
 func (s *PipeTestSuite) TestPipe_WriterSideClosesFirst() {
@@ -366,3 +368,23 @@ type nopWriteCloser struct{}
 
 func (nopWriteCloser) Write(p []byte) (int, error) { return len(p), nil }
 func (nopWriteCloser) Close() error                { return nil }
+
+// syncBuffer wraps bytes.Buffer with a mutex so it can be written
+// concurrently (by the copy goroutine) and read (by test assertions)
+// without triggering the race detector.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (sb *syncBuffer) Write(p []byte) (int, error) {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	return sb.buf.Write(p)
+}
+
+func (sb *syncBuffer) String() string {
+	sb.mu.Lock()
+	defer sb.mu.Unlock()
+	return sb.buf.String()
+}


### PR DESCRIPTION
## Summary

- Migrates `BuildAgentClient()` in `workspace_client.go` to use `tunnel.PipeBridge.RunPair()` instead of manual pipe creation and goroutine coordination
- Inlines the agent injection logic into the tunnel function closure, using a closure variable to capture the `*config2.Result` from the handler side
- Removes now-unused `createPipes()`, `agentInjectionOptions` struct, and `runAgentInjection()` function (~56 lines of dead code)
- Follows the same pattern established in `container.go` and `direct.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal coordination of the agent client’s bidirectional communication, increasing reliability and maintainability of background operations.
* **Tests**
  * Made pipe-related tests deterministic and more robust to concurrency, reducing flakiness by isolating copy directions and synchronizing access during verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->