### PR TITLE
fix(lifecycle): run initializeCommand named sub-commands in parallel

### DIFF
--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -443,6 +443,27 @@ var _ = ginkgo.Describe(
 			)
 		}, ginkgo.SpecTimeout(framework.GetTimeout()))
 
+		ginkgo.It(
+			"initializeCommand with object syntax runs named sub-commands in parallel",
+			func(ctx context.Context) {
+				tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker-initcmd-parallel")
+				framework.ExpectNoError(err)
+
+				one, err := os.ReadFile( //nolint:gosec // G304
+					filepath.Join(tempDir, "init-cmd-one.out"),
+				)
+				framework.ExpectNoError(err)
+				gomega.Expect(string(one)).To(gomega.Equal("initCmdOne"))
+
+				two, err := os.ReadFile( //nolint:gosec // G304
+					filepath.Join(tempDir, "init-cmd-two.out"),
+				)
+				framework.ExpectNoError(err)
+				gomega.Expect(string(two)).To(gomega.Equal("initCmdTwo"))
+			},
+			ginkgo.SpecTimeout(framework.GetTimeout()),
+		)
+
 		ginkgo.It("multi devcontainer selection", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
 				"tests/up/testdata/docker-multi-devcontainer",

--- a/e2e/tests/up/testdata/docker-initcmd-parallel/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-initcmd-parallel/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "image": "ghcr.io/devsy-org/test-images/go:1",
+  "initializeCommand": {
+    "write-one": "echo -n initCmdOne > ./init-cmd-one.out",
+    "write-two": ["sh", "-c", "echo -n initCmdTwo > ./init-cmd-two.out"]
+  }
+}

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -2,12 +2,14 @@ package devcontainer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
@@ -201,18 +203,26 @@ func isDockerFileConfig(config *config.DevContainerConfig) bool {
 	return config.GetDockerfile() != ""
 }
 
+// initCmdContext groups shared execution state for initializeCommand sub-commands.
+type initCmdContext struct {
+	shellArgs       []string
+	workspaceFolder string
+	extraEnvVars    []string
+}
+
 func runInitializeCommand(
 	workspaceFolder string,
-	config *config.DevContainerConfig,
+	conf *config.DevContainerConfig,
 	extraEnvVars []string,
 ) error {
-	if len(config.InitializeCommand) == 0 {
+	if len(conf.InitializeCommand) == 0 {
 		return nil
 	}
 
 	shellArgs := []string{"sh", "-c"}
 	// According to the devcontainer spec, `initializeCommand` needs to be run on the host.
-	// On Windows we can't assume everyone has `sh` added to their PATH so we need to use Windows default shell (usually cmd.exe)
+	// On Windows we can't assume everyone has `sh` added to their PATH so we need to use
+	// Windows default shell (usually cmd.exe).
 	if runtime.GOOS == "windows" {
 		comSpec := os.Getenv("COMSPEC")
 		if comSpec != "" {
@@ -222,38 +232,80 @@ func runInitializeCommand(
 		}
 	}
 
-	for _, cmd := range config.InitializeCommand {
-		// should run in shell?
-		var args []string
-		if len(cmd) == 1 {
-			args = []string{shellArgs[0], shellArgs[1], cmd[0]}
-		} else {
-			args = cmd
-		}
+	ctx := &initCmdContext{
+		shellArgs:       shellArgs,
+		workspaceFolder: workspaceFolder,
+		extraEnvVars:    extraEnvVars,
+	}
 
-		// run the command
-		log.Infof("Running initializeCommand from devcontainer.json: '%s'", strings.Join(args, " "))
-		writer := log.Writer(log.LevelInfo)
-		errwriter := log.Writer(log.LevelError)
-		defer func() { _ = writer.Close() }()
-		defer func() { _ = errwriter.Close() }()
+	if len(conf.InitializeCommand) > 1 {
+		return ctx.runParallel(conf.InitializeCommand)
+	}
 
-		// args come from devcontainer.json initializeCommand, a trusted local config.
-		cmd := exec.Command(args[0], args[1:]...) //nolint:gosec // G204
-		env := cmd.Environ()
-		env = append(env, extraEnvVars...)
-
-		cmd.Stdout = writer
-		cmd.Stderr = errwriter
-		cmd.Dir = workspaceFolder
-		cmd.Env = env
-		err := cmd.Run()
-		if err != nil {
+	for name, cmd := range conf.InitializeCommand {
+		if err := ctx.runSingle(name, cmd); err != nil {
 			return err
 		}
 	}
-
 	return nil
+}
+
+// runParallel executes all named sub-commands concurrently, collects errors, and returns them joined.
+func (c *initCmdContext) runParallel(hook map[string][]string) error {
+	var (
+		wg   sync.WaitGroup
+		mu   sync.Mutex
+		errs []error
+	)
+
+	wg.Add(len(hook))
+	for name, cmd := range hook {
+		go func() {
+			defer wg.Done()
+			if err := c.runSingle(name, cmd); err != nil {
+				mu.Lock()
+				errs = append(errs, fmt.Errorf("named command %q failed: %w", name, err))
+				mu.Unlock()
+			}
+		}()
+	}
+
+	wg.Wait()
+	return errors.Join(errs...)
+}
+
+// runSingle executes a single initializeCommand sub-command.
+func (c *initCmdContext) runSingle(name string, cmd []string) error {
+	var args []string
+	if len(cmd) == 1 {
+		args = make([]string, len(c.shellArgs)+1)
+		copy(args, c.shellArgs)
+		args[len(c.shellArgs)] = cmd[0]
+	} else {
+		args = cmd
+	}
+
+	log.Infof(
+		"Running initializeCommand %q from devcontainer.json: '%s'",
+		name,
+		strings.Join(args, " "),
+	)
+
+	writer := log.Writer(log.LevelInfo)
+	errwriter := log.Writer(log.LevelError)
+	defer func() { _ = writer.Close() }()
+	defer func() { _ = errwriter.Close() }()
+
+	// args come from devcontainer.json initializeCommand, a trusted local config.
+	c2 := exec.Command(args[0], args[1:]...) //nolint:gosec // G204
+	env := c2.Environ()
+	env = append(env, c.extraEnvVars...)
+
+	c2.Stdout = writer
+	c2.Stderr = errwriter
+	c2.Dir = c.workspaceFolder
+	c2.Env = env
+	return c2.Run()
 }
 
 func getWorkspace(

--- a/pkg/devcontainer/run_test.go
+++ b/pkg/devcontainer/run_test.go
@@ -37,7 +37,7 @@ func TestRunInitializeCommand_ParallelErrorCollection(t *testing.T) {
 	conf := &config.DevContainerConfig{}
 	conf.InitializeCommand = types.LifecycleHook{
 		"will-fail":    {"sh", "-c", "exit 1"},
-		"will-succeed": {"sh", "-c", "echo -n ok > " + markerFile},
+		"will-succeed": {"sh", "-c", "printf ok > " + markerFile},
 	}
 
 	err := runInitializeCommand(tmpDir, conf, nil)
@@ -63,7 +63,7 @@ func TestRunInitializeCommand_SingleKey(t *testing.T) {
 
 	conf := &config.DevContainerConfig{}
 	conf.InitializeCommand = types.LifecycleHook{
-		"write-file": {"sh", "-c", "echo -n single > " + outFile},
+		"write-file": {"sh", "-c", "printf single > " + outFile},
 	}
 
 	err := runInitializeCommand(tmpDir, conf, nil)
@@ -87,7 +87,7 @@ func TestRunInitializeCommand_StringFormat(t *testing.T) {
 	conf := &config.DevContainerConfig{}
 	// String format produces a single anonymous key with one-element slice.
 	conf.InitializeCommand = types.LifecycleHook{
-		"": {"echo -n stringfmt > " + outFile},
+		"": {"printf stringfmt > " + outFile},
 	}
 
 	err := runInitializeCommand(tmpDir, conf, nil)

--- a/pkg/devcontainer/run_test.go
+++ b/pkg/devcontainer/run_test.go
@@ -1,0 +1,132 @@
+package devcontainer
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/types"
+)
+
+func TestRunInitializeCommand_ParallelTiming(t *testing.T) {
+	tmpDir := t.TempDir()
+	conf := &config.DevContainerConfig{}
+	conf.InitializeCommand = types.LifecycleHook{
+		"sleep-one": {"sleep", "0.5"},
+		"sleep-two": {"sleep", "0.5"},
+	}
+
+	start := time.Now()
+	err := runInitializeCommand(tmpDir, conf, nil)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed >= 900*time.Millisecond {
+		t.Fatalf("expected parallel execution under 900ms, took %s", elapsed)
+	}
+}
+
+func TestRunInitializeCommand_ParallelErrorCollection(t *testing.T) {
+	tmpDir := t.TempDir()
+	markerFile := filepath.Join(tmpDir, "success.out")
+
+	conf := &config.DevContainerConfig{}
+	conf.InitializeCommand = types.LifecycleHook{
+		"will-fail":    {"sh", "-c", "exit 1"},
+		"will-succeed": {"sh", "-c", "echo -n ok > " + markerFile},
+	}
+
+	err := runInitializeCommand(tmpDir, conf, nil)
+	if err == nil {
+		t.Fatal("expected error from failing command")
+	}
+	if !contains(err.Error(), "will-fail") {
+		t.Fatalf("error should mention 'will-fail', got: %v", err)
+	}
+
+	data, readErr := os.ReadFile(markerFile) //nolint:gosec // G304 — test temp file
+	if readErr != nil {
+		t.Fatalf("success marker not written; parallel commands should all run: %v", readErr)
+	}
+	if string(data) != "ok" {
+		t.Fatalf("expected marker content 'ok', got %q", string(data))
+	}
+}
+
+func TestRunInitializeCommand_SingleKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "single.out")
+
+	conf := &config.DevContainerConfig{}
+	conf.InitializeCommand = types.LifecycleHook{
+		"write-file": {"sh", "-c", "echo -n single > " + outFile},
+	}
+
+	err := runInitializeCommand(tmpDir, conf, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(outFile) //nolint:gosec // G304 — test temp file
+	if err != nil {
+		t.Fatalf("output file not created: %v", err)
+	}
+	if string(data) != "single" {
+		t.Fatalf("expected 'single', got %q", string(data))
+	}
+}
+
+func TestRunInitializeCommand_StringFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	outFile := filepath.Join(tmpDir, "string.out")
+
+	conf := &config.DevContainerConfig{}
+	// String format produces a single anonymous key with one-element slice.
+	conf.InitializeCommand = types.LifecycleHook{
+		"": {"echo -n stringfmt > " + outFile},
+	}
+
+	err := runInitializeCommand(tmpDir, conf, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	data, err := os.ReadFile(outFile) //nolint:gosec // G304 — test temp file
+	if err != nil {
+		t.Fatalf("output file not created: %v", err)
+	}
+	if string(data) != "stringfmt" {
+		t.Fatalf("expected 'stringfmt', got %q", string(data))
+	}
+}
+
+func TestRunInitializeCommand_Empty(t *testing.T) {
+	// nil config
+	conf := &config.DevContainerConfig{}
+	if err := runInitializeCommand(t.TempDir(), conf, nil); err != nil {
+		t.Fatalf("nil InitializeCommand should return nil, got: %v", err)
+	}
+
+	// empty map
+	conf.InitializeCommand = types.LifecycleHook{}
+	if err := runInitializeCommand(t.TempDir(), conf, nil); err != nil {
+		t.Fatalf("empty InitializeCommand should return nil, got: %v", err)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchString(s, substr)
+}
+
+func searchString(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Refactors `runInitializeCommand` to run named sub-commands concurrently when `initializeCommand` uses object syntax with multiple keys, using goroutines + `sync.WaitGroup` + mutex-protected error collection (matching the `executeLifecycleHook` pattern for container-side hooks)
- Single-key and string-format `initializeCommand` continue to run sequentially as before
- Adds unit tests verifying parallel timing, error collection, single-key, string-format, and empty/nil cases
- Adds e2e test fixture (`docker-initcmd-parallel`) validating both string and array sub-command formats produce expected output files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multiple initialize commands now execute concurrently for improved performance.
  * Enhanced error handling aggregates and reports failures from all initialization commands.

* **Tests**
  * Added comprehensive test coverage for parallel command execution and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->