### PR TITLE
feat(build): add CLI --cache-from flags with priority over devcontainer.json

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -161,7 +161,7 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 		"Push image directly to registry during build, skipping load to local daemon.",
 	)
 	buildCmd.Flags().
-		StringSliceVar(&cmd.CacheFrom, "cache-from", []string{},
+		StringArrayVar(&cmd.CacheFrom, "cache-from", []string{},
 			"Cache sources for the build (e.g., myregistry.io/cache:latest or type=registry,ref=...). "+
 				"Takes priority over devcontainer.json build.cacheFrom")
 	buildCmd.Flags().

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -161,6 +161,10 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 		"Push image directly to registry during build, skipping load to local daemon.",
 	)
 	buildCmd.Flags().
+		StringSliceVar(&cmd.CacheFrom, "cache-from", []string{},
+			"Cache sources for the build (e.g., myregistry.io/cache:latest or type=registry,ref=...). "+
+				"Takes priority over devcontainer.json build.cacheFrom")
+	buildCmd.Flags().
 		Var(&cmd.GitCloneStrategy, "git-clone-strategy",
 			"The git clone strategy Devsy uses to checkout git based workspaces. "+
 				"Can be full (default), blobless, treeless or shallow")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -243,7 +243,7 @@ func (cmd *UpCmd) registerWorkspaceFlags(upCmd *cobra.Command) {
 		BoolVar(&cmd.DisableDaemon, "disable-daemon", false,
 			"If enabled, will not install a daemon into the target machine to track activity")
 	upCmd.Flags().
-		StringSliceVar(&cmd.CacheFrom, "cache-from", []string{},
+		StringArrayVar(&cmd.CacheFrom, "cache-from", []string{},
 			"Cache sources for the build (e.g., myregistry.io/cache:latest or type=registry,ref=...). "+
 				"Takes priority over devcontainer.json build.cacheFrom")
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -242,6 +242,10 @@ func (cmd *UpCmd) registerWorkspaceFlags(upCmd *cobra.Command) {
 	upCmd.Flags().
 		BoolVar(&cmd.DisableDaemon, "disable-daemon", false,
 			"If enabled, will not install a daemon into the target machine to track activity")
+	upCmd.Flags().
+		StringSliceVar(&cmd.CacheFrom, "cache-from", []string{},
+			"Cache sources for the build (e.g., myregistry.io/cache:latest or type=registry,ref=...). "+
+				"Takes priority over devcontainer.json build.cacheFrom")
 }
 
 func (cmd *UpCmd) registerTestingFlags(upCmd *cobra.Command) {

--- a/e2e/tests/build/build.go
+++ b/e2e/tests/build/build.go
@@ -242,6 +242,32 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 		},
 	)
 
+	ginkgo.It("should build with --cache-from flag",
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		func(ctx context.Context) {
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+			tempDir, err := framework.CopyToTempDir("tests/build/testdata/docker")
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+			_ = f.DevsyProviderDelete(ctx, "docker")
+			err = f.DevsyProviderAdd(ctx, "docker")
+			framework.ExpectNoError(err)
+			err = f.DevsyProviderUse(ctx, "docker")
+			framework.ExpectNoError(err)
+
+			ginkgo.DeferCleanup(f.DevsyWorkspaceDelete, tempDir)
+
+			err = f.DevsyBuild(
+				ctx,
+				tempDir,
+				"--skip-push",
+				"--cache-from",
+				"ghcr.io/devsy-org/test-images/base:alpine",
+			)
+			framework.ExpectNoError(err)
+		})
+
 	ginkgo.It("build docker internal buildkit",
 		ginkgo.SpecTimeout(framework.TimeoutShort()),
 		func(ctx context.Context) {

--- a/pkg/devcontainer/build/options.go
+++ b/pkg/devcontainer/build/options.go
@@ -155,7 +155,9 @@ func NewOptions(params NewOptionsParams) (*BuildOptions, error) {
 			}
 		}
 	}
-	if configCacheFrom := params.ParsedConfig.Config.GetCacheFrom(); len(configCacheFrom) > 0 {
+	if len(params.Options.CacheFrom) > 0 {
+		buildOptions.CacheFrom = append(buildOptions.CacheFrom, params.Options.CacheFrom...)
+	} else if configCacheFrom := params.ParsedConfig.Config.GetCacheFrom(); len(configCacheFrom) > 0 {
 		buildOptions.CacheFrom = append(buildOptions.CacheFrom, configCacheFrom...)
 	}
 	if len(buildOptions.CacheFrom) == 0 {

--- a/pkg/devcontainer/build/options_test.go
+++ b/pkg/devcontainer/build/options_test.go
@@ -8,7 +8,10 @@ import (
 	"github.com/devsy-org/devsy/pkg/types"
 )
 
-const testCacheImage = "myregistry.io/cache:latest"
+const (
+	testCacheImage    = "myregistry.io/cache:latest"
+	testCLICacheImage = "cli-override:v1"
+)
 
 func substitutedConfig(cfg *config.DevContainerConfig) *config.SubstitutedConfig {
 	return &config.SubstitutedConfig{Config: cfg, Raw: cfg}
@@ -65,6 +68,92 @@ func TestNewOptions_CacheFrom_CLIAndConfig(t *testing.T) {
 	}
 	if opts.CacheFrom[1] != testCacheImage {
 		t.Fatalf("expected config cache second, got: %s", opts.CacheFrom[1])
+	}
+}
+
+func TestNewOptions_CacheFrom_CLIOnly(t *testing.T) {
+	params := NewOptionsParams{
+		ParsedConfig: substitutedConfig(&config.DevContainerConfig{}),
+		Options: provider.BuildOptions{
+			CLIOptions: provider.CLIOptions{
+				CacheFrom: []string{"cli-cache:latest"},
+			},
+		},
+	}
+	opts, err := NewOptions(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(opts.CacheFrom) != 1 {
+		t.Fatalf("expected 1 CacheFrom entry, got %d: %v", len(opts.CacheFrom), opts.CacheFrom)
+	}
+	if opts.CacheFrom[0] != "cli-cache:latest" {
+		t.Fatalf("expected CLI cache-from value, got: %s", opts.CacheFrom[0])
+	}
+	if _, ok := opts.BuildArgs["BUILDKIT_INLINE_CACHE"]; ok {
+		t.Fatal("BUILDKIT_INLINE_CACHE should not be set when CLI cacheFrom is configured")
+	}
+}
+
+func TestNewOptions_CacheFrom_CLIOverridesConfig(t *testing.T) {
+	params := NewOptionsParams{
+		ParsedConfig: substitutedConfig(&config.DevContainerConfig{
+			DockerfileContainer: config.DockerfileContainer{
+				Build: &config.ConfigBuildOptions{
+					CacheFrom: types.StrArray{testCacheImage, "other:tag"},
+				},
+			},
+		}),
+		Options: provider.BuildOptions{
+			CLIOptions: provider.CLIOptions{
+				CacheFrom: []string{testCLICacheImage},
+			},
+		},
+	}
+	opts, err := NewOptions(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(opts.CacheFrom) != 1 {
+		t.Fatalf(
+			"expected 1 CacheFrom entry (CLI overrides config), got %d: %v",
+			len(opts.CacheFrom),
+			opts.CacheFrom,
+		)
+	}
+	if opts.CacheFrom[0] != testCLICacheImage {
+		t.Fatalf("expected CLI cache-from to override config, got: %s", opts.CacheFrom[0])
+	}
+}
+
+func TestNewOptions_CacheFrom_CLIOverridesConfigWithRegistryCache(t *testing.T) {
+	params := NewOptionsParams{
+		ParsedConfig: substitutedConfig(&config.DevContainerConfig{
+			DockerfileContainer: config.DockerfileContainer{
+				Build: &config.ConfigBuildOptions{
+					CacheFrom: types.StrArray{testCacheImage},
+				},
+			},
+		}),
+		Options: provider.BuildOptions{
+			CLIOptions: provider.CLIOptions{
+				CacheFrom: []string{testCLICacheImage},
+			},
+			RegistryCache: "registry.example.com/cache",
+		},
+	}
+	opts, err := NewOptions(params)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(opts.CacheFrom) != 2 {
+		t.Fatalf("expected 2 CacheFrom entries, got %d: %v", len(opts.CacheFrom), opts.CacheFrom)
+	}
+	if opts.CacheFrom[0] != "type=registry,ref=registry.example.com/cache" {
+		t.Fatalf("expected registry cache first, got: %s", opts.CacheFrom[0])
+	}
+	if opts.CacheFrom[1] != testCLICacheImage {
+		t.Fatalf("expected CLI cache-from second (overriding config), got: %s", opts.CacheFrom[1])
 	}
 }
 

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -256,6 +256,9 @@ type CLIOptions struct {
 	Platforms []string `json:"platform,omitempty"`
 	// Tag specifies additional image tags to apply to the built image beyond the default prebuild hash tag.
 	Tag []string `json:"tag,omitempty"`
+	// CacheFrom specifies images to use as cache sources. When set, these take priority over
+	// devcontainer.json build.cacheFrom values.
+	CacheFrom []string `json:"cacheFrom,omitempty"`
 
 	// ForceBuild forces a rebuild even if a cached image exists.
 	ForceBuild bool `json:"forceBuild,omitempty"`


### PR DESCRIPTION
## Summary

Adds `--cache-from` flag to `build` and `up` CLI commands. When specified, CLI cache-from values take priority over `devcontainer.json` `build.cacheFrom` config values, while `--registry-cache` entries are preserved independently. Includes unit tests for CLI-only, config-only, CLI-overrides-config, combined with registry-cache, and empty/fallback cases, plus an E2E test validating the flag works end-to-end with `devsy build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--cache-from` flag to the build and up commands, allowing users to provide one or more cache source specifications (registry references, etc.) that take priority over the corresponding settings in devcontainer.json.

* **Tests**
  * Extended test coverage to validate the new cache source feature across multiple scenarios, including CLI-only configurations, precedence behavior, and interactions with other build settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->