### PR TITLE
test(e2e): add parallel named lifecycle sub-commands e2e test

### DIFF
--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -464,6 +464,26 @@ var _ = ginkgo.Describe(
 			ginkgo.SpecTimeout(framework.GetTimeout()),
 		)
 
+		ginkgo.It(
+			"postCreateCommand with object syntax runs named sub-commands in parallel",
+			func(ctx context.Context) {
+				tempDir, err := dtc.setupAndUp(
+					ctx,
+					"tests/up/testdata/docker-postcreate-parallel",
+				)
+				framework.ExpectNoError(err)
+
+				one, err := dtc.execSSH(ctx, tempDir, "cat /tmp/post-create-one.out")
+				framework.ExpectNoError(err)
+				gomega.Expect(strings.TrimSpace(one)).To(gomega.Equal("postCreateOne"))
+
+				two, err := dtc.execSSH(ctx, tempDir, "cat /tmp/post-create-two.out")
+				framework.ExpectNoError(err)
+				gomega.Expect(strings.TrimSpace(two)).To(gomega.Equal("postCreateTwo"))
+			},
+			ginkgo.SpecTimeout(framework.GetTimeout()),
+		)
+
 		ginkgo.It("multi devcontainer selection", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
 				"tests/up/testdata/docker-multi-devcontainer",

--- a/e2e/tests/up/testdata/docker-postcreate-parallel/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-postcreate-parallel/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "image": "ghcr.io/devsy-org/test-images/go:1",
+  "postCreateCommand": {
+    "write-one": "printf postCreateOne > /tmp/post-create-one.out",
+    "write-two": "printf postCreateTwo > /tmp/post-create-two.out"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds e2e test verifying `postCreateCommand` with object syntax runs named sub-commands in parallel
- Creates testdata fixture `docker-postcreate-parallel` with two named commands that write marker files
- Uses `printf` instead of `echo -n` for macOS portability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test coverage for parallel execution of post-create commands using object syntax configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->