### PR TITLE
fix(tunnel): PipeBridge shutdown and goroutine leak fixes

### DIFF
--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -128,9 +128,16 @@ func (t *tunnelServer) RunWithResult(
 	go func() {
 		errChan <- s.Serve(lis)
 	}()
+	go func() {
+		<-ctx.Done()
+		s.Stop()
+	}()
 
 	select {
 	case err := <-errChan:
+		if t.result != nil {
+			return t.result, nil
+		}
 		return nil, err
 	case <-ctx.Done():
 		return t.result, nil

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -128,8 +128,11 @@ func (t *tunnelServer) RunWithResult(
 	go func() {
 		errChan <- s.Serve(lis)
 	}()
+
+	stopCtx, stopCancel := context.WithCancel(ctx)
+	defer stopCancel()
 	go func() {
-		<-ctx.Done()
+		<-stopCtx.Done()
 		s.Stop()
 	}()
 

--- a/pkg/tunnel/pipebridge.go
+++ b/pkg/tunnel/pipebridge.go
@@ -62,10 +62,11 @@ func (pb *PipeBridge) RunPair(
 		handlerChan <- handlerFn(cancelCtx, pb.StdoutReader, pb.StdinWriter)
 	}()
 
-	return awaitPair(tunnelChan, handlerChan, pb.StdoutWriter, pb.StdinWriter)
+	return awaitPair(cancel, tunnelChan, handlerChan, pb.StdoutWriter, pb.StdinWriter)
 }
 
 func awaitPair(
+	cancel context.CancelFunc,
 	tunnelChan, handlerChan <-chan error,
 	stdoutWriter, stdinWriter *os.File,
 ) error {
@@ -78,6 +79,7 @@ func awaitPair(
 		default:
 		}
 	case tunnelErr = <-tunnelChan:
+		cancel()
 		_ = stdoutWriter.Close()
 		_ = stdinWriter.Close()
 		handlerErr = <-handlerChan


### PR DESCRIPTION
## Summary

- **awaitPair context cancellation**: `awaitPair()` now accepts a `context.CancelFunc` parameter and calls `cancel()` when the tunnel finishes before the handler, ensuring the handler's context is properly cancelled and preventing hangs in dependent operations.
- **gRPC server shutdown on context cancel**: `RunWithResult()` now launches a goroutine that monitors the context and calls `grpcServer.Stop()` when the context is cancelled, preventing `RunWithResult` from hanging when the caller cancels.
- **Goroutine leak in RunWithResult stop goroutine**: The stop goroutine now uses a dedicated `stopCtx` that is cancelled after `grpcServer.Serve()` returns, ensuring the goroutine exits cleanly in the normal (non-cancelled) path instead of leaking.