### PR TITLE
feat(tunnel): apply otherPortsAttributes defaults to unlisted ports

### DIFF
--- a/cmd/agent/container/credentials_server.go
+++ b/cmd/agent/container/credentials_server.go
@@ -12,7 +12,9 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent/tunnel"
 	"github.com/devsy-org/devsy/pkg/agent/tunnelserver"
+	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/credentials"
+	devconfig "github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/dockercredentials"
 	"github.com/devsy-org/devsy/pkg/gitcredentials"
 	"github.com/devsy-org/devsy/pkg/gitsshsigning"
@@ -201,7 +203,31 @@ func configureGitUserLocally(
 }
 
 func forwardPorts(ctx context.Context, client tunnel.TunnelClient) error {
-	return netstat.NewWatcher(&forwarder{ctx: ctx, client: client}).Run(ctx)
+	opts := portFilterFromResult()
+	return netstat.NewWatcher(&forwarder{ctx: ctx, client: client}, opts...).Run(ctx)
+}
+
+func portFilterFromResult() []netstat.WatcherOption {
+	raw, err := os.ReadFile(config.DevContainerResultPath)
+	if err != nil {
+		log.Debugf("Could not read result for port attributes: %v", err)
+		return nil
+	}
+	result := &devconfig.Result{}
+	if err := json.Unmarshal(raw, result); err != nil {
+		log.Debugf("Could not parse result for port attributes: %v", err)
+		return nil
+	}
+	mc := result.MergedConfig
+	if mc == nil || (len(mc.PortsAttributes) == 0 && mc.OtherPortsAttributes == nil) {
+		return nil
+	}
+	pa, opa := mc.PortsAttributes, mc.OtherPortsAttributes
+	return []netstat.WatcherOption{
+		netstat.WithPortFilter(func(port string) bool {
+			return devconfig.ResolvePortAttribute(port, pa, opa).ShouldAutoForward()
+		}),
+	}
 }
 
 type forwarder struct {

--- a/e2e/tests/readconfiguration/readconfiguration.go
+++ b/e2e/tests/readconfiguration/readconfiguration.go
@@ -179,4 +179,43 @@ var _ = ginkgo.Describe("read-configuration command", ginkgo.Label("read-configu
 			gomega.Expect(ports).To(gomega.ContainElement("3005"))
 			gomega.Expect(ports).To(gomega.HaveLen(7))
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("preserves otherPortsAttributes in merged configuration",
+		func(ctx context.Context) {
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+			tempDir, err := framework.CopyToTempDirWithoutChdir(
+				"tests/readconfiguration/testdata-port-attributes",
+			)
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
+
+			stdout, _, err := f.ExecCommandCapture(ctx, []string{
+				"read-configuration",
+				"--workspace-folder", tempDir,
+				"--include-merged-configuration",
+			})
+			framework.ExpectNoError(err)
+
+			var result map[string]any
+			err = json.Unmarshal([]byte(stdout), &result)
+			framework.ExpectNoError(err)
+
+			merged, ok := result["mergedConfiguration"].(map[string]any)
+			gomega.Expect(ok).To(gomega.BeTrue())
+
+			pa, ok := merged["portsAttributes"].(map[string]any)
+			gomega.Expect(ok).To(gomega.BeTrue(), "portsAttributes should be present")
+			entry, ok := pa["8080"].(map[string]any)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			gomega.Expect(entry["label"]).To(gomega.Equal("web"))
+			gomega.Expect(entry["onAutoForward"]).To(gomega.Equal("silent"))
+
+			opa, ok := merged["otherPortsAttributes"].(map[string]any)
+			gomega.Expect(ok).To(
+				gomega.BeTrue(),
+				"otherPortsAttributes should be present in merged config",
+			)
+			gomega.Expect(opa["onAutoForward"]).To(gomega.Equal("ignore"))
+			gomega.Expect(opa["label"]).To(gomega.Equal("default"))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 })

--- a/e2e/tests/readconfiguration/testdata-port-attributes/.devcontainer/devcontainer.json
+++ b/e2e/tests/readconfiguration/testdata-port-attributes/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "Port Attributes Test",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "forwardPorts": [8080, 9090],
+  "portsAttributes": {
+    "8080": {
+      "label": "web",
+      "onAutoForward": "silent"
+    }
+  },
+  "otherPortsAttributes": {
+    "onAutoForward": "ignore",
+    "label": "default"
+  }
+}

--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -416,6 +416,28 @@ type PortAttribute struct {
 	Protocol string `json:"protocol,omitempty"`
 }
 
+const onAutoForwardIgnore = "ignore"
+
+// ShouldAutoForward reports whether a port with this attribute should be
+// automatically forwarded. Only onAutoForward=="ignore" suppresses forwarding.
+func (p *PortAttribute) ShouldAutoForward() bool {
+	return p == nil || p.OnAutoForward != onAutoForwardIgnore
+}
+
+// ResolvePortAttribute returns the effective PortAttribute for a port.
+// It checks portsAttributes first (exact port match), then falls back
+// to otherPortsAttributes for unlisted ports.
+func ResolvePortAttribute(
+	port string,
+	portsAttributes map[string]PortAttribute,
+	otherPortsAttributes *PortAttribute,
+) *PortAttribute {
+	if pa, ok := portsAttributes[port]; ok {
+		return &pa
+	}
+	return otherPortsAttributes
+}
+
 type DevsyCustomizations struct {
 	PrebuildRepository         types.StrArray    `json:"prebuildRepository,omitempty"`
 	FeatureDownloadHTTPHeaders map[string]string `json:"featureDownloadHTTPHeaders,omitempty"`

--- a/pkg/devcontainer/config/port_attribute_test.go
+++ b/pkg/devcontainer/config/port_attribute_test.go
@@ -1,0 +1,68 @@
+package config
+
+import "testing"
+
+const testAutoForwardSilent = "silent"
+
+func TestShouldAutoForward_NilReceiver(t *testing.T) {
+	var pa *PortAttribute
+	if !pa.ShouldAutoForward() {
+		t.Fatal("nil PortAttribute must allow forwarding")
+	}
+}
+
+func TestShouldAutoForward_Ignore(t *testing.T) {
+	pa := &PortAttribute{OnAutoForward: onAutoForwardIgnore}
+	if pa.ShouldAutoForward() {
+		t.Fatal("onAutoForward=ignore must suppress forwarding")
+	}
+}
+
+func TestShouldAutoForward_Defaults(t *testing.T) {
+	for _, value := range []string{"", "notify", "openBrowser", testAutoForwardSilent} {
+		pa := &PortAttribute{OnAutoForward: value}
+		if !pa.ShouldAutoForward() {
+			t.Errorf("onAutoForward=%q must allow forwarding", value)
+		}
+	}
+}
+
+func TestResolvePortAttribute_ExplicitMatch(t *testing.T) {
+	attrs := map[string]PortAttribute{
+		"8080": {OnAutoForward: onAutoForwardIgnore, Label: "web"},
+	}
+	other := &PortAttribute{OnAutoForward: testAutoForwardSilent}
+
+	got := ResolvePortAttribute("8080", attrs, other)
+	if got.OnAutoForward != onAutoForwardIgnore || got.Label != "web" {
+		t.Fatalf("expected explicit attrs, got %+v", got)
+	}
+}
+
+func TestResolvePortAttribute_FallbackToOther(t *testing.T) {
+	attrs := map[string]PortAttribute{
+		"8080": {OnAutoForward: onAutoForwardIgnore},
+	}
+	other := &PortAttribute{OnAutoForward: testAutoForwardSilent, Label: "default"}
+
+	got := ResolvePortAttribute("3000", attrs, other)
+	if got != other {
+		t.Fatalf("expected otherPortsAttributes, got %+v", got)
+	}
+}
+
+func TestResolvePortAttribute_NilOther(t *testing.T) {
+	attrs := map[string]PortAttribute{}
+	got := ResolvePortAttribute("3000", attrs, nil)
+	if got != nil {
+		t.Fatalf("expected nil when no match and no defaults, got %+v", got)
+	}
+}
+
+func TestResolvePortAttribute_EmptyMap(t *testing.T) {
+	other := &PortAttribute{OnAutoForward: "notify"}
+	got := ResolvePortAttribute("9090", nil, other)
+	if got != other {
+		t.Fatalf("expected otherPortsAttributes with nil map, got %+v", got)
+	}
+}

--- a/pkg/netstat/watcher.go
+++ b/pkg/netstat/watcher.go
@@ -14,17 +14,36 @@ type Forwarder interface {
 	StopForward(port string) error
 }
 
+// PortFilter decides whether a discovered port should be auto-forwarded.
+// Return true to forward, false to skip.
+type PortFilter func(port string) bool
+
 //nolint:funcorder
-func NewWatcher(forwarder Forwarder) *Watcher {
-	return &Watcher{
+func NewWatcher(forwarder Forwarder, opts ...WatcherOption) *Watcher {
+	w := &Watcher{
 		forwarder:      forwarder,
 		forwardedPorts: map[string]bool{},
 	}
+	for _, o := range opts {
+		o(w)
+	}
+	return w
+}
+
+// WatcherOption configures a Watcher.
+type WatcherOption func(*Watcher)
+
+// WithPortFilter sets a filter that is consulted before forwarding
+// each auto-discovered port. Ports for which the filter returns false
+// are silently skipped.
+func WithPortFilter(f PortFilter) WatcherOption {
+	return func(w *Watcher) { w.portFilter = f }
 }
 
 type Watcher struct {
 	forwarder      Forwarder
 	forwardedPorts map[string]bool
+	portFilter     PortFilter
 }
 
 func (w *Watcher) Run(ctx context.Context) error {
@@ -61,6 +80,10 @@ func (w *Watcher) runOnce() error {
 	// start ports that were not there before
 	for port := range newPorts {
 		if !w.forwardedPorts[port] {
+			if w.portFilter != nil && !w.portFilter(port) {
+				log.Debugf("Skipping port %s (filtered)", port)
+				continue
+			}
 			log.Debugf("Found open port %s ready to forward", port)
 			err = w.forwarder.Forward(port)
 			if err != nil {

--- a/pkg/netstat/watcher_test.go
+++ b/pkg/netstat/watcher_test.go
@@ -1,0 +1,50 @@
+package netstat
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockForwarder struct {
+	forwarded []string
+	stopped   []string
+}
+
+func (m *mockForwarder) Forward(port string) error {
+	m.forwarded = append(m.forwarded, port)
+	return nil
+}
+
+func (m *mockForwarder) StopForward(port string) error {
+	m.stopped = append(m.stopped, port)
+	return nil
+}
+
+func TestNewWatcher_NilFilter(t *testing.T) {
+	w := NewWatcher(&mockForwarder{})
+	assert.Nil(t, w.portFilter)
+}
+
+func TestNewWatcher_WithPortFilter(t *testing.T) {
+	f := func(string) bool { return true }
+	w := NewWatcher(&mockForwarder{}, WithPortFilter(f))
+	assert.NotNil(t, w.portFilter)
+}
+
+func TestWatcher_PortFilterSkipsIgnored(t *testing.T) {
+	mf := &mockForwarder{}
+	w := NewWatcher(mf, WithPortFilter(func(port string) bool {
+		return port != "9090"
+	}))
+
+	// Simulate discovered ports by injecting into forwardedPorts after
+	// a hand-crafted runOnce cycle. Since findPorts reads /proc we
+	// drive the filter path by directly manipulating state.
+	w.forwardedPorts = map[string]bool{}
+
+	// We can't call runOnce (it reads /proc), so verify the filter
+	// is wired correctly by checking the contract.
+	assert.False(t, w.portFilter("9090"), "filter should reject 9090")
+	assert.True(t, w.portFilter("8080"), "filter should accept 8080")
+}


### PR DESCRIPTION
## Summary

Wires `otherPortsAttributes` from devcontainer.json into the port auto-forwarding layer. Previously, `portsAttributes` and `otherPortsAttributes` were parsed and merged but never consulted at runtime — all auto-discovered ports in range 1024–12000 were forwarded unconditionally.

Now the credentials-server reads the merged config at startup and builds a port filter:
- Ports listed in `portsAttributes` get their specific attributes applied
- Ports NOT in `portsAttributes` fall back to `otherPortsAttributes` defaults
- When `onAutoForward` is `"ignore"`, the port is silently skipped
- When `otherPortsAttributes` is unset, behavior is unchanged (preserves backward compatibility)

Changes:
- `config.ResolvePortAttribute()` — resolves effective PortAttribute for a port (explicit → fallback)
- `PortAttribute.ShouldAutoForward()` — returns false only for `onAutoForward=ignore`
- `netstat.Watcher` — accepts optional `WithPortFilter()` option to filter auto-discovered ports
- `credentials_server.go` — reads result.json and constructs the filter at startup
- Unit tests for resolution logic, filter wiring, and nil-safety
- E2E test validates `otherPortsAttributes` is preserved through config merge pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic port forwarding now respects port attribute settings defined in devcontainer configuration, giving you finer control over which ports are forwarded using port-specific attributes like `onAutoForward`.

* **Tests**
  * Added comprehensive end-to-end and unit tests to verify port attribute handling and auto-forwarding behavior with various configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->