### PR TITLE
test(e2e): add E2E tests for OCI extends and outdated command

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -204,6 +204,12 @@ jobs:
             install-kind: false
             requires-secret: false
 
+          - label: outdated
+            runner: ubuntu-latest
+            free-disk-space: false
+            install-kind: false
+            requires-secret: false
+
           - label: down
             runner: ubuntu-latest
             free-disk-space: false

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/devsy-org/devsy/e2e/tests/logs"
 	_ "github.com/devsy-org/devsy/e2e/tests/machine"
 	_ "github.com/devsy-org/devsy/e2e/tests/machineprovider"
+	_ "github.com/devsy-org/devsy/e2e/tests/outdated"
 	_ "github.com/devsy-org/devsy/e2e/tests/provider"
 	_ "github.com/devsy-org/devsy/e2e/tests/readconfiguration"
 	_ "github.com/devsy-org/devsy/e2e/tests/ssh"

--- a/e2e/tests/extends/extends.go
+++ b/e2e/tests/extends/extends.go
@@ -1,11 +1,25 @@
 package extends
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -168,7 +182,155 @@ var _ = ginkgo.Describe("extends property", ginkgo.Label("extends"), func() {
 		_, _, err = readConfiguration(ctx, f, tempDir)
 		framework.ExpectError(err)
 	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("resolves OCI registry extends reference", func(ctx context.Context) {
+		f := framework.NewDefaultFramework(initialDir + "/bin")
+
+		srv := httptest.NewServer(registry.New())
+		ginkgo.DeferCleanup(func() { srv.Close() })
+
+		regHost := strings.TrimPrefix(srv.URL, "http://")
+
+		parentJSON := `{
+			"name": "oci-parent",
+			"image": "ubuntu:22.04",
+			"remoteUser": "vscode",
+			"containerEnv": {"FROM_OCI": "oci-value"}
+		}`
+		pushOCIImage(regHost+"/test/devcontainer-base:latest", parentJSON)
+
+		tempDir, err := os.MkdirTemp("", "oci-extends-*")
+		framework.ExpectNoError(err)
+		ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
+
+		devcontainerDir := filepath.Join(tempDir, ".devcontainer")
+		framework.ExpectNoError(os.MkdirAll(devcontainerDir, 0o750))
+
+		childJSON := fmt.Sprintf(`{
+			"name": "OCI Child",
+			"extends": "%s/test/devcontainer-base:latest"
+		}`, regHost)
+		framework.ExpectNoError(
+			os.WriteFile(
+				filepath.Join(devcontainerDir, "devcontainer.json"),
+				[]byte(childJSON),
+				0o600,
+			),
+		)
+
+		stdout, _, err := readConfiguration(ctx, f, tempDir)
+		framework.ExpectNoError(err)
+
+		config := parseConfigFromOutput(stdout)
+		gomega.Expect(config).To(gomega.HaveKeyWithValue("name", "OCI Child"))
+		gomega.Expect(config).To(gomega.HaveKeyWithValue("image", "ubuntu:22.04"))
+		gomega.Expect(config).To(gomega.HaveKeyWithValue("remoteUser", "vscode"))
+
+		containerEnv, ok := config["containerEnv"].(map[string]any)
+		gomega.Expect(ok).To(gomega.BeTrue(), "containerEnv should be an object")
+		gomega.Expect(containerEnv).To(gomega.HaveKeyWithValue("FROM_OCI", "oci-value"))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It(
+		"resolves OCI extends with deep merge of parent fields",
+		func(ctx context.Context) {
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+
+			srv := httptest.NewServer(registry.New())
+			ginkgo.DeferCleanup(func() { srv.Close() })
+
+			regHost := strings.TrimPrefix(srv.URL, "http://")
+
+			parentJSON := `{
+			"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+			"containerEnv": {"PARENT_KEY": "parent-value", "SHARED": "from-parent"},
+			"features": {"ghcr.io/devcontainers/features/node:1": {}}
+		}`
+			pushOCIImage(regHost+"/test/merge-base:v1", parentJSON)
+
+			tempDir, err := os.MkdirTemp("", "oci-extends-merge-*")
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
+
+			devcontainerDir := filepath.Join(tempDir, ".devcontainer")
+			framework.ExpectNoError(os.MkdirAll(devcontainerDir, 0o750))
+
+			childJSON := fmt.Sprintf(`{
+			"name": "OCI Merge Child",
+			"extends": "%s/test/merge-base:v1",
+			"containerEnv": {"CHILD_KEY": "child-value", "SHARED": "from-child"},
+			"features": {"ghcr.io/devcontainers/features/go:1": {}}
+		}`, regHost)
+			framework.ExpectNoError(
+				os.WriteFile(
+					filepath.Join(devcontainerDir, "devcontainer.json"),
+					[]byte(childJSON),
+					0o600,
+				),
+			)
+
+			stdout, _, err := readConfiguration(ctx, f, tempDir)
+			framework.ExpectNoError(err)
+
+			config := parseConfigFromOutput(stdout)
+			gomega.Expect(config).To(gomega.HaveKeyWithValue("name", "OCI Merge Child"))
+			gomega.Expect(config).To(
+				gomega.HaveKeyWithValue(
+					"image",
+					"mcr.microsoft.com/devcontainers/base:ubuntu",
+				),
+			)
+
+			containerEnv, ok := config["containerEnv"].(map[string]any)
+			gomega.Expect(ok).To(gomega.BeTrue(), "containerEnv should be an object")
+			gomega.Expect(containerEnv).To(
+				gomega.HaveKeyWithValue("PARENT_KEY", "parent-value"),
+			)
+			gomega.Expect(containerEnv).To(
+				gomega.HaveKeyWithValue("CHILD_KEY", "child-value"),
+			)
+			gomega.Expect(containerEnv).To(gomega.HaveKeyWithValue("SHARED", "from-child"))
+
+			features, ok := config["features"].(map[string]any)
+			gomega.Expect(ok).To(gomega.BeTrue(), "features should be an object")
+			gomega.Expect(features).To(
+				gomega.HaveKey("ghcr.io/devcontainers/features/node:1"),
+			)
+			gomega.Expect(features).To(
+				gomega.HaveKey("ghcr.io/devcontainers/features/go:1"),
+			)
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 })
+
+func pushOCIImage(refStr, jsonContent string) {
+	layer := static.NewLayer(buildOCITarGz("devcontainer.json", jsonContent), types.OCILayer)
+
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	framework.ExpectNoError(err)
+
+	ref, err := name.ParseReference(refStr, name.Insecure)
+	framework.ExpectNoError(err)
+
+	framework.ExpectNoError(remote.Write(ref, img))
+}
+
+func buildOCITarGz(filename, content string) []byte {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	hdr := &tar.Header{
+		Name: filename,
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}
+	gomega.Expect(tw.WriteHeader(hdr)).To(gomega.Succeed())
+	_, err := tw.Write([]byte(content))
+	framework.ExpectNoError(err)
+	gomega.Expect(tw.Close()).To(gomega.Succeed())
+	gomega.Expect(gz.Close()).To(gomega.Succeed())
+	return buf.Bytes()
+}
 
 func readConfiguration(
 	ctx context.Context,

--- a/e2e/tests/outdated/outdated.go
+++ b/e2e/tests/outdated/outdated.go
@@ -23,6 +23,11 @@ import (
 	"github.com/onsi/gomega"
 )
 
+const (
+	cmdOutdated         = "outdated"
+	flagWorkspaceFolder = "--workspace-folder"
+)
+
 var _ = ginkgo.Describe("outdated command", ginkgo.Label("outdated"), func() {
 	var initialDir string
 
@@ -52,8 +57,8 @@ var _ = ginkgo.Describe("outdated command", ginkgo.Label("outdated"), func() {
 		ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
 
 		stdout, _, err := f.ExecCommandCapture(ctx, []string{
-			"outdated",
-			"--workspace-folder", tempDir,
+			cmdOutdated,
+			flagWorkspaceFolder, tempDir,
 		})
 		framework.ExpectNoError(err)
 
@@ -82,8 +87,8 @@ var _ = ginkgo.Describe("outdated command", ginkgo.Label("outdated"), func() {
 			ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
 
 			stdout, _, err := f.ExecCommandCapture(ctx, []string{
-				"outdated",
-				"--workspace-folder", tempDir,
+				cmdOutdated,
+				flagWorkspaceFolder, tempDir,
 			})
 			framework.ExpectNoError(err)
 
@@ -103,8 +108,8 @@ var _ = ginkgo.Describe("outdated command", ginkgo.Label("outdated"), func() {
 			ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
 
 			stdout, _, err := f.ExecCommandCapture(ctx, []string{
-				"outdated",
-				"--workspace-folder", tempDir,
+				cmdOutdated,
+				flagWorkspaceFolder, tempDir,
 			})
 			framework.ExpectNoError(err)
 

--- a/e2e/tests/outdated/outdated.go
+++ b/e2e/tests/outdated/outdated.go
@@ -1,0 +1,164 @@
+package outdated
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("outdated command", ginkgo.Label("outdated"), func() {
+	var initialDir string
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		initialDir, err = os.Getwd()
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("reports newer versions available for a feature", func(ctx context.Context) {
+		f := framework.NewDefaultFramework(initialDir + "/bin")
+
+		srv := httptest.NewServer(registry.New())
+		ginkgo.DeferCleanup(func() { srv.Close() })
+
+		regHost := strings.TrimPrefix(srv.URL, "http://")
+		featureRepo := regHost + "/test/my-feature"
+
+		pushFeatureTag(featureRepo + ":1.0.0")
+		pushFeatureTag(featureRepo + ":1.1.0")
+		pushFeatureTag(featureRepo + ":2.0.0")
+
+		tempDir := writeDevcontainerJSON(fmt.Sprintf(`{
+			"image": "ubuntu:22.04",
+			"features": {"%s:1.0.0": {}}
+		}`, featureRepo))
+		ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
+
+		stdout, _, err := f.ExecCommandCapture(ctx, []string{
+			"outdated",
+			"--workspace-folder", tempDir,
+		})
+		framework.ExpectNoError(err)
+
+		gomega.Expect(stdout).To(gomega.ContainSubstring("2.0.0"))
+		gomega.Expect(stdout).To(gomega.ContainSubstring("1.0.0"))
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It(
+		"reports all up to date when feature is at latest version",
+		func(ctx context.Context) {
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+
+			srv := httptest.NewServer(registry.New())
+			ginkgo.DeferCleanup(func() { srv.Close() })
+
+			regHost := strings.TrimPrefix(srv.URL, "http://")
+			featureRepo := regHost + "/test/my-feature"
+
+			pushFeatureTag(featureRepo + ":1.0.0")
+			pushFeatureTag(featureRepo + ":1.1.0")
+
+			tempDir := writeDevcontainerJSON(fmt.Sprintf(`{
+			"image": "ubuntu:22.04",
+			"features": {"%s:1.1.0": {}}
+		}`, featureRepo))
+			ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
+
+			stdout, _, err := f.ExecCommandCapture(ctx, []string{
+				"outdated",
+				"--workspace-folder", tempDir,
+			})
+			framework.ExpectNoError(err)
+
+			gomega.Expect(stdout).To(gomega.ContainSubstring("All features are up to date."))
+		},
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
+	)
+
+	ginkgo.It(
+		"reports no features found when devcontainer has no features",
+		func(ctx context.Context) {
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+
+			tempDir := writeDevcontainerJSON(`{
+			"image": "ubuntu:22.04"
+		}`)
+			ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
+
+			stdout, _, err := f.ExecCommandCapture(ctx, []string{
+				"outdated",
+				"--workspace-folder", tempDir,
+			})
+			framework.ExpectNoError(err)
+
+			gomega.Expect(stdout).To(gomega.ContainSubstring("No features found."))
+		},
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
+	)
+})
+
+func writeDevcontainerJSON(content string) string {
+	tempDir, err := os.MkdirTemp("", "outdated-test-*")
+	framework.ExpectNoError(err)
+
+	devcontainerDir := filepath.Join(tempDir, ".devcontainer")
+	framework.ExpectNoError(os.MkdirAll(devcontainerDir, 0o750))
+	framework.ExpectNoError(
+		os.WriteFile(
+			filepath.Join(devcontainerDir, "devcontainer.json"),
+			[]byte(content),
+			0o600,
+		),
+	)
+	return tempDir
+}
+
+func pushFeatureTag(refStr string) {
+	layer := static.NewLayer(
+		buildFeatureTarGz("devcontainer-feature.json", `{"id":"my-feature","version":"1.0.0"}`),
+		types.OCILayer,
+	)
+
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	framework.ExpectNoError(err)
+
+	ref, err := name.ParseReference(refStr, name.Insecure)
+	framework.ExpectNoError(err)
+
+	framework.ExpectNoError(remote.Write(ref, img))
+}
+
+func buildFeatureTarGz(filename, content string) []byte {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	hdr := &tar.Header{
+		Name: filename,
+		Mode: 0o644,
+		Size: int64(len(content)),
+	}
+	gomega.Expect(tw.WriteHeader(hdr)).To(gomega.Succeed())
+	_, err := tw.Write([]byte(content))
+	framework.ExpectNoError(err)
+	gomega.Expect(tw.Close()).To(gomega.Succeed())
+	gomega.Expect(gz.Close()).To(gomega.Succeed())
+	return buf.Bytes()
+}


### PR DESCRIPTION
## Summary

- Add OCI registry extends E2E tests to `e2e/tests/extends/extends.go` verifying remote devcontainer.json resolution and deep merge via a local httptest registry
- Create new `e2e/tests/outdated/` package with tests for newer-version-available, all-up-to-date, and no-features scenarios using a local OCI registry with multiple version tags
- Register the new outdated test package in `e2e/e2e_suite_test.go`