### PR TITLE
fix(ux): prevent remote agent fatal log from killing local CLI

### DIFF
--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -512,7 +512,7 @@ func logAtLevel(level, msg string) {
 	case "error":
 		log.Error(msg)
 	case "fatal":
-		log.Fatal(msg)
+		log.Error(msg)
 	default:
 		log.Debug(msg)
 	}


### PR DESCRIPTION
## Summary

- In `logAtLevel()` (`pkg/devcontainer/sshtunnel/sshtunnel.go`), the `"fatal"` case called `log.Fatal(msg)` which invokes `os.Exit(1)` — meaning a remote agent could kill the local CLI process by sending a fatal-level log message.
- Changed to `log.Error(msg)` so the message is still visible to the user but the local process continues running. Error propagation through the tunnel handles shutdown if needed.