### PR TITLE
refactor(e2e): consolidate test timeouts into centralized tiers

### DIFF
--- a/e2e/framework/timeouts.go
+++ b/e2e/framework/timeouts.go
@@ -1,0 +1,34 @@
+package framework
+
+import (
+	"runtime"
+	"time"
+)
+
+func TimeoutShort() time.Duration {
+	if runtime.GOOS == "windows" {
+		return 10 * time.Minute
+	}
+	return 2 * time.Minute
+}
+
+func TimeoutModerate() time.Duration {
+	if runtime.GOOS == "windows" {
+		return 25 * time.Minute
+	}
+	return 5 * time.Minute
+}
+
+func TimeoutLong() time.Duration {
+	if runtime.GOOS == "windows" {
+		return 50 * time.Minute
+	}
+	return 10 * time.Minute
+}
+
+func TimeoutVeryLong() time.Duration {
+	if runtime.GOOS == "windows" {
+		return 100 * time.Minute
+	}
+	return 20 * time.Minute
+}

--- a/e2e/framework/timeouts.go
+++ b/e2e/framework/timeouts.go
@@ -5,29 +5,31 @@ import (
 	"time"
 )
 
+const osWindows = "windows"
+
 func TimeoutShort() time.Duration {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		return 10 * time.Minute
 	}
 	return 2 * time.Minute
 }
 
 func TimeoutModerate() time.Duration {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		return 25 * time.Minute
 	}
 	return 5 * time.Minute
 }
 
 func TimeoutLong() time.Duration {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		return 50 * time.Minute
 	}
 	return 10 * time.Minute
 }
 
 func TimeoutVeryLong() time.Duration {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == osWindows {
 		return 100 * time.Minute
 	}
 	return 20 * time.Minute

--- a/e2e/framework/util.go
+++ b/e2e/framework/util.go
@@ -5,23 +5,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"time"
 )
-
-func GetTimeout() time.Duration {
-	if runtime.GOOS == "windows" {
-		return 600 * time.Second
-	}
-
-	// NOTE: Downloading container images can be slow depending on network conditions.
-	// If tests need to download a large container image or multiple images, it
-	// may fail due to timeout. Recommend, pre-staging images in local Docker cache
-	// during the workflow before the start of the tests to mitigate timeout issues
-	// caused by slow image downloads.
-	return 120 * time.Second
-}
 
 func CreateTempDir() (string, error) {
 	return createTempDir("")

--- a/e2e/tests/build/build.go
+++ b/e2e/tests/build/build.go
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 	})
 
 	ginkgo.It("build docker buildx",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			f := framework.NewDefaultFramework(initialDir + "/bin")
 			tempDir, err := framework.CopyToTempDir("tests/build/testdata/docker")
@@ -144,7 +144,7 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 
 	ginkgo.It(
 		"should build image without repository specified if skip-push flag is set",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			f := framework.NewDefaultFramework(initialDir + "/bin")
 			tempDir, err := framework.CopyToTempDir("tests/build/testdata/docker")
@@ -195,7 +195,7 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 
 	ginkgo.It(
 		"should build the image of the referenced service from the docker compose file",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			f := framework.NewDefaultFramework(initialDir + "/bin")
 			tempDir, err := framework.CopyToTempDir("tests/build/testdata/docker-compose")
@@ -220,7 +220,7 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 
 	ginkgo.It(
 		"should build docker-compose with features when build context differs from devcontainer location",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			f := framework.NewDefaultFramework(initialDir + "/bin")
 			tempDir, err := framework.CopyToTempDir(
@@ -243,7 +243,7 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 	)
 
 	ginkgo.It("build docker internal buildkit",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			f := framework.NewDefaultFramework(initialDir + "/bin")
 			tempDir, err := framework.CopyToTempDir("tests/build/testdata/docker")
@@ -300,7 +300,7 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 		})
 
 	ginkgo.It("build kubernetes dockerless",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			if runtime.GOOS == osWindows {
 				ginkgo.Skip("skipping on windows")
@@ -335,7 +335,7 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 		})
 
 	ginkgo.It("rebuild kubernetes dockerless",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			validateKubernetesDeploymentWithoutDocker(
 				ctx,
@@ -347,7 +347,7 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 		})
 
 	ginkgo.It("reset kubernetes dockerless",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			validateKubernetesDeploymentWithoutDocker(
 				ctx,

--- a/e2e/tests/context/context.go
+++ b/e2e/tests/context/context.go
@@ -27,7 +27,7 @@ var _ = ginkgo.Describe(
 
 		ginkgo.It(
 			"create a new context, switch to it and delete afterwards",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				f := framework.NewDefaultFramework(initialDir + "/bin")
 
@@ -47,7 +47,7 @@ var _ = ginkgo.Describe(
 
 		ginkgo.It(
 			"should use shared context in IDE commands",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				f := framework.NewDefaultFramework(initialDir + "/bin")
 

--- a/e2e/tests/ide/ide.go
+++ b/e2e/tests/ide/ide.go
@@ -17,7 +17,7 @@ var _ = ginkgo.Describe("devsy ide test suite", ginkgo.Label("ide"), ginkgo.Orde
 		framework.ExpectNoError(err)
 	})
 
-	ginkgo.It("start ides", ginkgo.SpecTimeout(framework.GetTimeout()), func(ctx context.Context) {
+	ginkgo.It("start ides", ginkgo.SpecTimeout(framework.TimeoutShort()), func(ctx context.Context) {
 		f := framework.NewDefaultFramework(initialDir + "/bin")
 		tempDir, err := framework.CopyToTempDir("tests/ide/testdata")
 		framework.ExpectNoError(err)

--- a/e2e/tests/ide/ide.go
+++ b/e2e/tests/ide/ide.go
@@ -17,39 +17,40 @@ var _ = ginkgo.Describe("devsy ide test suite", ginkgo.Label("ide"), ginkgo.Orde
 		framework.ExpectNoError(err)
 	})
 
-	ginkgo.It("start ides", ginkgo.SpecTimeout(framework.TimeoutShort()), func(ctx context.Context) {
-		f := framework.NewDefaultFramework(initialDir + "/bin")
-		tempDir, err := framework.CopyToTempDir("tests/ide/testdata")
-		framework.ExpectNoError(err)
-		ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
-
-		err = f.DevsyProviderAdd(ctx, "docker")
-		framework.ExpectNoError(err)
-		err = f.DevsyProviderUse(ctx, "docker")
-		framework.ExpectNoError(err)
-
-		ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
-			err = f.DevsyWorkspaceDelete(cleanupCtx, tempDir)
+	ginkgo.It(
+		"start ides", ginkgo.SpecTimeout(framework.TimeoutShort()), func(ctx context.Context) {
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+			tempDir, err := framework.CopyToTempDir("tests/ide/testdata")
 			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+			err = f.DevsyProviderAdd(ctx, "docker")
+			framework.ExpectNoError(err)
+			err = f.DevsyProviderUse(ctx, "docker")
+			framework.ExpectNoError(err)
+
+			ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
+				err = f.DevsyWorkspaceDelete(cleanupCtx, tempDir)
+				framework.ExpectNoError(err)
+			})
+
+			err = f.DevsyUpWithIDE(ctx, tempDir, "--open-ide=false", "--ide=vscode")
+			framework.ExpectNoError(err)
+
+			err = f.DevsyUpWithIDE(ctx, tempDir, "--open-ide=false", "--ide=openvscode")
+			framework.ExpectNoError(err)
+
+			err = f.DevsyUpWithIDE(ctx, tempDir, "--open-ide=false", "--ide=jupyternotebook")
+			framework.ExpectNoError(err)
+
+			// TODO: Fix broken IDE
+			// err = f.DevsyUpWithIDE(ctx, tempDir, "--open-ide=false", "--ide=fleet")
+			// framework.ExpectNoError(err)
+
+			// check if ssh works
+			err = f.DevsySSHEchoTestString(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			// TODO: test jetbrains ides
 		})
-
-		err = f.DevsyUpWithIDE(ctx, tempDir, "--open-ide=false", "--ide=vscode")
-		framework.ExpectNoError(err)
-
-		err = f.DevsyUpWithIDE(ctx, tempDir, "--open-ide=false", "--ide=openvscode")
-		framework.ExpectNoError(err)
-
-		err = f.DevsyUpWithIDE(ctx, tempDir, "--open-ide=false", "--ide=jupyternotebook")
-		framework.ExpectNoError(err)
-
-		// TODO: Fix broken IDE
-		// err = f.DevsyUpWithIDE(ctx, tempDir, "--open-ide=false", "--ide=fleet")
-		// framework.ExpectNoError(err)
-
-		// check if ssh works
-		err = f.DevsySSHEchoTestString(ctx, tempDir)
-		framework.ExpectNoError(err)
-
-		// TODO: test jetbrains ides
-	})
 })

--- a/e2e/tests/integration/integration.go
+++ b/e2e/tests/integration/integration.go
@@ -24,7 +24,7 @@ var _ = ginkgo.Describe(
 
 		ginkgo.It(
 			"should setup ssh, add provider, run workspace, test ssh, and cleanup",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				sshDir := os.Getenv("HOME") + "/.ssh"
 				if _, err := os.Stat(sshDir); os.IsNotExist(err) {

--- a/e2e/tests/machine/machine.go
+++ b/e2e/tests/machine/machine.go
@@ -20,7 +20,7 @@ var _ = ginkgo.Describe("devsy testing machine", ginkgo.Label("machine"), ginkgo
 
 	ginkgo.It(
 		"should add simple machine and then delete it",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			tempDir, err := framework.CopyToTempDir("tests/machine/testdata")
 			framework.ExpectNoError(err)
@@ -58,7 +58,7 @@ var _ = ginkgo.Describe("devsy testing machine", ginkgo.Label("machine"), ginkgo
 
 	ginkgo.It(
 		"should delete a non-existing machine and get an error",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			tempDir, err := framework.CopyToTempDir("tests/machine/testdata")
 			framework.ExpectNoError(err)

--- a/e2e/tests/machineprovider/machineprovider.go
+++ b/e2e/tests/machineprovider/machineprovider.go
@@ -27,7 +27,7 @@ var _ = ginkgo.Describe(
 		})
 
 		ginkgo.It("test start / stop / status",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				f := framework.NewDefaultFramework(initialDir + "/bin")
 
@@ -98,7 +98,7 @@ var _ = ginkgo.Describe(
 			})
 
 		ginkgo.It("test devsy inactivity timeout",
-			ginkgo.SpecTimeout(framework.GetTimeout()*5),
+			ginkgo.SpecTimeout(framework.TimeoutLong()),
 			func(ctx context.Context) {
 				f := framework.NewDefaultFramework(initialDir + "/bin")
 
@@ -171,7 +171,7 @@ var _ = ginkgo.Describe(
 			})
 
 		ginkgo.It("test shutdownAction none suppresses inactivity timeout",
-			ginkgo.SpecTimeout(framework.GetTimeout()*5),
+			ginkgo.SpecTimeout(framework.TimeoutLong()),
 			func(ctx context.Context) {
 				f := framework.NewDefaultFramework(initialDir + "/bin")
 

--- a/e2e/tests/provider/provider.go
+++ b/e2e/tests/provider/provider.go
@@ -35,7 +35,7 @@ var _ = ginkgo.Describe(
 		})
 
 		ginkgo.It("should add simple provider and delete it",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				tempDir, err := framework.CopyToTempDir(
 					"tests/provider/testdata/simple-k8s-provider",
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe(
 			})
 
 		ginkgo.It("should add simple provider and update it",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				tempDir, err := framework.CopyToTempDir(
 					"tests/provider/testdata/simple-k8s-provider",
@@ -121,7 +121,7 @@ var _ = ginkgo.Describe(
 			})
 
 		ginkgo.It("should list all providers",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				tempDir, err := framework.CopyToTempDir(
 					"tests/provider/testdata/simple-k8s-provider",
@@ -154,7 +154,7 @@ var _ = ginkgo.Describe(
 			})
 
 		ginkgo.It("should parse options",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				tempDir, err := framework.CopyToTempDir(
 					"tests/provider/testdata/simple-k8s-provider",
@@ -198,7 +198,7 @@ spec:
 
 		// RENAME-1.
 		ginkgo.It("should rename a provider to a new, valid name",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				tempDir, err := framework.CopyToTempDir(
 					"tests/provider/testdata/simple-k8s-provider",
@@ -239,7 +239,7 @@ spec:
 		// RENAME-2.
 		ginkgo.It(
 			"should fail to rename a provider to a name that already exists",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				tempDir, err := framework.CopyToTempDir(
 					"tests/provider/testdata/simple-k8s-provider",
@@ -292,7 +292,7 @@ spec:
 		)
 
 		ginkgo.It("should fail to rename a non-existent provider",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				f := framework.NewDefaultFramework(initialDir + "/bin")
 
@@ -309,7 +309,7 @@ spec:
 
 		ginkgo.It(
 			"should rename a provider with an associated running workspace",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				f := framework.NewDefaultFramework(initialDir + "/bin")
 
@@ -387,7 +387,7 @@ spec:
 		)
 
 		ginkgo.It("should fail to rename a provider to an invalid name",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				tempDir, err := framework.CopyToTempDir(
 					"tests/provider/testdata/simple-k8s-provider",
@@ -416,7 +416,7 @@ spec:
 			})
 
 		ginkgo.It("should preserve provider options after rename",
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 			func(ctx context.Context) {
 				f := framework.NewDefaultFramework(initialDir + "/bin")
 

--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -31,7 +31,7 @@ var _ = ginkgo.Describe("devsy ssh test suite", ginkgo.Label("ssh"), ginkgo.Orde
 
 	ginkgo.It(
 		"should start a new workspace with a docker provider (default) and SSH into it",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			tempDir, err := framework.CopyToTempDir("tests/ssh/testdata/local-test")
 			framework.ExpectNoError(err)
@@ -64,7 +64,7 @@ var _ = ginkgo.Describe("devsy ssh test suite", ginkgo.Label("ssh"), ginkgo.Orde
 	ginkgo.It(
 		"should start workspace with GPG forwarding when host uses SSH signing format",
 		ginkgo.Label("gpg"),
-		ginkgo.SpecTimeout(5*time.Minute),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 		func(ctx ginkgo.SpecContext) {
 			if runtime.GOOS == osWindows {
 				ginkgo.Skip("skipping on windows")
@@ -113,7 +113,7 @@ var _ = ginkgo.Describe("devsy ssh test suite", ginkgo.Label("ssh"), ginkgo.Orde
 
 	ginkgo.It(
 		"should set up git SSH signature helper and sign a commit",
-		ginkgo.SpecTimeout(7*time.Minute),
+		ginkgo.SpecTimeout(framework.TimeoutLong()),
 		func(ctx ginkgo.SpecContext) {
 			if runtime.GOOS == osWindows {
 				ginkgo.Skip("skipping on windows")
@@ -276,7 +276,7 @@ var _ = ginkgo.Describe("devsy ssh test suite", ginkgo.Label("ssh"), ginkgo.Orde
 
 	ginkgo.It(
 		"should not install git SSH signature helper when signing key is not provided",
-		ginkgo.SpecTimeout(5*time.Minute),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 		func(ctx ginkgo.SpecContext) {
 			if runtime.GOOS == osWindows {
 				ginkgo.Skip("skipping on windows")
@@ -323,7 +323,7 @@ var _ = ginkgo.Describe("devsy ssh test suite", ginkgo.Label("ssh"), ginkgo.Orde
 
 	ginkgo.It(
 		"should surface clear error when SSH signing fails",
-		ginkgo.SpecTimeout(7*time.Minute),
+		ginkgo.SpecTimeout(framework.TimeoutLong()),
 		func(ctx ginkgo.SpecContext) {
 			if runtime.GOOS == osWindows {
 				ginkgo.Skip("skipping on windows")
@@ -398,7 +398,7 @@ var _ = ginkgo.Describe("devsy ssh test suite", ginkgo.Label("ssh"), ginkgo.Orde
 
 	ginkgo.It(
 		"should start a new workspace with a docker provider (default) and forward a port into it",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			if runtime.GOOS == osWindows {
 				ginkgo.Skip("skipping on windows")

--- a/e2e/tests/tunnel/tunnel.go
+++ b/e2e/tests/tunnel/tunnel.go
@@ -26,7 +26,7 @@ var _ = ginkgo.Describe(
 		})
 
 		ginkgo.It("should tunnel to workspace and exchange data bidirectionally",
-			ginkgo.SpecTimeout(framework.GetTimeout()*3),
+			ginkgo.SpecTimeout(framework.TimeoutLong()),
 			func(ctx context.Context) {
 				f := framework.NewDefaultFramework(initialDir + "/bin")
 
@@ -70,7 +70,7 @@ var _ = ginkgo.Describe(
 			})
 
 		ginkgo.It("should keep workspace running when stdin closes before stdout",
-			ginkgo.SpecTimeout(framework.GetTimeout()*3),
+			ginkgo.SpecTimeout(framework.TimeoutLong()),
 			func(ctx context.Context) {
 				f := framework.NewDefaultFramework(initialDir + "/bin")
 

--- a/e2e/tests/up-docker-compose/build.go
+++ b/e2e/tests/up-docker-compose/build.go
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe(
 			// Wait for devsy workspace to come online (deadline: 30s)
 			err = f.DevsyUp(ctx, tempDir, "--debug")
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()*3))
+		}, ginkgo.SpecTimeout(framework.TimeoutLong()))
 
 		ginkgo.It("should NOT delete container when rebuild fails", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(

--- a/e2e/tests/up-docker-compose/config.go
+++ b/e2e/tests/up-docker-compose/config.go
@@ -44,7 +44,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			framework.ExpectNoError(tc.verifyWorkspaceMount(ctx, workspace, tempDir))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("sub-folder", func(ctx context.Context) {
 			tempDir, workspace, err := tc.setupAndStartWorkspace(
@@ -53,7 +53,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			framework.ExpectNoError(tc.verifyWorkspaceMount(ctx, workspace, tempDir))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("overrides", func(ctx context.Context) {
 			tempDir, workspace, err := tc.setupAndStartWorkspace(
@@ -62,7 +62,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			framework.ExpectNoError(tc.verifyWorkspaceMount(ctx, workspace, tempDir))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("env-file", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe(
 			gomega.Expect(ids).To(gomega.HaveLen(1), "1 compose container to be created")
 			gomega.Expect(devsyUpOutput).
 				NotTo(gomega.ContainSubstring("Defaulting to a blank string."))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("restart", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -133,7 +133,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			gomega.Expect(restartIds).To(gomega.HaveLen(1), "1 compose container after restart")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("environment variables", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -160,7 +160,7 @@ var _ = ginkgo.Describe(
 				[]string{"ssh", "--command", "echo $FOO", workspace.ID},
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("user", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -187,7 +187,7 @@ var _ = ginkgo.Describe(
 				[]string{"ssh", "--command", "ps u -p 1", workspace.ID},
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("override command", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -201,7 +201,7 @@ var _ = ginkgo.Describe(
 			gomega.Expect(detail.Config.Entrypoint).
 				NotTo(gomega.ContainElement("bash"), "overrides container entry point")
 			gomega.Expect(detail.Config.Cmd).To(gomega.BeEmpty(), "overrides container command")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It(
 			"implements updateRemoteUserUID with root container user",
@@ -265,7 +265,7 @@ var _ = ginkgo.Describe(
 				verifyHostFileAccess(hostFile, expectedContent)
 				verifyHostFileOwnership(hostFile, testUID, testGID, testUID == 0)
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 		)
 
 		ginkgo.It(
@@ -323,7 +323,7 @@ var _ = ginkgo.Describe(
 				verifyHostFileAccess(hostFile, expectedContent)
 				verifyHostFileOwnership(hostFile, testUID, testGID, testUID == 0)
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 		)
 
 		ginkgo.It("privileged", func(ctx context.Context) {
@@ -337,7 +337,7 @@ var _ = ginkgo.Describe(
 			framework.ExpectNoError(err)
 			gomega.Expect(detail.HostConfig.Privileged).
 				To(gomega.BeTrue(), "container run with privileged true")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("capabilities", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -354,7 +354,7 @@ var _ = ginkgo.Describe(
 			gomega.Expect(detail.HostConfig.CapAdd).
 				To(gomega.Or(gomega.ContainElement("NET_ADMIN"), gomega.ContainElement("CAP_NET_ADMIN")),
 					"devcontainer configuration can add capabilities")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("security options", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -369,7 +369,7 @@ var _ = ginkgo.Describe(
 				To(gomega.ContainElement("seccomp=unconfined"), "securityOpts contain seccomp=unconfined")
 			gomega.Expect(detail.HostConfig.SecurityOpt).
 				To(gomega.ContainElement("apparmor=unconfined"), "securityOpts contain apparmor=unconfined")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("remote env", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -405,7 +405,7 @@ var _ = ginkgo.Describe(
 				[]string{"ssh", "--command", "cat $HOME/remote-env.out", workspace.ID},
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("remote env null unsets variable", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -454,7 +454,7 @@ var _ = ginkgo.Describe(
 				},
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("remote user", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -481,7 +481,7 @@ var _ = ginkgo.Describe(
 				[]string{"ssh", "--command", "cat $HOME/remote-user.out", workspace.ID},
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("variables substitution", func(ctx context.Context) {
 			tempDir, workspace, err := tc.setupAndStartWorkspace(
@@ -544,6 +544,6 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			gomega.Expect(containerWorkspaceFolderBasename).To(gomega.Equal("workspaces"))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 	},
 )

--- a/e2e/tests/up-docker-compose/up_docker_compose.go
+++ b/e2e/tests/up-docker-compose/up_docker_compose.go
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe(
 			bar, err := tc.execSSH(ctx, tempDir, "cat $HOME/mnt2/bar.txt")
 			framework.ExpectNoError(err)
 			gomega.Expect(strings.TrimSpace(bar)).To(gomega.Equal("FOO"))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("port forwarding", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -158,7 +158,7 @@ var _ = ginkgo.Describe(
 				gomega.MatchError("signal: killed"),
 				gomega.MatchError(context.Canceled),
 			))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("features", func(ctx context.Context) {
 			tempDir, workspace, err := tc.setupAndStartWorkspace(
@@ -182,7 +182,7 @@ var _ = ginkgo.Describe(
 			framework.ExpectNoError(err)
 			gomega.Expect(vclusterVersionOutput).
 				To(gomega.ContainSubstring("vcluster version 0.24.1"))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It(
 			"does not retag shared image when applying features to image backed services",
@@ -291,7 +291,7 @@ var _ = ginkgo.Describe(
 				gomega.Expect(strings.TrimSpace(nodeLookupOutput)).
 					To(gomega.Equal("missing"), "project A should not inherit project B's node feature")
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()*4),
+			ginkgo.SpecTimeout(framework.TimeoutLong()),
 		)
 
 		ginkgo.It("array based commands", func(ctx context.Context) {
@@ -346,7 +346,7 @@ var _ = ginkgo.Describe(
 			postAttachCommand, err := tc.execSSH(ctx, tempDir, "cat $HOME/post-attach-command.out")
 			framework.ExpectNoError(err)
 			gomega.Expect(postAttachCommand).To(gomega.Equal("postAttachCommand"))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("parallel object based commands", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -380,7 +380,7 @@ var _ = ginkgo.Describe(
 			parallelB, err := tc.execSSH(ctx, tempDir, "cat $HOME/parallel-b.out")
 			framework.ExpectNoError(err)
 			gomega.Expect(parallelB).To(gomega.Equal("parallelB"))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("commands with quotes", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -410,7 +410,7 @@ var _ = ginkgo.Describe(
 			quotedTest, err := tc.execSSH(ctx, tempDir, "cat $HOME/quoted-test.out")
 			framework.ExpectNoError(err)
 			gomega.Expect(quotedTest).To(gomega.Equal("quoted value"))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("v2 features", func(ctx context.Context) {
 			_, ws, err := tc.setupAndStartWorkspace(
@@ -427,7 +427,7 @@ var _ = ginkgo.Describe(
 			var containerDetails []container.InspectResponse
 			err = tc.dockerHelper.Inspect(ctx, ids, "container", &containerDetails)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("v1 fallback", func(ctx context.Context) {
 			_, ws, err := tc.setupAndStartWorkspace(
@@ -444,7 +444,7 @@ var _ = ginkgo.Describe(
 			var containerDetails []container.InspectResponse
 			err = tc.dockerHelper.Inspect(ctx, ids, "container", &containerDetails)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("multiple services", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -472,7 +472,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			gomega.Expect(dbIDs).To(gomega.HaveLen(1), "db container to be created")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("specific services", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -500,7 +500,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			gomega.Expect(dbIDs).To(gomega.BeEmpty(), "db container not to be created")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("user lookup with no remoteUser", func(ctx context.Context) {
 			_, _, err := tc.setupAndStartWorkspace(
@@ -508,7 +508,7 @@ var _ = ginkgo.Describe(
 				"tests/up-docker-compose/testdata/docker-compose-lookup-user",
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("dockerfile with args", func(ctx context.Context) {
 			tempDir, workspace, err := tc.setupAndStartWorkspace(
@@ -532,7 +532,7 @@ var _ = ginkgo.Describe(
 			framework.ExpectNoError(err)
 			gomega.Expect(strings.TrimSpace(buildArgs)).
 				To(gomega.Equal("ghcr.io/devsy-org/test-images/go:1"))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("multi-stage dockerfile with args", func(ctx context.Context) {
 			tempDir, workspace, err := tc.setupAndStartWorkspace(
@@ -556,6 +556,6 @@ var _ = ginkgo.Describe(
 			framework.ExpectNoError(err)
 			gomega.Expect(strings.TrimSpace(buildArgs)).
 				To(gomega.Equal("ghcr.io/devsy-org/test-images/go:1"))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 	},
 )

--- a/e2e/tests/up-features/up_features.go
+++ b/e2e/tests/up-features/up_features.go
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 		out, err = f.DevsySSH(ctx, wsName, "cat /tmp/feature-postStart.txt")
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(strings.TrimSpace(out), "feature-postStart")
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 	ginkgo.It("http headers download", func(ctx context.Context) {
 		server := ghttp.NewServer()
@@ -105,7 +105,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 
 		err = f.DevsyUp(ctx, tempDir)
 		framework.ExpectNoError(err)
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 	ginkgo.It(
 		"direct tar feature uses cached download with integrity verification",
@@ -198,7 +198,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			// Only one HTTP request was made — proves cache was reused with passing integrity
 			gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It("should install with lifecycle hooks", func(ctx context.Context) {
@@ -216,7 +216,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 
 		err = f.DevsyUp(ctx, tempDir)
 		framework.ExpectNoError(err)
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 	ginkgo.It(
 		"should automatically install dependsOn features",
@@ -242,7 +242,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			gomega.Expect(out).To(gomega.ContainSubstring("SUCCESS: hello command is available"))
 			gomega.Expect(out).To(gomega.ContainSubstring("hey, vscode"))
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It(
@@ -269,7 +269,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			gomega.Expect(out).To(gomega.ContainSubstring("SUCCESS: hello command is available"))
 			gomega.Expect(out).To(gomega.ContainSubstring("hey, vscode"))
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It(
@@ -296,7 +296,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			framework.ExpectNoError(err)
 			gomega.Expect(out).To(gomega.ContainSubstring("All dependencies available"))
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It(
@@ -320,7 +320,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			// The logs show "circular dependency detected" in the debug output
 			framework.ExpectError(err)
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It(
@@ -347,7 +347,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			framework.ExpectNoError(err)
 			gomega.Expect(out).To(gomega.ContainSubstring("custom greeting"))
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It(
@@ -374,7 +374,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			framework.ExpectNoError(err)
 			gomega.Expect(out).To(gomega.ContainSubstring("Correct order"))
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It(
@@ -397,7 +397,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			err = f.DevsyUp(ctx, tempDir)
 			framework.ExpectError(err)
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It(
@@ -420,7 +420,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			err = f.DevsyUp(ctx, tempDir)
 			framework.ExpectError(err)
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It(
@@ -448,7 +448,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			// Should contain greeting from one of the features (last one wins)
 			gomega.Expect(out).To(gomega.ContainSubstring("from"))
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It(
@@ -476,7 +476,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			framework.ExpectNoError(err)
 			gomega.Expect(out).To(gomega.ContainSubstring("Python 3.11"))
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()*5),
+		ginkgo.SpecTimeout(framework.TimeoutLong()),
 	) // This test compiles Python
 
 	ginkgo.It(
@@ -506,7 +506,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			framework.ExpectNoError(err)
 			gomega.Expect(out).To(gomega.MatchRegexp(`v\d+\.\d+\.\d+`))
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It("resolves user variable in dockerfile", func(ctx context.Context) {
@@ -528,7 +528,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 		out, err := f.DevsySSH(ctx, wsName, "whoami")
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(strings.TrimSpace(out), "testuser")
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 	ginkgo.It("preserves user when feature is present with variable", func(ctx context.Context) {
 		f, err := setupDockerProvider(initialDir+"/bin", "docker")
@@ -549,5 +549,5 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 		out, err := f.DevsySSH(ctx, wsName, "whoami")
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(strings.TrimSpace(out), "ubuntu")
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 })

--- a/e2e/tests/up-features/wsl.go
+++ b/e2e/tests/up-features/wsl.go
@@ -82,7 +82,7 @@ var _ = ginkgo.Describe(
 			// Wait for devsy workspace to come online (deadline: 30s)
 			err = f.DevsyUp(ctx, tempDir)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It(
 			"ensure dependencies installed via features are accessible in lifecycle hooks",
@@ -103,7 +103,7 @@ var _ = ginkgo.Describe(
 				err = f.DevsyUp(ctx, tempDir, "--debug")
 				framework.ExpectNoError(err)
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 		)
 	},
 )

--- a/e2e/tests/up/docker_wsl.go
+++ b/e2e/tests/up/docker_wsl.go
@@ -34,7 +34,7 @@ var _ = ginkgo.Describe("testing up command for windows", ginkgo.Label("up-docke
 
 		err = f.DevsyUp(ctx, tempDir)
 		framework.ExpectNoError(err)
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 	ginkgo.It("should start a new workspace with mounts", func(ctx context.Context) {
 		tempDir, err := setupWorkspace("tests/up/testdata/docker-mounts", initialDir, f)
@@ -60,7 +60,7 @@ var _ = ginkgo.Describe("testing up command for windows", ginkgo.Label("up-docke
 		bar, err := f.DevsySSH(ctx, projectName, "cat $HOME/mnt2/bar.txt")
 		framework.ExpectNoError(err)
 		gomega.Expect(strings.TrimSpace(bar)).To(gomega.Equal("FOO"))
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 	ginkgo.It(
 		"should start a new workspace with dotfiles - no install script",
@@ -86,7 +86,7 @@ var _ = ginkgo.Describe("testing up command for windows", ginkgo.Label("up-docke
 `
 			framework.ExpectEqual(out, expectedOutput, "should match")
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It(
@@ -112,7 +112,7 @@ var _ = ginkgo.Describe("testing up command for windows", ginkgo.Label("up-docke
 
 			framework.ExpectEqual(out, expectedOutput, "should match")
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It(
@@ -138,7 +138,7 @@ var _ = ginkgo.Describe("testing up command for windows", ginkgo.Label("up-docke
 `
 			framework.ExpectEqual(out, expectedOutput, "should match")
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It(
@@ -161,7 +161,7 @@ var _ = ginkgo.Describe("testing up command for windows", ginkgo.Label("up-docke
 			expectedOutput := "test\n"
 			framework.ExpectEqual(out, expectedOutput, "should match")
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 
 	ginkgo.It("should start a new workspace with custom image", func(ctx context.Context) {
@@ -179,7 +179,7 @@ var _ = ginkgo.Describe("testing up command for windows", ginkgo.Label("up-docke
 
 		framework.ExpectEqual(out, expectedOutput, "should match")
 		framework.ExpectNotEqual(out, unexpectedOutput, "should NOT match")
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 	ginkgo.It(
 		"should start a new workspace with custom image and skip building",
@@ -203,6 +203,6 @@ var _ = ginkgo.Describe("testing up command for windows", ginkgo.Label("up-docke
 			framework.ExpectEqual(out, expectedOutput, "should match")
 			framework.ExpectNotEqual(out, unexpectedOutput, "should NOT match")
 		},
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
 })

--- a/e2e/tests/up/dockerfile_build.go
+++ b/e2e/tests/up/dockerfile_build.go
@@ -42,7 +42,7 @@ var _ = ginkgo.Describe(
 
 			err = f.DevsyUp(ctx, tempDir, "--debug")
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()*3))
+		}, ginkgo.SpecTimeout(framework.TimeoutLong()))
 
 		ginkgo.It(
 			"should resolve localWorkspaceFolder variable in dockerfile path",
@@ -57,7 +57,7 @@ var _ = ginkgo.Describe(
 				err = f.DevsyUp(ctx, tempDir, "--debug")
 				framework.ExpectNoError(err)
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()*3),
+			ginkgo.SpecTimeout(framework.TimeoutLong()),
 		)
 
 		ginkgo.It(
@@ -103,7 +103,7 @@ var _ = ginkgo.Describe(
 
 				gomega.Expect(image2).ShouldNot(gomega.Equal(image1), "images should be different")
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 		)
 
 		ginkgo.It(
@@ -150,7 +150,7 @@ var _ = ginkgo.Describe(
 
 				gomega.Expect(image2).Should(gomega.Equal(image1), "image should be same")
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 		)
 	},
 )

--- a/e2e/tests/up/dotfiles.go
+++ b/e2e/tests/up/dotfiles.go
@@ -43,7 +43,7 @@ var _ = ginkgo.Describe(
 				out,
 				"/home/vscode/.file1\n/home/vscode/.file2\n/home/vscode/.file3\n",
 			)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("with install script", func(ctx context.Context) {
 			tempDir, err := dtc.setupAndUp(
@@ -59,7 +59,7 @@ var _ = ginkgo.Describe(
 			out, err := dtc.execSSH(ctx, tempDir, "ls /tmp/worked")
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(out, "/tmp/worked\n")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("specific commit", func(ctx context.Context) {
 			tempDir, err := dtc.setupAndUp(
@@ -76,7 +76,7 @@ var _ = ginkgo.Describe(
 				out,
 				"/home/vscode/.file1\n/home/vscode/.file2\n/home/vscode/.file3\n",
 			)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("specific branch", func(ctx context.Context) {
 			tempDir, err := dtc.setupAndUp(
@@ -90,7 +90,7 @@ var _ = ginkgo.Describe(
 			out, err := dtc.execSSH(ctx, tempDir, "cat ~/.branch_test")
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(out, "test\n")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("dotfiles installed between postCreate and postStart", func(ctx context.Context) {
 			tempDir, err := dtc.setupAndUp(
@@ -123,6 +123,6 @@ var _ = ginkgo.Describe(
 				"dotfiles-before-postStart",
 				"postStart",
 			}), "lifecycle ordering should be: postCreate → dotfiles → postStart")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 	},
 )

--- a/e2e/tests/up/git_repositories.go
+++ b/e2e/tests/up/git_repositories.go
@@ -37,7 +37,7 @@ var _ = ginkgo.Describe(
 				)
 				framework.ExpectNoError(err)
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 		)
 
 		ginkgo.It(
@@ -52,7 +52,7 @@ var _ = ginkgo.Describe(
 				err = f.DevsyUp(ctx, "github.com/devsy-org/devsy@pull/1/head")
 				framework.ExpectNoError(err)
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()*3),
+			ginkgo.SpecTimeout(framework.TimeoutLong()),
 		)
 
 		ginkgo.It("create workspace in a subpath", func(ctx context.Context) {
@@ -83,6 +83,6 @@ var _ = ginkgo.Describe(
 
 			err = f.DevsyWorkspaceDelete(ctx, id)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 	},
 )

--- a/e2e/tests/up/handles_errors.go
+++ b/e2e/tests/up/handles_errors.go
@@ -60,7 +60,7 @@ var _ = ginkgo.Describe(
 					),
 				)
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 		)
 
 		ginkgo.It(
@@ -82,7 +82,7 @@ var _ = ginkgo.Describe(
 				framework.ExpectNoError(err)
 				framework.ExpectEqual(out, initialList)
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 		)
 
 		ginkgo.It(
@@ -106,7 +106,7 @@ var _ = ginkgo.Describe(
 				gomega.Expect(err.Error()).To(gomega.ContainSubstring("devsy up failed"))
 				gomega.Expect(err.Error()).To(gomega.ContainSubstring("exit status 1"))
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 		)
 
 		ginkgo.It("ensure workspace cleanup when not a git or folder", func(ctx context.Context) {
@@ -122,6 +122,6 @@ var _ = ginkgo.Describe(
 			out, err := f.DevsyList(ctx)
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(out, initialList)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 	},
 )

--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -37,7 +37,7 @@ var _ = ginkgo.Describe(
 		ginkgo.It("existing image", func(ctx context.Context) {
 			_, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker")
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("existing running container", func(ctx context.Context) {
 			tempDir, err := framework.CopyToTempDir("tests/up/testdata/no-devcontainer")
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe(
 				fmt.Sprintf("container:%s", containerDetails[0].ID),
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("variables substitution", func(ctx context.Context) {
 			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker-variables",
@@ -173,7 +173,7 @@ var _ = ginkgo.Describe(
 			customImage, err := dtc.execSSHCapture(ctx, workspace.ID, "cat $HOME/custom-image.out")
 			framework.ExpectNoError(err)
 			gomega.Expect(customImage).To(gomega.Equal("alpine:latest"))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("variable substitution with defaults", func(ctx context.Context) {
 			tempDir, err := dtc.setupAndUp(
@@ -217,7 +217,7 @@ var _ = ginkgo.Describe(
 			gomega.Expect(setVar).To(
 				gomega.Equal(os.Getenv("HOME")),
 			)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("remoteEnv null unsets variable", func(ctx context.Context) {
 			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker-remote-env-null")
@@ -241,7 +241,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			gomega.Expect(unsetLine).To(gomega.Equal("UNSET=true"))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("mounts", func(ctx context.Context) {
 			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker-mounts", "--debug")
@@ -261,7 +261,7 @@ var _ = ginkgo.Describe(
 			bar, err := dtc.execSSHCapture(ctx, workspace.ID, "cat $HOME/mnt2/bar.txt")
 			framework.ExpectNoError(err)
 			gomega.Expect(strings.TrimSpace(bar)).To(gomega.Equal("FOO"))
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("custom image", func(ctx context.Context) {
 			if runtime.GOOS == "windows" {
@@ -279,7 +279,7 @@ var _ = ginkgo.Describe(
 			out, err := dtc.execSSH(ctx, tempDir, "grep ^ID= /etc/os-release")
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(out, "ID=alpine\n")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("custom image skip build", func(ctx context.Context) {
 			tempDir, err := dtc.setupAndUp(
@@ -293,7 +293,7 @@ var _ = ginkgo.Describe(
 			out, err := dtc.execSSH(ctx, tempDir, "grep ^ID= /etc/os-release")
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(out, "ID=alpine\n")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("extra devcontainer merge", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -317,7 +317,7 @@ var _ = ginkgo.Describe(
 
 			err = dtc.f.DevsyWorkspaceDelete(ctx, tempDir)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("extra devcontainer override", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -337,7 +337,7 @@ var _ = ginkgo.Describe(
 
 			err = dtc.f.DevsyWorkspaceDelete(ctx, tempDir)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("postStartCommand runs after restart", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -370,7 +370,7 @@ var _ = ginkgo.Describe(
 			lines = strings.Count(strings.TrimSpace(out), "\n") + 1
 			gomega.Expect(lines).To(gomega.Equal(2),
 				"postStartCommand should have run again after restart")
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("waitFor defers postCreateCommand to background", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -428,7 +428,7 @@ var _ = ginkgo.Describe(
 				gomega.Equal("postStartDone"),
 				"deferred postStartCommand should eventually complete in background",
 			)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("IDE accessible before postAttachCommand completes", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -465,7 +465,7 @@ var _ = ginkgo.Describe(
 				gomega.Equal("postAttachDone"),
 				"postAttachCommand should eventually complete in the background",
 			)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It(
 			"initializeCommand with object syntax runs named sub-commands in parallel",
@@ -485,7 +485,7 @@ var _ = ginkgo.Describe(
 				framework.ExpectNoError(err)
 				gomega.Expect(string(two)).To(gomega.Equal("initCmdTwo"))
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 		)
 
 		ginkgo.It(
@@ -505,7 +505,7 @@ var _ = ginkgo.Describe(
 				framework.ExpectNoError(err)
 				gomega.Expect(strings.TrimSpace(two)).To(gomega.Equal("postCreateTwo"))
 			},
-			ginkgo.SpecTimeout(framework.GetTimeout()),
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
 		)
 
 		ginkgo.It("multi devcontainer selection", func(ctx context.Context) {
@@ -535,6 +535,6 @@ var _ = ginkgo.Describe(
 
 			err = dtc.f.DevsyWorkspaceDelete(ctx, tempDir)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 	},
 )

--- a/e2e/tests/up/provider_kubernetes.go
+++ b/e2e/tests/up/provider_kubernetes.go
@@ -105,6 +105,6 @@ var _ = ginkgo.Describe(
 			// check if ssh works
 			err = f.DevsySSHEchoTestString(ctx, tempDir)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 	},
 )

--- a/e2e/tests/up/provider_podman.go
+++ b/e2e/tests/up/provider_podman.go
@@ -39,7 +39,7 @@ var _ = ginkgo.Describe(
 					err = f.DevsyUp(ctx, tempDir)
 					framework.ExpectNoError(err)
 				},
-				ginkgo.SpecTimeout(framework.GetTimeout()),
+				ginkgo.SpecTimeout(framework.TimeoutShort()),
 			)
 		})
 
@@ -83,7 +83,7 @@ var _ = ginkgo.Describe(
 					err = f.DevsyUp(ctx, tempDir)
 					framework.ExpectNoError(err)
 				},
-				ginkgo.SpecTimeout(framework.GetTimeout()),
+				ginkgo.SpecTimeout(framework.TimeoutShort()),
 			)
 		})
 	},

--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -140,7 +140,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-workspaces"), fun
 		out, err = f.DevsySSH(ctx, name, "echo -n $TEST_OTHER_VAR")
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(out, value, "should be set now")
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 	ginkgo.It("create workspace without devcontainer.json", func(ctx context.Context) {
 		const providerName = "test-docker"
@@ -187,7 +187,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-workspaces"), fun
 
 		err = f.DevsyWorkspaceDelete(ctx, tempDir)
 		framework.ExpectNoError(err)
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 	ginkgo.It("recreate a local workspace", func(ctx context.Context) {
 		const providerName = "test-docker"
@@ -216,7 +216,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-workspaces"), fun
 
 		err = f.DevsyWorkspaceDelete(ctx, tempDir)
 		framework.ExpectNoError(err)
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 	ginkgo.It("recreate a remote workspace", func(ctx context.Context) {
 		const providerName = "test-docker"
@@ -255,7 +255,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-workspaces"), fun
 
 		err = f.DevsyWorkspaceDelete(ctx, id)
 		framework.ExpectNoError(err)
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 	ginkgo.It("reset a remote workspace", func(ctx context.Context) {
 		const providerName = "test-docker"
@@ -301,5 +301,5 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-workspaces"), fun
 
 		err = f.DevsyWorkspaceDelete(ctx, id)
 		framework.ExpectNoError(err)
-	}, ginkgo.SpecTimeout(framework.GetTimeout()))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 })

--- a/e2e/tests/up/up_private_token.go
+++ b/e2e/tests/up/up_private_token.go
@@ -66,6 +66,6 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			ginkgo.By(out)
-		}, ginkgo.SpecTimeout(framework.GetTimeout()))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 	},
 )

--- a/e2e/tests/upgrade/upgrade.go
+++ b/e2e/tests/upgrade/upgrade.go
@@ -14,7 +14,7 @@ import (
 var _ = ginkgo.Describe("testing upgrade command", ginkgo.Label("upgrade"), ginkgo.Ordered, func() {
 	ginkgo.It(
 		"should detect correct binary for current OS and architecture using dry-run",
-		ginkgo.SpecTimeout(framework.GetTimeout()),
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {
 			initialDir, err := os.Getwd()
 			framework.ExpectNoError(err, "getting current working directory should not error")


### PR DESCRIPTION
## Summary

Replace ad-hoc `SpecTimeout` / `NodeTimeout` values across all E2E tests with named tier functions defined in `e2e/framework/timeouts.go`. Each tier preserves the existing Windows 5x multiplier pattern from the original `GetTimeout()`.

### Timeout tier mapping

| Old pattern | Effective (Linux) | New replacement |
|---|---|---|
| `framework.GetTimeout()` | 2m | `framework.TimeoutShort()` |
| `5*time.Minute` | 5m | `framework.TimeoutModerate()` |
| `framework.GetTimeout()*3` | 6m | `framework.TimeoutLong()` |
| `7*time.Minute` | 7m | `framework.TimeoutLong()` |
| `framework.GetTimeout()*4` | 8m | `framework.TimeoutLong()` |
| `framework.GetTimeout()*5` | 10m | `framework.TimeoutLong()` |

### New tier definitions (Linux / Windows)

| Tier | Linux | Windows |
|---|---|---|
| `TimeoutShort()` | 2m | 10m |
| `TimeoutModerate()` | 5m | 25m |
| `TimeoutLong()` | 10m | 50m |
| `TimeoutVeryLong()` | 20m | 100m |

- **26 files** modified across `e2e/tests/`
- No test logic, assertions, or control flow changes
- `GetTimeout()` removed from `framework/util.go` — no remaining callers
- Internal test body timeouts (Eventually, context.WithTimeout, etc.) left untouched