### PR TITLE
refactor(sshtunnel): migrate to PipeBridge, eliminate 10s cleanup timer

### DIFF
--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -128,9 +128,16 @@ func (t *tunnelServer) RunWithResult(
 	go func() {
 		errChan <- s.Serve(lis)
 	}()
+	go func() {
+		<-ctx.Done()
+		s.Stop()
+	}()
 
 	select {
 	case err := <-errChan:
+		if t.result != nil {
+			return t.result, nil
+		}
 		return nil, err
 	case <-ctx.Done():
 		return t.result, nil

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -128,8 +128,11 @@ func (t *tunnelServer) RunWithResult(
 	go func() {
 		errChan <- s.Serve(lis)
 	}()
+
+	stopCtx, stopCancel := context.WithCancel(ctx)
+	defer stopCancel()
 	go func() {
-		<-ctx.Done()
+		<-stopCtx.Done()
 		s.Stop()
 	}()
 

--- a/pkg/devcontainer/sshtunnel/sshtunnel.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel.go
@@ -18,6 +18,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	devssh "github.com/devsy-org/devsy/pkg/ssh"
 	devsshagent "github.com/devsy-org/devsy/pkg/ssh/agent"
+	"github.com/devsy-org/devsy/pkg/tunnel"
 	"golang.org/x/crypto/ssh"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -36,181 +37,47 @@ type ExecuteCommandOptions struct {
 	TunnelServerFunc TunnelServerFunc
 }
 
-// sshTunnelResult carries the result of a single goroutine so the caller
-// knows which component reported the error.
-type sshTunnelResult struct {
-	source string
-	err    error
-}
-
-type sshSessionTunnel struct {
-	opts ExecuteCommandOptions
-
-	helperDone chan sshTunnelResult
-	tunnelDone chan sshTunnelResult
-
-	sshPipes  *pipePair
-	grpcPipes *pipePair
-}
-
 // ExecuteCommand runs the command in an SSH Tunnel and returns the result.
+// It uses two PipeBridges: sshBridge connects the helper (agent inject) to
+// the SSH tunnel, and grpcBridge connects the SSH command to the gRPC server.
 func ExecuteCommand(ctx context.Context, opts ExecuteCommandOptions) (*config2.Result, error) {
 	log.Debugf("starting SSH tunnel execution: ssh=%q workspace=%q addKeys=%v",
 		opts.SSHCommand, opts.Command, opts.AddPrivateKeys)
 
-	cancelCtx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	ts, err := setupTunnelContext(opts)
+	sshBridge, err := tunnel.NewPipeBridge()
 	if err != nil {
 		return nil, err
 	}
-	defer ts.cleanup()
+	defer sshBridge.Close()
 
-	var wg sync.WaitGroup
-
-	wg.Go(func() {
-		// helper receives parent ctx; it calls cancel() to signal tunnel goroutine
-		ts.helperDone <- executeSSHServerHelper(ctx, cancel, ts)
-	})
-
-	if opts.AddPrivateKeys {
-		addPrivateKeys(cancelCtx)
+	grpcBridge, err := tunnel.NewPipeBridge()
+	if err != nil {
+		return nil, err
 	}
+	defer grpcBridge.Close()
 
-	wg.Go(func() {
-		ts.tunnelDone <- runSSHTunnel(cancelCtx, cancel, ts)
-	})
+	var result *config2.Result
 
-	result, err := waitForTunnelCompletion(cancelCtx, ts)
-	wg.Wait()
+	err = sshBridge.RunPair(ctx,
+		func(ctx context.Context, stdin, stdout *os.File) error {
+			return executeSSHServerHelper(ctx, opts, stdin, stdout)
+		},
+		func(ctx context.Context, stdout, stdin *os.File) error {
+			if opts.AddPrivateKeys {
+				addPrivateKeys(ctx)
+			}
+			var runErr error
+			result, runErr = runSSHTunnel(ctx, sshTunnelParams{
+				opts:       opts,
+				stdout:     stdout,
+				stdin:      stdin,
+				grpcBridge: grpcBridge,
+			})
+			return runErr
+		},
+	)
 
 	return result, err
-}
-
-func setupTunnelContext(opts ExecuteCommandOptions) (*sshSessionTunnel, error) {
-	sshPipes, err := createPipes()
-	if err != nil {
-		return nil, err
-	}
-
-	grpcPipes, err := createPipes()
-	if err != nil {
-		sshPipes.Close()
-		return nil, err
-	}
-
-	return &sshSessionTunnel{
-		opts:       opts,
-		helperDone: make(chan sshTunnelResult, 1),
-		tunnelDone: make(chan sshTunnelResult, 1),
-		sshPipes:   sshPipes,
-		grpcPipes:  grpcPipes,
-	}, nil
-}
-
-func (ts *sshSessionTunnel) cleanup() {
-	ts.sshPipes.Close()
-	ts.grpcPipes.Close()
-}
-
-// cleanupTimeout is how long waitForTunnelCompletion waits for goroutines
-// to report after the tunnel server has returned a valid result.
-const cleanupTimeout = 10 * time.Second
-
-func waitForTunnelCompletion(ctx context.Context, ts *sshSessionTunnel) (*config2.Result, error) {
-	result, err := ts.opts.TunnelServerFunc(
-		ctx,
-		ts.grpcPipes.stdinWriter,
-		ts.grpcPipes.stdoutReader,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("tunnel server: %w", err)
-	}
-
-	log.Debug("awaiting tunnel server command completion")
-	errs := collectTunnelErrors(ts, result)
-	log.Debug("SSH tunnel execution completed")
-
-	return result, errors.Join(errs...)
-}
-
-// collectTunnelErrors drains helperDone and tunnelDone, returning any
-// real errors. EOF from the tunnel goroutine is ignored when a valid result
-// already exists.
-func collectTunnelErrors(
-	ts *sshSessionTunnel,
-	result *config2.Result,
-) []error {
-	var errs []error
-	timer := time.NewTimer(cleanupTimeout)
-	defer timer.Stop()
-
-	for range 2 {
-		select {
-		case r := <-ts.helperDone:
-			if r.err != nil {
-				log.Debugf("helper goroutine error: %v", r.err)
-				errs = append(errs, r.err)
-			}
-		case r := <-ts.tunnelDone:
-			if isTunnelError(r.err, result) {
-				log.Debugf("tunnel goroutine error: %v", r.err)
-				errs = append(errs, r.err)
-			}
-		case <-timer.C:
-			log.Debug("timed out waiting for goroutines after successful result")
-
-			return errs
-		}
-	}
-
-	return errs
-}
-
-// isTunnelError reports whether a tunnel goroutine error is a real failure.
-// EOF is expected when a valid result exists (the SSH session closes normally).
-func isTunnelError(err error, result *config2.Result) bool {
-	return err != nil && (result == nil || !errors.Is(err, io.EOF))
-}
-
-type pipePair struct {
-	stdoutReader *os.File
-	stdoutWriter *os.File
-	stdinReader  *os.File
-	stdinWriter  *os.File
-}
-
-func (p *pipePair) Close() {
-	closeFile := func(fp **os.File) {
-		if *fp != nil {
-			_ = (*fp).Close()
-			*fp = nil
-		}
-	}
-	closeFile(&p.stdoutReader)
-	closeFile(&p.stdoutWriter)
-	closeFile(&p.stdinReader)
-	closeFile(&p.stdinWriter)
-}
-
-func createPipes() (*pipePair, error) {
-	stdoutReader, stdoutWriter, err := os.Pipe()
-	if err != nil {
-		return nil, err
-	}
-	stdinReader, stdinWriter, err := os.Pipe()
-	if err != nil {
-		_ = stdoutReader.Close()
-		_ = stdoutWriter.Close()
-		return nil, err
-	}
-	return &pipePair{
-		stdoutReader: stdoutReader,
-		stdoutWriter: stdoutWriter,
-		stdinReader:  stdinReader,
-		stdinWriter:  stdinWriter,
-	}, nil
 }
 
 func isExpectedError(err error) bool {
@@ -224,35 +91,22 @@ func isExpectedError(err error) bool {
 	return false
 }
 
-// executeSSHServerHelper injects the agent and runs the SSH server helper
-// command. It returns a single goroutineResult; the caller sends it to
-// helperDone.
 func executeSSHServerHelper(
 	ctx context.Context,
-	cancel context.CancelFunc,
-	ts *sshSessionTunnel,
-) sshTunnelResult {
+	opts ExecuteCommandOptions,
+	stdin, stdout *os.File,
+) error {
 	defer log.Debug("done executing SSH server helper command")
-	defer cancel()
 
 	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 
-	log.Debugf("injecting and running SSH server command: %q", ts.opts.SSHCommand)
-	err := ts.opts.AgentInject(
-		ctx,
-		ts.opts.SSHCommand,
-		ts.sshPipes.stdinReader,
-		ts.sshPipes.stdoutWriter,
-		writer,
-	)
+	log.Debugf("injecting and running SSH server command: %q", opts.SSHCommand)
+	err := opts.AgentInject(ctx, opts.SSHCommand, stdin, stdout, writer)
 	if err != nil && !isExpectedError(err) {
-		return sshTunnelResult{
-			source: "helper",
-			err:    fmt.Errorf("executing agent command: %w", err),
-		}
+		return fmt.Errorf("executing agent command: %w", err)
 	}
-	return sshTunnelResult{source: "helper"}
+	return nil
 }
 
 func addPrivateKeys(ctx context.Context) {
@@ -263,27 +117,22 @@ func addPrivateKeys(ctx context.Context) {
 	}
 }
 
-// runSSHTunnel creates the SSH client, establishes a session, and runs the
-// agent command. It returns a single goroutineResult; the caller sends it to
-// tunnelDone.
-func runSSHTunnel(
-	ctx context.Context,
-	cancel context.CancelFunc,
-	ts *sshSessionTunnel,
-) sshTunnelResult {
-	defer cancel()
+type sshTunnelParams struct {
+	opts       ExecuteCommandOptions
+	stdout     *os.File
+	stdin      *os.File
+	grpcBridge *tunnel.PipeBridge
+}
 
+func runSSHTunnel(ctx context.Context, p sshTunnelParams) (*config2.Result, error) {
 	start := time.Now()
 	log.Infof("tunnel: setup start")
 	defer func() { log.Infof("tunnel: setup complete elapsed=%s", time.Since(start)) }()
 
 	log.Debug("creating SSH client")
-	sshClient, err := devssh.StdioClient(ts.sshPipes.stdoutReader, ts.sshPipes.stdinWriter, false)
+	sshClient, err := devssh.StdioClient(p.stdout, p.stdin, false)
 	if err != nil {
-		return sshTunnelResult{
-			source: "tunnel",
-			err:    fmt.Errorf("failed to create SSH client: %w", err),
-		}
+		return nil, fmt.Errorf("failed to create SSH client: %w", err)
 	}
 	log.Debugf("tunnel: ssh client created elapsed=%s", time.Since(start))
 	defer func() {
@@ -293,7 +142,7 @@ func runSSHTunnel(
 
 	sess, err := establishSSHSession(ctx, sshClient)
 	if err != nil {
-		return sshTunnelResult{source: "tunnel", err: err}
+		return nil, err
 	}
 	log.Debugf("tunnel: ssh session established elapsed=%s", time.Since(start))
 	defer func() {
@@ -301,11 +150,25 @@ func runSSHTunnel(
 		log.Debug("SSH session closed")
 	}()
 
-	if err = setupSSHAgentForwarding(sshClient, sess); err != nil {
-		return sshTunnelResult{source: "tunnel", err: fmt.Errorf("forward agent: %w", err)}
-	}
+	setupSSHAgentForwarding(sshClient, sess)
 
-	return runCommandInSSHTunnel(ctx, ts, sshClient)
+	var result *config2.Result
+
+	err = p.grpcBridge.RunPair(ctx,
+		func(ctx context.Context, stdin, stdout *os.File) error {
+			return runCommandInSSHTunnel(ctx, sshCommandParams{
+				sshClient: sshClient,
+				command:   p.opts.Command,
+			}, stdin, stdout)
+		},
+		func(ctx context.Context, stdout, stdin *os.File) error {
+			var serverErr error
+			result, serverErr = p.opts.TunnelServerFunc(ctx, stdin, stdout)
+			return serverErr
+		},
+	)
+
+	return result, err
 }
 
 func establishSSHSession(
@@ -353,13 +216,10 @@ func establishSSHSession(
 //
 // Stale SSH_AUTH_SOCK is common in practice (tmux, screen, reconnected
 // terminals), so a fatal error here would break devsy up for many users.
-func setupSSHAgentForwarding(
-	sshClient *ssh.Client,
-	sess *ssh.Session,
-) error {
+func setupSSHAgentForwarding(sshClient *ssh.Client, sess *ssh.Session) {
 	identityAgent := devsshagent.GetSSHAuthSocket()
 	if identityAgent == "" {
-		return nil
+		return
 	}
 
 	log.Debugf("forwarding SSH agent: socket=%s", identityAgent)
@@ -372,42 +232,33 @@ func setupSSHAgentForwarding(
 	if err != nil {
 		log.Warnf("SSH agent forwarding failed (continuing without agent): %v", err)
 	}
-	return nil
 }
 
-// runCommandInSSHTunnel runs the agent command over the SSH tunnel and returns
-// the result. EOF errors preserve the underlying io.EOF so the caller can
-// distinguish expected session closure from real failures.
-func runCommandInSSHTunnel(
-	ctx context.Context,
-	ts *sshSessionTunnel,
-	sshClient *ssh.Client,
-) sshTunnelResult {
+type sshCommandParams struct {
+	sshClient *ssh.Client
+	command   string
+}
+
+func runCommandInSSHTunnel(ctx context.Context, p sshCommandParams, stdin, stdout *os.File) error {
 	streamer := NewTunnelLogStreamer()
 	defer func() { _ = streamer.Close() }()
 
-	log.Debugf("running agent command in SSH tunnel: %q", ts.opts.Command)
+	log.Debugf("running agent command in SSH tunnel: %q", p.command)
 	err := devssh.Run(ctx, devssh.RunOptions{
-		Client:  sshClient,
-		Command: ts.opts.Command,
-		Stdin:   ts.grpcPipes.stdinReader,
-		Stdout:  ts.grpcPipes.stdoutWriter,
+		Client:  p.sshClient,
+		Command: p.command,
+		Stdin:   stdin,
+		Stdout:  stdout,
 		Stderr:  streamer,
 	})
 	if err != nil {
 		_ = streamer.Close()
 		if out := streamer.ErrorOutput(); out != "" {
-			return sshTunnelResult{
-				source: "tunnel",
-				err:    fmt.Errorf("run agent command failed: %w\n%s", err, out),
-			}
+			return fmt.Errorf("run agent command failed: %w\n%s", err, out)
 		}
-		return sshTunnelResult{
-			source: "tunnel",
-			err:    fmt.Errorf("run agent command failed: %w", err),
-		}
+		return fmt.Errorf("run agent command failed: %w", err)
 	}
-	return sshTunnelResult{source: "tunnel"}
+	return nil
 }
 
 const maxLogLines = 1

--- a/pkg/devcontainer/sshtunnel/sshtunnel_test.go
+++ b/pkg/devcontainer/sshtunnel/sshtunnel_test.go
@@ -2,10 +2,15 @@ package sshtunnel
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
+	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/tunnel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
@@ -184,21 +189,23 @@ func TestExtractLogLevel(t *testing.T) {
 func TestRunSSHTunnel_TimingLogs(t *testing.T) {
 	logs := log.InitTestObserved(t, zapcore.DebugLevel)
 
-	pipes, err := createPipes()
+	pb, err := tunnel.NewPipeBridge()
 	require.NoError(t, err)
+	defer pb.Close()
+
 	// Close the read side so StdioClient fails immediately.
-	_ = pipes.stdoutReader.Close()
+	_ = pb.StdoutReader.Close()
 
-	ts := &sshSessionTunnel{
-		sshPipes:  pipes,
-		grpcPipes: &pipePair{},
-	}
+	grpcBridge, err := tunnel.NewPipeBridge()
+	require.NoError(t, err)
+	defer grpcBridge.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	result := runSSHTunnel(ctx, cancel, ts)
-	require.Error(t, result.err)
+	_, err = runSSHTunnel(t.Context(), sshTunnelParams{
+		stdout:     pb.StdoutReader,
+		stdin:      pb.StdinWriter,
+		grpcBridge: grpcBridge,
+	})
+	require.Error(t, err)
 
 	messages := make([]string, 0, len(logs.All()))
 	for _, entry := range logs.All() {
@@ -240,4 +247,63 @@ func TestNormalizeLevel(t *testing.T) {
 			assert.Equal(t, tt.want, normalizeLevel(tt.input))
 		})
 	}
+}
+
+func TestExecuteCommand_PipeBridgeIntegration(t *testing.T) {
+	t.Run("helper error propagates through PipeBridge", func(t *testing.T) {
+		wantErr := fmt.Errorf("inject failed")
+
+		_, err := ExecuteCommand(context.Background(), ExecuteCommandOptions{
+			AgentInject: func(_ context.Context, _ string, _ *os.File, _ *os.File, _ io.WriteCloser) error {
+				return wantErr
+			},
+			SSHCommand: "test-ssh",
+			Command:    "test-cmd",
+			TunnelServerFunc: func(_ context.Context, _ io.WriteCloser, _ io.Reader) (*config2.Result, error) {
+				return nil, nil
+			},
+		})
+
+		require.Error(t, err)
+		// Error message varies by platform (pipe teardown ordering), so we
+		// only verify an error occurred.
+	})
+
+	t.Run("context cancellation stops execution", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		_, err := ExecuteCommand(ctx, ExecuteCommandOptions{
+			AgentInject: func(ctx context.Context, _ string, _ *os.File, _ *os.File, _ io.WriteCloser) error {
+				cancel()
+				<-ctx.Done()
+				return ctx.Err()
+			},
+			SSHCommand: "test-ssh",
+			Command:    "test-cmd",
+			TunnelServerFunc: func(_ context.Context, _ io.WriteCloser, _ io.Reader) (*config2.Result, error) {
+				return nil, nil
+			},
+		})
+
+		// Context cancellation is an expected error — RunPair classifies it
+		// and may return nil or a wrapped error. Either way, no hang.
+		_ = err
+	})
+}
+
+func TestExecuteCommand_NoPipePairOrTimerTypes(t *testing.T) {
+	// Verify the old types are gone by confirming the new code compiles
+	// without pipePair, sshTunnelResult, sshSessionTunnel, createPipes,
+	// collectTunnelErrors, waitForTunnelCompletion, or cleanupTimeout.
+	// This test documents the migration: if someone re-adds the old types,
+	// it signals they should use tunnel.PipeBridge instead.
+
+	pb, err := tunnel.NewPipeBridge()
+	require.NoError(t, err)
+	defer pb.Close()
+
+	assert.NotNil(t, pb.StdoutReader)
+	assert.NotNil(t, pb.StdoutWriter)
+	assert.NotNil(t, pb.StdinReader)
+	assert.NotNil(t, pb.StdinWriter)
 }

--- a/pkg/tunnel/pipebridge.go
+++ b/pkg/tunnel/pipebridge.go
@@ -62,10 +62,11 @@ func (pb *PipeBridge) RunPair(
 		handlerChan <- handlerFn(cancelCtx, pb.StdoutReader, pb.StdinWriter)
 	}()
 
-	return awaitPair(tunnelChan, handlerChan, pb.StdoutWriter, pb.StdinWriter)
+	return awaitPair(cancel, tunnelChan, handlerChan, pb.StdoutWriter, pb.StdinWriter)
 }
 
 func awaitPair(
+	cancel context.CancelFunc,
 	tunnelChan, handlerChan <-chan error,
 	stdoutWriter, stdinWriter *os.File,
 ) error {
@@ -78,6 +79,7 @@ func awaitPair(
 		default:
 		}
 	case tunnelErr = <-tunnelChan:
+		cancel()
 		_ = stdoutWriter.Close()
 		_ = stdinWriter.Close()
 		handlerErr = <-handlerChan


### PR DESCRIPTION
## Summary

- Replace hand-rolled `pipePair`/`createPipes` with `tunnel.PipeBridge` and use `RunPair` for both the SSH bridge (helper↔tunnel) and gRPC bridge (SSH command↔TunnelServerFunc)
- Eliminate the 10s `cleanupTimeout` timer that caused leaked goroutines to hold pipes open, leading to blocked pipes → timeout → context cancel → container SIGKILL → workspace stuck STOPPED
- Remove `pipePair`, `sshTunnelResult`, `sshSessionTunnel`, `setupTunnelContext`, `waitForTunnelCompletion`, and `collectTunnelErrors` — all replaced by `PipeBridge.RunPair` + `ClassifyTunnelErrors`
- Net reduction of ~80 lines; follows the same pattern used in `pkg/tunnel/container.go` and `pkg/tunnel/direct.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH tunnel concurrency and cancellation so commands no longer hang and helper errors surface reliably.
  * Agent forwarding is now best‑effort to avoid failing command execution.

* **Chores**
  * Internal refactor of SSH tunnel execution and coordination for clearer, more robust behavior; no public API changes.

* **Tests**
  * Added integration and timing tests to verify error propagation, cancellation behavior, and migration wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->