### PR TITLE
fix(ux): propagate swallowed errors in workspace resolution

### DIFF
--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -624,7 +624,7 @@ func resolveMergedWorkspaceFolder(
 
 	result, err := provider.LoadWorkspaceResult(workspaceConfig.Context, workspaceConfig.ID)
 	if err != nil {
-		log.Debugf("Error loading workspace result for workdir resolution: %v", err)
+		log.Warnf("Error loading workspace result for workdir resolution: %v", err)
 		return ""
 	}
 	if result == nil || result.MergedConfig == nil {

--- a/pkg/loftconfig/config.go
+++ b/pkg/loftconfig/config.go
@@ -21,7 +21,7 @@ func AuthDevsyCliToPlatform(config *client.Config) error {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Debugf(
-			"Failed executing `%s pro login`: %w, output: %s",
+			"Failed executing `%s pro login`: %v, output: %s",
 			pkgconfig.BinaryName,
 			err,
 			out,
@@ -47,7 +47,7 @@ func AuthVClusterCliToPlatform(config *client.Config) error {
 	cmd := exec.Command("vcluster", "login", "--access-key", config.AccessKey, config.Host)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
-		log.Debugf("Failed executing `vcluster login` : %w, output: %s", err, out)
+		log.Debugf("Failed executing `vcluster login` : %v, output: %s", err, out)
 		return fmt.Errorf("error executing 'vcluster login' command: %w", err)
 	}
 

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -236,7 +236,10 @@ func resolveWorkspace(
 	// check if we have no args
 	if len(params.Args) == 0 {
 		if params.DesiredID != "" {
-			workspace, _ := findWorkspace(ctx, devsyConfig, nil, params.DesiredID, params.Owner)
+			workspace, err := findWorkspace(ctx, devsyConfig, nil, params.DesiredID, params.Owner)
+			if err != nil {
+				return nil, nil, nil, fmt.Errorf("find workspace: %w", err)
+			}
 			if workspace == nil {
 				return nil, nil, nil, fmt.Errorf("workspace %s doesn't exist", params.DesiredID)
 			}


### PR DESCRIPTION
## Summary

- `resolveWorkspace` was discarding `findWorkspace` errors with `_`, causing misleading "workspace doesn't exist" messages when the real error was a network failure, permission denied, etc. Now propagates the actual error.
- Promotes workdir resolution error logging in `resolveMergedWorkspaceFolder` from `Debug` to `Warn` so users have visibility when workspace result loading fails.
- `findLocalWorkspace` error swallowing was already addressed by PR #124 (which fixed the parent `findWorkspace` function to propagate `List()` errors).