### PR TITLE
feat(cli): add --id-label flag for custom container identification

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -30,6 +30,7 @@ type ExecCmd struct {
 	WorkspaceFolder     string
 	RemoteEnv           []string
 	DefaultUserEnvProbe string
+	IDLabels            []string
 }
 
 func NewExecCmd(f *flags.GlobalFlags) *cobra.Command {
@@ -66,12 +67,22 @@ func NewExecCmd(f *flags.GlobalFlags) *cobra.Command {
 			"",
 			"Override userEnvProbe from config (loginInteractiveShell, loginShell, interactiveShell, none)",
 		)
+	execCmd.Flags().
+		StringArrayVar(
+			&cmd.IDLabels,
+			"id-label",
+			[]string{},
+			"Override the default container identification labels (format: key=value, can be specified multiple times)",
+		)
 
 	return execCmd
 }
 
 func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
 	if err := cmd.validateRemoteEnv(); err != nil {
+		return err
+	}
+	if err := devcconfig.ValidateIDLabels(cmd.IDLabels); err != nil {
 		return err
 	}
 
@@ -93,7 +104,7 @@ func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
 	dockerCommand := resolveDockerCommand(workspaceConfig)
 
 	containerDetails, err := findRunningContainer(
-		ctx, dockerCommand, devcontainer.GetRunnerIDFromWorkspace(workspaceConfig),
+		ctx, dockerCommand, devcontainer.GetRunnerIDFromWorkspace(workspaceConfig), cmd.IDLabels,
 	)
 	if err != nil {
 		return err
@@ -158,12 +169,13 @@ func findRunningContainer(
 	ctx context.Context,
 	dockerCommand string,
 	workspaceID string,
+	idLabels []string,
 ) (*devcconfig.ContainerDetails, error) {
 	dockerHelper := &docker.DockerHelper{
 		DockerCommand: dockerCommand,
 	}
 
-	labels := devcconfig.GetDockerLabelForID(workspaceID)
+	labels := devcconfig.GetIDLabels(workspaceID, idLabels)
 	container, err := dockerHelper.FindDevContainer(ctx, labels)
 	if err != nil {
 		return nil, fmt.Errorf("find container: %w", err)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -99,6 +99,9 @@ func (cmd *UpCmd) validate() error {
 	if err := validatePodmanFlags(cmd); err != nil {
 		return err
 	}
+	if err := config2.ValidateIDLabels(cmd.IDLabels); err != nil {
+		return err
+	}
 	if cmd.ExtraDevContainerPath != "" {
 		absPath, err := filepath.Abs(cmd.ExtraDevContainerPath)
 		if err != nil {
@@ -165,6 +168,9 @@ func (cmd *UpCmd) registerDevContainerFlags(upCmd *cobra.Command) {
 	upCmd.Flags().
 		StringVar(&cmd.AdditionalFeatures, "additional-features", "",
 			`Additional features to apply to the dev container (JSON as per "features" section in devcontainer.json)`)
+	upCmd.Flags().
+		StringArrayVar(&cmd.IDLabels, "id-label", []string{},
+			"Override the default container identification labels (format: key=value, can be specified multiple times)")
 }
 
 func (cmd *UpCmd) registerIDEFlags(upCmd *cobra.Command) {

--- a/e2e/tests/exec/exec.go
+++ b/e2e/tests/exec/exec.go
@@ -159,4 +159,23 @@ var _ = ginkgo.Describe("devsy exec test suite", ginkgo.Label("exec"), ginkgo.Or
 			})
 			framework.ExpectError(err)
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("should find container by custom id-label",
+		func(ctx context.Context) {
+			tempDir, f, err := setupWorkspace("tests/exec/testdata/exec", initialDir)
+			framework.ExpectNoError(err)
+
+			err = f.DevsyUp(ctx, tempDir,
+				"--id-label", "devsy.exec.test=idlabel")
+			framework.ExpectNoError(err)
+
+			stdout, _, err := f.ExecCommandCapture(ctx, []string{
+				execCommand,
+				workspaceFolderFlag, tempDir,
+				"--id-label", "devsy.exec.test=idlabel",
+				"--", echoCommand, "-n", "found",
+			})
+			framework.ExpectNoError(err)
+			gomega.Expect(stdout).To(gomega.Equal("found"))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 })

--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -536,5 +536,29 @@ var _ = ginkgo.Describe(
 			err = dtc.f.DevsyWorkspaceDelete(ctx, tempDir)
 			framework.ExpectNoError(err)
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+		ginkgo.It("id-label replaces default container label", func(ctx context.Context) {
+			_, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker",
+				"--id-label", "devsy.test.app=myproject",
+				"--id-label", "devsy.test.env=ci")
+			framework.ExpectNoError(err)
+
+			ids, err := dtc.dockerHelper.FindContainer(
+				ctx,
+				[]string{"devsy.test.app=myproject", "devsy.test.env=ci"},
+			)
+			framework.ExpectNoError(err)
+			gomega.Expect(ids).To(gomega.HaveLen(1))
+
+			var containerDetails []container.InspectResponse
+			err = dtc.dockerHelper.Inspect(ctx, ids, "container", &containerDetails)
+			framework.ExpectNoError(err)
+			gomega.Expect(containerDetails[0].Config.Labels).To(gomega.HaveKeyWithValue(
+				"devsy.test.app", "myproject"))
+			gomega.Expect(containerDetails[0].Config.Labels).To(gomega.HaveKeyWithValue(
+				"devsy.test.env", "ci"))
+			gomega.Expect(containerDetails[0].Config.Labels).NotTo(gomega.HaveKey(
+				"dev.containers.id"))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 	},
 )

--- a/e2e/tests/up/provider_docker.go
+++ b/e2e/tests/up/provider_docker.go
@@ -726,7 +726,7 @@ var _ = ginkgo.Describe(
 		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("id-label replaces default container label", func(ctx context.Context) {
-			_, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker",
+			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker",
 				"--id-label", "devsy.test.app=myproject",
 				"--id-label", "devsy.test.env=ci")
 			framework.ExpectNoError(err)
@@ -745,8 +745,12 @@ var _ = ginkgo.Describe(
 				"devsy.test.app", "myproject"))
 			gomega.Expect(containerDetails[0].Config.Labels).To(gomega.HaveKeyWithValue(
 				"devsy.test.env", "ci"))
-			gomega.Expect(containerDetails[0].Config.Labels).NotTo(gomega.HaveKey(
-				"dev.containers.id"))
+
+			workspace, err := dtc.f.FindWorkspace(ctx, tempDir)
+			framework.ExpectNoError(err)
+			gomega.Expect(containerDetails[0].Config.Labels["dev.containers.id"]).
+				NotTo(gomega.Equal(workspace.UID),
+					"workspace UID should not be used as label when --id-label is specified")
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 	},
 )

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -1091,8 +1091,14 @@ exec "$$@"
 	}
 	entrypoint = append(entrypoint, userEntrypoint...)
 
-	labels := composetypes.Labels{
-		config.DockerIDLabel: r.ID,
+	labels := composetypes.Labels{}
+	if len(r.IDLabels) > 0 {
+		for _, l := range r.IDLabels {
+			k, v, _ := strings.Cut(l, "=")
+			labels[k] = v
+		}
+	} else {
+		labels[config.DockerIDLabel] = r.ID
 	}
 	for k, v := range additionalLabels {
 		// Escape $ and ' to prevent substituting local environment variables!

--- a/pkg/devcontainer/config/build.go
+++ b/pkg/devcontainer/config/build.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"fmt"
+	"strings"
+
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/dockerfile"
 )
@@ -15,6 +18,23 @@ const (
 
 func GetDockerLabelForID(id string) []string {
 	return []string{DockerIDLabel + "=" + id}
+}
+
+func GetIDLabels(id string, idLabels []string) []string {
+	if len(idLabels) > 0 {
+		return idLabels
+	}
+	return GetDockerLabelForID(id)
+}
+
+func ValidateIDLabels(labels []string) error {
+	for _, label := range labels {
+		k, _, ok := strings.Cut(label, "=")
+		if !ok || k == "" {
+			return fmt.Errorf("invalid --id-label %q: must be in key=value format", label)
+		}
+	}
+	return nil
 }
 
 type BuildInfo struct {

--- a/pkg/devcontainer/config/build_test.go
+++ b/pkg/devcontainer/config/build_test.go
@@ -1,0 +1,111 @@
+package config
+
+import (
+	"testing"
+)
+
+const (
+	testWorkspaceID = "workspace-123"
+	testLabelApp    = "app=myapp"
+)
+
+func TestGetIDLabels(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       string
+		idLabels []string
+		want     []string
+	}{
+		{
+			name:     "no custom labels uses default",
+			id:       testWorkspaceID,
+			idLabels: nil,
+			want:     []string{"dev.containers.id=" + testWorkspaceID},
+		},
+		{
+			name:     "empty slice uses default",
+			id:       testWorkspaceID,
+			idLabels: []string{},
+			want:     []string{"dev.containers.id=" + testWorkspaceID},
+		},
+		{
+			name:     "custom labels replace default",
+			id:       testWorkspaceID,
+			idLabels: []string{"myapp.id=custom"},
+			want:     []string{"myapp.id=custom"},
+		},
+		{
+			name:     "multiple custom labels",
+			id:       testWorkspaceID,
+			idLabels: []string{testLabelApp, "env=dev"},
+			want:     []string{testLabelApp, "env=dev"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetIDLabels(tt.id, tt.idLabels)
+			if len(got) != len(tt.want) {
+				t.Fatalf("GetIDLabels() returned %d labels, want %d", len(got), len(tt.want))
+			}
+			for i, label := range got {
+				if label != tt.want[i] {
+					t.Errorf("GetIDLabels()[%d] = %q, want %q", i, label, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestValidateIDLabels(t *testing.T) {
+	tests := []struct {
+		name    string
+		labels  []string
+		wantErr bool
+	}{
+		{
+			name:    "valid single label",
+			labels:  []string{"key=value"},
+			wantErr: false,
+		},
+		{
+			name:    "valid multiple labels",
+			labels:  []string{testLabelApp, "env=prod"},
+			wantErr: false,
+		},
+		{
+			name:    "empty value is valid",
+			labels:  []string{"key="},
+			wantErr: false,
+		},
+		{
+			name:    "empty slice is valid",
+			labels:  []string{},
+			wantErr: false,
+		},
+		{
+			name:    "missing equals sign",
+			labels:  []string{"noequalssign"},
+			wantErr: true,
+		},
+		{
+			name:    "empty key",
+			labels:  []string{"=value"},
+			wantErr: true,
+		},
+		{
+			name:    "one valid one invalid",
+			labels:  []string{"good=label", "bad"},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateIDLabels(tt.labels)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateIDLabels() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -61,6 +61,7 @@ func NewRunner(
 		AgentDownloadURL:     agentDownloadURL,
 		LocalWorkspaceFolder: workspaceConfig.ContentFolder,
 		ID:                   GetRunnerIDFromWorkspace(workspaceConfig.Workspace),
+		IDLabels:             workspaceConfig.CLIOptions.IDLabels,
 		WorkspaceConfig:      workspaceConfig,
 	}, nil
 }
@@ -74,7 +75,8 @@ type runner struct {
 
 	LocalWorkspaceFolder string
 
-	ID string
+	ID       string
+	IDLabels []string
 }
 
 type UpOptions struct {

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -57,12 +57,14 @@ func NewDockerDriver(
 			ContainerID:   workspaceInfo.Workspace.Source.Container,
 			Builder:       builder,
 		},
+		IDLabels: workspaceInfo.CLIOptions.IDLabels,
 	}, nil
 }
 
 type dockerDriver struct {
-	Docker  *docker.DockerHelper
-	Compose *compose.ComposeHelper
+	Docker   *docker.DockerHelper
+	Compose  *compose.ComposeHelper
+	IDLabels []string
 }
 
 func (d *dockerDriver) TargetArchitecture(ctx context.Context, workspaceId string) (string, error) {
@@ -243,7 +245,7 @@ func (d *dockerDriver) FindDevContainer(
 	} else {
 		containerDetails, err = d.Docker.FindDevContainer(
 			ctx,
-			[]string{config.DockerIDLabel + "=" + workspaceId},
+			config.GetIDLabels(workspaceId, d.IDLabels),
 		)
 	}
 	if err != nil {
@@ -735,7 +737,7 @@ func (d *dockerDriver) addLabelArgs(
 	workspaceId string,
 	options *driver.RunOptions,
 ) []string {
-	labels := append(config.GetDockerLabelForID(workspaceId), options.Labels...)
+	labels := append(config.GetIDLabels(workspaceId, d.IDLabels), options.Labels...)
 	for _, label := range labels {
 		args = append(args, "-l", label)
 	}

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -234,6 +234,7 @@ type CLIOptions struct {
 	Userns                      string            `json:"userns,omitempty"`
 	UidMap                      []string          `json:"uidMap,omitempty"`
 	GidMap                      []string          `json:"gidMap,omitempty"`
+	IDLabels                    []string          `json:"idLabels,omitempty"`
 
 	// dotfiles options
 	DotfilesRepo   string `json:"dotfilesRepo,omitempty"`


### PR DESCRIPTION
## Summary

- Adds `--id-label key=value` flag to `up` and `exec` commands, allowing users to override the default `dev.containers.id` label for container identification
- When `--id-label` is provided, custom labels **replace** the default label for both container creation and container lookup
- Without the flag, behavior is unchanged (backward compatible)
- Validates label format (must be `key=value`) at flag parsing time
- Threads labels through the full path: CLI flag → CLIOptions → docker driver → Docker labels/filters, and compose override labels

**Spec alignment**: The official devcontainer CLI supports `--id-label` on up/exec/stop/down. This implementation follows the same semantics — custom labels replace (not augment) the default identification label. The `stop`/`down` commands automatically use labels persisted from workspace creation via CLIOptions serialization.

**Files changed**: `cmd/up.go`, `cmd/exec.go`, `pkg/provider/workspace.go`, `pkg/devcontainer/config/build.go`, `pkg/devcontainer/run.go`, `pkg/driver/docker/docker.go`, `pkg/devcontainer/compose.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--id-label` CLI flag to customize container identification labels (repeatable, supports multiple values)
  * Containers now use custom identification labels when specified; falls back to default labeling if not provided

* **Tests**
  * Added unit tests validating label format and configuration behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->