### PR TITLE
fix(config): union hostRequirements across merge sources

### DIFF
--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -322,7 +322,7 @@ func (h *HostRequirements) ShouldEnableGPU(gpuAvailable bool) (enable bool, warn
 	}
 
 	gpuValue := string(h.GPU)
-	if gpuValue == "optional" {
+	if gpuValue == gpuOptional {
 		return gpuAvailable, false
 	}
 

--- a/pkg/devcontainer/config/merge.go
+++ b/pkg/devcontainer/config/merge.go
@@ -9,6 +9,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/types"
 )
 
+const gpuOptional = "optional"
+
 func MergeConfiguration(
 	config *DevContainerConfig,
 	imageMetadataEntries []*ImageMetadata,
@@ -222,7 +224,7 @@ func gpuStrBoolPriority(g types.StrBool) int {
 		return 0
 	case "false":
 		return 1
-	case "optional":
+	case gpuOptional:
 		return 2
 	default: // "true"
 		return 3

--- a/pkg/devcontainer/config/merge.go
+++ b/pkg/devcontainer/config/merge.go
@@ -3,6 +3,8 @@ package config
 import (
 	"maps"
 	"strconv"
+	"strings"
+	"unicode"
 
 	"github.com/devsy-org/devsy/pkg/types"
 )
@@ -152,14 +154,87 @@ func firstString(entries []*ImageMetadata, m func(entry *ImageMetadata) string) 
 }
 
 func mergeHostRequirements(entries []*ImageMetadata) *HostRequirements {
-	// TODO: union requirements here
+	var merged *HostRequirements
 	for _, entry := range entries {
-		if entry.HostRequirements != nil {
-			return entry.HostRequirements
+		if entry.HostRequirements == nil {
+			continue
 		}
+		if merged == nil {
+			merged = &HostRequirements{}
+		}
+		if entry.HostRequirements.CPUs > merged.CPUs {
+			merged.CPUs = entry.HostRequirements.CPUs
+		}
+		merged.Memory = maxByteString(merged.Memory, entry.HostRequirements.Memory)
+		merged.Storage = maxByteString(merged.Storage, entry.HostRequirements.Storage)
+		merged.GPU = mergeGPU(merged.GPU, entry.HostRequirements.GPU)
+	}
+	return merged
+}
+
+var byteSizeMultipliers = map[string]uint64{
+	"":   1,
+	"kb": 1024,
+	"mb": 1024 * 1024,
+	"gb": 1024 * 1024 * 1024,
+	"tb": 1024 * 1024 * 1024 * 1024,
+}
+
+// parseByteSize parses a size string like "8gb", "512mb", "1tb" into bytes.
+// Returns 0 for empty or unparseable input so comparisons degrade gracefully.
+func parseByteSize(s string) uint64 {
+	s = strings.TrimSpace(strings.ToLower(s))
+	if s == "" {
+		return 0
 	}
 
-	return nil
+	i := 0
+	for i < len(s) && (unicode.IsDigit(rune(s[i])) || s[i] == '.') {
+		i++
+	}
+
+	num, err := strconv.ParseFloat(s[:i], 64)
+	if err != nil {
+		return 0
+	}
+
+	return uint64(num * float64(byteSizeMultipliers[strings.TrimSpace(s[i:])]))
+}
+
+// maxByteString returns whichever of a or b represents more bytes.
+func maxByteString(a, b string) string {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	if parseByteSize(b) > parseByteSize(a) {
+		return b
+	}
+	return a
+}
+
+// gpuStrBoolPriority ranks GPU StrBool values: true > optional > false > empty.
+func gpuStrBoolPriority(g types.StrBool) int {
+	switch string(g) {
+	case "":
+		return 0
+	case "false":
+		return 1
+	case "optional":
+		return 2
+	default: // "true"
+		return 3
+	}
+}
+
+// mergeGPU returns the stronger of two GPU StrBool values.
+func mergeGPU(a, b types.StrBool) types.StrBool {
+	if gpuStrBoolPriority(b) > gpuStrBoolPriority(a) {
+		return b
+	}
+	return a
 }
 
 func mergeForwardPorts(entries []*ImageMetadata) types.StrIntArray {

--- a/pkg/devcontainer/config/merge_test.go
+++ b/pkg/devcontainer/config/merge_test.go
@@ -1,0 +1,326 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/types"
+)
+
+const gpuTrue types.StrBool = "true"
+
+func TestMergeHostRequirements_AllNil(t *testing.T) {
+	entries := []*ImageMetadata{
+		{},
+		{},
+	}
+	got := mergeHostRequirements(entries)
+	if got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestMergeHostRequirements_SingleEntry(t *testing.T) {
+	entries := []*ImageMetadata{
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{CPUs: 4, Memory: "8gb", Storage: "32gb"},
+		}},
+	}
+	got := mergeHostRequirements(entries)
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if got.CPUs != 4 {
+		t.Errorf("CPUs = %d, want 4", got.CPUs)
+	}
+	if got.Memory != "8gb" {
+		t.Errorf("Memory = %q, want %q", got.Memory, "8gb")
+	}
+	if got.Storage != "32gb" {
+		t.Errorf("Storage = %q, want %q", got.Storage, "32gb")
+	}
+}
+
+func TestMergeHostRequirements_MaxCPUs(t *testing.T) {
+	entries := []*ImageMetadata{
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{CPUs: 2},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{CPUs: 8},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{CPUs: 4},
+		}},
+	}
+	got := mergeHostRequirements(entries)
+	if got.CPUs != 8 {
+		t.Errorf("CPUs = %d, want 8", got.CPUs)
+	}
+}
+
+func TestMergeHostRequirements_MaxMemory(t *testing.T) {
+	entries := []*ImageMetadata{
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{Memory: "4gb"},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{Memory: "16gb"},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{Memory: "8gb"},
+		}},
+	}
+	got := mergeHostRequirements(entries)
+	if got.Memory != "16gb" {
+		t.Errorf("Memory = %q, want %q", got.Memory, "16gb")
+	}
+}
+
+func TestMergeHostRequirements_MaxStorage(t *testing.T) {
+	entries := []*ImageMetadata{
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{Storage: "64gb"},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{Storage: "1tb"},
+		}},
+	}
+	got := mergeHostRequirements(entries)
+	if got.Storage != "1tb" {
+		t.Errorf("Storage = %q, want %q", got.Storage, "1tb")
+	}
+}
+
+func TestMergeHostRequirements_MixedUnits(t *testing.T) {
+	entries := []*ImageMetadata{
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{Memory: "512mb"},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{Memory: "1gb"},
+		}},
+	}
+	got := mergeHostRequirements(entries)
+	if got.Memory != "1gb" {
+		t.Errorf("Memory = %q, want %q", got.Memory, "1gb")
+	}
+}
+
+func TestMergeHostRequirements_GPUTrueBeatsOptional(t *testing.T) {
+	entries := []*ImageMetadata{
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{GPU: "optional"},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{GPU: "true"},
+		}},
+	}
+	got := mergeHostRequirements(entries)
+	if got.GPU != gpuTrue {
+		t.Errorf("GPU = %q, want %q", got.GPU, gpuTrue)
+	}
+}
+
+func TestMergeHostRequirements_GPUOptionalBeatsFalse(t *testing.T) {
+	entries := []*ImageMetadata{
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{GPU: "false"},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{GPU: "optional"},
+		}},
+	}
+	got := mergeHostRequirements(entries)
+	if got.GPU != "optional" {
+		t.Errorf("GPU = %q, want %q", got.GPU, "optional")
+	}
+}
+
+func TestMergeHostRequirements_GPUTrueBeatsFalse(t *testing.T) {
+	entries := []*ImageMetadata{
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{GPU: "false"},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{GPU: "true"},
+		}},
+	}
+	got := mergeHostRequirements(entries)
+	if got.GPU != gpuTrue {
+		t.Errorf("GPU = %q, want %q", got.GPU, gpuTrue)
+	}
+}
+
+func TestMergeHostRequirements_GPUEmptyPreservesValue(t *testing.T) {
+	entries := []*ImageMetadata{
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{GPU: "optional"},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{},
+		}},
+	}
+	got := mergeHostRequirements(entries)
+	if got.GPU != "optional" {
+		t.Errorf("GPU = %q, want %q", got.GPU, "optional")
+	}
+}
+
+func TestMergeHostRequirements_MultiSource(t *testing.T) {
+	entries := []*ImageMetadata{
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{
+				CPUs:    2,
+				Memory:  "4gb",
+				Storage: "32gb",
+				GPU:     "false",
+			},
+		}},
+		{}, // no requirements
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{CPUs: 4, Memory: "8gb", GPU: "optional"},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{
+				CPUs:    1,
+				Memory:  "16gb",
+				Storage: "64gb",
+				GPU:     "true",
+			},
+		}},
+	}
+	got := mergeHostRequirements(entries)
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if got.CPUs != 4 {
+		t.Errorf("CPUs = %d, want 4", got.CPUs)
+	}
+	if got.Memory != "16gb" {
+		t.Errorf("Memory = %q, want %q", got.Memory, "16gb")
+	}
+	if got.Storage != "64gb" {
+		t.Errorf("Storage = %q, want %q", got.Storage, "64gb")
+	}
+	if got.GPU != gpuTrue {
+		t.Errorf("GPU = %q, want %q", got.GPU, gpuTrue)
+	}
+}
+
+func TestMergeHostRequirements_PartialFields(t *testing.T) {
+	entries := []*ImageMetadata{
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{CPUs: 4},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{Memory: "8gb"},
+		}},
+		{DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: &HostRequirements{Storage: "100gb"},
+		}},
+	}
+	got := mergeHostRequirements(entries)
+	if got.CPUs != 4 {
+		t.Errorf("CPUs = %d, want 4", got.CPUs)
+	}
+	if got.Memory != "8gb" {
+		t.Errorf("Memory = %q, want %q", got.Memory, "8gb")
+	}
+	if got.Storage != "100gb" {
+		t.Errorf("Storage = %q, want %q", got.Storage, "100gb")
+	}
+}
+
+func TestParseByteSize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  uint64
+	}{
+		{"", 0},
+		{"garbage", 0},
+		{"1024", 1024},
+		{"4kb", 4 * 1024},
+		{"512mb", 512 * 1024 * 1024},
+		{"8gb", 8 * 1024 * 1024 * 1024},
+		{"1tb", 1024 * 1024 * 1024 * 1024},
+		{"1.5gb", uint64(1.5 * 1024 * 1024 * 1024)},
+		{"  16GB  ", 16 * 1024 * 1024 * 1024},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseByteSize(tt.input)
+			if got != tt.want {
+				t.Errorf("parseByteSize(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaxByteString(t *testing.T) {
+	tests := []struct {
+		a, b, want string
+	}{
+		{"", "", ""},
+		{"4gb", "", "4gb"},
+		{"", "8gb", "8gb"},
+		{"4gb", "8gb", "8gb"},
+		{"8gb", "4gb", "8gb"},
+		{"512mb", "1gb", "1gb"},
+		{"1gb", "512mb", "1gb"},
+		{"1tb", "1024gb", "1tb"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			got := maxByteString(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("maxByteString(%q, %q) = %q, want %q", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGpuStrBoolPriority(t *testing.T) {
+	tests := []struct {
+		input types.StrBool
+		want  int
+	}{
+		{"", 0},
+		{"false", 1},
+		{"optional", 2},
+		{"true", 3},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.input), func(t *testing.T) {
+			got := gpuStrBoolPriority(tt.input)
+			if got != tt.want {
+				t.Errorf("gpuStrBoolPriority(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeGPU(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b types.StrBool
+		want types.StrBool
+	}{
+		{"empty_empty", "", "", ""},
+		{"true_false", "true", "false", "true"},
+		{"false_true", "false", "true", "true"},
+		{"optional_true", "optional", "true", "true"},
+		{"true_optional", "true", "optional", "true"},
+		{"false_optional", "false", "optional", "optional"},
+		{"optional_false", "optional", "false", "optional"},
+		{"empty_true", "", "true", "true"},
+		{"true_empty", "true", "", "true"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mergeGPU(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("mergeGPU(%q, %q) = %q, want %q", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `mergeHostRequirements` now takes the max of each field (CPUs, memory, storage, GPU) across all image metadata entries instead of returning the first non-nil entry
- Memory and storage values are parsed and compared numerically with unit support (kb, mb, gb, tb) via `parseByteSize`
- GPU is unioned by priority: `true` > `optional` > `false` > empty
- Added comprehensive unit tests covering multi-source merging, mixed units, partial fields, and GPU priority

## Local validation

- `task cli:test` — all config package tests pass with `-race`; pre-existing failures in `cmd/ssh_test.go` (GPG signing key tests) are unrelated
- `task cli:lint:new` — 0 issues
- `task cli:format` — clean