### PR TITLE
feat(tunnel): add PipeBridge and ConnError primitives

### DIFF
--- a/pkg/tunnel/connerror.go
+++ b/pkg/tunnel/connerror.go
@@ -1,0 +1,50 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type ErrorKind int
+
+const (
+	ErrorTransient ErrorKind = iota
+	ErrorPermanent
+	ErrorShutdown
+)
+
+func ClassifyError(err error) ErrorKind {
+	if err == nil {
+		return ErrorShutdown
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return ErrorShutdown
+	}
+	if IsEOF(err) {
+		return ErrorTransient
+	}
+	return ErrorPermanent
+}
+
+func IsEOF(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, io.EOF) || strings.Contains(err.Error(), ": EOF")
+}
+
+func ClassifyTunnelErrors(tunnelErr, handlerErr error) error {
+	if handlerErr == nil {
+		return nil
+	}
+	if IsEOF(handlerErr) {
+		if tunnelErr != nil {
+			return fmt.Errorf("connect to server: %w", tunnelErr)
+		}
+		return nil
+	}
+	return fmt.Errorf("tunnel to container: %w", handlerErr)
+}

--- a/pkg/tunnel/connerror_test.go
+++ b/pkg/tunnel/connerror_test.go
@@ -1,0 +1,99 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func TestIsEOF(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil input", nil, false},
+		{"bare io.EOF", io.EOF, true},
+		{"wrapped EOF", fmt.Errorf("read failed: %w", io.EOF), true},
+		{"string containing EOF", errors.New("connection closed: EOF"), true},
+		{"non-EOF", errors.New("timeout"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsEOF(tt.err); got != tt.want {
+				t.Errorf("IsEOF(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want ErrorKind
+	}{
+		{"nil", nil, ErrorShutdown},
+		{"context.Canceled", context.Canceled, ErrorShutdown},
+		{"context.DeadlineExceeded", context.DeadlineExceeded, ErrorShutdown},
+		{"io.EOF", io.EOF, ErrorTransient},
+		{"wrapped EOF", fmt.Errorf("read: %w", io.EOF), ErrorTransient},
+		{"random error", errors.New("something broke"), ErrorPermanent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ClassifyError(tt.err); got != tt.want {
+				t.Errorf("ClassifyError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifyTunnelErrors(t *testing.T) {
+	t.Parallel()
+
+	tunnelErr := errors.New("dial failed")
+	handlerNonEOF := errors.New("handler broke")
+
+	tests := []struct {
+		name       string
+		tunnelErr  error
+		handlerErr error
+		wantNil    bool
+		wantSubstr string
+	}{
+		{"handler nil", tunnelErr, nil, true, ""},
+		{"handler EOF with tunnel err", tunnelErr, io.EOF, false, "connect to server: dial failed"},
+		{"handler EOF no tunnel err", nil, io.EOF, true, ""},
+		{"handler non-EOF", nil, handlerNonEOF, false, "tunnel to container: handler broke"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := ClassifyTunnelErrors(tt.tunnelErr, tt.handlerErr)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("ClassifyTunnelErrors() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("ClassifyTunnelErrors() = nil, want error")
+			}
+			if got.Error() != tt.wantSubstr {
+				t.Errorf("ClassifyTunnelErrors() = %q, want %q", got.Error(), tt.wantSubstr)
+			}
+		})
+	}
+}

--- a/pkg/tunnel/pipebridge.go
+++ b/pkg/tunnel/pipebridge.go
@@ -1,0 +1,87 @@
+package tunnel
+
+import (
+	"context"
+	"os"
+)
+
+type PipeBridge struct {
+	StdoutReader *os.File
+	StdoutWriter *os.File
+	StdinReader  *os.File
+	StdinWriter  *os.File
+}
+
+func NewPipeBridge() (*PipeBridge, error) {
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	stdinReader, stdinWriter, err := os.Pipe()
+	if err != nil {
+		_ = stdoutReader.Close()
+		_ = stdoutWriter.Close()
+		return nil, err
+	}
+	return &PipeBridge{
+		StdoutReader: stdoutReader,
+		StdoutWriter: stdoutWriter,
+		StdinReader:  stdinReader,
+		StdinWriter:  stdinWriter,
+	}, nil
+}
+
+func (pb *PipeBridge) Close() {
+	_ = pb.StdoutReader.Close()
+	_ = pb.StdoutWriter.Close()
+	_ = pb.StdinReader.Close()
+	_ = pb.StdinWriter.Close()
+}
+
+type (
+	TunnelFunc  func(ctx context.Context, stdin *os.File, stdout *os.File) error
+	HandlerFunc func(ctx context.Context, stdout *os.File, stdin *os.File) error
+)
+
+func (pb *PipeBridge) RunPair(
+	ctx context.Context,
+	tunnelFn TunnelFunc,
+	handlerFn HandlerFunc,
+) error {
+	cancelCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	tunnelChan := make(chan error, 1)
+	go func() {
+		tunnelChan <- tunnelFn(cancelCtx, pb.StdinReader, pb.StdoutWriter)
+	}()
+
+	handlerChan := make(chan error, 1)
+	go func() {
+		defer cancel()
+		handlerChan <- handlerFn(cancelCtx, pb.StdoutReader, pb.StdinWriter)
+	}()
+
+	return awaitPair(tunnelChan, handlerChan, pb.StdoutWriter, pb.StdinWriter)
+}
+
+func awaitPair(
+	tunnelChan, handlerChan <-chan error,
+	stdoutWriter, stdinWriter *os.File,
+) error {
+	var tunnelErr, handlerErr error
+
+	select {
+	case handlerErr = <-handlerChan:
+		select {
+		case tunnelErr = <-tunnelChan:
+		default:
+		}
+	case tunnelErr = <-tunnelChan:
+		_ = stdoutWriter.Close()
+		_ = stdinWriter.Close()
+		handlerErr = <-handlerChan
+	}
+
+	return ClassifyTunnelErrors(tunnelErr, handlerErr)
+}

--- a/pkg/tunnel/pipebridge_test.go
+++ b/pkg/tunnel/pipebridge_test.go
@@ -1,0 +1,216 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestNewPipeBridge(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	msg := []byte("hello")
+
+	_, err = pb.StdoutWriter.Write(msg)
+	if err != nil {
+		t.Fatalf("write to stdout pipe: %v", err)
+	}
+
+	buf := make([]byte, len(msg))
+	_, err = io.ReadFull(pb.StdoutReader, buf)
+	if err != nil {
+		t.Fatalf("read from stdout pipe: %v", err)
+	}
+	if string(buf) != "hello" {
+		t.Errorf("stdout pipe: got %q, want %q", buf, "hello")
+	}
+
+	_, err = pb.StdinWriter.Write(msg)
+	if err != nil {
+		t.Fatalf("write to stdin pipe: %v", err)
+	}
+
+	_, err = io.ReadFull(pb.StdinReader, buf)
+	if err != nil {
+		t.Fatalf("read from stdin pipe: %v", err)
+	}
+	if string(buf) != "hello" {
+		t.Errorf("stdin pipe: got %q, want %q", buf, "hello")
+	}
+}
+
+func TestRunPairBothSucceed(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	tunnel := func(_ context.Context, stdin *os.File, stdout *os.File) error {
+		buf := make([]byte, 4)
+		_, err := io.ReadFull(stdin, buf)
+		if err != nil {
+			return err
+		}
+		_, err = stdout.Write(buf)
+		return err
+	}
+
+	handler := func(_ context.Context, stdout *os.File, stdin *os.File) error {
+		_, err := stdin.Write([]byte("ping"))
+		if err != nil {
+			return err
+		}
+		buf := make([]byte, 4)
+		_, err = io.ReadFull(stdout, buf)
+		if err != nil {
+			return err
+		}
+		if string(buf) != "ping" {
+			t.Errorf("handler got %q, want %q", buf, "ping")
+		}
+		return nil
+	}
+
+	err = pb.RunPair(context.Background(), tunnel, handler)
+	if err != nil {
+		t.Errorf("RunPair() error = %v, want nil", err)
+	}
+}
+
+func TestRunPairTunnelError(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	dialErr := errors.New("dial failed")
+
+	tunnel := func(_ context.Context, _ *os.File, _ *os.File) error {
+		return dialErr
+	}
+
+	handler := func(_ context.Context, stdout *os.File, _ *os.File) error {
+		buf := make([]byte, 1)
+		_, err := stdout.Read(buf)
+		return err
+	}
+
+	err = pb.RunPair(context.Background(), tunnel, handler)
+	if err == nil {
+		t.Fatal("RunPair() = nil, want error")
+	}
+	want := "connect to server: dial failed"
+	if err.Error() != want {
+		t.Errorf("RunPair() error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRunPairHandlerError(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	handlerErr := errors.New("handler broke")
+
+	tunnel := func(ctx context.Context, _ *os.File, _ *os.File) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	handler := func(_ context.Context, _ *os.File, _ *os.File) error {
+		return handlerErr
+	}
+
+	err = pb.RunPair(context.Background(), tunnel, handler)
+	if err == nil {
+		t.Fatal("RunPair() = nil, want error")
+	}
+	want := "tunnel to container: handler broke"
+	if err.Error() != want {
+		t.Errorf("RunPair() error = %q, want %q", err.Error(), want)
+	}
+}
+
+func TestRunPairContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+	defer pb.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	tunnel := func(ctx context.Context, _ *os.File, _ *os.File) error {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	handler := func(_ context.Context, _ *os.File, _ *os.File) error {
+		cancel()
+		return nil
+	}
+
+	err = pb.RunPair(ctx, tunnel, handler)
+	if err != nil {
+		t.Errorf("RunPair() error = %v, want nil", err)
+	}
+}
+
+func TestRunPairPipesClosedAfterReturn(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatalf("NewPipeBridge() error = %v", err)
+	}
+
+	tunnel := func(_ context.Context, _ *os.File, _ *os.File) error {
+		return nil
+	}
+	handler := func(_ context.Context, _ *os.File, _ *os.File) error {
+		return nil
+	}
+
+	_ = pb.RunPair(context.Background(), tunnel, handler)
+	pb.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, err := pb.StdoutWriter.Write([]byte("x"))
+		if err == nil {
+			t.Error("write to closed StdoutWriter should fail")
+		}
+		_, err = pb.StdinWriter.Write([]byte("x"))
+		if err == nil {
+			t.Error("write to closed StdinWriter should fail")
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for write checks")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ConnError` primitives (`ErrorKind`, `ClassifyError`, `IsEOF` with nil guard, `ClassifyTunnelErrors`) for consistent tunnel error classification
- Add `PipeBridge` struct with `NewPipeBridge`, `Close`, and `RunPair` for pipe-based concurrent tunnel+handler goroutine orchestration
- Comprehensive stdlib table-driven tests for both modules (15 test cases covering all error paths and pipe lifecycle)

Pure addition — zero modifications to existing files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tunnel connection error handling with intelligent categorization to distinguish between recoverable and permanent connection issues
  * Added bidirectional pipe-based communication support for tunnel operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->