### PR TITLE
fix(build): wire devcontainer.json cacheFrom into docker build args

### DIFF
--- a/pkg/devcontainer/build/options.go
+++ b/pkg/devcontainer/build/options.go
@@ -154,7 +154,11 @@ func NewOptions(params NewOptionsParams) (*BuildOptions, error) {
 				),
 			}
 		}
-	} else {
+	}
+	if configCacheFrom := params.ParsedConfig.Config.GetCacheFrom(); len(configCacheFrom) > 0 {
+		buildOptions.CacheFrom = append(buildOptions.CacheFrom, configCacheFrom...)
+	}
+	if len(buildOptions.CacheFrom) == 0 {
 		buildOptions.BuildArgs["BUILDKIT_INLINE_CACHE"] = "1"
 	}
 

--- a/pkg/devcontainer/build/options_test.go
+++ b/pkg/devcontainer/build/options_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/types"
 )
 
+const testCacheImage = "myregistry.io/cache:latest"
+
 func substitutedConfig(cfg *config.DevContainerConfig) *config.SubstitutedConfig {
 	return &config.SubstitutedConfig{Config: cfg, Raw: cfg}
 }
@@ -17,7 +19,7 @@ func TestNewOptions_CacheFrom_ConfigOnly(t *testing.T) {
 		ParsedConfig: substitutedConfig(&config.DevContainerConfig{
 			DockerfileContainer: config.DockerfileContainer{
 				Build: &config.ConfigBuildOptions{
-					CacheFrom: types.StrArray{"myregistry.io/cache:latest", "other:tag"},
+					CacheFrom: types.StrArray{testCacheImage, "other:tag"},
 				},
 			},
 		}),
@@ -30,7 +32,7 @@ func TestNewOptions_CacheFrom_ConfigOnly(t *testing.T) {
 	if len(opts.CacheFrom) != 2 {
 		t.Fatalf("expected 2 CacheFrom entries, got %d: %v", len(opts.CacheFrom), opts.CacheFrom)
 	}
-	if opts.CacheFrom[0] != "myregistry.io/cache:latest" || opts.CacheFrom[1] != "other:tag" {
+	if opts.CacheFrom[0] != testCacheImage || opts.CacheFrom[1] != "other:tag" {
 		t.Fatalf("unexpected CacheFrom: %v", opts.CacheFrom)
 	}
 	if _, ok := opts.BuildArgs["BUILDKIT_INLINE_CACHE"]; ok {
@@ -43,7 +45,7 @@ func TestNewOptions_CacheFrom_CLIAndConfig(t *testing.T) {
 		ParsedConfig: substitutedConfig(&config.DevContainerConfig{
 			DockerfileContainer: config.DockerfileContainer{
 				Build: &config.ConfigBuildOptions{
-					CacheFrom: types.StrArray{"myregistry.io/cache:latest"},
+					CacheFrom: types.StrArray{testCacheImage},
 				},
 			},
 		}),
@@ -61,7 +63,7 @@ func TestNewOptions_CacheFrom_CLIAndConfig(t *testing.T) {
 	if opts.CacheFrom[0] != "type=registry,ref=registry.example.com/cache" {
 		t.Fatalf("expected CLI registry cache first, got: %s", opts.CacheFrom[0])
 	}
-	if opts.CacheFrom[1] != "myregistry.io/cache:latest" {
+	if opts.CacheFrom[1] != testCacheImage {
 		t.Fatalf("expected config cache second, got: %s", opts.CacheFrom[1])
 	}
 }

--- a/pkg/devcontainer/build/options_test.go
+++ b/pkg/devcontainer/build/options_test.go
@@ -1,0 +1,84 @@
+package build
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/provider"
+	"github.com/devsy-org/devsy/pkg/types"
+)
+
+func substitutedConfig(cfg *config.DevContainerConfig) *config.SubstitutedConfig {
+	return &config.SubstitutedConfig{Config: cfg, Raw: cfg}
+}
+
+func TestNewOptions_CacheFrom_ConfigOnly(t *testing.T) {
+	params := NewOptionsParams{
+		ParsedConfig: substitutedConfig(&config.DevContainerConfig{
+			DockerfileContainer: config.DockerfileContainer{
+				Build: &config.ConfigBuildOptions{
+					CacheFrom: types.StrArray{"myregistry.io/cache:latest", "other:tag"},
+				},
+			},
+		}),
+		Options: provider.BuildOptions{},
+	}
+	opts, err := NewOptions(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(opts.CacheFrom) != 2 {
+		t.Fatalf("expected 2 CacheFrom entries, got %d: %v", len(opts.CacheFrom), opts.CacheFrom)
+	}
+	if opts.CacheFrom[0] != "myregistry.io/cache:latest" || opts.CacheFrom[1] != "other:tag" {
+		t.Fatalf("unexpected CacheFrom: %v", opts.CacheFrom)
+	}
+	if _, ok := opts.BuildArgs["BUILDKIT_INLINE_CACHE"]; ok {
+		t.Fatal("BUILDKIT_INLINE_CACHE should not be set when cacheFrom is configured")
+	}
+}
+
+func TestNewOptions_CacheFrom_CLIAndConfig(t *testing.T) {
+	params := NewOptionsParams{
+		ParsedConfig: substitutedConfig(&config.DevContainerConfig{
+			DockerfileContainer: config.DockerfileContainer{
+				Build: &config.ConfigBuildOptions{
+					CacheFrom: types.StrArray{"myregistry.io/cache:latest"},
+				},
+			},
+		}),
+		Options: provider.BuildOptions{
+			RegistryCache: "registry.example.com/cache",
+		},
+	}
+	opts, err := NewOptions(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(opts.CacheFrom) != 2 {
+		t.Fatalf("expected 2 CacheFrom entries, got %d: %v", len(opts.CacheFrom), opts.CacheFrom)
+	}
+	if opts.CacheFrom[0] != "type=registry,ref=registry.example.com/cache" {
+		t.Fatalf("expected CLI registry cache first, got: %s", opts.CacheFrom[0])
+	}
+	if opts.CacheFrom[1] != "myregistry.io/cache:latest" {
+		t.Fatalf("expected config cache second, got: %s", opts.CacheFrom[1])
+	}
+}
+
+func TestNewOptions_CacheFrom_Fallback(t *testing.T) {
+	params := NewOptionsParams{
+		ParsedConfig: substitutedConfig(&config.DevContainerConfig{}),
+		Options:      provider.BuildOptions{},
+	}
+	opts, err := NewOptions(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(opts.CacheFrom) != 0 {
+		t.Fatalf("expected empty CacheFrom, got: %v", opts.CacheFrom)
+	}
+	if opts.BuildArgs["BUILDKIT_INLINE_CACHE"] != "1" {
+		t.Fatal("expected BUILDKIT_INLINE_CACHE=1 as fallback")
+	}
+}


### PR DESCRIPTION
## Summary

- `GetCacheFrom()` at `config.go:278-283` had zero call sites — devcontainer.json `build.cacheFrom` values were parsed but never reached the Docker build command
- Wired `GetCacheFrom()` result into `buildOptions.CacheFrom` in `build/options.go` alongside the existing CLI `RegistryCache` path
- CLI registry cache entries take priority (first in the list), followed by devcontainer.json values
- `BUILDKIT_INLINE_CACHE` fallback only activates when no cache sources exist from either CLI or config
- Added test coverage for config-only, CLI+config combined, and fallback scenarios (3 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker build cache handling: cache sources from configuration files are now properly combined with CLI options, prioritizing registry caches.
  * Refined cache fallback behavior: inline caching only enables when no cache sources are configured.

* **Tests**
  * Added comprehensive test coverage for cache configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->