### PR TITLE
fix(ci): use goreleaser-action in act workflow to avoid Go version mismatch

### DIFF
--- a/.github/workflows/act.yml
+++ b/.github/workflows/act.yml
@@ -29,7 +29,11 @@ jobs:
         run: go install github.com/go-task/task/v3/cmd/task@latest
 
       - name: install goreleaser
-        run: go install github.com/goreleaser/goreleaser/v2@latest
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          install-only: true
 
       - name: check docker access
         run: docker version && docker ps -a


### PR DESCRIPTION
## Summary

- Replace `go install github.com/goreleaser/goreleaser/v2@latest` with `goreleaser/goreleaser-action@v7` (install-only mode) in the act workflow's e2e-test job
- goreleaser v2.15.4+ now requires Go >= 1.26.2, but the act workflow installs Go 1.25.8 from go.mod with `GOTOOLCHAIN=local`, causing the install to fail
- The goreleaser-action downloads a pre-built binary and doesn't depend on the installed Go version, matching the approach already used by the `build-desktop` job in the same workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release pipeline configuration to use a dedicated release tool action, improving build reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->