### PR TITLE
feat(cli): add flag aliases for devcontainer CLI compatibility

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -137,6 +137,8 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 			"The container image to use, this will override the devcontainer.json value in the project")
 	buildCmd.Flags().
 		StringVar(&cmd.DevContainerPath, "devcontainer-path", "", "The path to the devcontainer.json relative to the project")
+	buildCmd.Flags().StringVar(&cmd.DevContainerPath, "config", "", "Alias for --devcontainer-path")
+	_ = buildCmd.Flags().MarkHidden("config")
 	buildCmd.Flags().
 		StringVar(&cmd.AdditionalFeatures, "additional-features", "",
 			`Additional features to apply to the dev container (JSON as per "features" section in devcontainer.json)`)

--- a/cmd/flag_aliases_test.go
+++ b/cmd/flag_aliases_test.go
@@ -8,51 +8,58 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	flagConfig           = "--config"
+	flagDevcontainerPath = "devcontainer-path"
+	flagLogFormat        = "--log-format"
+	formatJSON           = "json"
+)
+
 func TestUpCmd_ConfigAlias(t *testing.T) {
 	upCmd := NewUpCmd(&flags.GlobalFlags{})
-	err := upCmd.ParseFlags([]string{"--config", ".devcontainer/custom.json"})
+	err := upCmd.ParseFlags([]string{flagConfig, ".devcontainer/custom.json"})
 	require.NoError(t, err)
 
-	val, err := upCmd.Flags().GetString("devcontainer-path")
+	val, err := upCmd.Flags().GetString(flagDevcontainerPath)
 	require.NoError(t, err)
 	assert.Equal(t, ".devcontainer/custom.json", val)
 }
 
 func TestBuildCmd_ConfigAlias(t *testing.T) {
 	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
-	err := buildCmd.ParseFlags([]string{"--config", "path/to/devcontainer.json"})
+	err := buildCmd.ParseFlags([]string{flagConfig, "path/to/devcontainer.json"})
 	require.NoError(t, err)
 
-	val, err := buildCmd.Flags().GetString("devcontainer-path")
+	val, err := buildCmd.Flags().GetString(flagDevcontainerPath)
 	require.NoError(t, err)
 	assert.Equal(t, "path/to/devcontainer.json", val)
 }
 
 func TestGlobalFlags_LogFormatAlias(t *testing.T) {
 	rootCmd := BuildRoot()
-	rootCmd.SetArgs([]string{"--log-format", "json", "version"})
+	rootCmd.SetArgs([]string{flagLogFormat, formatJSON, "version"})
 	err := rootCmd.Execute()
 	require.NoError(t, err)
-	assert.Equal(t, "json", globalFlags.LogOutput)
+	assert.Equal(t, formatJSON, globalFlags.LogOutput)
 }
 
 func TestConfigAlias_IsHidden(t *testing.T) {
 	upCmd := NewUpCmd(&flags.GlobalFlags{})
 	f := upCmd.Flags().Lookup("config")
 	require.NotNil(t, f)
-	assert.True(t, f.Hidden, "--config alias should be hidden")
+	assert.True(t, f.Hidden, flagConfig+" alias should be hidden")
 }
 
 func TestLogFormatAlias_IsHidden(t *testing.T) {
 	rootCmd := BuildRoot()
 	f := rootCmd.PersistentFlags().Lookup("log-format")
 	require.NotNil(t, f)
-	assert.True(t, f.Hidden, "--log-format alias should be hidden")
+	assert.True(t, f.Hidden, flagLogFormat+" alias should be hidden")
 }
 
 func TestConfigAlias_E2E(t *testing.T) {
 	rootCmd := BuildRoot()
-	rootCmd.SetArgs([]string{"up", "--config", "/tmp/test.json", "--help"})
+	rootCmd.SetArgs([]string{"up", flagConfig, "/tmp/test.json", "--help"})
 	err := rootCmd.Execute()
 	require.NoError(t, err)
 }

--- a/cmd/flag_aliases_test.go
+++ b/cmd/flag_aliases_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpCmd_ConfigAlias(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	err := upCmd.ParseFlags([]string{"--config", ".devcontainer/custom.json"})
+	require.NoError(t, err)
+
+	val, err := upCmd.Flags().GetString("devcontainer-path")
+	require.NoError(t, err)
+	assert.Equal(t, ".devcontainer/custom.json", val)
+}
+
+func TestBuildCmd_ConfigAlias(t *testing.T) {
+	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
+	err := buildCmd.ParseFlags([]string{"--config", "path/to/devcontainer.json"})
+	require.NoError(t, err)
+
+	val, err := buildCmd.Flags().GetString("devcontainer-path")
+	require.NoError(t, err)
+	assert.Equal(t, "path/to/devcontainer.json", val)
+}
+
+func TestGlobalFlags_LogFormatAlias(t *testing.T) {
+	rootCmd := BuildRoot()
+	rootCmd.SetArgs([]string{"--log-format", "json", "version"})
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+	assert.Equal(t, "json", globalFlags.LogOutput)
+}
+
+func TestConfigAlias_IsHidden(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	f := upCmd.Flags().Lookup("config")
+	require.NotNil(t, f)
+	assert.True(t, f.Hidden, "--config alias should be hidden")
+}
+
+func TestLogFormatAlias_IsHidden(t *testing.T) {
+	rootCmd := BuildRoot()
+	f := rootCmd.PersistentFlags().Lookup("log-format")
+	require.NotNil(t, f)
+	assert.True(t, f.Hidden, "--log-format alias should be hidden")
+}
+
+func TestConfigAlias_E2E(t *testing.T) {
+	rootCmd := BuildRoot()
+	rootCmd.SetArgs([]string{"up", "--config", "/tmp/test.json", "--help"})
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+}

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -36,6 +36,8 @@ func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 		"text",
 		"The log format to use. Can be text, json, or logfmt",
 	)
+	flags.StringVar(&globalFlags.LogOutput, "log-format", "text", "Alias for --log-output")
+	_ = flags.MarkHidden("log-format")
 	flags.StringVar(&globalFlags.Context, "context", "", "The context to use")
 	flags.StringVar(
 		&globalFlags.Provider,

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -152,6 +152,8 @@ func (cmd *UpCmd) registerDevContainerFlags(upCmd *cobra.Command) {
 			"The container image to use, this will override the devcontainer.json value in the project")
 	upCmd.Flags().
 		StringVar(&cmd.DevContainerPath, "devcontainer-path", "", "The path to the devcontainer.json relative to the project")
+	upCmd.Flags().StringVar(&cmd.DevContainerPath, "config", "", "Alias for --devcontainer-path")
+	_ = upCmd.Flags().MarkHidden("config")
 	upCmd.Flags().
 		StringVar(&cmd.DevContainerID, "devcontainer-id", "",
 			"The ID of the devcontainer to use when multiple exist "+


### PR DESCRIPTION
## Summary

- Adds hidden `--config` flag alias (points to `--devcontainer-path`) on `up` and `build` commands
- Adds hidden `--log-format` global flag alias (points to `--log-output`)
- These match the official devcontainer CLI reference naming, improving compatibility for users migrating from the reference implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced hidden CLI flag aliases to provide alternative naming conventions for improved command flexibility.

* **Tests**
  * Comprehensive test coverage added to verify flag alias functionality and integration across commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->