### PR TITLE
fix(config): union hostRequirements across merge sources

### DIFF
--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -379,7 +379,7 @@ func (h *HostRequirements) ShouldEnableGPU(gpuAvailable bool) (enable bool, warn
 		return false, false
 	}
 
-	if h.GPU.Value == "optional" {
+	if h.GPU.Value == gpuOptional {
 		return gpuAvailable, false
 	}
 

--- a/pkg/devcontainer/config/merge.go
+++ b/pkg/devcontainer/config/merge.go
@@ -3,8 +3,16 @@ package config
 import (
 	"maps"
 	"strconv"
+	"strings"
+	"unicode"
 
 	"github.com/devsy-org/devsy/pkg/types"
+)
+
+const (
+	gpuTrue     = "true"
+	gpuFalse    = "false"
+	gpuOptional = "optional"
 )
 
 func MergeConfiguration(
@@ -152,14 +160,83 @@ func firstString(entries []*ImageMetadata, m func(entry *ImageMetadata) string) 
 }
 
 func mergeHostRequirements(entries []*ImageMetadata) *HostRequirements {
-	// TODO: union requirements here
+	var merged *HostRequirements
 	for _, entry := range entries {
-		if entry.HostRequirements != nil {
-			return entry.HostRequirements
+		if entry.HostRequirements == nil {
+			continue
 		}
+		if merged == nil {
+			merged = &HostRequirements{}
+		}
+		if entry.HostRequirements.CPUs > merged.CPUs {
+			merged.CPUs = entry.HostRequirements.CPUs
+		}
+		merged.Memory = maxByteString(merged.Memory, entry.HostRequirements.Memory)
+		merged.Storage = maxByteString(merged.Storage, entry.HostRequirements.Storage)
+		merged.GPU = mergeGPU(merged.GPU, entry.HostRequirements.GPU)
 	}
+	return merged
+}
 
-	return nil
+var byteSizeMultipliers = map[string]uint64{
+	"kb": 1024,
+	"mb": 1024 * 1024,
+	"gb": 1024 * 1024 * 1024,
+	"tb": 1024 * 1024 * 1024 * 1024,
+}
+
+func parseByteSize(s string) uint64 {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0
+	}
+	i := 0
+	for i < len(s) && (s[i] == '.' || (s[i] >= '0' && s[i] <= '9')) {
+		i++
+	}
+	numStr := s[:i]
+	unit := strings.TrimSpace(s[i:])
+	unit = strings.Map(unicode.ToLower, unit)
+
+	val, err := strconv.ParseFloat(numStr, 64)
+	if err != nil {
+		return 0
+	}
+	if mult, ok := byteSizeMultipliers[unit]; ok {
+		return uint64(val * float64(mult))
+	}
+	return uint64(val)
+}
+
+func maxByteString(a, b string) string {
+	if parseByteSize(b) > parseByteSize(a) {
+		return b
+	}
+	if a == "" {
+		return b
+	}
+	return a
+}
+
+func gpuPriority(g *GPURequirement) int {
+	if g == nil {
+		return 0
+	}
+	switch strings.ToLower(g.Value) {
+	case gpuFalse:
+		return 1
+	case gpuOptional:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func mergeGPU(a, b *GPURequirement) *GPURequirement {
+	if gpuPriority(b) > gpuPriority(a) {
+		return b
+	}
+	return a
 }
 
 func mergeForwardPorts(entries []*ImageMetadata) types.StrIntArray {

--- a/pkg/devcontainer/config/merge_test.go
+++ b/pkg/devcontainer/config/merge_test.go
@@ -1,0 +1,226 @@
+package config
+
+import (
+	"testing"
+)
+
+func gpu(val string) *GPURequirement {
+	return &GPURequirement{Value: val}
+}
+
+func hr(h *HostRequirements) *ImageMetadata {
+	return &ImageMetadata{
+		DevContainerConfigBase: DevContainerConfigBase{
+			HostRequirements: h,
+		},
+	}
+}
+
+func TestMergeHostRequirements_AllNil(t *testing.T) {
+	entries := []*ImageMetadata{{}, {}, {}}
+	got := mergeHostRequirements(entries)
+	if got != nil {
+		t.Fatalf("expected nil, got %+v", got)
+	}
+}
+
+func TestMergeHostRequirements_SingleEntry(t *testing.T) {
+	entries := []*ImageMetadata{
+		hr(&HostRequirements{CPUs: 4, Memory: "8gb", Storage: "32gb", GPU: gpu(gpuTrue)}),
+	}
+	got := mergeHostRequirements(entries)
+	if got == nil {
+		t.Fatal("expected non-nil")
+	}
+	if got.CPUs != 4 {
+		t.Errorf("CPUs = %d, want 4", got.CPUs)
+	}
+	if got.Memory != "8gb" {
+		t.Errorf("Memory = %q, want %q", got.Memory, "8gb")
+	}
+	if got.Storage != "32gb" {
+		t.Errorf("Storage = %q, want %q", got.Storage, "32gb")
+	}
+	if got.GPU == nil || got.GPU.Value != gpuTrue {
+		t.Errorf("GPU = %+v, want true", got.GPU)
+	}
+}
+
+func TestMergeHostRequirements_MaxCPUs(t *testing.T) {
+	entries := []*ImageMetadata{
+		hr(&HostRequirements{CPUs: 2}),
+		hr(&HostRequirements{CPUs: 8}),
+		hr(&HostRequirements{CPUs: 4}),
+	}
+	got := mergeHostRequirements(entries)
+	if got.CPUs != 8 {
+		t.Errorf("CPUs = %d, want 8", got.CPUs)
+	}
+}
+
+func TestMergeHostRequirements_MaxMemory(t *testing.T) {
+	entries := []*ImageMetadata{
+		hr(&HostRequirements{Memory: "4gb"}),
+		hr(&HostRequirements{Memory: "16gb"}),
+		hr(&HostRequirements{Memory: "8gb"}),
+	}
+	got := mergeHostRequirements(entries)
+	if got.Memory != "16gb" {
+		t.Errorf("Memory = %q, want %q", got.Memory, "16gb")
+	}
+}
+
+func TestMergeHostRequirements_MaxStorage(t *testing.T) {
+	entries := []*ImageMetadata{
+		hr(&HostRequirements{Storage: "64gb"}),
+		hr(&HostRequirements{Storage: "1tb"}),
+	}
+	got := mergeHostRequirements(entries)
+	if got.Storage != "1tb" {
+		t.Errorf("Storage = %q, want %q", got.Storage, "1tb")
+	}
+}
+
+func TestMergeHostRequirements_MixedUnits(t *testing.T) {
+	entries := []*ImageMetadata{
+		hr(&HostRequirements{Memory: "512mb"}),
+		hr(&HostRequirements{Memory: "1gb"}),
+	}
+	got := mergeHostRequirements(entries)
+	if got.Memory != "1gb" {
+		t.Errorf("Memory = %q, want %q", got.Memory, "1gb")
+	}
+}
+
+func TestMergeHostRequirements_GPUTrueBeatsOptional(t *testing.T) {
+	entries := []*ImageMetadata{
+		hr(&HostRequirements{GPU: gpu(gpuOptional)}),
+		hr(&HostRequirements{GPU: gpu(gpuTrue)}),
+	}
+	got := mergeHostRequirements(entries)
+	if got.GPU == nil || got.GPU.Value != gpuTrue {
+		t.Errorf("GPU = %+v, want true", got.GPU)
+	}
+}
+
+func TestMergeHostRequirements_GPUOptionalBeatsFalse(t *testing.T) {
+	entries := []*ImageMetadata{
+		hr(&HostRequirements{GPU: gpu(gpuFalse)}),
+		hr(&HostRequirements{GPU: gpu(gpuOptional)}),
+	}
+	got := mergeHostRequirements(entries)
+	if got.GPU == nil || got.GPU.Value != gpuOptional {
+		t.Errorf("GPU = %+v, want optional", got.GPU)
+	}
+}
+
+func TestMergeHostRequirements_GPUTrueBeatsFalse(t *testing.T) {
+	entries := []*ImageMetadata{
+		hr(&HostRequirements{GPU: gpu(gpuTrue)}),
+		hr(&HostRequirements{GPU: gpu(gpuFalse)}),
+	}
+	got := mergeHostRequirements(entries)
+	if got.GPU == nil || got.GPU.Value != gpuTrue {
+		t.Errorf("GPU = %+v, want true", got.GPU)
+	}
+}
+
+func TestMergeHostRequirements_GPUEmptyPreservesValue(t *testing.T) {
+	entries := []*ImageMetadata{
+		hr(&HostRequirements{GPU: gpu(gpuTrue)}),
+		{},
+	}
+	got := mergeHostRequirements(entries)
+	if got.GPU == nil || got.GPU.Value != gpuTrue {
+		t.Errorf("GPU = %+v, want true", got.GPU)
+	}
+}
+
+func TestMergeHostRequirements_MultiSource(t *testing.T) {
+	entries := []*ImageMetadata{
+		hr(&HostRequirements{CPUs: 2, Memory: "4gb"}),
+		hr(&HostRequirements{CPUs: 4, Storage: "64gb", GPU: gpu(gpuOptional)}),
+		hr(&HostRequirements{Memory: "8gb", GPU: gpu(gpuTrue)}),
+		hr(&HostRequirements{CPUs: 1, Storage: "128gb"}),
+	}
+	got := mergeHostRequirements(entries)
+	if got.CPUs != 4 {
+		t.Errorf("CPUs = %d, want 4", got.CPUs)
+	}
+	if got.Memory != "8gb" {
+		t.Errorf("Memory = %q, want %q", got.Memory, "8gb")
+	}
+	if got.Storage != "128gb" {
+		t.Errorf("Storage = %q, want %q", got.Storage, "128gb")
+	}
+	if got.GPU == nil || got.GPU.Value != gpuTrue {
+		t.Errorf("GPU = %+v, want true", got.GPU)
+	}
+}
+
+func TestMergeHostRequirements_PartialFields(t *testing.T) {
+	entries := []*ImageMetadata{
+		hr(&HostRequirements{CPUs: 8}),
+		hr(&HostRequirements{Memory: "16gb"}),
+		hr(&HostRequirements{Storage: "1tb"}),
+	}
+	got := mergeHostRequirements(entries)
+	if got.CPUs != 8 {
+		t.Errorf("CPUs = %d, want 8", got.CPUs)
+	}
+	if got.Memory != "16gb" {
+		t.Errorf("Memory = %q, want %q", got.Memory, "16gb")
+	}
+	if got.Storage != "1tb" {
+		t.Errorf("Storage = %q, want %q", got.Storage, "1tb")
+	}
+}
+
+func TestParseByteSize(t *testing.T) {
+	tests := []struct {
+		input string
+		want  uint64
+	}{
+		{"", 0},
+		{"garbage", 0},
+		{"1024", 1024},
+		{"4kb", 4 * 1024},
+		{"512mb", 512 * 1024 * 1024},
+		{"8gb", 8 * 1024 * 1024 * 1024},
+		{"1tb", 1024 * 1024 * 1024 * 1024},
+		{"1.5gb", uint64(1.5 * 1024 * 1024 * 1024)},
+		{"  16GB  ", 16 * 1024 * 1024 * 1024},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseByteSize(tt.input)
+			if got != tt.want {
+				t.Errorf("parseByteSize(%q) = %d, want %d", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMaxByteString(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want string
+	}{
+		{"", "", ""},
+		{"", "8gb", "8gb"},
+		{"8gb", "", "8gb"},
+		{"4gb", "8gb", "8gb"},
+		{"8gb", "4gb", "8gb"},
+		{"512mb", "1gb", "1gb"},
+		{"1gb", "512mb", "1gb"},
+		{"1tb", "512gb", "1tb"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.a+"_vs_"+tt.b, func(t *testing.T) {
+			got := maxByteString(tt.a, tt.b)
+			if got != tt.want {
+				t.Errorf("maxByteString(%q, %q) = %q, want %q", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `mergeHostRequirements` now takes the max of each field (CPUs, memory, storage, GPU) across all image metadata entries instead of returning the first non-nil entry
- Adds `parseByteSize` / `maxByteString` helpers for comparing memory/storage strings (e.g. "512mb" vs "1gb")
- GPU merges by priority: `true` > `optional` > `false` > `nil`
- Uses the new `*GPURequirement` type from PR #117
- Adds comprehensive unit tests for all merge logic and helpers