### PR TITLE
fix(ux): include lifecycle phase name in hook error messages

### DIFF
--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -305,7 +305,10 @@ func (c *initCmdContext) runSingle(name string, cmd []string) error {
 	c2.Stderr = errwriter
 	c2.Dir = c.workspaceFolder
 	c2.Env = env
-	return c2.Run()
+	if err := c2.Run(); err != nil {
+		return fmt.Errorf("initializeCommand %q failed: %w", name, err)
+	}
+	return nil
 }
 
 func getWorkspace(

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -488,10 +488,10 @@ func runSingleHookCommand(
 		Env:  append(os.Environ(), remoteEnvArr...),
 	}
 
-	return executeAndLog(cmd, key, c)
+	return executeAndLog(cmd, p.name, key, c)
 }
 
-func executeAndLog(cmd *exec.Cmd, key string, c []string) error {
+func executeAndLog(cmd *exec.Cmd, phaseName string, key string, c []string) error {
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("failed to get stdout pipe: %w", err)
@@ -526,7 +526,7 @@ func executeAndLog(cmd *exec.Cmd, key string, c []string) error {
 			cmd.Args,
 			err,
 		)
-		return fmt.Errorf("failed to run: %s, error: %w", strings.Join(c, " "), err)
+		return fmt.Errorf("%s: command %q failed: %w", phaseName, strings.Join(c, " "), err)
 	}
 
 	log.Infof("ran command: command=%s, args=%s", key, strings.Join(c, " "))


### PR DESCRIPTION
## Summary

- initializeCommand errors now include "initializeCommand" and the command name in the error message (e.g., `initializeCommand "setup" failed: exit status 1`)
- Lifecycle hook errors (postCreateCommand, postStartCommand, etc.) now include the phase name so users can identify which hook failed (e.g., `postCreateCommands: command "npm install" failed: exit status 1`)