### PR TITLE
fix(e2e): replace MCR image reference with GHCR test image

### DIFF
--- a/e2e/tests/up-docker-compose/up_docker_compose.go
+++ b/e2e/tests/up-docker-compose/up_docker_compose.go
@@ -188,8 +188,7 @@ var _ = ginkgo.Describe(
 			"does not retag shared image when applying features to image backed services",
 			func(ctx context.Context) {
 				const (
-					sourceImage = "mcr.microsoft.com/devcontainers/base" +
-						"@sha256:d94c97dd9cacf183d0a6fd12a8e87b526e9e928307674ae9c94139139c0c6eae"
+					sourceImage = "ghcr.io/devsy-org/test-images/base:ubuntu"
 					sharedImage = "devsy-e2e-compose-shared-base:latest"
 				)
 				const (

--- a/e2e/tests/up-docker-compose/up_docker_compose.go
+++ b/e2e/tests/up-docker-compose/up_docker_compose.go
@@ -188,7 +188,8 @@ var _ = ginkgo.Describe(
 			"does not retag shared image when applying features to image backed services",
 			func(ctx context.Context) {
 				const (
-					sourceImage = "ghcr.io/devsy-org/test-images/base:ubuntu"
+					sourceImage = "ghcr.io/devsy-org/test-images/base:ubuntu" +
+						"@sha256:4bcb1b466771b1ba1ea110e2a27daea2f6093f9527fb75ee59703ec89b5561cb"
 					sharedImage = "devsy-e2e-compose-shared-base:latest"
 				)
 				const (


### PR DESCRIPTION
## Summary

- Replace `mcr.microsoft.com/devcontainers/base@sha256:...` with `ghcr.io/devsy-org/test-images/base:ubuntu` in the shared image retag e2e test (`e2e/tests/up-docker-compose/up_docker_compose.go`)
- Fixes CI failures caused by MCR CDN rate limiting (403 errors) by using the project's own GHCR test image registry, consistent with all other e2e tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to validate feature configuration handling with alternative image references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->