### PR TITLE
feat(up): add --gpu-availability flag to override GPU detection

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -211,6 +211,9 @@ func (cmd *UpCmd) registerDevContainerFlags(upCmd *cobra.Command) {
 	upCmd.Flags().
 		StringVar(&cmd.DefaultUserEnvProbe, "default-user-env-probe", "",
 			"Override userEnvProbe from devcontainer.json (loginInteractiveShell, loginShell, interactiveShell, none)")
+	upCmd.Flags().
+		StringVar(&cmd.GPUAvailability, "gpu-availability", "",
+			"Override GPU availability detection (detect, true, false)")
 }
 
 func (cmd *UpCmd) registerIDEFlags(upCmd *cobra.Command) {

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -1135,7 +1135,7 @@ exec "$$@"
 		overrideService.Privileged = *mergedConfig.Privileged
 	}
 
-	gpuSupportEnabled, _ := composeHelper.Docker.GPUSupportEnabled()
+	gpuSupportEnabled := r.resolveComposeGPUAvailability(composeHelper)
 	r.configureGPUResources(parsedConfig, gpuSupportEnabled, overrideService)
 
 	for _, mount := range mergedConfig.Mounts {
@@ -1170,6 +1170,18 @@ exec "$$@"
 	}
 
 	return project
+}
+
+func (r *runner) resolveComposeGPUAvailability(composeHelper *compose.ComposeHelper) bool {
+	switch r.WorkspaceConfig.CLIOptions.GPUAvailability {
+	case stringTrue:
+		return true
+	case stringFalse:
+		return false
+	default:
+		available, _ := composeHelper.Docker.GPUSupportEnabled()
+		return available
+	}
 }
 
 func (r *runner) configureGPUResources(

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -373,6 +373,7 @@ func (r *runner) runContainer(
 			IDE:                  r.WorkspaceConfig.Workspace.IDE.Name,
 			IDEOptions:           r.WorkspaceConfig.Workspace.IDE.Options,
 			LocalWorkspaceFolder: r.LocalWorkspaceFolder,
+			GPUAvailability:      r.WorkspaceConfig.CLIOptions.GPUAvailability,
 		})
 	}
 

--- a/pkg/driver/docker.go
+++ b/pkg/driver/docker.go
@@ -19,6 +19,7 @@ type RunDockerDevContainerParams struct {
 	IDE                  string
 	IDEOptions           map[string]config2.OptionValue
 	LocalWorkspaceFolder string
+	GPUAvailability      string
 }
 
 type BuildRequest struct {

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -576,7 +576,7 @@ func (b *runArgsBuilder) addLabels() *runArgsBuilder {
 }
 
 func (b *runArgsBuilder) addGPU() *runArgsBuilder {
-	b.args = appendGPUOptions(b.params.ParsedConfig, b.driver, b.args)
+	b.args = appendGPUOptions(b.params.ParsedConfig, b.driver, b.args, b.params.GPUAvailability)
 	return b
 }
 
@@ -788,13 +788,26 @@ func (d *dockerDriver) startContainer(
 	return nil
 }
 
+func resolveGPUAvailability(override string, d *dockerDriver) bool {
+	switch override {
+	case "true":
+		return true
+	case "false":
+		return false
+	default:
+		available, _ := d.Docker.GPUSupportEnabled()
+		return available
+	}
+}
+
 func appendGPUOptions(
 	parsedConfig *config.DevContainerConfig,
 	d *dockerDriver,
 	args []string,
+	gpuAvailabilityOverride string,
 ) []string {
 	if parsedConfig.HostRequirements != nil {
-		gpuAvailable, _ := d.Docker.GPUSupportEnabled()
+		gpuAvailable := resolveGPUAvailability(gpuAvailabilityOverride, d)
 		enableGPU, warnIfMissing := parsedConfig.HostRequirements.ShouldEnableGPU(gpuAvailable)
 		if enableGPU {
 			args = append(args, "--gpus", "all")

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -237,6 +237,7 @@ type CLIOptions struct {
 	UidMap                      []string          `json:"uidMap,omitempty"`
 	GidMap                      []string          `json:"gidMap,omitempty"`
 	IDLabels                    []string          `json:"idLabels,omitempty"`
+	GPUAvailability             string            `json:"gpuAvailability,omitempty"`
 
 	// dotfiles options
 	DotfilesRepo   string `json:"dotfilesRepo,omitempty"`


### PR DESCRIPTION
## Summary

- Adds `--gpu-availability` CLI flag to `devsy up` for overriding GPU auto-detection
- Accepted values: `detect` (default, existing behavior), `true` (force available), `false` (force unavailable)
- Threads override through both single-container and compose paths
- Aligns with official devcontainer CLI's `--gpu-availability` flag (P2 CLI parity, DEVSY-018)