### PR TITLE
fix(config): support hostRequirements.gpu object format

### DIFF
--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -311,22 +312,63 @@ type HostRequirements struct {
 	// Amount of required disk space in bytes. Supports units tb, gb, mb and kb.
 	Storage string `json:"storage,omitempty"`
 
-	// If GPU support should be enabled
-	GPU types.StrBool `json:"gpu,omitempty"`
+	// If GPU support should be enabled. Accepts bool, "optional", or an object
+	// like {"cores": 2, "memory": "8gb"} (object format enables GPU; resource
+	// constraints are advisory).
+	GPU *GPURequirement `json:"gpu,omitempty"`
+}
+
+// GPURequirement represents the gpu field in hostRequirements. It can be
+// unmarshalled from a boolean (true/false), a string ("optional"), or an object
+// ({"cores": N, "memory": "Xgb"}). The object format enables GPU; specific
+// resource constraints are informational/advisory per the devcontainer spec.
+type GPURequirement struct {
+	// Value is "true", "false", or "optional" for simple formats.
+	Value string
+	// Cores is the requested number of GPU cores (object format, advisory).
+	Cores int
+	// Memory is the requested GPU memory (object format, advisory).
+	GPUMemory string
+}
+
+func (g *GPURequirement) UnmarshalJSON(data []byte) error {
+	var raw any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("unmarshal gpu requirement: %w", err)
+	}
+
+	switch v := raw.(type) {
+	case bool:
+		g.Value = strconv.FormatBool(v)
+		return nil
+	case string:
+		g.Value = v
+		return nil
+	case map[string]any:
+		// Object format — GPU is enabled; fields are advisory.
+		g.Value = "true"
+		if cores, ok := v["cores"].(float64); ok {
+			g.Cores = int(cores)
+		}
+		if mem, ok := v["memory"].(string); ok {
+			g.GPUMemory = mem
+		}
+		return nil
+	}
+	return fmt.Errorf("unmarshal gpu requirement: %w", types.ErrUnsupportedType)
 }
 
 // ShouldEnableGPU determines if GPU should be enabled based on requirements and availability.
 func (h *HostRequirements) ShouldEnableGPU(gpuAvailable bool) (enable bool, warnIfMissing bool) {
-	if h == nil || h.GPU == "" {
+	if h == nil || h.GPU == nil {
 		return false, false
 	}
 
-	gpuValue := string(h.GPU)
-	if gpuValue == "optional" {
+	if h.GPU.Value == "optional" {
 		return gpuAvailable, false
 	}
 
-	required, err := h.GPU.Bool()
+	required, err := strconv.ParseBool(h.GPU.Value)
 	if err != nil {
 		return false, false
 	}

--- a/pkg/devcontainer/config/gpu_test.go
+++ b/pkg/devcontainer/config/gpu_test.go
@@ -1,0 +1,153 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func unmarshalGPU(t *testing.T, input string) (*HostRequirements, error) {
+	t.Helper()
+	var hr HostRequirements
+	err := json.Unmarshal([]byte(input), &hr)
+	return &hr, err
+}
+
+func assertGPU(t *testing.T, got *GPURequirement, want GPURequirement) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("expected GPU to be non-nil")
+	}
+	if *got != want {
+		t.Errorf("GPU = %+v, want %+v", *got, want)
+	}
+}
+
+func TestGPURequirement_BoolAndString(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  GPURequirement
+	}{
+		{"bool true", `{"gpu": true}`, GPURequirement{Value: "true"}},
+		{"bool false", `{"gpu": false}`, GPURequirement{Value: "false"}},
+		{"string optional", `{"gpu": "optional"}`, GPURequirement{Value: "optional"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hr, err := unmarshalGPU(t, tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assertGPU(t, hr.GPU, tt.want)
+		})
+	}
+}
+
+func TestGPURequirement_ObjectFormat(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  GPURequirement
+	}{
+		{
+			"cores and memory",
+			`{"gpu": {"cores": 2, "memory": "8gb"}}`,
+			GPURequirement{Value: "true", Cores: 2, GPUMemory: "8gb"},
+		},
+		{
+			"cores only",
+			`{"gpu": {"cores": 4}}`,
+			GPURequirement{Value: "true", Cores: 4},
+		},
+		{
+			"memory only",
+			`{"gpu": {"memory": "16gb"}}`,
+			GPURequirement{Value: "true", GPUMemory: "16gb"},
+		},
+		{
+			"empty object",
+			`{"gpu": {}}`,
+			GPURequirement{Value: "true"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hr, err := unmarshalGPU(t, tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			assertGPU(t, hr.GPU, tt.want)
+		})
+	}
+}
+
+func TestGPURequirement_InvalidType(t *testing.T) {
+	_, err := unmarshalGPU(t, `{"gpu": [1, 2]}`)
+	if err == nil {
+		t.Fatal("expected error for array type, got nil")
+	}
+}
+
+func TestGPURequirement_OmittedIsNil(t *testing.T) {
+	hr, err := unmarshalGPU(t, `{"cpus": 4}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hr.GPU != nil {
+		t.Errorf(
+			"expected GPU to be nil when omitted, got %+v",
+			hr.GPU,
+		)
+	}
+}
+
+func TestShouldEnableGPU(t *testing.T) {
+	tests := []struct {
+		name         string
+		gpu          *GPURequirement
+		gpuAvailable bool
+		wantEnable   bool
+		wantWarn     bool
+	}{
+		{"nil GPU", nil, false, false, false},
+		{"true avail", &GPURequirement{Value: "true"}, true, true, false},
+		{"true unavail", &GPURequirement{Value: "true"}, false, false, true},
+		{"false", &GPURequirement{Value: "false"}, false, false, false},
+		{"optional avail", &GPURequirement{Value: "optional"}, true, true, false},
+		{"optional unavail", &GPURequirement{Value: "optional"}, false, false, false},
+		{
+			"object avail",
+			&GPURequirement{Value: "true", Cores: 2, GPUMemory: "8gb"},
+			true, true, false,
+		},
+		{
+			"object unavail",
+			&GPURequirement{Value: "true", Cores: 2, GPUMemory: "8gb"},
+			false, false, true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hr := &HostRequirements{GPU: tt.gpu}
+			enable, warn := hr.ShouldEnableGPU(tt.gpuAvailable)
+			if enable != tt.wantEnable {
+				t.Errorf("enable = %v, want %v", enable, tt.wantEnable)
+			}
+			if warn != tt.wantWarn {
+				t.Errorf("warn = %v, want %v", warn, tt.wantWarn)
+			}
+		})
+	}
+}
+
+func TestShouldEnableGPU_NilReceiver(t *testing.T) {
+	var hr *HostRequirements
+	enable, warn := hr.ShouldEnableGPU(true)
+	if enable || warn {
+		t.Errorf(
+			"expected (false, false) for nil receiver, got (%v, %v)",
+			enable,
+			warn,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

- Replace `types.StrBool` with a new `GPURequirement` type for the `HostRequirements.GPU` field
- `GPURequirement.UnmarshalJSON` accepts bool (`true`/`false`), string (`"optional"`), and object (`{"cores": N, "memory": "Xgb"}`) formats per the devcontainer spec
- Object format enables GPU (same effect as `gpu: true`); resource constraints (cores, memory) are stored but advisory
- `ShouldEnableGPU` updated to work with the new type, all existing behavior preserved
- Unit tests cover all formats (bool, string, object, omitted, invalid) and ShouldEnableGPU logic