### PR TITLE
fix(lifecycle): surface deferred hook errors instead of swallowing them

### DIFF
--- a/cmd/agent/container/deferred_hooks.go
+++ b/cmd/agent/container/deferred_hooks.go
@@ -5,6 +5,7 @@ package container
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/compress"
@@ -70,12 +71,11 @@ func (cmd *DeferredHooksCmd) Run(ctx context.Context) error {
 		RemoteUser:    config.GetRemoteUser(setupInfo),
 	}, cmd.SecretsEnv)
 	if err != nil {
-		log.Errorf("deferred hooks setup failed: %v", err)
-		return nil
+		return fmt.Errorf("deferred hooks setup: %w", err)
 	}
 
 	if err := deferred.Run(); err != nil {
-		log.Errorf("deferred lifecycle hooks failed: %v", err)
+		return fmt.Errorf("deferred lifecycle hooks: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Deferred lifecycle hooks (postStart, postAttach) ran as a background subprocess that always exited 0, even on failure
- Now returns errors properly so the process exits non-zero and failures are observable via process monitoring and stream logs
- Net-zero change: +3/-3 lines in `cmd/agent/container/deferred_hooks.go`
- Spec alignment: DEVSY-019 (P2 spec compliance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to properly report failures instead of silently ignoring them, ensuring errors are correctly propagated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->