### PR TITLE
fix(e2e): verify up-private-token test after adding devcontainer.json to test repo

### DIFF
--- a/e2e/tests/up/up_private_token.go
+++ b/e2e/tests/up/up_private_token.go
@@ -54,6 +54,7 @@ var _ = ginkgo.Describe(
 			name := "testprivaterepo"
 			ginkgo.DeferCleanup(f.DevsyWorkspaceDelete, name)
 
+			// test repo must have .devcontainer.json to avoid MCR rate limits
 			err = f.DevsyUp(ctx, "https://github.com/"+username+"/test_private_repo.git")
 			framework.ExpectNoError(err)
 


### PR DESCRIPTION
## Summary

- Added `.devcontainer.json` to `devsy-org/test_private_repo` with image `ghcr.io/devsy-org/test-images/base:ubuntu` to avoid MCR rate-limit 403s in CI
- This PR triggers CI to verify the `up-private-token` E2E test now passes with the devcontainer.json in place