### PR TITLE
fix(e2e): increase machineprovider inactivity timeout for GHA runners

### DIFF
--- a/e2e/tests/machineprovider/testdata/machineprovider2/provider.yaml
+++ b/e2e/tests/machineprovider/testdata/machineprovider2/provider.yaml
@@ -8,7 +8,7 @@ options:
     default: devsy-e2e
   INACTIVITY_TIMEOUT:
     description: The timeout until the pod will be stopped
-    default: 5s
+    default: 30s
 agent:
   path: /usr/local/bin/devsy
   inactivityTimeout: ${INACTIVITY_TIMEOUT}


### PR DESCRIPTION
## Summary

**Root cause:** The `machineprovider2` test fixture sets `INACTIVITY_TIMEOUT` to `5s`. On GitHub Actions runners, the second `DevsyUp` call (machineprovider.go:150) takes longer than 5s for injection + SSH tunnel setup. The daemon fires `kill 1` before setup completes, killing the container with SIGKILL (exit 137). The subsequent status check at line 156 gets `STOPPED` instead of `RUNNING`.

**Evidence:** 6/6 CI failures on PR #139 all show the identical SIGKILL pattern — the container is killed mid-setup by the inactivity timeout.

**Fix:** Increase `INACTIVITY_TIMEOUT` default from `5s` to `30s` in `e2e/tests/machineprovider/testdata/machineprovider2/provider.yaml`. This gives the injection + SSH tunnel setup enough time to complete on slower GHA runners.

The test still validates inactivity timeout behavior correctly: `machineprovider.go:163-170` uses `gomega.Eventually` with a 2-minute timeout to wait for the workspace to stop due to inactivity, so even with a 30s timeout the test exercises the same shutdown path.