### PR TITLE
fix(ux): replace %w with %v in log format strings

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -798,7 +798,7 @@ func startSSHKeepAlive(
 		case <-ticker.C:
 			_, _, err := client.SendRequest("keepalive@openssh.com", true, nil)
 			if err != nil {
-				log.Errorf("Failed to send keepalive: %w", err)
+				log.Errorf("Failed to send keepalive: %v", err)
 			}
 		}
 	}

--- a/pkg/daemon/platform/local_server.go
+++ b/pkg/daemon/platform/local_server.go
@@ -603,7 +603,7 @@ func (l *localServer) watchWorkspaces(
 			fmt.Errorf("failed to watch workspaces: %w", err).Error(),
 			http.StatusInternalServerError,
 		)
-		log.Errorf("watch workspaces: %w", err)
+		log.Errorf("watch workspaces: %v", err)
 		return
 	}
 }

--- a/pkg/loftconfig/client.go
+++ b/pkg/loftconfig/client.go
@@ -18,7 +18,7 @@ func GetDevsyConfig(context, provider string, port int) (*client.Config, error) 
 
 	rawJson, err := json.Marshal(request)
 	if err != nil {
-		log.Errorf("Error parsing request: %w", err)
+		log.Errorf("Error parsing request: %v", err)
 		return nil, err
 	}
 

--- a/pkg/loftconfig/config.go
+++ b/pkg/loftconfig/config.go
@@ -21,7 +21,7 @@ func AuthDevsyCliToPlatform(config *client.Config) error {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Debugf(
-			"Failed executing `%s pro login`: %w, output: %s",
+			"Failed executing `%s pro login`: %v, output: %s",
 			pkgconfig.BinaryName,
 			err,
 			out,
@@ -47,7 +47,7 @@ func AuthVClusterCliToPlatform(config *client.Config) error {
 	cmd := exec.Command("vcluster", "login", "--access-key", config.AccessKey, config.Host)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Debugf("Failed executing `vcluster login` : %w, output: %s", err, out)
+		log.Debugf("Failed executing `vcluster login` : %v, output: %s", err, out)
 		return fmt.Errorf("error executing 'vcluster login' command: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Three `log.Errorf()` calls used the `%w` format verb, which only works with `fmt.Errorf` for error wrapping. In log functions, `%w` produces garbled output like `%!w(*errors.errorString=&{...})` instead of the human-readable error message. Changed all three to `%v` to display errors correctly.

**Files fixed:**
- `cmd/ssh.go:801` — keepalive error logging
- `pkg/daemon/platform/local_server.go:606` — workspace watch error logging
- `pkg/loftconfig/client.go:21` — request parsing error logging