### PR TITLE
fix(exec): use workspace UID for container lookup

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/devcontainer"
 	devcconfig "github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/log"
@@ -82,7 +83,7 @@ func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
 	dockerCommand := resolveDockerCommand(client.WorkspaceConfig())
 
 	containerDetails, err := findRunningContainer(
-		ctx, dockerCommand, client.Workspace(),
+		ctx, dockerCommand, devcontainer.GetRunnerIDFromWorkspace(client.WorkspaceConfig()),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- The `devsy exec` command was looking up containers using `workspace.ID` (e.g., `temp-3184360560`), but containers are labeled during `devsy up` using `GetRunnerIDFromWorkspace()` which returns `workspace.UID` (e.g., `default-te-3bd5e`). This mismatch caused `no running container found` errors.
- Changed `cmd/exec.go` to use `devcontainer.GetRunnerIDFromWorkspace(client.WorkspaceConfig())` for the container lookup, matching how containers are labeled during creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container identification mechanism to use workspace configuration sources for more accurate and reliable container lookup during execution operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->