### PR TITLE
fix(ux): add operation context to error messages at command boundary

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -63,7 +63,7 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 		Owner:       cmd.Owner,
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("get workspace for logs: %w", err)
 	}
 
 	client, ok := baseClient.(clientpkg.WorkspaceClient)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -72,7 +72,7 @@ func (cmd *UpCmd) execute(cobraCmd *cobra.Command, args []string) error {
 	}
 	devsyConfig, err := config.LoadConfig(cmd.Context, cmd.Provider)
 	if err != nil {
-		return err
+		return fmt.Errorf("load devsy config: %w", err)
 	}
 	if devsyConfig.ContextOption(config.ContextOptionSSHStrictHostKeyChecking) == config.BoolTrue {
 		cmd.StrictHostKeyChecking = true
@@ -331,7 +331,7 @@ func (cmd *UpCmd) executeDevsyUp(
 ) (*workspaceContext, error) {
 	result, err := cmd.devsyUp(ctx, devsyConfig, client)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("start workspace: %w", err)
 	}
 	if result == nil {
 		return nil, fmt.Errorf("did not receive a result back from agent")
@@ -439,7 +439,7 @@ func (cmd *UpCmd) devsyUp(
 	if !cmd.Platform.Enabled {
 		err := client.Lock(ctx)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("lock workspace: %w", err)
 		}
 		defer client.Unlock()
 	}
@@ -584,13 +584,13 @@ func (cmd *UpCmd) devsyUpMachine(
 ) (*config2.Result, error) {
 	err := clientimplementation.StartWait(ctx, client, true)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("wait for machine: %w", err)
 	}
 
 	// compress info
 	workspaceInfo, wInfo, err := client.AgentInfo(cmd.CLIOptions)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("get agent info: %w", err)
 	}
 
 	// create container etc.


### PR DESCRIPTION
## Summary

Wraps 6 bare `return err` / `return nil, err` sites at the cmd/ boundary (`cmd/up.go` and `cmd/logs.go`) with `fmt.Errorf` context so that errors reaching the top-level `log.Fatal` handler tell the user what operation failed:

- `load devsy config` — config loading in `up` command
- `start workspace` — `devsyUp` call in `executeDevsyUp`
- `lock workspace` — `client.Lock` in `devsyUp`
- `wait for machine` — `StartWait` in `devsyUpMachine`
- `get agent info` — `AgentInfo` in `devsyUpMachine`
- `get workspace for logs` — `workspace.Get` in `logs` command