### PR TITLE
feat(feature): validate option type and enum constraints at install time

### DIFF
--- a/pkg/devcontainer/feature/extend.go
+++ b/pkg/devcontainer/feature/extend.go
@@ -348,6 +348,10 @@ func (p *featureProcessor) processFeature(
 		return nil, fmt.Errorf("parse feature: %w", err)
 	}
 
+	if err := ValidateFeatureOptions(featureID, featureConfig, featureOptions); err != nil {
+		return nil, err
+	}
+
 	return &config.FeatureSet{
 		ConfigID: normalizeFeatureID(featureID),
 		Folder:   featureFolder,

--- a/pkg/devcontainer/feature/options.go
+++ b/pkg/devcontainer/feature/options.go
@@ -3,10 +3,14 @@ package feature
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
+	"strings"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 )
+
+const optionTypeBoolean = "boolean"
 
 func getFeatureEnvVariables(feature *config.FeatureConfig, featureOptions any) []string {
 	options := getFeatureValueObject(feature, featureOptions)
@@ -50,4 +54,76 @@ func getFeatureDefaults(feature *config.FeatureConfig) map[string]any {
 	}
 
 	return ret
+}
+
+// ValidateFeatureOptions checks that user-provided option values satisfy
+// the type and enum constraints declared in the feature configuration.
+func ValidateFeatureOptions(
+	featureID string,
+	featureCfg *config.FeatureConfig,
+	userOptions any,
+) error {
+	if featureCfg == nil || len(featureCfg.Options) == 0 {
+		return nil
+	}
+
+	optionsMap := toOptionsMap(userOptions, featureCfg)
+	if len(optionsMap) == 0 {
+		return nil
+	}
+
+	for name, value := range optionsMap {
+		option, exists := featureCfg.Options[name]
+		if !exists {
+			continue
+		}
+
+		if err := validateOptionValue(featureID, name, option, value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateOptionValue(
+	featureID, name string,
+	option config.FeatureConfigOption,
+	value any,
+) error {
+	strVal := fmt.Sprintf("%v", value)
+
+	if option.Type == optionTypeBoolean {
+		if !strings.EqualFold(strVal, "true") && !strings.EqualFold(strVal, "false") {
+			return fmt.Errorf(
+				"feature %q option %q: must be true or false, got %q",
+				featureID, name, strVal,
+			)
+		}
+	}
+
+	if len(option.Enum) > 0 && !slices.Contains(option.Enum, strVal) {
+		return fmt.Errorf(
+			"feature %q option %q: must be one of %v, got %q",
+			featureID, name, option.Enum, strVal,
+		)
+	}
+
+	return nil
+}
+
+func toOptionsMap(userOptions any, featureCfg *config.FeatureConfig) map[string]any {
+	switch t := userOptions.(type) {
+	case map[string]any:
+		return t
+	case string:
+		if featureCfg.Options == nil {
+			return nil
+		}
+		if _, ok := featureCfg.Options["version"]; ok {
+			return map[string]any{"version": t}
+		}
+		return nil
+	}
+	return nil
 }

--- a/pkg/devcontainer/feature/options_test.go
+++ b/pkg/devcontainer/feature/options_test.go
@@ -1,0 +1,253 @@
+package feature
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testFeatureID     = "ghcr.io/devcontainers/features/go"
+	testOptionName    = "version"
+	testOptionInstall = "install"
+	optionTypeString  = "string"
+	testEnumVal120    = "1.20"
+	testEnumVal121    = "1.21"
+	testEnumValLatest = "latest"
+)
+
+type OptionsTestSuite struct {
+	suite.Suite
+}
+
+func TestOptionsTestSuite(t *testing.T) {
+	suite.Run(t, new(OptionsTestSuite))
+}
+
+func (s *OptionsTestSuite) TestValidBooleanStringTrue() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionInstall: {Type: optionTypeBoolean},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionInstall: "true"})
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestValidBooleanStringFalse() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionInstall: {Type: optionTypeBoolean},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionInstall: "false"})
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestValidBooleanCaseInsensitive() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionInstall: {Type: optionTypeBoolean},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionInstall: "True"})
+	s.NoError(err)
+
+	err = ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionInstall: "FALSE"})
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestValidBooleanGoBoolTrue() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionInstall: {Type: optionTypeBoolean},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionInstall: true})
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestValidBooleanGoBoolFalse() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionInstall: {Type: optionTypeBoolean},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionInstall: false})
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestInvalidBooleanYes() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionInstall: {Type: optionTypeBoolean},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionInstall: "yes"})
+	s.Error(err)
+	s.Contains(err.Error(), "must be true or false")
+	s.Contains(err.Error(), `got "yes"`)
+}
+
+func (s *OptionsTestSuite) TestInvalidBooleanOne() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionInstall: {Type: optionTypeBoolean},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionInstall: "1"})
+	s.Error(err)
+	s.Contains(err.Error(), "must be true or false")
+}
+
+func (s *OptionsTestSuite) TestInvalidBooleanMaybe() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionInstall: {Type: optionTypeBoolean},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionInstall: "maybe"})
+	s.Error(err)
+	s.Contains(err.Error(), "must be true or false")
+	s.Contains(err.Error(), `got "maybe"`)
+}
+
+func (s *OptionsTestSuite) TestValidEnumValue() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionName: {
+				Type: optionTypeString,
+				Enum: []string{testEnumVal120, testEnumVal121, testEnumValLatest},
+			},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionName: "1.21"})
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestInvalidEnumValue() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionName: {
+				Type: optionTypeString,
+				Enum: []string{testEnumVal120, testEnumVal121, testEnumValLatest},
+			},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionName: "1.19"})
+	s.Error(err)
+	s.Contains(err.Error(), "must be one of")
+	s.Contains(err.Error(), `got "1.19"`)
+	s.Contains(err.Error(), testEnumVal120)
+}
+
+func (s *OptionsTestSuite) TestStringTypeNoEnum() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionName: {Type: optionTypeString},
+		},
+	}
+	err := ValidateFeatureOptions(
+		testFeatureID,
+		cfg,
+		map[string]any{testOptionName: "anything-goes"},
+	)
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestNoTypeNoEnum() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionName: {},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionName: "whatever"})
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestNilUserOptions() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionName: {Type: optionTypeBoolean},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, nil)
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestEmptyMapUserOptions() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionName: {Type: optionTypeBoolean},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{})
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestNilFeatureConfig() {
+	err := ValidateFeatureOptions(testFeatureID, nil, map[string]any{testOptionName: "value"})
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestEmptyOptionsMap() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionName: "value"})
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestStringShorthandValidatesVersion() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionName: {
+				Type: optionTypeString,
+				Enum: []string{testEnumVal120, testEnumVal121, testEnumValLatest},
+			},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, "1.21")
+	s.NoError(err)
+
+	err = ValidateFeatureOptions(testFeatureID, cfg, "1.19")
+	s.Error(err)
+	s.Contains(err.Error(), "must be one of")
+}
+
+func (s *OptionsTestSuite) TestStringShorthandNoVersionOption() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionInstall: {Type: optionTypeBoolean},
+		},
+	}
+	// String shorthand with no "version" option defined - no validation
+	err := ValidateFeatureOptions(testFeatureID, cfg, "anything")
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestUnknownOptionIgnored() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionName: {
+				Type: optionTypeString,
+				Enum: []string{testEnumVal120, testEnumVal121},
+			},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{"unknownOpt": "whatever"})
+	s.NoError(err)
+}
+
+func (s *OptionsTestSuite) TestErrorContainsFeatureID() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionInstall: {Type: optionTypeBoolean},
+		},
+	}
+	err := ValidateFeatureOptions(testFeatureID, cfg, map[string]any{testOptionInstall: "bad"})
+	s.Error(err)
+	s.Contains(err.Error(), testFeatureID)
+	s.Contains(err.Error(), "install")
+}


### PR DESCRIPTION
## Summary

- Adds validation for feature option values against declared `type` and `enum` constraints before installation
- Boolean-typed options reject any value other than "true"/"false" (case-insensitive)
- Enum-constrained options reject values not in the declared list
- Validation runs in `processFeature` immediately after parsing `devcontainer-feature.json`
- 253 lines of unit tests covering all edge cases (Go bools, string shorthand, nil options, unknown keys)
- Spec alignment: DEVSY-013 (P2 spec compliance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Feature options are now validated against their configured types and constraints, providing clearer error messages for invalid configurations.

* **Tests**
  * Added comprehensive test coverage for option validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->