### PR TITLE
fix(lifecycle): accept initializeCommand as a valid waitFor value

### DIFF
--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -74,6 +74,12 @@ func promoteDotfilesWaitFor(waitFor LifecyclePhase, dotfiles DotfilesConfig) Lif
 	if dotfiles.Repository == "" {
 		return waitFor
 	}
+	// initializeCommand is a host-side phase that precedes all container
+	// lifecycle phases. The user explicitly wants everything deferred, so
+	// dotfiles promotion must not override that.
+	if waitFor == PhaseInitializeCommand {
+		return waitFor
+	}
 	// PhaseDotfiles sits between PostCreate and PostStart in the hook list.
 	// If waitFor is already at or past that position, no promotion needed.
 	if phaseIndex(waitFor) >= phaseIndex(PhaseDotfiles) {

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -25,11 +25,12 @@ import (
 type LifecyclePhase string
 
 const (
-	PhaseOnCreate      LifecyclePhase = "onCreateCommand"
-	PhaseUpdateContent LifecyclePhase = "updateContentCommand"
-	PhasePostCreate    LifecyclePhase = "postCreateCommand"
-	PhasePostStart     LifecyclePhase = "postStartCommand"
-	PhasePostAttach    LifecyclePhase = "postAttachCommand"
+	PhaseInitializeCommand LifecyclePhase = "initializeCommand"
+	PhaseOnCreate          LifecyclePhase = "onCreateCommand"
+	PhaseUpdateContent     LifecyclePhase = "updateContentCommand"
+	PhasePostCreate        LifecyclePhase = "postCreateCommand"
+	PhasePostStart         LifecyclePhase = "postStartCommand"
+	PhasePostAttach        LifecyclePhase = "postAttachCommand"
 )
 
 // DefaultWaitFor is the spec-defined default for the waitFor property.
@@ -45,8 +46,10 @@ var phaseOrder = []LifecyclePhase{
 }
 
 // validWaitForPhase returns true when phase is an allowed waitFor value.
+// initializeCommand is a valid waitFor value (host-side phase) even though
+// it is not in phaseOrder (which lists only container-side phases).
 func validWaitForPhase(phase LifecyclePhase) bool {
-	return slices.Contains(phaseOrder, phase)
+	return phase == PhaseInitializeCommand || slices.Contains(phaseOrder, phase)
 }
 
 // resolveWaitFor normalises the raw waitFor string from the config,
@@ -274,10 +277,17 @@ func runPrebuildHooks(all []phaseHook) error {
 
 // runWithWaitFor runs hooks up to and including waitFor synchronously
 // and returns the remaining hooks as deferred.
+//
+// When waitFor is initializeCommand (a host-side phase that precedes all
+// container lifecycle phases), every container phase is deferred.
 func runWithWaitFor(
 	all []phaseHook,
 	waitFor LifecyclePhase,
 ) ([]phaseHook, error) {
+	if waitFor == PhaseInitializeCommand {
+		return append([]phaseHook(nil), all...), nil
+	}
+
 	pastWaitFor := false
 	var deferred []phaseHook
 

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -579,6 +579,15 @@ func (s *LifecycleHookTestSuite) TestPromoteDotfilesWaitForPostStartNotPromoted(
 	assert.Equal(t, PhasePostStart, result)
 }
 
+func (s *LifecycleHookTestSuite) TestPromoteDotfilesWaitForInitializeCommandNotPromoted() {
+	t := s.T()
+	cfg := DotfilesConfig{Repository: "https://github.com/user/dotfiles"}
+
+	// initializeCommand defers everything; dotfiles promotion must not override it.
+	result := promoteDotfilesWaitFor(PhaseInitializeCommand, cfg)
+	assert.Equal(t, PhaseInitializeCommand, result)
+}
+
 func (s *LifecycleHookTestSuite) TestPromoteDotfilesWaitForNoDotfiles() {
 	t := s.T()
 

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -146,11 +146,11 @@ func (s *LifecycleHookTestSuite) TestResolveWaitForValid() {
 	assert.Equal(s.T(), PhaseOnCreate, resolveWaitFor("onCreateCommand"))
 	assert.Equal(s.T(), PhasePostAttach, resolveWaitFor("postAttachCommand"))
 	assert.Equal(s.T(), PhaseUpdateContent, resolveWaitFor("updateContentCommand"))
+	assert.Equal(s.T(), PhaseInitializeCommand, resolveWaitFor("initializeCommand"))
 }
 
 func (s *LifecycleHookTestSuite) TestResolveWaitForInvalid() {
 	assert.Equal(s.T(), DefaultWaitFor, resolveWaitFor("bogus"))
-	assert.Equal(s.T(), DefaultWaitFor, resolveWaitFor("initializeCommand"))
 	assert.Equal(s.T(), DefaultWaitFor, resolveWaitFor("POSTCREATECOMMAND"))
 }
 
@@ -203,6 +203,33 @@ func (s *LifecycleHookTestSuite) TestRunWithWaitForOnCreate() {
 	assert.Equal(t, PhaseUpdateContent, deferred[0].phase)
 	assert.Equal(t, PhasePostCreate, deferred[1].phase)
 	assert.Equal(t, PhasePostStart, deferred[2].phase)
+}
+
+func (s *LifecycleHookTestSuite) TestRunWithWaitForInitializeCommand() {
+	t := s.T()
+	all := makeTestPhaseHooks()
+
+	deferred, err := runWithWaitFor(all, PhaseInitializeCommand)
+	assert.NoError(t, err)
+
+	// initializeCommand is a host-side phase; all container phases are deferred.
+	assert.Len(t, deferred, len(all))
+	assert.Equal(t, PhaseOnCreate, deferred[0].phase)
+	assert.Equal(t, PhaseUpdateContent, deferred[1].phase)
+	assert.Equal(t, PhasePostCreate, deferred[2].phase)
+	assert.Equal(t, PhasePostStart, deferred[3].phase)
+}
+
+func (s *LifecycleHookTestSuite) TestRunWithWaitForInitializeCommandSliceCopy() {
+	t := s.T()
+	all := makeTestPhaseHooks()
+
+	deferred, err := runWithWaitFor(all, PhaseInitializeCommand)
+	assert.NoError(t, err)
+
+	// Mutating the deferred slice must not affect the original.
+	deferred[0].phase = "mutated"
+	assert.Equal(t, PhaseOnCreate, all[0].phase, "original slice must not be affected")
 }
 
 func (s *LifecycleHookTestSuite) TestPrebuildIgnoresWaitFor() {


### PR DESCRIPTION
## Summary

Adds `PhaseInitializeCommand` as a recognized `waitFor` value in the devcontainer lifecycle. The devcontainer spec allows `waitFor` to reference any lifecycle command, but our implementation was missing `initializeCommand`.

Since `initializeCommand` is a host-side phase that runs before the container lifecycle begins, setting `waitFor=initializeCommand` means all container lifecycle phases (onCreateCommand, updateContentCommand, postCreateCommand, postStartCommand) are deferred to run as background tasks — the container is considered ready as soon as the host-side initializeCommand completes.

Changes:
- Added `PhaseInitializeCommand` constant (`"initializeCommand"`)
- Updated `validWaitForPhase()` to recognize initializeCommand as valid (host-side phase not in container-side `phaseOrder`)
- Updated `runWithWaitFor()` to defer all container hooks when `waitFor=initializeCommand`, with a defensive slice copy to prevent aliasing bugs
- Added unit tests for: valid phase recognition, all-deferred hook ordering, and slice aliasing protection

Re-implementation of original PR #98.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new lifecycle phase option that defers all container lifecycle phases instead of executing them synchronously, establishing a host-side barrier in the lifecycle workflow.

* **Tests**
  * Expanded test coverage for the new lifecycle phase, including phase validation and phase deferral behavior verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->