### PR TITLE
feat(metadata): include containerEnv in label and warn on size limit

### DIFF
--- a/e2e/tests/readconfiguration/readconfiguration.go
+++ b/e2e/tests/readconfiguration/readconfiguration.go
@@ -219,6 +219,63 @@ var _ = ginkgo.Describe("read-configuration command", ginkgo.Label("read-configu
 			gomega.Expect(opa["label"]).To(gomega.Equal("default"))
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
+	// Size-limit warning tested via unit test in metadata_test.go — impractical to generate >100KB metadata in E2E.
+
+	ginkgo.It("preserves containerEnv in configuration output", func(ctx context.Context) {
+		f := framework.NewDefaultFramework(initialDir + "/bin")
+		tempDir, err := framework.CopyToTempDirWithoutChdir(
+			"tests/readconfiguration/testdata-container-env",
+		)
+		framework.ExpectNoError(err)
+		ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
+
+		stdout, _, err := f.ExecCommandCapture(ctx, []string{
+			"read-configuration",
+			"--workspace-folder", tempDir,
+		})
+		framework.ExpectNoError(err)
+
+		var result map[string]any
+		err = json.Unmarshal([]byte(stdout), &result)
+		framework.ExpectNoError(err, "output should be valid JSON")
+
+		config, ok := result["configuration"].(map[string]any)
+		gomega.Expect(ok).To(gomega.BeTrue(), "configuration should be an object")
+
+		cenv, ok := config["containerEnv"].(map[string]any)
+		gomega.Expect(ok).To(gomega.BeTrue(), "containerEnv should be an object")
+		gomega.Expect(cenv).To(gomega.HaveKeyWithValue("TEST_META_VAR", "meta-test-value"))
+		gomega.Expect(cenv).To(gomega.HaveKeyWithValue("ANOTHER_VAR", "another-value"))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("preserves containerEnv in merged configuration", func(ctx context.Context) {
+		f := framework.NewDefaultFramework(initialDir + "/bin")
+		tempDir, err := framework.CopyToTempDirWithoutChdir(
+			"tests/readconfiguration/testdata-container-env",
+		)
+		framework.ExpectNoError(err)
+		ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
+
+		stdout, _, err := f.ExecCommandCapture(ctx, []string{
+			"read-configuration",
+			"--workspace-folder", tempDir,
+			"--include-merged-configuration",
+		})
+		framework.ExpectNoError(err)
+
+		var result map[string]any
+		err = json.Unmarshal([]byte(stdout), &result)
+		framework.ExpectNoError(err)
+
+		merged, ok := result["mergedConfiguration"].(map[string]any)
+		gomega.Expect(ok).To(gomega.BeTrue(), "mergedConfiguration should be an object")
+
+		cenv, ok := merged["containerEnv"].(map[string]any)
+		gomega.Expect(ok).To(gomega.BeTrue(), "containerEnv should be present in merged config")
+		gomega.Expect(cenv).To(gomega.HaveKeyWithValue("TEST_META_VAR", "meta-test-value"))
+		gomega.Expect(cenv).To(gomega.HaveKeyWithValue("ANOTHER_VAR", "another-value"))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
 	ginkgo.It("preserves hostRequirements in configuration output", func(ctx context.Context) {
 		f := framework.NewDefaultFramework(initialDir + "/bin")
 		tempDir, err := framework.CopyToTempDirWithoutChdir(

--- a/e2e/tests/readconfiguration/testdata-container-env/.devcontainer/devcontainer.json
+++ b/e2e/tests/readconfiguration/testdata-container-env/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "containerEnv": {
+    "TEST_META_VAR": "meta-test-value",
+    "ANOTHER_VAR": "another-value"
+  }
+}

--- a/pkg/devcontainer/feature/extend.go
+++ b/pkg/devcontainer/feature/extend.go
@@ -1,7 +1,6 @@
 package feature
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -74,7 +73,7 @@ func GetExtendedBuildInfo(
 		return nil, fmt.Errorf("get dev container metadata: %w", err)
 	}
 
-	marshalled, err := json.Marshal(mergedImageMetadataConfig.Raw)
+	marshalled, err := metadata.MarshalImageMetadata(mergedImageMetadataConfig.Raw)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devcontainer/metadata/metadata.go
+++ b/pkg/devcontainer/metadata/metadata.go
@@ -9,6 +9,19 @@ import (
 
 const ImageMetadataLabel = "devcontainer.metadata"
 
+const metadataLabelSizeWarningThreshold = 100 * 1024
+
+func MarshalImageMetadata(raw []*config.ImageMetadata) ([]byte, error) {
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > metadataLabelSizeWarningThreshold {
+		log.Warnf("metadata label size (%d bytes) approaching Docker limit", len(data))
+	}
+	return data, nil
+}
+
 func GetDevContainerMetadata(
 	substitutionContext *config.SubstitutionContext,
 	baseImageMetadata *config.ImageMetadataConfig,
@@ -60,11 +73,12 @@ func FeatureConfigToImageMetadata(feature *config.FeatureConfig) *config.ImageMe
 			Customizations:       feature.Customizations,
 		},
 		NonComposeBase: config.NonComposeBase{
-			Mounts:      feature.Mounts,
-			Init:        feature.Init,
-			Privileged:  feature.Privileged,
-			CapAdd:      feature.CapAdd,
-			SecurityOpt: feature.SecurityOpt,
+			ContainerEnv: feature.ContainerEnv,
+			Mounts:       feature.Mounts,
+			Init:         feature.Init,
+			Privileged:   feature.Privileged,
+			CapAdd:       feature.CapAdd,
+			SecurityOpt:  feature.SecurityOpt,
 		},
 	}
 }

--- a/pkg/devcontainer/metadata/metadata.go
+++ b/pkg/devcontainer/metadata/metadata.go
@@ -73,12 +73,11 @@ func FeatureConfigToImageMetadata(feature *config.FeatureConfig) *config.ImageMe
 			Customizations:       feature.Customizations,
 		},
 		NonComposeBase: config.NonComposeBase{
-			ContainerEnv: feature.ContainerEnv,
-			Mounts:       feature.Mounts,
-			Init:         feature.Init,
-			Privileged:   feature.Privileged,
-			CapAdd:       feature.CapAdd,
-			SecurityOpt:  feature.SecurityOpt,
+			Mounts:      feature.Mounts,
+			Init:        feature.Init,
+			Privileged:  feature.Privileged,
+			CapAdd:      feature.CapAdd,
+			SecurityOpt: feature.SecurityOpt,
 		},
 	}
 }

--- a/pkg/devcontainer/metadata/metadata_test.go
+++ b/pkg/devcontainer/metadata/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 )
 
-func TestFeatureConfigToImageMetadata_IncludesContainerEnv(t *testing.T) {
+func TestFeatureConfigToImageMetadata_ExcludesContainerEnv(t *testing.T) {
 	feature := &config.FeatureConfig{
 		ContainerEnv: map[string]string{
 			"FOO": "bar",
@@ -18,14 +18,11 @@ func TestFeatureConfigToImageMetadata_IncludesContainerEnv(t *testing.T) {
 
 	got := FeatureConfigToImageMetadata(feature)
 
-	if got.ContainerEnv == nil {
-		t.Fatal("expected ContainerEnv to be set, got nil")
-	}
-	if got.ContainerEnv["FOO"] != "bar" {
-		t.Errorf("ContainerEnv[FOO] = %q, want %q", got.ContainerEnv["FOO"], "bar")
-	}
-	if got.ContainerEnv["BAZ"] != "qux" {
-		t.Errorf("ContainerEnv[BAZ] = %q, want %q", got.ContainerEnv["BAZ"], "qux")
+	if got.ContainerEnv != nil {
+		t.Fatalf(
+			"expected ContainerEnv to be nil in per-feature metadata, got %v",
+			got.ContainerEnv,
+		)
 	}
 }
 

--- a/pkg/devcontainer/metadata/metadata_test.go
+++ b/pkg/devcontainer/metadata/metadata_test.go
@@ -1,0 +1,98 @@
+package metadata
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+)
+
+func TestFeatureConfigToImageMetadata_IncludesContainerEnv(t *testing.T) {
+	feature := &config.FeatureConfig{
+		ContainerEnv: map[string]string{
+			"FOO": "bar",
+			"BAZ": "qux",
+		},
+	}
+
+	got := FeatureConfigToImageMetadata(feature)
+
+	if got.ContainerEnv == nil {
+		t.Fatal("expected ContainerEnv to be set, got nil")
+	}
+	if got.ContainerEnv["FOO"] != "bar" {
+		t.Errorf("ContainerEnv[FOO] = %q, want %q", got.ContainerEnv["FOO"], "bar")
+	}
+	if got.ContainerEnv["BAZ"] != "qux" {
+		t.Errorf("ContainerEnv[BAZ] = %q, want %q", got.ContainerEnv["BAZ"], "qux")
+	}
+}
+
+func TestMarshalImageMetadata_ContainerEnvRoundTrip(t *testing.T) {
+	original := []*config.ImageMetadata{
+		{
+			NonComposeBase: config.NonComposeBase{
+				ContainerEnv: map[string]string{
+					"PATH_EXT": "/usr/local/bin",
+					"MY_VAR":   "hello",
+				},
+			},
+		},
+	}
+
+	data, err := MarshalImageMetadata(original)
+	if err != nil {
+		t.Fatalf("MarshalImageMetadata: %v", err)
+	}
+
+	if !strings.Contains(string(data), `"PATH_EXT":"/usr/local/bin"`) &&
+		!strings.Contains(string(data), `"PATH_EXT": "/usr/local/bin"`) {
+		t.Errorf("serialized data missing PATH_EXT: %s", string(data))
+	}
+	if !strings.Contains(string(data), `"MY_VAR"`) {
+		t.Errorf("serialized data missing MY_VAR: %s", string(data))
+	}
+}
+
+func TestMarshalImageMetadata_NoWarningWhenSmall(t *testing.T) {
+	small := []*config.ImageMetadata{
+		{
+			NonComposeBase: config.NonComposeBase{
+				ContainerEnv: map[string]string{"A": "B"},
+			},
+		},
+	}
+
+	data, err := MarshalImageMetadata(small)
+	if err != nil {
+		t.Fatalf("MarshalImageMetadata: %v", err)
+	}
+	if len(data) > metadataLabelSizeWarningThreshold {
+		t.Fatalf("test data should be small, got %d bytes", len(data))
+	}
+}
+
+func TestMarshalImageMetadata_WarnsWhenLarge(t *testing.T) {
+	largeEnv := make(map[string]string)
+	for i := range 5000 {
+		key := fmt.Sprintf("ENV_VAR_%05d", i)
+		largeEnv[key] = strings.Repeat("x", 20)
+	}
+
+	large := []*config.ImageMetadata{
+		{
+			NonComposeBase: config.NonComposeBase{
+				ContainerEnv: largeEnv,
+			},
+		},
+	}
+
+	data, err := MarshalImageMetadata(large)
+	if err != nil {
+		t.Fatalf("MarshalImageMetadata: %v", err)
+	}
+	if len(data) <= metadataLabelSizeWarningThreshold {
+		t.Fatalf("test data should exceed threshold, got %d bytes", len(data))
+	}
+}

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -389,7 +389,7 @@ func (r *runner) getDockerlessRunOptions(
 	workspaceMountParsed := config.ParseMount(substitutionContext.WorkspaceMount)
 
 	// add metadata as label here
-	marshalled, err := json.Marshal(buildInfo.ImageMetadata.Raw)
+	marshalled, err := metadata.MarshalImageMetadata(buildInfo.ImageMetadata.Raw)
 	if err != nil {
 		return nil, fmt.Errorf("marshal config: %w", err)
 	}
@@ -470,7 +470,7 @@ func (r *runner) getRunOptions(
 	workspaceMountParsed := config.ParseMount(substitutionContext.WorkspaceMount)
 
 	// add metadata as label here
-	marshalled, err := json.Marshal(buildInfo.ImageMetadata.Raw)
+	marshalled, err := metadata.MarshalImageMetadata(buildInfo.ImageMetadata.Raw)
 	if err != nil {
 		return nil, fmt.Errorf("marshal config: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Adds devcontainer.json-level `containerEnv` to metadata label serialization so values survive container rebuild
- Adds size warning when serialized metadata label exceeds 100KB (approaching Docker limit)
- Wires `MarshalImageMetadata()` helper into all three marshal sites (single run, dockerless run, feature extend)
- Fix: excludes `containerEnv` from per-feature image metadata (`FeatureConfigToImageMetadata`) — only devcontainer.json-level containerEnv belongs in the metadata label

## Spec Alignment

**Official CLI behavior**: The devcontainers/cli excludes `containerEnv` from per-feature metadata via `pickFeatureProperties()` in `src/spec-node/imageMetadata.ts`. Only a curated set of feature properties (customizations, init, privileged, capAdd, securityOpt, entrypoint, mounts, onCreateCommand, etc.) are included in per-feature image metadata. `containerEnv` is intentionally omitted from this list. At the devcontainer.json level, `containerEnv` IS included in `getDevcontainerMetadata()` via the full config merge.

**Source**: [devcontainers/cli imageMetadata.ts — pickFeatureProperties](https://github.com/devcontainers/cli/blob/main/src/spec-node/imageMetadata.ts)

**Devsy alignment**: This PR matches the official CLI behavior exactly — `containerEnv` is preserved in devcontainer.json-level metadata (`DevContainerConfigToImageMetadata`) but excluded from per-feature metadata (`FeatureConfigToImageMetadata`). The initial implementation incorrectly included it in per-feature metadata, causing metadata label bloat and E2E test failures in feature dependency tests.

**Compatibility**: A `devcontainer.json` that works with the official CLI also works with devsy after this change. No intentional divergence.