### PR TITLE
test(e2e): add parallel named lifecycle sub-commands e2e test

### DIFF
--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -497,6 +497,28 @@ var _ = ginkgo.Describe(
 			ginkgo.SpecTimeout(framework.GetTimeout()),
 		)
 
+		ginkgo.It(
+			"postCreateCommand with object syntax runs named sub-commands in parallel",
+			func(ctx context.Context) {
+				tempDir, err := dtc.setupAndUp(
+					ctx,
+					"tests/up/testdata/docker-postcreate-parallel",
+				)
+				framework.ExpectNoError(err)
+
+				// Both named postCreateCommand sub-commands run inside the
+				// container and write marker files to /tmp.
+				one, err := dtc.execSSH(ctx, tempDir, "cat /tmp/post-create-one.out")
+				framework.ExpectNoError(err)
+				gomega.Expect(strings.TrimSpace(one)).To(gomega.Equal("postCreateOne"))
+
+				two, err := dtc.execSSH(ctx, tempDir, "cat /tmp/post-create-two.out")
+				framework.ExpectNoError(err)
+				gomega.Expect(strings.TrimSpace(two)).To(gomega.Equal("postCreateTwo"))
+			},
+			ginkgo.SpecTimeout(framework.GetTimeout()),
+		)
+
 		ginkgo.It("IDE accessible before postAttachCommand completes", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
 				"tests/up/testdata/docker-post-attach-nonblocking",

--- a/e2e/tests/up/testdata/docker-postcreate-parallel/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-postcreate-parallel/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "image": "ghcr.io/devsy-org/test-images/go:1",
+  "postCreateCommand": {
+    "write-one": "echo -n postCreateOne > /tmp/post-create-one.out",
+    "write-two": "echo -n postCreateTwo > /tmp/post-create-two.out"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds e2e testdata with `postCreateCommand` using object format (`{"write-one": "...", "write-two": "..."}`) containing two named sub-commands
- Adds e2e test that verifies both marker files exist inside the container after workspace creation, confirming parallel named sub-commands work correctly for container lifecycle hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end testing for post-create command execution with named sub-commands in object syntax configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->