### PR TITLE
test(e2e): add overrideCommand E2E coverage

### DIFF
--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -668,9 +668,9 @@ var _ = ginkgo.Describe(
 			err = dtc.dockerHelper.Inspect(ctx, ids, "container", &details)
 			framework.ExpectNoError(err)
 
-			// With overrideCommand=false the image's Cmd ("bash") is appended
-			// after the start-script preamble ["-c", <script>, "-"].
-			gomega.Expect(details[0].Config.Cmd).To(gomega.ContainElement("bash"),
+			// With overrideCommand=false the image's Cmd is appended after the
+			// start-script preamble ["-c", <script>, "-"].
+			gomega.Expect(details[0].Config.Cmd).To(gomega.ContainElement("sleep"),
 				"image cmd should be preserved when overrideCommand is false")
 		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 

--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -652,5 +652,49 @@ var _ = ginkgo.Describe(
 			err = dtc.f.DevsyWorkspaceDelete(ctx, tempDir)
 			framework.ExpectNoError(err)
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+		ginkgo.It("overrideCommand false preserves image entrypoint", func(ctx context.Context) {
+			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker-override-command-false")
+			framework.ExpectNoError(err)
+
+			workspace, err := dtc.f.FindWorkspace(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			ids, err := dtc.findWorkspaceContainer(ctx, workspace)
+			framework.ExpectNoError(err)
+			gomega.Expect(ids).To(gomega.HaveLen(1))
+
+			var details []container.InspectResponse
+			err = dtc.dockerHelper.Inspect(ctx, ids, "container", &details)
+			framework.ExpectNoError(err)
+
+			// With overrideCommand=false the image's Cmd ("bash") is appended
+			// after the start-script preamble ["-c", <script>, "-"].
+			gomega.Expect(details[0].Config.Cmd).To(gomega.ContainElement("bash"),
+				"image cmd should be preserved when overrideCommand is false")
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+		ginkgo.It("overrideCommand default overrides image entrypoint", func(ctx context.Context) {
+			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker")
+			framework.ExpectNoError(err)
+
+			workspace, err := dtc.f.FindWorkspace(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			ids, err := dtc.findWorkspaceContainer(ctx, workspace)
+			framework.ExpectNoError(err)
+			gomega.Expect(ids).To(gomega.HaveLen(1))
+
+			var details []container.InspectResponse
+			err = dtc.dockerHelper.Inspect(ctx, ids, "container", &details)
+			framework.ExpectNoError(err)
+
+			// Default behavior (no overrideCommand set): image cmd is NOT appended.
+			// Cmd should be exactly ["-c", <script>, "-"].
+			gomega.Expect(details[0].Config.Cmd).To(gomega.HaveLen(3),
+				"image cmd should be overridden by default")
+			gomega.Expect(details[0].Config.Cmd[0]).To(gomega.Equal("-c"))
+			gomega.Expect(details[0].Config.Cmd[2]).To(gomega.Equal("-"))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 	},
 )

--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -672,7 +672,7 @@ var _ = ginkgo.Describe(
 			// after the start-script preamble ["-c", <script>, "-"].
 			gomega.Expect(details[0].Config.Cmd).To(gomega.ContainElement("bash"),
 				"image cmd should be preserved when overrideCommand is false")
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("overrideCommand default overrides image entrypoint", func(ctx context.Context) {
 			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker")
@@ -695,6 +695,6 @@ var _ = ginkgo.Describe(
 				"image cmd should be overridden by default")
 			gomega.Expect(details[0].Config.Cmd[0]).To(gomega.Equal("-c"))
 			gomega.Expect(details[0].Config.Cmd[2]).To(gomega.Equal("-"))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 	},
 )

--- a/e2e/tests/up/testdata/docker-override-command-false/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-override-command-false/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Go",
-  "image": "ghcr.io/devsy-org/test-images/go:1",
+  "name": "OverrideCommandFalse",
+  "build": { "dockerfile": "Dockerfile" },
   "overrideCommand": false
 }

--- a/e2e/tests/up/testdata/docker-override-command-false/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-override-command-false/.devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "name": "Go",
+  "image": "ghcr.io/devsy-org/test-images/go:1",
+  "overrideCommand": false
+}

--- a/e2e/tests/up/testdata/docker-override-command-false/Dockerfile
+++ b/e2e/tests/up/testdata/docker-override-command-false/Dockerfile
@@ -1,0 +1,2 @@
+FROM ghcr.io/devsy-org/test-images/base:alpine
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
## Summary

- Adds E2E test verifying `overrideCommand: false` preserves the image's original CMD (`bash`) in the container args
- Adds E2E test verifying the default behavior (no `overrideCommand` set) overrides the image entrypoint, producing exactly `["-c", <script>, "-"]`
- Tests exercise the wiring at `pkg/devcontainer/single.go:560-564`

## Spec alignment

Per the [devcontainers spec](https://containers.dev/implementors/json_reference/) and the official CLI implementation (`src/spec-node/containerFeatures.ts`):
- The default behavior overrides the image entrypoint/cmd with the devcontainer start script
- When `overrideCommand: false`, the image's original entrypoint and cmd are preserved (appended as args to the start script's `exec "$@"`)

This implementation matches spec behavior. No intentional divergences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests validating Docker `overrideCommand` behavior: when set to false the image entrypoint is preserved, and under the default setting the entrypoint is overridden. Includes corresponding test configuration and container image used for validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->