### PR TITLE
refactor(cli): migrate 3 CLI command sites to PipeBridge.RunPair()

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -13,6 +13,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/ssh"
+	"github.com/devsy-org/devsy/pkg/tunnel"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
 )
@@ -70,17 +71,6 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 	if !ok {
 		return fmt.Errorf("this command is not supported for proxy providers")
 	}
-	// create readers
-	stdoutReader, stdoutWriter, err := os.Pipe()
-	if err != nil {
-		return err
-	}
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = stdoutWriter.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
 	// ssh tunnel command
 	sshServerCmd := fmt.Sprintf("'%s' helper ssh-server --stdio", client.AgentPath())
 	if log.DebugEnabled() {
@@ -89,33 +79,6 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 
 	// Get the timeout from the context options
 	timeout := config.ParseTimeOption(devsyConfig, config.ContextOptionAgentInjectTimeout)
-
-	// start ssh server in background
-	errChan := make(chan error, 1)
-	go func() {
-		stderr := log.Writer(log.LevelDebug)
-		defer func() { _ = stderr.Close() }()
-
-		errChan <- agent.InjectAgent(&agent.InjectOptions{
-			Ctx: ctx,
-			Exec: func(ctx context.Context, command string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
-				return client.Command(ctx, clientpkg.CommandOptions{
-					Command: command,
-					Stdin:   stdin,
-					Stdout:  stdout,
-					Stderr:  stderr,
-				})
-			},
-			IsLocal:         client.AgentLocal(),
-			RemoteAgentPath: client.AgentPath(),
-			DownloadURL:     client.AgentURL(),
-			Command:         sshServerCmd,
-			Stdin:           stdinReader,
-			Stdout:          stdoutWriter,
-			Stderr:          stderr,
-			Timeout:         timeout,
-		})
-	}()
 
 	// create agent command
 	agentCommand := fmt.Sprintf(
@@ -128,26 +91,53 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 		agentCommand += " --debug"
 	}
 
-	// create new ssh client
-	// start ssh client as root / default user
-	sshClient, err := ssh.StdioClientWithUser(stdoutReader, stdinWriter, "" /* default */, false)
+	pb, err := tunnel.NewPipeBridge()
 	if err != nil {
 		return err
 	}
-	defer func() { _ = sshClient.Close() }()
+	defer pb.Close()
 
-	session, err := sshClient.NewSession()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = session.Close() }()
+	return pb.RunPair(ctx,
+		func(ctx context.Context, stdin *os.File, stdout *os.File) error {
+			stderr := log.Writer(log.LevelDebug)
+			defer func() { _ = stderr.Close() }()
 
-	session.Stdout = os.Stdout
-	session.Stderr = os.Stderr
-	err = session.Run(agentCommand)
-	if err != nil {
-		return err
-	}
+			return agent.InjectAgent(&agent.InjectOptions{
+				Ctx: ctx,
+				Exec: func(ctx context.Context, command string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
+					return client.Command(ctx, clientpkg.CommandOptions{
+						Command: command,
+						Stdin:   stdin,
+						Stdout:  stdout,
+						Stderr:  stderr,
+					})
+				},
+				IsLocal:         client.AgentLocal(),
+				RemoteAgentPath: client.AgentPath(),
+				DownloadURL:     client.AgentURL(),
+				Command:         sshServerCmd,
+				Stdin:           stdin,
+				Stdout:          stdout,
+				Stderr:          stderr,
+				Timeout:         timeout,
+			})
+		},
+		func(ctx context.Context, stdout *os.File, stdin *os.File) error {
+			sshClient, err := ssh.StdioClientWithUser(stdout, stdin, "" /* default */, false)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = sshClient.Close() }()
 
-	return nil
+			session, err := sshClient.NewSession()
+			if err != nil {
+				return err
+			}
+			defer func() { _ = session.Close() }()
+
+			session.Stdout = os.Stdout
+			session.Stderr = os.Stderr
+			return session.Run(agentCommand)
+		},
+	)
 }

--- a/cmd/machine/ssh.go
+++ b/cmd/machine/ssh.go
@@ -18,6 +18,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/pty"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
 	devsshagent "github.com/devsy-org/devsy/pkg/ssh/agent"
+	"github.com/devsy-org/devsy/pkg/tunnel"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
@@ -170,38 +171,31 @@ func (cmd *SSHCmd) Run(ctx context.Context, args []string) error {
 type ExecFunc func(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writer) error
 
 func StartSSHSession(ctx context.Context, options StartSSHSessionOptions) error {
-	// create readers
-	stdoutReader, stdoutWriter, err := os.Pipe()
+	pb, err := tunnel.NewPipeBridge()
 	if err != nil {
 		return err
 	}
-	defer func() { _ = stdoutReader.Close() }()
-	defer func() { _ = stdoutWriter.Close() }()
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = stdinWriter.Close() }()
-	defer func() { _ = stdinReader.Close() }()
+	defer pb.Close()
 
-	// start ssh machine
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- options.Exec(ctx, stdinReader, stdoutWriter, options.Stderr)
-	}()
+	return pb.RunPair(ctx,
+		func(ctx context.Context, stdin *os.File, stdout *os.File) error {
+			return options.Exec(ctx, stdin, stdout, options.Stderr)
+		},
+		func(ctx context.Context, stdout *os.File, stdin *os.File) error {
+			sshClient, err := devssh.StdioClientWithUser(stdout, stdin, options.User, false)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = sshClient.Close() }()
 
-	sshClient, err := devssh.StdioClientWithUser(stdoutReader, stdinWriter, options.User, false)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = sshClient.Close() }()
-
-	return RunSSHSession(ctx, sshClient, RunSSHSessionOptions{
-		Command:         options.Command,
-		AgentForwarding: options.AgentForwarding,
-		SessionOptions:  options.SessionOptions,
-		Stderr:          options.Stderr,
-	})
+			return RunSSHSession(ctx, sshClient, RunSSHSessionOptions{
+				Command:         options.Command,
+				AgentForwarding: options.AgentForwarding,
+				SessionOptions:  options.SessionOptions,
+				Stderr:          options.Stderr,
+			})
+		},
+	)
 }
 
 func RunSSHSession(ctx context.Context, sshClient *ssh.Client, options RunSSHSessionOptions) error {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -27,6 +27,7 @@ import (
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
 	"github.com/devsy-org/devsy/pkg/telemetry"
+	"github.com/devsy-org/devsy/pkg/tunnel"
 	"github.com/devsy-org/devsy/pkg/util"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
@@ -480,74 +481,62 @@ func (cmd *UpCmd) devsyUpProxy(
 	ctx context.Context,
 	client client2.ProxyClient,
 ) (*config2.Result, error) {
-	// create pipes
-	stdoutReader, stdoutWriter, err := os.Pipe()
+	pb, err := tunnel.NewPipeBridge()
 	if err != nil {
 		return nil, err
 	}
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = stdoutWriter.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
+	defer pb.Close()
 
-	// start machine on stdio
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
+	var result *config2.Result
+	err = pb.RunPair(ctx,
+		func(ctx context.Context, stdin *os.File, stdout *os.File) error {
+			defer log.Debug("done executing up command")
 
-	// create up command
-	errChan := make(chan error, 1)
-	go func() {
-		defer log.Debug("done executing up command")
-		defer cancel()
+			// build devsy up options
+			workspace := client.WorkspaceConfig()
+			baseOptions := cmd.CLIOptions
+			baseOptions.ID = workspace.ID
+			baseOptions.DevContainerPath = workspace.DevContainerPath
+			baseOptions.DevContainerImage = workspace.DevContainerImage
+			baseOptions.IDE = workspace.IDE.Name
+			baseOptions.IDEOptions = nil
+			baseOptions.Source = workspace.Source.String()
+			for optionName, optionValue := range workspace.IDE.Options {
+				baseOptions.IDEOptions = append(
+					baseOptions.IDEOptions,
+					optionName+"="+optionValue.Value,
+				)
+			}
 
-		// build devsy up options
-		workspace := client.WorkspaceConfig()
-		baseOptions := cmd.CLIOptions
-		baseOptions.ID = workspace.ID
-		baseOptions.DevContainerPath = workspace.DevContainerPath
-		baseOptions.DevContainerImage = workspace.DevContainerImage
-		baseOptions.IDE = workspace.IDE.Name
-		baseOptions.IDEOptions = nil
-		baseOptions.Source = workspace.Source.String()
-		for optionName, optionValue := range workspace.IDE.Options {
-			baseOptions.IDEOptions = append(
-				baseOptions.IDEOptions,
-				optionName+"="+optionValue.Value,
+			// run devsy up elsewhere
+			if err := client.Up(ctx, client2.UpOptions{
+				CLIOptions: baseOptions,
+				Debug:      cmd.Debug,
+
+				Stdin:  stdin,
+				Stdout: stdout,
+			}); err != nil {
+				return fmt.Errorf("executing up proxy command: %w", err)
+			}
+			return nil
+		},
+		func(ctx context.Context, stdout *os.File, stdin *os.File) error {
+			var handlerErr error
+			result, handlerErr = tunnelserver.RunUpServer(
+				ctx,
+				stdout,
+				stdin,
+				true,
+				true,
+				client.WorkspaceConfig(),
 			)
-		}
-
-		// run devsy up elsewhere
-		err = client.Up(ctx, client2.UpOptions{
-			CLIOptions: baseOptions,
-			Debug:      cmd.Debug,
-
-			Stdin:  stdinReader,
-			Stdout: stdoutWriter,
-		})
-		if err != nil {
-			errChan <- fmt.Errorf("executing up proxy command: %w", err)
-		} else {
-			errChan <- nil
-		}
-	}()
-
-	// create container etc.
-	result, err := tunnelserver.RunUpServer(
-		cancelCtx,
-		stdoutReader,
-		stdinWriter,
-		true,
-		true,
-		client.WorkspaceConfig(),
+			if handlerErr != nil {
+				return fmt.Errorf("run tunnel machine: %w", handlerErr)
+			}
+			return nil
+		},
 	)
-	if err != nil {
-		return nil, fmt.Errorf("run tunnel machine: %w", err)
-	}
-
-	// wait until command finished
-	return result, <-errChan
+	return result, err
 }
 
 func (cmd *UpCmd) devsyUpDaemon(


### PR DESCRIPTION
## Summary

- Migrates manual pipe-bridge patterns in `cmd/logs.go`, `cmd/machine/ssh.go`, and `cmd/up.go` to use `tunnel.NewPipeBridge()` + `pb.RunPair()`
- Eliminates goroutine leaks from undrained `errChan` channels (pre-existing bugs in logs and ssh commands)
- Replaces manual `os.Pipe` creation and deferred close calls with centralized `pb.Close()` lifecycle management