### PR TITLE
test(e2e): add remoteEnv null unset e2e test

### DIFF
--- a/e2e/tests/up/helper.go
+++ b/e2e/tests/up/helper.go
@@ -36,7 +36,7 @@ func (btc *baseTestContext) execSSHCapture(
 		ctx,
 		[]string{"ssh", "--command", command, projectName},
 	)
-	return output, err
+	return strings.TrimSpace(output), err
 }
 
 func (btc *baseTestContext) execSSH(ctx context.Context, tempDir, command string) (string, error) {

--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -219,6 +219,30 @@ var _ = ginkgo.Describe(
 			)
 		}, ginkgo.SpecTimeout(framework.GetTimeout()))
 
+		ginkgo.It("remoteEnv null unsets variable", func(ctx context.Context) {
+			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker-remote-env-null")
+			framework.ExpectNoError(err)
+
+			workspace, err := dtc.f.FindWorkspace(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			setLine, err := dtc.execSSHCapture(
+				ctx,
+				workspace.ID,
+				`head -1 $HOME/remote-env-null.out`,
+			)
+			framework.ExpectNoError(err)
+			gomega.Expect(setLine).To(gomega.Equal("SET=hello"))
+
+			unsetLine, err := dtc.execSSHCapture(
+				ctx,
+				workspace.ID,
+				`tail -1 $HOME/remote-env-null.out`,
+			)
+			framework.ExpectNoError(err)
+			gomega.Expect(unsetLine).To(gomega.Equal("UNSET=true"))
+		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+
 		ginkgo.It("mounts", func(ctx context.Context) {
 			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker-mounts", "--debug")
 			framework.ExpectNoError(err)

--- a/e2e/tests/up/testdata/docker-remote-env-null/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-remote-env-null/.devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "Remote Env Null Test",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "remoteEnv": {
+    "SET_VAR": "hello",
+    "UNSET_VAR": null
+  },
+  "postCreateCommand": [
+    "sh",
+    "-c",
+    "echo SET=$SET_VAR > $HOME/remote-env-null.out && if [ -z \"${UNSET_VAR+x}\" ]; then echo UNSET=true >> $HOME/remote-env-null.out; else echo UNSET=false >> $HOME/remote-env-null.out; fi"
+  ]
+}

--- a/e2e/tests/up/testdata/docker-remote-env-null/Dockerfile
+++ b/e2e/tests/up/testdata/docker-remote-env-null/Dockerfile
@@ -1,0 +1,2 @@
+FROM ghcr.io/devsy-org/test-images/go:1
+ENV UNSET_VAR=should_be_gone


### PR DESCRIPTION
## Summary

- Add e2e test verifying that `remoteEnv` with a `null` value fully unsets a variable (not just empties it)
- Dockerfile pre-sets `UNSET_VAR=should_be_gone`, devcontainer.json nulls it via `"UNSET_VAR": null`
- postCreateCommand checks the variable is truly unset using `${UNSET_VAR+x}` shell idiom

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive end-to-end test coverage for Docker-based workspaces to validate remote environment variable handling and configuration within dev containers, ensuring proper behavior for both setting and unsetting variables.
  * Enhanced SSH command output normalization for improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->