### PR TITLE
feat(tunnel): extract PipeBridge and ConnError primitives, refactor container and direct tunnels

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -324,7 +324,17 @@ func pipe(
 	_ = toStdin.Close()
 	_ = fromStdout.Close()
 
-	<-errChan
+	second := <-errChan
 
-	return first
+	if first != nil {
+		return first
+	}
+	if second != nil && !isClosedErr(second) {
+		return second
+	}
+	return nil
+}
+
+func isClosedErr(err error) bool {
+	return errors.Is(err, os.ErrClosed) || errors.Is(err, io.ErrClosedPipe)
 }

--- a/pkg/tunnel/connerror.go
+++ b/pkg/tunnel/connerror.go
@@ -1,0 +1,44 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type ErrorKind int
+
+const (
+	ErrorTransient ErrorKind = iota
+	ErrorPermanent
+	ErrorShutdown
+)
+
+func ClassifyError(err error) ErrorKind {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return ErrorShutdown
+	}
+	if IsEOF(err) {
+		return ErrorTransient
+	}
+	return ErrorPermanent
+}
+
+func IsEOF(err error) bool {
+	return errors.Is(err, io.EOF) || strings.Contains(err.Error(), ": EOF")
+}
+
+func ClassifyTunnelErrors(tunnelErr, handlerErr error) error {
+	if handlerErr == nil {
+		return nil
+	}
+	if IsEOF(handlerErr) {
+		if tunnelErr != nil {
+			return fmt.Errorf("connect to server: %w", tunnelErr)
+		}
+		return nil
+	}
+	return fmt.Errorf("tunnel to container: %w", handlerErr)
+}

--- a/pkg/tunnel/connerror_test.go
+++ b/pkg/tunnel/connerror_test.go
@@ -1,0 +1,106 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func TestIsEOF(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"bare io.EOF", io.EOF, true},
+		{"wrapped EOF", fmt.Errorf("read: %w", io.EOF), true},
+		{"string containing EOF", errors.New("ssh: handshake failed: EOF"), true},
+		{"non-EOF error", errors.New("connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsEOF(tt.err); got != tt.want {
+				t.Errorf("IsEOF(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+		want ErrorKind
+	}{
+		{"nil", nil, ErrorShutdown},
+		{"context.Canceled", context.Canceled, ErrorShutdown},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, ErrorShutdown},
+		{"io.EOF", io.EOF, ErrorTransient},
+		{"wrapped EOF", fmt.Errorf("read: %w", io.EOF), ErrorTransient},
+		{"random error", errors.New("something broke"), ErrorPermanent},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ClassifyError(tt.err); got != tt.want {
+				t.Errorf("ClassifyError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyTunnelErrors(t *testing.T) {
+	t.Parallel()
+	tunnelErr := errors.New("tunnel died")
+	handlerEOF := fmt.Errorf("read: %w", io.EOF)
+	handlerNonEOF := errors.New("handler broke")
+
+	tests := []struct {
+		name       string
+		tunnelErr  error
+		handlerErr error
+		wantNil    bool
+		wantSubstr string
+	}{
+		{"handler nil", tunnelErr, nil, true, ""},
+		{"handler EOF + tunnel err", tunnelErr, handlerEOF, false, "connect to server"},
+		{"handler EOF + no tunnel", nil, handlerEOF, true, ""},
+		{"handler non-EOF", nil, handlerNonEOF, false, "tunnel to container"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClassifyTunnelErrors(tt.tunnelErr, tt.handlerErr)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("ClassifyTunnelErrors() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("ClassifyTunnelErrors() = nil, want error containing %q", tt.wantSubstr)
+			}
+			if msg := got.Error(); !contains(msg, tt.wantSubstr) {
+				t.Errorf("ClassifyTunnelErrors() = %q, want substring %q", msg, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(substr) == 0 || len(s) >= len(substr) && containsAt(s, substr)
+}
+
+func containsAt(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/tunnel/container.go
+++ b/pkg/tunnel/container.go
@@ -6,11 +6,9 @@ package tunnel
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/devsy-org/devsy/pkg/agent"
@@ -22,22 +20,20 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
+// ContainerTunnel manages the state of the tunnel to the container.
+type ContainerTunnel struct {
+	client               client.WorkspaceClient
+	updateConfigInterval time.Duration
+}
+
 // NewContainerTunnel constructs a ContainerTunnel using the workspace client, if proxy is True then
 // the workspace's agent config is not periodically updated.
-//
-//nolint:funcorder
 func NewContainerTunnel(client client.WorkspaceClient) *ContainerTunnel {
 	updateConfigInterval := time.Second * 30
 	return &ContainerTunnel{
 		client:               client,
 		updateConfigInterval: updateConfigInterval,
 	}
-}
-
-// ContainerTunnel manages the state of the tunnel to the container.
-type ContainerTunnel struct {
-	client               client.WorkspaceClient
-	updateConfigInterval time.Duration
 }
 
 // Handler defines what to do once the tunnel has a client established.
@@ -55,56 +51,40 @@ func (c *ContainerTunnel) Run(
 		return nil
 	}
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	stdoutReader, stdoutWriter, err := os.Pipe()
+	pb, err := NewPipeBridge()
 	if err != nil {
 		return err
 	}
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = stdoutWriter.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
+	defer pb.Close()
 
 	timeout := config.ParseTimeOption(cfg, config.ContextOptionAgentInjectTimeout)
 
-	// tunnel to host
-	tunnelChan := make(chan error, 1)
-	go func() {
-		tunnelChan <- c.runHostTunnel(cancelCtx, stdinReader, stdoutWriter, timeout)
-	}()
+	tunnelFn := func(ctx context.Context, stdin *os.File, stdout *os.File) error {
+		return c.runHostTunnel(ctx, stdin, stdout, timeout)
+	}
 
-	// connect to container
-	containerChan := make(chan error, 1)
-	go func() {
-		sshClient, err := devssh.StdioClient(stdoutReader, stdinWriter, false)
+	handlerFn := func(ctx context.Context, stdout *os.File, stdin *os.File) error {
+		sshClient, err := devssh.StdioClient(stdout, stdin, false)
 		if err != nil {
-			containerChan <- fmt.Errorf("create ssh client: %w", err)
-			return
+			return fmt.Errorf("create ssh client: %w", err)
 		}
-
 		defer func() { _ = sshClient.Close() }()
-		defer cancel()
 		defer log.Debugf("connection to container closed")
 		log.Debugf("connected to host")
 
 		if c.updateConfigInterval > 0 {
 			go func() {
-				c.updateConfig(cancelCtx, sshClient)
+				c.updateConfig(ctx, sshClient)
 			}()
 		}
 
-		if err := c.runInContainer(cancelCtx, sshClient, handler, envVars); err != nil {
-			containerChan <- fmt.Errorf("run in container: %w", err)
-		} else {
-			containerChan <- nil
+		if err := c.runInContainer(ctx, sshClient, handler, envVars); err != nil {
+			return fmt.Errorf("run in container: %w", err)
 		}
-	}()
+		return nil
+	}
 
-	return awaitGoroutines(tunnelChan, containerChan, stdoutWriter, stdinWriter)
+	return pb.RunPair(ctx, tunnelFn, handlerFn)
 }
 
 // runHostTunnel injects the devsy agent onto the host and starts the SSH server,
@@ -141,54 +121,6 @@ func (c *ContainerTunnel) runHostTunnel(
 		Stderr:          writer,
 		Timeout:         timeout,
 	})
-}
-
-// awaitGoroutines waits for both the container and tunnel goroutines to report
-// and returns the appropriate error. The container result is the primary result;
-// the tunnel result provides root-cause context when the container gets EOF.
-func awaitGoroutines(
-	tunnelChan, containerChan <-chan error,
-	stdoutWriter, stdinWriter *os.File,
-) error {
-	var tunnelErr, containerErr error
-
-	select {
-	case containerErr = <-containerChan:
-		select {
-		case tunnelErr = <-tunnelChan:
-		default:
-		}
-	case tunnelErr = <-tunnelChan:
-		// Host tunnel exited before container finished. Close pipes to unblock
-		// the container goroutine (may be blocked in SSH handshake).
-		_ = stdoutWriter.Close()
-		_ = stdinWriter.Close()
-		containerErr = <-containerChan
-	}
-
-	return classifyTunnelErrors(tunnelErr, containerErr)
-}
-
-// classifyTunnelErrors determines which error to report when the tunnel and/or
-// container goroutines fail. EOF errors from the container are suppressed when
-// the tunnel error is the root cause.
-func classifyTunnelErrors(tunnelErr, containerErr error) error {
-	if containerErr == nil {
-		return nil
-	}
-	if isEOFError(containerErr) {
-		if tunnelErr != nil {
-			return fmt.Errorf("connect to server: %w", tunnelErr)
-		}
-		return nil
-	}
-	return fmt.Errorf("tunnel to container: %w", containerErr)
-}
-
-// isEOFError reports whether an error is caused by an EOF condition,
-// including wrapped SSH handshake failures from closed pipes.
-func isEOFError(err error) bool {
-	return errors.Is(err, io.EOF) || strings.Contains(err.Error(), ": EOF")
 }
 
 // updateConfig is called periodically to keep the workspace agent config up to date.
@@ -253,36 +185,25 @@ func (c *ContainerTunnel) runInContainer(
 		return err
 	}
 
-	stdoutReader, stdoutWriter, err := os.Pipe()
+	pb, err := NewPipeBridge()
 	if err != nil {
 		return err
 	}
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = stdoutWriter.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
+	defer pb.Close()
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// tunnel to container
 	tunnelDone := make(chan error, 1)
 	go func() {
-		tunnelDone <- c.runContainerTunnel(cancelCtx, containerTunnelOpts{
+		tunnelDone <- c.runContainerTunnel(ctx, containerTunnelOpts{
 			sshClient:     sshClient,
 			workspaceInfo: workspaceInfo,
-			stdinReader:   stdinReader,
-			stdoutWriter:  stdoutWriter,
+			stdinReader:   pb.StdinReader,
+			stdoutWriter:  pb.StdoutWriter,
 			envVars:       envVars,
 		})
 	}()
 
-	containerClient, err := devssh.StdioClient(stdoutReader, stdinWriter, false)
+	containerClient, err := devssh.StdioClient(pb.StdoutReader, pb.StdinWriter, false)
 	if err != nil {
-		// StdioClient failed — check if the tunnel goroutine already exited
-		// with an error. If so, the tunnel error is the root cause.
 		select {
 		case tunnelErr := <-tunnelDone:
 			if tunnelErr != nil {
@@ -295,7 +216,7 @@ func (c *ContainerTunnel) runInContainer(
 	defer func() { _ = containerClient.Close() }()
 	log.Debugf("connected to container")
 
-	return handler(cancelCtx, containerClient)
+	return handler(ctx, containerClient)
 }
 
 type containerTunnelOpts struct {

--- a/pkg/tunnel/direct.go
+++ b/pkg/tunnel/direct.go
@@ -2,7 +2,6 @@ package tunnel
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 
@@ -18,48 +17,24 @@ type Tunnel func(ctx context.Context, stdin io.Reader, stdout io.Writer) error
 // the handler will be the function to execute the command using the
 // connected SSH client.
 func NewTunnel(ctx context.Context, tunnel Tunnel, handler Handler) error {
-	// create context
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	// create readers
-	stdoutReader, stdoutWriter, err := os.Pipe()
+	pb, err := NewPipeBridge()
 	if err != nil {
 		return err
 	}
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		return err
+	defer pb.Close()
+
+	tunnelFn := func(ctx context.Context, stdin *os.File, stdout *os.File) error {
+		return tunnel(ctx, stdin, stdout)
 	}
-	defer func() { _ = stdoutWriter.Close() }()
-	defer func() { _ = stdinWriter.Close() }()
 
-	// start ssh proxy
-	outerTunnelChan := make(chan error, 1)
-	go func() {
-		outerTunnelChan <- tunnel(ctx, stdinReader, stdoutWriter)
-	}()
-
-	// start ssh client as root / default user
-	innerTunnelChan := make(chan error, 1)
-	go func() {
-		sshClient, err := devssh.StdioClient(stdoutReader, stdinWriter, false)
+	handlerFn := func(ctx context.Context, stdout *os.File, stdin *os.File) error {
+		sshClient, err := devssh.StdioClient(stdout, stdin, false)
 		if err != nil {
-			innerTunnelChan <- err
-			return
+			return err
 		}
 		defer func() { _ = sshClient.Close() }()
-		defer cancel()
-
-		// start ssh tunnel
-		innerTunnelChan <- handler(cancelCtx, sshClient)
-	}()
-
-	// wait for result
-	select {
-	case err := <-innerTunnelChan:
-		return fmt.Errorf("inner tunnel: %w", err)
-	case err := <-outerTunnelChan:
-		return fmt.Errorf("outer tunnel: %w", err)
+		return handler(ctx, sshClient)
 	}
+
+	return pb.RunPair(ctx, tunnelFn, handlerFn)
 }

--- a/pkg/tunnel/pipebridge.go
+++ b/pkg/tunnel/pipebridge.go
@@ -1,0 +1,84 @@
+package tunnel
+
+import (
+	"context"
+	"os"
+)
+
+type PipeBridge struct {
+	StdoutReader *os.File
+	StdoutWriter *os.File
+	StdinReader  *os.File
+	StdinWriter  *os.File
+}
+
+func NewPipeBridge() (*PipeBridge, error) {
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		_ = stdoutReader.Close()
+		_ = stdoutWriter.Close()
+		return nil, err
+	}
+	return &PipeBridge{
+		StdoutReader: stdoutReader,
+		StdoutWriter: stdoutWriter,
+		StdinReader:  stdinReader,
+		StdinWriter:  stdinWriter,
+	}, nil
+}
+
+func (pb *PipeBridge) Close() {
+	_ = pb.StdoutReader.Close()
+	_ = pb.StdoutWriter.Close()
+	_ = pb.StdinReader.Close()
+	_ = pb.StdinWriter.Close()
+}
+
+type (
+	TunnelFunc  func(ctx context.Context, stdin *os.File, stdout *os.File) error
+	HandlerFunc func(ctx context.Context, stdout *os.File, stdin *os.File) error
+)
+
+func (pb *PipeBridge) RunPair(
+	ctx context.Context,
+	tunnelFn TunnelFunc,
+	handlerFn HandlerFunc,
+) error {
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	tunnelChan := make(chan error, 1)
+	go func() {
+		tunnelChan <- tunnelFn(cancelCtx, pb.StdinReader, pb.StdoutWriter)
+	}()
+
+	handlerChan := make(chan error, 1)
+	go func() {
+		defer cancel()
+		handlerChan <- handlerFn(cancelCtx, pb.StdoutReader, pb.StdinWriter)
+	}()
+
+	return awaitPair(tunnelChan, handlerChan, pb.StdoutWriter, pb.StdinWriter)
+}
+
+func awaitPair(tunnelChan, handlerChan <-chan error, stdoutWriter, stdinWriter *os.File) error {
+	var tunnelErr, handlerErr error
+
+	select {
+	case handlerErr = <-handlerChan:
+		select {
+		case tunnelErr = <-tunnelChan:
+		default:
+		}
+	case tunnelErr = <-tunnelChan:
+		_ = stdoutWriter.Close()
+		_ = stdinWriter.Close()
+		handlerErr = <-handlerChan
+	}
+
+	return ClassifyTunnelErrors(tunnelErr, handlerErr)
+}

--- a/pkg/tunnel/pipebridge_test.go
+++ b/pkg/tunnel/pipebridge_test.go
@@ -1,0 +1,184 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestNewPipeBridge(t *testing.T) {
+	t.Parallel()
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	msg := []byte("hello")
+	if _, err := pb.StdoutWriter.Write(msg); err != nil {
+		t.Fatalf("write to StdoutWriter: %v", err)
+	}
+	buf := make([]byte, len(msg))
+	if _, err := io.ReadFull(pb.StdoutReader, buf); err != nil {
+		t.Fatalf("read from StdoutReader: %v", err)
+	}
+	if string(buf) != "hello" {
+		t.Errorf("stdout pipe got %q, want %q", string(buf), "hello")
+	}
+
+	if _, err := pb.StdinWriter.Write(msg); err != nil {
+		t.Fatalf("write to StdinWriter: %v", err)
+	}
+	if _, err := io.ReadFull(pb.StdinReader, buf); err != nil {
+		t.Fatalf("read from StdinReader: %v", err)
+	}
+	if string(buf) != "hello" {
+		t.Errorf("stdin pipe got %q, want %q", string(buf), "hello")
+	}
+}
+
+func TestRunPairBothSucceed(t *testing.T) {
+	t.Parallel()
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	tunnelFn := func(_ context.Context, stdin *os.File, stdout *os.File) error {
+		buf := make([]byte, 4)
+		n, err := stdin.Read(buf)
+		if err != nil {
+			return err
+		}
+		_, err = stdout.Write(buf[:n])
+		return err
+	}
+	handlerFn := func(_ context.Context, stdout *os.File, stdin *os.File) error {
+		if _, err := stdin.Write([]byte("ping")); err != nil {
+			return err
+		}
+		buf := make([]byte, 4)
+		n, err := stdout.Read(buf)
+		if err != nil {
+			return err
+		}
+		if got := string(buf[:n]); got != "ping" {
+			return fmt.Errorf("got %q, want %q", got, "ping")
+		}
+		return nil
+	}
+
+	if err := pb.RunPair(context.Background(), tunnelFn, handlerFn); err != nil {
+		t.Errorf("RunPair() error = %v, want nil", err)
+	}
+}
+
+func TestRunPairTunnelError(t *testing.T) {
+	t.Parallel()
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	tunnelFn := func(_ context.Context, _ *os.File, _ *os.File) error {
+		return errors.New("tunnel exploded")
+	}
+	handlerFn := func(_ context.Context, stdout *os.File, _ *os.File) error {
+		buf := make([]byte, 1)
+		_, err := stdout.Read(buf)
+		return err
+	}
+
+	got := pb.RunPair(context.Background(), tunnelFn, handlerFn)
+	if got == nil {
+		t.Fatal("RunPair() = nil, want error")
+	}
+	if msg := got.Error(); !stringContains(msg, "connect to server") {
+		t.Errorf("RunPair() = %q, want substring %q", msg, "connect to server")
+	}
+}
+
+func TestRunPairHandlerError(t *testing.T) {
+	t.Parallel()
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	tunnelFn := func(ctx context.Context, _ *os.File, _ *os.File) error {
+		<-ctx.Done()
+		return nil
+	}
+	handlerFn := func(_ context.Context, _ *os.File, _ *os.File) error {
+		return errors.New("handler broke")
+	}
+
+	got := pb.RunPair(context.Background(), tunnelFn, handlerFn)
+	if got == nil {
+		t.Fatal("RunPair() = nil, want error")
+	}
+	if msg := got.Error(); !stringContains(msg, "tunnel to container") {
+		t.Errorf("RunPair() = %q, want substring %q", msg, "tunnel to container")
+	}
+}
+
+func TestRunPairContextCancellation(t *testing.T) {
+	t.Parallel()
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	tunnelFn := func(ctx context.Context, _ *os.File, _ *os.File) error {
+		<-ctx.Done()
+		return nil
+	}
+	handlerFn := func(ctx context.Context, _ *os.File, _ *os.File) error {
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := pb.RunPair(ctx, tunnelFn, handlerFn); err != nil {
+		t.Errorf("RunPair() error = %v, want nil", err)
+	}
+}
+
+func TestRunPairPipesClosedAfterReturn(t *testing.T) {
+	t.Parallel()
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+
+	tunnelFn := func(_ context.Context, _ *os.File, _ *os.File) error { return nil }
+	handlerFn := func(_ context.Context, _ *os.File, _ *os.File) error { return nil }
+
+	_ = pb.RunPair(context.Background(), tunnelFn, handlerFn)
+	pb.Close()
+
+	_, err = pb.StdoutWriter.Write([]byte("x"))
+	if err == nil {
+		t.Error("write to StdoutWriter after Close() should fail")
+	}
+	_, err = pb.StdinWriter.Write([]byte("x"))
+	if err == nil {
+		t.Error("write to StdinWriter after Close() should fail")
+	}
+}
+
+func stringContains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Re-applies PR #91 (reverted by #111) on top of current main, which already includes the bug-fix re-application from PR #126.

- **New `connerror.go`**: Extracts `ErrorKind`, `ClassifyError`, `IsEOF`, and `ClassifyTunnelErrors` from container.go into a reusable error classification module
- **New `pipebridge.go`**: Extracts pipe creation and goroutine coordination into `PipeBridge` struct with `NewPipeBridge()`, `Close()`, and `RunPair()` — eliminates duplicated pipe/goroutine boilerplate
- **Refactored `container.go`**: `Run()` uses `PipeBridge.RunPair()`, `runInContainer()` uses `NewPipeBridge()` for pipe management, deleted `awaitGoroutines`/`classifyTunnelErrors`/`isEOFError`, moved struct above constructor
- **Refactored `direct.go`**: `NewTunnel()` replaced with `PipeBridge.RunPair()`, removed manual pipe/goroutine coordination
- Full table-driven test coverage for both new modules