### PR TITLE
feat(config): add securityOpt passthrough to container create

### DIFF
--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -508,6 +508,26 @@ var _ = ginkgo.Describe(
 			ginkgo.SpecTimeout(framework.TimeoutShort()),
 		)
 
+		ginkgo.It("security options", func(ctx context.Context) {
+			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker-securityopt")
+			framework.ExpectNoError(err)
+
+			workspace, err := dtc.f.FindWorkspace(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			ids, err := dtc.findWorkspaceContainer(ctx, workspace)
+			framework.ExpectNoError(err)
+			gomega.Expect(ids).To(gomega.HaveLen(1))
+
+			var details []container.InspectResponse
+			err = dtc.dockerHelper.Inspect(ctx, ids, "container", &details)
+			framework.ExpectNoError(err)
+			gomega.Expect(details[0].HostConfig.SecurityOpt).
+				To(gomega.ContainElement("seccomp=unconfined"))
+			gomega.Expect(details[0].HostConfig.SecurityOpt).
+				To(gomega.ContainElement("apparmor=unconfined"))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
 		ginkgo.It("multi devcontainer selection", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
 				"tests/up/testdata/docker-multi-devcontainer",

--- a/e2e/tests/up/testdata/docker-securityopt/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-securityopt/.devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "Go",
+  "image": "ghcr.io/devsy-org/test-images/go:1",
+  "securityOpt": ["seccomp=unconfined", "apparmor=unconfined"]
+}

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -438,8 +438,9 @@ func (r *runner) getDockerlessRunOptions(
 			"--cmd", GetStartScript(mergedConfig),
 			"--user", buildInfo.Dockerless.User,
 		},
-		Env:    env,
-		CapAdd: mergedConfig.CapAdd,
+		Env:         env,
+		CapAdd:      mergedConfig.CapAdd,
+		SecurityOpt: mergedConfig.SecurityOpt,
 		Labels: []string{
 			metadata.ImageMetadataLabel + "=" + string(marshalled),
 			config.UserLabel + "=" + buildInfo.Dockerless.User,

--- a/pkg/driver/docker/docker_test.go
+++ b/pkg/driver/docker/docker_test.go
@@ -5,7 +5,13 @@ import (
 	"testing"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/driver"
 	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testSeccompUnconfined = "seccomp=unconfined"
+	testSecurityOptFlag   = "--security-opt"
 )
 
 type DockerDriverTestSuite struct {
@@ -136,4 +142,39 @@ func (s *DockerDriverTestSuite) TestGatherUpdateRequirements_WithContainerUser()
 	s.NoError(err)
 	s.NotNil(localUser)
 	s.Equal("container", containerUser)
+}
+
+func (s *DockerDriverTestSuite) TestAddCapabilityArgs_SingleSecurityOpt() {
+	opts := &driver.RunOptions{SecurityOpt: []string{testSeccompUnconfined}}
+	args := s.driver.addCapabilityArgs(nil, opts)
+	s.Equal([]string{testSecurityOptFlag, testSeccompUnconfined}, args)
+}
+
+func (s *DockerDriverTestSuite) TestAddCapabilityArgs_MultipleSecurityOpts() {
+	opts := &driver.RunOptions{
+		SecurityOpt: []string{testSeccompUnconfined, "apparmor=unconfined"},
+	}
+	args := s.driver.addCapabilityArgs(nil, opts)
+	s.Equal([]string{
+		testSecurityOptFlag, testSeccompUnconfined,
+		testSecurityOptFlag, "apparmor=unconfined",
+	}, args)
+}
+
+func (s *DockerDriverTestSuite) TestAddCapabilityArgs_EmptySecurityOpt() {
+	opts := &driver.RunOptions{}
+	args := s.driver.addCapabilityArgs(nil, opts)
+	s.Nil(args)
+}
+
+func (s *DockerDriverTestSuite) TestAddCapabilityArgs_CapAddAndSecurityOpt() {
+	opts := &driver.RunOptions{
+		CapAdd:      []string{"SYS_PTRACE"},
+		SecurityOpt: []string{testSeccompUnconfined},
+	}
+	args := s.driver.addCapabilityArgs(nil, opts)
+	s.Equal([]string{
+		"--cap-add", "SYS_PTRACE",
+		testSecurityOptFlag, testSeccompUnconfined,
+	}, args)
 }


### PR DESCRIPTION
## Summary

- Wire `securityOpt` values from `devcontainer.json` through to `docker run` as `--security-opt` flags
- Fix missing `SecurityOpt` field in the dockerless container creation path (`getDockerlessRunOptions`)
- Add unit tests covering single opt, multiple opts, empty opts, and combined cap-add + security-opt
- Add E2E test and testdata for docker provider validating `seccomp=unconfined` and `apparmor=unconfined` applied to container

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Docker security options configuration in devcontainer files, enabling users to customize security enforcement settings including seccomp and AppArmor profiles.

* **Tests**
  * Added comprehensive test suite covering Docker security option argument generation, configuration parsing, and end-to-end fixture validation with various security option combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->