### PR TITLE
fix(features): enforce dependsOn constraints in overrideFeatureInstallOrder

### DIFF
--- a/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/.devcontainer.json
+++ b/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/.devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "image": "ghcr.io/devsy-org/test-images/base:alpine",
+  "features": {
+    "./features/base": {},
+    "./features/consumer": {}
+  },
+  "overrideFeatureInstallOrder": ["./features/consumer", "./features/base"]
+}

--- a/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/features/base/devcontainer-feature.json
+++ b/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/features/base/devcontainer-feature.json
@@ -1,0 +1,5 @@
+{
+  "id": "base",
+  "version": "0.1.0",
+  "name": "Base feature"
+}

--- a/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/features/base/install.sh
+++ b/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/features/base/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+echo "base" >> /tmp/feature-install-order.txt

--- a/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/features/base/install.sh
+++ b/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/features/base/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-echo "base" >> /tmp/feature-install-order.txt
+echo "base" >>/tmp/feature-install-order.txt

--- a/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/features/consumer/devcontainer-feature.json
+++ b/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/features/consumer/devcontainer-feature.json
@@ -1,0 +1,8 @@
+{
+  "id": "consumer",
+  "version": "0.1.0",
+  "name": "Consumer feature",
+  "dependsOn": {
+    "./features/base": {}
+  }
+}

--- a/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/features/consumer/install.sh
+++ b/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/features/consumer/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-echo "consumer" >> /tmp/feature-install-order.txt
+echo "consumer" >>/tmp/feature-install-order.txt

--- a/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/features/consumer/install.sh
+++ b/e2e/tests/up-features/testdata/docker-features-override-violates-depends-on/features/consumer/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+echo "consumer" >> /tmp/feature-install-order.txt

--- a/e2e/tests/up-features/testdata/docker-features-valid-override/.devcontainer.json
+++ b/e2e/tests/up-features/testdata/docker-features-valid-override/.devcontainer.json
@@ -5,5 +5,9 @@
     "./features/alpha": {},
     "./features/consumer": {}
   },
-  "overrideFeatureInstallOrder": ["./features/alpha", "./features/base", "./features/consumer"]
+  "overrideFeatureInstallOrder": [
+    "./features/alpha",
+    "./features/base",
+    "./features/consumer"
+  ]
 }

--- a/e2e/tests/up-features/testdata/docker-features-valid-override/.devcontainer.json
+++ b/e2e/tests/up-features/testdata/docker-features-valid-override/.devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "image": "ghcr.io/devsy-org/test-images/base:alpine",
+  "features": {
+    "./features/base": {},
+    "./features/alpha": {},
+    "./features/consumer": {}
+  },
+  "overrideFeatureInstallOrder": ["./features/alpha", "./features/base", "./features/consumer"]
+}

--- a/e2e/tests/up-features/testdata/docker-features-valid-override/features/alpha/devcontainer-feature.json
+++ b/e2e/tests/up-features/testdata/docker-features-valid-override/features/alpha/devcontainer-feature.json
@@ -1,0 +1,5 @@
+{
+  "id": "alpha",
+  "version": "0.1.0",
+  "name": "Alpha feature"
+}

--- a/e2e/tests/up-features/testdata/docker-features-valid-override/features/alpha/install.sh
+++ b/e2e/tests/up-features/testdata/docker-features-valid-override/features/alpha/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-echo "alpha" >> /tmp/feature-install-order.txt
+echo "alpha" >>/tmp/feature-install-order.txt

--- a/e2e/tests/up-features/testdata/docker-features-valid-override/features/alpha/install.sh
+++ b/e2e/tests/up-features/testdata/docker-features-valid-override/features/alpha/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+echo "alpha" >> /tmp/feature-install-order.txt

--- a/e2e/tests/up-features/testdata/docker-features-valid-override/features/base/devcontainer-feature.json
+++ b/e2e/tests/up-features/testdata/docker-features-valid-override/features/base/devcontainer-feature.json
@@ -1,0 +1,5 @@
+{
+  "id": "base",
+  "version": "0.1.0",
+  "name": "Base feature"
+}

--- a/e2e/tests/up-features/testdata/docker-features-valid-override/features/base/install.sh
+++ b/e2e/tests/up-features/testdata/docker-features-valid-override/features/base/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+echo "base" >> /tmp/feature-install-order.txt

--- a/e2e/tests/up-features/testdata/docker-features-valid-override/features/base/install.sh
+++ b/e2e/tests/up-features/testdata/docker-features-valid-override/features/base/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-echo "base" >> /tmp/feature-install-order.txt
+echo "base" >>/tmp/feature-install-order.txt

--- a/e2e/tests/up-features/testdata/docker-features-valid-override/features/consumer/devcontainer-feature.json
+++ b/e2e/tests/up-features/testdata/docker-features-valid-override/features/consumer/devcontainer-feature.json
@@ -1,0 +1,8 @@
+{
+  "id": "consumer",
+  "version": "0.1.0",
+  "name": "Consumer feature",
+  "dependsOn": {
+    "./features/base": {}
+  }
+}

--- a/e2e/tests/up-features/testdata/docker-features-valid-override/features/consumer/install.sh
+++ b/e2e/tests/up-features/testdata/docker-features-valid-override/features/consumer/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-echo "consumer" >> /tmp/feature-install-order.txt
+echo "consumer" >>/tmp/feature-install-order.txt

--- a/e2e/tests/up-features/testdata/docker-features-valid-override/features/consumer/install.sh
+++ b/e2e/tests/up-features/testdata/docker-features-valid-override/features/consumer/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+echo "consumer" >> /tmp/feature-install-order.txt

--- a/e2e/tests/up-features/up_features.go
+++ b/e2e/tests/up-features/up_features.go
@@ -550,4 +550,52 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(strings.TrimSpace(out), "ubuntu")
 	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It(
+		"should reject overrideFeatureInstallOrder that violates dependsOn",
+		ginkgo.Label("features", "override"),
+		func(ctx context.Context) {
+			f, err := setupDockerProvider(initialDir+"/bin", "docker")
+			framework.ExpectNoError(err)
+
+			tempDir, err := framework.CopyToTempDir(
+				"tests/up-features/testdata/docker-features-override-violates-depends-on",
+			)
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+			wsName := filepath.Base(tempDir)
+			ginkgo.DeferCleanup(f.DevsyWorkspaceDelete, wsName)
+
+			err = f.DevsyUp(ctx, tempDir)
+			framework.ExpectError(err)
+		},
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
+	)
+
+	ginkgo.It(
+		"should respect overrideFeatureInstallOrder when it satisfies dependsOn",
+		ginkgo.Label("features", "override"),
+		func(ctx context.Context) {
+			f, err := setupDockerProvider(initialDir+"/bin", "docker")
+			framework.ExpectNoError(err)
+
+			tempDir, err := framework.CopyToTempDir(
+				"tests/up-features/testdata/docker-features-valid-override",
+			)
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+			wsName := filepath.Base(tempDir)
+			ginkgo.DeferCleanup(f.DevsyWorkspaceDelete, wsName)
+
+			err = f.DevsyUp(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			out, err := f.DevsySSH(ctx, wsName, "cat /tmp/feature-install-order.txt")
+			framework.ExpectNoError(err)
+			gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("alpha\nbase\nconsumer"))
+		},
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
+	)
 })

--- a/pkg/devcontainer/feature/extend.go
+++ b/pkg/devcontainer/feature/extend.go
@@ -441,46 +441,93 @@ func getSortedFeatureSets(
 	devContainer *config.DevContainerConfig,
 	featureSets []*config.FeatureSet,
 ) ([]*config.FeatureSet, error) {
-	orderedFeatureSets, err := getOrderedFeatureSets(featureSets)
-	if err != nil {
+	if len(devContainer.OverrideFeatureInstallOrder) == 0 {
+		return getOrderedFeatureSets(featureSets)
+	}
+
+	featureLookup := buildFeatureLookupMap(featureSets)
+	priority := buildOverridePriority(devContainer.OverrideFeatureInstallOrder, featureLookup)
+
+	if err := validateOverrideOrder(priority, featureSets, featureLookup); err != nil {
 		return nil, err
 	}
 
-	if len(devContainer.OverrideFeatureInstallOrder) == 0 {
-		return orderedFeatureSets, nil
-	}
-
-	return sortFeaturesByOverride(devContainer.OverrideFeatureInstallOrder, orderedFeatureSets), nil
+	return getOrderedFeatureSetsWithPriority(featureSets, priority)
 }
 
-func sortFeaturesByOverride(
+func buildOverridePriority(
 	overrideOrder []string,
+	featureLookup map[string]*config.FeatureSet,
+) map[string]int {
+	priority := make(map[string]int)
+	for i, id := range overrideOrder {
+		if _, exists := featureLookup[id]; exists {
+			priority[id] = i
+			continue
+		}
+		normalizedID := normalizeFeatureID(id)
+		if _, exists := featureLookup[normalizedID]; exists {
+			priority[normalizedID] = i
+		}
+	}
+	return priority
+}
+
+func validateOverrideOrder(
+	priority map[string]int,
 	featureSets []*config.FeatureSet,
-) []*config.FeatureSet {
-	orderedFeatures := make([]*config.FeatureSet, 0, len(featureSets))
-	seen := make(map[string]bool)
-
-	for _, overrideFeatureID := range overrideOrder {
-		feature := extractFeatureByID(featureSets, overrideFeatureID)
-		if feature == nil {
-			normalizedID := normalizeFeatureID(overrideFeatureID)
-			feature = extractFeatureByID(featureSets, normalizedID)
-		}
-
-		if feature != nil && !seen[feature.ConfigID] {
-			orderedFeatures = append(orderedFeatures, feature)
-			seen[feature.ConfigID] = true
-		}
-	}
-
+	featureLookup map[string]*config.FeatureSet,
+) error {
 	for _, feature := range featureSets {
-		if !seen[feature.ConfigID] {
-			orderedFeatures = append(orderedFeatures, feature)
-			seen[feature.ConfigID] = true
+		featurePriority, featureHasPriority := priority[feature.ConfigID]
+		if !featureHasPriority {
+			continue
+		}
+
+		for depID := range feature.Config.DependsOn {
+			depConfigID := resolveDepConfigID(depID, featureLookup)
+			if depConfigID == "" {
+				continue
+			}
+			depPriority, depHasPriority := priority[depConfigID]
+			if !depHasPriority {
+				continue
+			}
+			if featurePriority < depPriority {
+				return fmt.Errorf(
+					"overrideFeatureInstallOrder places %q (position %d)"+
+						" before its dependency %q (position %d)",
+					feature.ConfigID,
+					featurePriority,
+					depConfigID,
+					depPriority,
+				)
+			}
 		}
 	}
+	return nil
+}
 
-	return orderedFeatures
+func resolveDepConfigID(depID string, featureLookup map[string]*config.FeatureSet) string {
+	if _, exists := featureLookup[depID]; exists {
+		return depID
+	}
+	normalizedID := normalizeFeatureID(depID)
+	if _, exists := featureLookup[normalizedID]; exists {
+		return normalizedID
+	}
+	return ""
+}
+
+func getOrderedFeatureSetsWithPriority(
+	features []*config.FeatureSet,
+	priority map[string]int,
+) ([]*config.FeatureSet, error) {
+	dependencyGraph, err := buildFeatureDependencyGraph(features)
+	if err != nil {
+		return nil, err
+	}
+	return dependencyGraph.SortWithPriority(priority)
 }
 
 func extractFeatureByID(features []*config.FeatureSet, featureID string) *config.FeatureSet {

--- a/pkg/devcontainer/feature/extend_test.go
+++ b/pkg/devcontainer/feature/extend_test.go
@@ -330,7 +330,7 @@ func (suite *ExtendTestSuite) TestComputeFeatureOrder_NoOverride() {
 	}
 }
 
-func (suite *ExtendTestSuite) TestComputeFeatureOrder_WithOverride() {
+func (suite *ExtendTestSuite) TestComputeFeatureOrder_OverrideViolatesDependsOn() {
 	devContainer := &config.DevContainerConfig{
 		DevContainerConfigBase: config.DevContainerConfigBase{
 			OverrideFeatureInstallOrder: []string{"feature-a", "feature-b"},
@@ -347,17 +347,34 @@ func (suite *ExtendTestSuite) TestComputeFeatureOrder_WithOverride() {
 		{ConfigID: "feature-b", Config: &config.FeatureConfig{DependsOn: config.DependsOnField{}}},
 	}
 
+	_, err := getSortedFeatureSets(devContainer, features)
+	suite.Error(err)
+	suite.Contains(err.Error(), "overrideFeatureInstallOrder")
+	suite.Contains(err.Error(), "dependency")
+}
+
+func (suite *ExtendTestSuite) TestComputeFeatureOrder_ValidOverride() {
+	devContainer := &config.DevContainerConfig{
+		DevContainerConfigBase: config.DevContainerConfigBase{
+			OverrideFeatureInstallOrder: []string{"feature-b", "feature-a"},
+		},
+	}
+
+	features := []*config.FeatureSet{
+		{
+			ConfigID: "feature-a",
+			Config: &config.FeatureConfig{
+				DependsOn: config.DependsOnField{"feature-b": map[string]any{}},
+			},
+		},
+		{ConfigID: "feature-b", Config: &config.FeatureConfig{DependsOn: config.DependsOnField{}}},
+	}
+
 	order, err := getSortedFeatureSets(devContainer, features)
 	suite.Require().NoError(err)
 	suite.Len(order, 2)
-	if order[0].ConfigID != "feature-a" || order[1].ConfigID != "feature-b" {
-		suite.Failf(
-			"Order mismatch",
-			"Expected [feature-a, feature-b], got [%s, %s]",
-			order[0].ConfigID,
-			order[1].ConfigID,
-		)
-	}
+	suite.Equal("feature-b", order[0].ConfigID)
+	suite.Equal("feature-a", order[1].ConfigID)
 }
 
 func (suite *ExtendTestSuite) TestComputeFeatureOrder_PartialOverride() {
@@ -387,28 +404,42 @@ func (suite *ExtendTestSuite) TestComputeFeatureOrder_PartialOverride() {
 	}
 }
 
-func (suite *ExtendTestSuite) TestApplyManualOrdering() {
-	automaticOrder := []*config.FeatureSet{
-		{ConfigID: "feature-a"},
-		{ConfigID: "feature-b"},
-		{ConfigID: "feature-c"},
+func (suite *ExtendTestSuite) TestBuildOverridePriority() {
+	features := []*config.FeatureSet{
+		{ConfigID: "feature-a", Config: &config.FeatureConfig{DependsOn: config.DependsOnField{}}},
+		{ConfigID: "feature-b", Config: &config.FeatureConfig{DependsOn: config.DependsOnField{}}},
+		{ConfigID: "feature-c", Config: &config.FeatureConfig{DependsOn: config.DependsOnField{}}},
 	}
+	lookup := buildFeatureLookupMap(features)
 
 	overrideOrder := []string{"feature-c", "feature-a"}
-	result := sortFeaturesByOverride(overrideOrder, automaticOrder)
-	expected := []string{"feature-c", "feature-a", "feature-b"}
-	suite.Len(result, 3)
-	for i, expectedID := range expected {
-		if result[i].ConfigID != expectedID {
-			suite.Failf(
-				"Position mismatch",
-				"Position %d: expected %s, got %s",
-				i,
-				expectedID,
-				result[i].ConfigID,
-			)
-		}
+	priority := buildOverridePriority(overrideOrder, lookup)
+
+	suite.Equal(0, priority["feature-c"])
+	suite.Equal(1, priority["feature-a"])
+	_, hasB := priority["feature-b"]
+	suite.False(hasB)
+}
+
+func (suite *ExtendTestSuite) TestOverridePriorityAffectsSortOrder() {
+	devContainer := &config.DevContainerConfig{
+		DevContainerConfigBase: config.DevContainerConfigBase{
+			OverrideFeatureInstallOrder: []string{"feature-c", "feature-a"},
+		},
 	}
+
+	features := []*config.FeatureSet{
+		{ConfigID: "feature-a", Config: &config.FeatureConfig{DependsOn: config.DependsOnField{}}},
+		{ConfigID: "feature-b", Config: &config.FeatureConfig{DependsOn: config.DependsOnField{}}},
+		{ConfigID: "feature-c", Config: &config.FeatureConfig{DependsOn: config.DependsOnField{}}},
+	}
+
+	order, err := getSortedFeatureSets(devContainer, features)
+	suite.Require().NoError(err)
+	suite.Len(order, 3)
+	suite.Equal("feature-c", order[0].ConfigID)
+	suite.Equal("feature-a", order[1].ConfigID)
+	suite.Equal("feature-b", order[2].ConfigID)
 }
 
 func (suite *ExtendTestSuite) TestExtractFeatureByID() {

--- a/pkg/devcontainer/graph/graph.go
+++ b/pkg/devcontainer/graph/graph.go
@@ -248,6 +248,22 @@ func (g *Graph[T]) Sort() ([]T, error) {
 	return result, nil
 }
 
+// SortWithPriority performs a topological sort where, within each round of
+// nodes that have zero in-degree, nodes are ordered by the supplied priority
+// map (lower value = installed first). Nodes not in the priority map sort
+// alphabetically after prioritized nodes.
+func (g *Graph[T]) SortWithPriority(priority map[string]int) ([]T, error) {
+	sortedIDs, err := g.sortNodeIDsWithPriority(priority)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]T, len(sortedIDs))
+	for i, id := range sortedIDs {
+		result[i] = g.nodes[id]
+	}
+	return result, nil
+}
+
 func (g *Graph[T]) SortNodeIDs() ([]string, error) {
 	return g.sortNodeIDs()
 }
@@ -349,4 +365,69 @@ func processNeighbors(
 			*queue = slices.Insert(*queue, insertPosition, neighborNode)
 		}
 	}
+}
+
+func (g *Graph[T]) sortNodeIDsWithPriority(priority map[string]int) ([]string, error) {
+	workingInDegree := copyInDegreeMap(g.inDegree)
+	ready := initializeQueue(workingInDegree)
+	sortedResult := make([]string, 0, len(g.nodes))
+
+	for len(ready) > 0 {
+		sortByPriority(ready, priority)
+
+		current := ready[0]
+		ready = ready[1:]
+		sortedResult = append(sortedResult, current)
+
+		processNeighborsUnordered(g.edges, current, workingInDegree, &ready)
+	}
+
+	if len(sortedResult) != len(g.nodes) {
+		return nil, circularDependencyError(workingInDegree)
+	}
+
+	return sortedResult, nil
+}
+
+func sortByPriority(ids []string, priority map[string]int) {
+	sort.Slice(ids, func(i, j int) bool {
+		return comparePriority(ids[i], ids[j], priority)
+	})
+}
+
+func comparePriority(a, b string, priority map[string]int) bool {
+	pa, oka := priority[a]
+	pb, okb := priority[b]
+	if oka != okb {
+		return oka
+	}
+	if oka && pa != pb {
+		return pa < pb
+	}
+	return a < b
+}
+
+func processNeighborsUnordered(
+	edges map[string][]string,
+	currentNode string,
+	inDegree map[string]int,
+	queue *[]string,
+) {
+	for _, neighbor := range edges[currentNode] {
+		inDegree[neighbor]--
+		if inDegree[neighbor] == 0 {
+			*queue = append(*queue, neighbor)
+		}
+	}
+}
+
+func circularDependencyError(inDegree map[string]int) error {
+	remaining := []string{}
+	for id, deg := range inDegree {
+		if deg > 0 {
+			remaining = append(remaining, id)
+		}
+	}
+	sort.Strings(remaining)
+	return fmt.Errorf("circular dependency detected among nodes: %v", remaining)
 }


### PR DESCRIPTION
## Summary

- **Enforce dependsOn constraints**: `overrideFeatureInstallOrder` now returns an error if it places a feature before any of its `dependsOn` dependencies, rather than silently accepting the violation
- **Spec-compliant round-based sorting**: Replace the two-phase approach (Kahn topological sort + post-sort reorder) with a single priority-aware topological sort that integrates `overrideFeatureInstallOrder` priorities directly into each round of the algorithm
- **New graph method**: Add `SortWithPriority()` to the graph package, which performs topological sort with priority-based tie-breaking within each round of zero in-degree nodes
- **Updated tests**: Convert the existing override-violates-dependency test to expect an error, add new tests for valid overrides, priority building, and priority-influenced sort order