### PR TITLE
refactor(feature): use k8s wait.ExponentialBackoff for OCI retry

### DIFF
--- a/pkg/devcontainer/feature/oci_retry.go
+++ b/pkg/devcontainer/feature/oci_retry.go
@@ -7,16 +7,15 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-const (
-	ociMaxRetries    = 3
-	ociBaseDelay     = 1 * time.Second
-	ociRetryExponent = 2
-)
+var ociBackoff = wait.Backoff{
+	Duration: 1 * time.Second,
+	Factor:   2.0,
+	Steps:    3,
+}
 
-// isTransientError returns true for errors that may resolve on retry:
-// network timeouts, connection resets, and 5xx server errors.
 func isTransientError(err error) bool {
 	if err == nil {
 		return false
@@ -30,30 +29,21 @@ func isTransientError(err error) bool {
 	return true
 }
 
-// retryOCIPull executes fn up to ociMaxRetries times with exponential backoff.
-// It only retries when isTransientError returns true.
 func retryOCIPull(fn func() error) error {
 	var lastErr error
-	delay := ociBaseDelay
-
-	for attempt := range ociMaxRetries {
-		if attempt > 0 {
-			log.Debugf("OCI pull retry: attempt=%d, delay=%v", attempt+1, delay)
-			time.Sleep(delay)
-			delay *= ociRetryExponent
-		}
-
+	err := wait.ExponentialBackoff(ociBackoff, func() (bool, error) {
 		lastErr = fn()
 		if lastErr == nil {
-			return nil
+			return true, nil
 		}
-
 		if !isTransientError(lastErr) {
-			return lastErr
+			return false, lastErr
 		}
-
-		log.Debugf("OCI pull transient failure: attempt=%d, error=%v", attempt+1, lastErr)
+		log.Debugf("OCI pull transient failure: %v", lastErr)
+		return false, nil
+	})
+	if wait.Interrupted(err) {
+		return lastErr
 	}
-
-	return lastErr
+	return err
 }

--- a/pkg/devcontainer/feature/oci_retry_test.go
+++ b/pkg/devcontainer/feature/oci_retry_test.go
@@ -40,7 +40,7 @@ func (s *OCIRetryTestSuite) TestRetryGivesUpAfterMaxAttempts() {
 	})
 
 	s.Error(err)
-	s.Equal(ociMaxRetries, attempts)
+	s.Equal(ociBackoff.Steps, attempts)
 	s.Contains(err.Error(), "persistent network error")
 }
 


### PR DESCRIPTION
## Summary
- Replaces custom retry loop with k8s wait.ExponentialBackoff
- Same behavior (1s base, factor 2, 3 retries), clearer code
- Preserves transient/permanent error distinction and URL sanitization