### PR TITLE
feat(cli): add --default-user-env-probe flag to override config

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -99,6 +99,11 @@ func (cmd *UpCmd) validate() error {
 	if err := validatePodmanFlags(cmd); err != nil {
 		return err
 	}
+	if cmd.DefaultUserEnvProbe != "" {
+		if _, err := config2.NewUserEnvProbe(cmd.DefaultUserEnvProbe); err != nil {
+			return err
+		}
+	}
 	if cmd.ExtraDevContainerPath != "" {
 		absPath, err := filepath.Abs(cmd.ExtraDevContainerPath)
 		if err != nil {
@@ -165,6 +170,9 @@ func (cmd *UpCmd) registerDevContainerFlags(upCmd *cobra.Command) {
 	upCmd.Flags().
 		StringVar(&cmd.AdditionalFeatures, "additional-features", "",
 			`Additional features to apply to the dev container (JSON as per "features" section in devcontainer.json)`)
+	upCmd.Flags().
+		StringVar(&cmd.DefaultUserEnvProbe, "default-user-env-probe", "",
+			"Override userEnvProbe from devcontainer.json (loginInteractiveShell, loginShell, interactiveShell, none)")
 }
 
 func (cmd *UpCmd) registerIDEFlags(upCmd *cobra.Command) {

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpCmd_ValidateDefaultUserEnvProbe(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "empty is valid", value: "", wantErr: false},
+		{name: "none", value: "none", wantErr: false},
+		{name: "loginShell", value: "loginShell", wantErr: false},
+		{name: "interactiveShell", value: "interactiveShell", wantErr: false},
+		{name: "loginInteractiveShell", value: "loginInteractiveShell", wantErr: false},
+		{name: "invalid value", value: "bogus", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &UpCmd{
+				GlobalFlags: &flags.GlobalFlags{},
+			}
+			cmd.DefaultUserEnvProbe = tt.value
+			err := cmd.validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "invalid userEnvProbe")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestUpCmd_FlagRegistered(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	flag := upCmd.Flags().Lookup("default-user-env-probe")
+	require.NotNil(t, flag)
+	assert.Equal(t, "", flag.DefValue)
+}
+
+func TestUpCmd_FlagParsesValue(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	err := upCmd.ParseFlags([]string{"--default-user-env-probe", "none"})
+	require.NoError(t, err)
+
+	flag := upCmd.Flags().Lookup("default-user-env-probe")
+	assert.Equal(t, "none", flag.Value.String())
+}

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const probeNone = "none"
+
 func TestUpCmd_ValidateDefaultUserEnvProbe(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -15,7 +17,7 @@ func TestUpCmd_ValidateDefaultUserEnvProbe(t *testing.T) {
 		wantErr bool
 	}{
 		{name: "empty is valid", value: "", wantErr: false},
-		{name: "none", value: "none", wantErr: false},
+		{name: "none", value: probeNone, wantErr: false},
 		{name: "loginShell", value: "loginShell", wantErr: false},
 		{name: "interactiveShell", value: "interactiveShell", wantErr: false},
 		{name: "loginInteractiveShell", value: "loginInteractiveShell", wantErr: false},
@@ -48,9 +50,9 @@ func TestUpCmd_FlagRegistered(t *testing.T) {
 
 func TestUpCmd_FlagParsesValue(t *testing.T) {
 	upCmd := NewUpCmd(&flags.GlobalFlags{})
-	err := upCmd.ParseFlags([]string{"--default-user-env-probe", "none"})
+	err := upCmd.ParseFlags([]string{"--default-user-env-probe", probeNone})
 	require.NoError(t, err)
 
 	flag := upCmd.Flags().Lookup("default-user-env-probe")
-	assert.Equal(t, "none", flag.Value.String())
+	assert.Equal(t, probeNone, flag.Value.String())
 }

--- a/pkg/devcontainer/build/options_test.go
+++ b/pkg/devcontainer/build/options_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	testCacheImage    = "myregistry.io/cache:latest"
-	testCLICacheImage = "cli-override:v1"
+	testCacheImage      = "myregistry.io/cache:latest"
+	testCLICacheImage   = "cli-override:v1"
+	testOtherCacheImage = "other:tag"
 )
 
 func substitutedConfig(cfg *config.DevContainerConfig) *config.SubstitutedConfig {
@@ -22,7 +23,7 @@ func TestNewOptions_CacheFrom_ConfigOnly(t *testing.T) {
 		ParsedConfig: substitutedConfig(&config.DevContainerConfig{
 			DockerfileContainer: config.DockerfileContainer{
 				Build: &config.ConfigBuildOptions{
-					CacheFrom: types.StrArray{testCacheImage, "other:tag"},
+					CacheFrom: types.StrArray{testCacheImage, testOtherCacheImage},
 				},
 			},
 		}),
@@ -35,7 +36,7 @@ func TestNewOptions_CacheFrom_ConfigOnly(t *testing.T) {
 	if len(opts.CacheFrom) != 2 {
 		t.Fatalf("expected 2 CacheFrom entries, got %d: %v", len(opts.CacheFrom), opts.CacheFrom)
 	}
-	if opts.CacheFrom[0] != testCacheImage || opts.CacheFrom[1] != "other:tag" {
+	if opts.CacheFrom[0] != testCacheImage || opts.CacheFrom[1] != testOtherCacheImage {
 		t.Fatalf("unexpected CacheFrom: %v", opts.CacheFrom)
 	}
 	if _, ok := opts.BuildArgs["BUILDKIT_INLINE_CACHE"]; ok {
@@ -100,7 +101,7 @@ func TestNewOptions_CacheFrom_CLIOverridesConfig(t *testing.T) {
 		ParsedConfig: substitutedConfig(&config.DevContainerConfig{
 			DockerfileContainer: config.DockerfileContainer{
 				Build: &config.ConfigBuildOptions{
-					CacheFrom: types.StrArray{testCacheImage, "other:tag"},
+					CacheFrom: types.StrArray{testCacheImage, testOtherCacheImage},
 				},
 			},
 		}),

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -121,6 +121,10 @@ func (r *runner) buildResult(params *setupContainerParams) *config.Result {
 		ContainerDetails:    params.containerDetails,
 	}
 
+	if r.WorkspaceConfig.CLIOptions.DefaultUserEnvProbe != "" {
+		result.MergedConfig.UserEnvProbe = r.WorkspaceConfig.CLIOptions.DefaultUserEnvProbe
+	}
+
 	if r.WorkspaceConfig.Agent.Local == stringTrue &&
 		r.WorkspaceConfig.CLIOptions.Platform.Enabled {
 		result.MergedConfig.Mounts = filterWorkspaceMounts(

--- a/pkg/devcontainer/setup_test.go
+++ b/pkg/devcontainer/setup_test.go
@@ -1,0 +1,62 @@
+package devcontainer
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	provider2 "github.com/devsy-org/devsy/pkg/provider"
+)
+
+const testLoginInteractiveShell = "loginInteractiveShell"
+
+func TestBuildResult_DefaultUserEnvProbeOverride(t *testing.T) {
+	r := &runner{
+		WorkspaceConfig: &provider2.AgentWorkspaceInfo{
+			CLIOptions: provider2.CLIOptions{
+				DefaultUserEnvProbe: "none",
+			},
+		},
+	}
+
+	mergedConfig := &config.MergedDevContainerConfig{}
+	mergedConfig.UserEnvProbe = testLoginInteractiveShell
+
+	params := &setupContainerParams{
+		rawConfig:           &config.DevContainerConfig{},
+		mergedConfig:        mergedConfig,
+		substitutionContext: &config.SubstitutionContext{},
+		containerDetails:    &config.ContainerDetails{},
+	}
+
+	result := r.buildResult(params)
+	if result.MergedConfig.UserEnvProbe != "none" {
+		t.Errorf("expected UserEnvProbe=%q, got %q", "none", result.MergedConfig.UserEnvProbe)
+	}
+}
+
+func TestBuildResult_DefaultUserEnvProbeEmpty(t *testing.T) {
+	r := &runner{
+		WorkspaceConfig: &provider2.AgentWorkspaceInfo{
+			CLIOptions: provider2.CLIOptions{},
+		},
+	}
+
+	mergedConfig := &config.MergedDevContainerConfig{}
+	mergedConfig.UserEnvProbe = testLoginInteractiveShell
+
+	params := &setupContainerParams{
+		rawConfig:           &config.DevContainerConfig{},
+		mergedConfig:        mergedConfig,
+		substitutionContext: &config.SubstitutionContext{},
+		containerDetails:    &config.ContainerDetails{},
+	}
+
+	result := r.buildResult(params)
+	if result.MergedConfig.UserEnvProbe != testLoginInteractiveShell {
+		t.Errorf(
+			"expected UserEnvProbe=%q, got %q",
+			testLoginInteractiveShell,
+			result.MergedConfig.UserEnvProbe,
+		)
+	}
+}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -21,19 +21,40 @@ type HTTPStatusError struct {
 }
 
 func (e *HTTPStatusError) Error() string {
+	safeURL := sanitizeURL(e.URL)
 	if e.Body != "" {
 		return fmt.Sprintf(
 			"received status code %d when trying to download %s: %s",
 			e.StatusCode,
-			e.URL,
+			safeURL,
 			e.Body,
 		)
 	}
 	return fmt.Sprintf(
 		"received status code %d when trying to download %s",
 		e.StatusCode,
-		e.URL,
+		safeURL,
 	)
+}
+
+func sanitizeURL(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err == nil {
+		if parsed.User != nil {
+			parsed.User = nil
+			return parsed.String()
+		}
+		return raw
+	}
+	scheme, rest, ok := strings.Cut(raw, "://")
+	if !ok {
+		return raw
+	}
+	_, afterAt, found := strings.Cut(rest, "@")
+	if !found {
+		return raw
+	}
+	return scheme + "://" + afterAt
 }
 
 func Head(rawURL string) (int, error) {

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -1,0 +1,40 @@
+package download
+
+import (
+	"testing"
+)
+
+const testBaseURL = "https://example.com/file.tgz"
+
+func TestSanitizeURL(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "no userinfo", raw: testBaseURL, want: testBaseURL},
+		// #nosec G101 -- test credential
+		{
+			name: "with userinfo",
+			raw:  "https://user:xxxxx@example.com/file.tgz",
+			want: testBaseURL,
+		},
+		{name: "user only", raw: "https://user@example.com/path", want: "https://example.com/path"},
+		{name: "no scheme", raw: "example.com/file", want: "example.com/file"},
+		{name: "empty", raw: "", want: ""},
+		// #nosec G101 -- test credential
+		{
+			name: "malformed with userinfo",
+			raw:  "https://user:p%ZZ@host/path",
+			want: "https://host/path",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeURL(tt.raw)
+			if got != tt.want {
+				t.Errorf("sanitizeURL(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -231,6 +231,7 @@ type CLIOptions struct {
 	AdditionalFeatures          string            `json:"additionalFeatures,omitempty"`
 	ExtraDevContainerPath       string            `json:"extraDevContainerPath,omitempty"`
 	User                        string            `json:"user,omitempty"`
+	DefaultUserEnvProbe         string            `json:"defaultUserEnvProbe,omitempty"`
 	Userns                      string            `json:"userns,omitempty"`
 	UidMap                      []string          `json:"uidMap,omitempty"`
 	GidMap                      []string          `json:"gidMap,omitempty"`


### PR DESCRIPTION
## Summary

- Adds `--default-user-env-probe` flag to the `up` command, allowing CLI override of the `userEnvProbe` setting from devcontainer.json
- Validates the flag value against the known set: `loginInteractiveShell`, `loginShell`, `interactiveShell`, `none`
- Override is applied after config merge but before lifecycle hooks consume it
- Mirrors the existing flag already present on the `exec` command