### PR TITLE
fix(ux): use %w for proper error chain wrapping

### DIFF
--- a/pkg/command/credential_supported.go
+++ b/pkg/command/credential_supported.go
@@ -14,17 +14,17 @@ func ForUser(cmd *exec.Cmd, userName string) error {
 	// Look up the user's UID and GID
 	u, err := user.Lookup(userName)
 	if err != nil {
-		return fmt.Errorf("failed to look up user %s: %v", userName, err)
+		return fmt.Errorf("failed to look up user %s: %w", userName, err)
 	}
 
 	uid, err := strconv.Atoi(u.Uid)
 	if err != nil {
-		return fmt.Errorf("invalid UID %s: %v", u.Uid, err)
+		return fmt.Errorf("invalid UID %s: %w", u.Uid, err)
 	}
 
 	gid, err := strconv.Atoi(u.Gid)
 	if err != nil {
-		return fmt.Errorf("invalid GID %s: %v", u.Gid, err)
+		return fmt.Errorf("invalid GID %s: %w", u.Gid, err)
 	}
 
 	// Set the user cmd should run as

--- a/pkg/survey/survey.go
+++ b/pkg/survey/survey.go
@@ -122,7 +122,7 @@ func buildValidator(params *QuestionOptions, compiledRegex *regexp.Regexp) func(
 					return errors.New(params.ValidationMessage)
 				}
 
-				return fmt.Errorf("%v", err)
+				return err
 			}
 		}
 

--- a/pkg/util/hash/hash.go
+++ b/pkg/util/hash/hash.go
@@ -217,7 +217,7 @@ func (w *fileWalker) shouldSkipPath(relFilePath string) (bool, error) {
 
 	skip, err := w.pm.MatchesOrParentMatches(relFilePath)
 	if err != nil {
-		return false, fmt.Errorf("failed to match %s: %v", relFilePath, err)
+		return false, fmt.Errorf("failed to match %s: %w", relFilePath, err)
 	}
 
 	return skip, nil


### PR DESCRIPTION
## Summary

- Replace `%v` with `%w` in `fmt.Errorf` calls across `pkg/util/hash/hash.go` and `pkg/command/credential_supported.go` so callers can use `errors.Is`/`errors.As` to inspect underlying errors
- Simplify `fmt.Errorf("%v", err)` in `pkg/survey/survey.go` to `return err` directly, preserving the error chain without a redundant wrapper