### PR TITLE
fix(e2e): add retry logic for transient workspace lookup in port-forward test

### DIFF
--- a/e2e/framework/command.go
+++ b/e2e/framework/command.go
@@ -401,10 +401,8 @@ func (f *Framework) DevsySSHGpgTestKey(ctx context.Context, workspace string) er
 }
 
 func (f *Framework) DevsyPortTest(ctx context.Context, port string, workspace string) error {
-	// First run to trigger the first forwarding
-	_, _, err := f.ExecCommandCapture(ctx, []string{
-		"ssh",
-		"--forward-ports", port, workspace,
+	_, err := execWithSSHRetry(ctx, workspace, func(ctx context.Context) (string, string, error) {
+		return f.ExecCommandCapture(ctx, []string{"ssh", "--forward-ports", port, workspace})
 	})
 	return err
 }

--- a/e2e/framework/retry.go
+++ b/e2e/framework/retry.go
@@ -51,6 +51,7 @@ var retryableSSHPatterns = []string{
 	"no such container",
 	"connection timed out",
 	"broken pipe",
+	"workspace not found",
 }
 
 // isRetryableSSHError returns true when the error indicates a transient SSH

--- a/e2e/framework/retry_test.go
+++ b/e2e/framework/retry_test.go
@@ -61,6 +61,16 @@ func TestIsRetryableSSHError_ConnectionTimedOut(t *testing.T) {
 	)
 }
 
+func TestIsRetryableSSHError_WorkspaceNotFound(t *testing.T) {
+	assert.True(
+		t,
+		isRetryableSSHError(
+			exitError(t, "1"),
+			"workspace not found for args: [/tmp/temp-XXXXXXX]",
+		),
+	)
+}
+
 func TestIsRetryableSSHError_ExitCode1_NoSSHPattern(t *testing.T) {
 	// Remote command failure (e.g. cat on missing file) — should NOT be retried.
 	assert.False(


### PR DESCRIPTION
## Summary

- Add `"workspace not found"` to `retryableSSHPatterns` in `e2e/framework/retry.go` so transient workspace lookup failures during Docker load are retried
- Wrap `DevsyPortTest` in `execWithSSHRetry` to give the port-forward command the same 3-attempt backoff (5s, 10s) that other SSH commands already use
- Add test case verifying the new pattern is recognized as retryable