### PR TITLE
test(e2e): add remoteEnv null unset e2e test

### DIFF
--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -219,6 +219,30 @@ var _ = ginkgo.Describe(
 			)
 		}, ginkgo.SpecTimeout(framework.GetTimeout()))
 
+		ginkgo.It("remoteEnv null unsets variable", func(ctx context.Context) {
+			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker-remote-env-null")
+			framework.ExpectNoError(err)
+
+			workspace, err := dtc.f.FindWorkspace(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			// Verify SET_VAR is set
+			setLine, err := dtc.execSSHCapture(
+				ctx, workspace.ID,
+				"head -1 $HOME/remote-env-null.out",
+			)
+			framework.ExpectNoError(err)
+			gomega.Expect(setLine).To(gomega.Equal("SET=hello"))
+
+			// Verify UNSET_VAR was unset (not just empty)
+			unsetLine, err := dtc.execSSHCapture(
+				ctx, workspace.ID,
+				"tail -1 $HOME/remote-env-null.out",
+			)
+			framework.ExpectNoError(err)
+			gomega.Expect(unsetLine).To(gomega.Equal("UNSET=true"))
+		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+
 		ginkgo.It("mounts", func(ctx context.Context) {
 			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker-mounts", "--debug")
 			framework.ExpectNoError(err)

--- a/e2e/tests/up/testdata/docker-remote-env-null/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-remote-env-null/.devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "Remote Env Null Test",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "remoteEnv": {
+    "SET_VAR": "hello",
+    "UNSET_VAR": null
+  },
+  "postCreateCommand": [
+    "sh",
+    "-c",
+    "echo SET=$SET_VAR > $HOME/remote-env-null.out && if [ -z \"${UNSET_VAR+x}\" ]; then echo UNSET=true >> $HOME/remote-env-null.out; else echo UNSET=false >> $HOME/remote-env-null.out; fi"
+  ]
+}

--- a/e2e/tests/up/testdata/docker-remote-env-null/Dockerfile
+++ b/e2e/tests/up/testdata/docker-remote-env-null/Dockerfile
@@ -1,0 +1,2 @@
+FROM ghcr.io/devsy-org/test-images/go:1
+ENV UNSET_VAR=should_be_gone


### PR DESCRIPTION
## Summary

- Add e2e test for docker provider that verifies `remoteEnv: {"VAR": null}` causes the variable to be fully unset in the container (not just empty)
- Test uses a Dockerfile with `ENV UNSET_VAR=should_be_gone`, then sets `"UNSET_VAR": null` in remoteEnv and confirms the variable is absent via `${UNSET_VAR+x}` shell test
- Follows the existing compose-based `docker-compose-remote-env-null` test pattern, adapted for the docker provider