### PR TITLE
fix(config): remove unsupported ${env:VAR} variable substitution

### DIFF
--- a/docs/pages/developing-in-workspaces/devcontainer-json.mdx
+++ b/docs/pages/developing-in-workspaces/devcontainer-json.mdx
@@ -92,7 +92,7 @@ field of the `devcontainer.json` file as follows:
   "customizations": {
     "devsy": {
       "featureDownloadHTTPHeaders": {
-        "FOO_HEADER": "${env:FOO_ENV_VAR}"
+        "FOO_HEADER": "${localEnv:FOO_ENV_VAR}"
         "BAR_HEADER": "bar"
       }
     }

--- a/pkg/devcontainer/config/substitute.go
+++ b/pkg/devcontainer/config/substitute.go
@@ -113,8 +113,6 @@ func replaceWithContext(
 			return substitutionCtx.DevContainerID
 		}
 		return match
-	case "env":
-		fallthrough
 	case "localEnv":
 		return lookupValue(isWindows, substitutionCtx.Env, args, match)
 	case "localWorkspaceFolder":

--- a/pkg/devcontainer/config/substitute_test.go
+++ b/pkg/devcontainer/config/substitute_test.go
@@ -103,6 +103,54 @@ func TestReplaceWithContainerEnvUnknownPreservedAsLiteral(t *testing.T) {
 	}
 }
 
+func TestReplaceWithContextLocalEnvResolves(t *testing.T) {
+	ctx := &SubstitutionContext{
+		Env: map[string]string{"HOME": "/root"},
+	}
+	match := "${localEnv:HOME}"
+	result := replaceWithContext(
+		false, ctx, match, "localEnv", []string{"HOME"},
+	)
+	if result != "/root" {
+		t.Errorf(
+			"expected localEnv to resolve to %q, got %q",
+			"/root", result,
+		)
+	}
+}
+
+func TestReplaceWithContextEnvPreservedAsLiteral(t *testing.T) {
+	ctx := &SubstitutionContext{
+		Env: map[string]string{"HOME": "/root"},
+	}
+	match := "${env:HOME}"
+	result := replaceWithContext(
+		false, ctx, match, "env", []string{"HOME"},
+	)
+	if result != match {
+		t.Errorf(
+			"expected env var preserved as %q, got %q",
+			match, result,
+		)
+	}
+}
+
+func TestReplaceWithContextEnvDefaultPreservedAsLiteral(t *testing.T) {
+	ctx := &SubstitutionContext{
+		Env: map[string]string{},
+	}
+	match := "${env:MISSING:default}"
+	result := replaceWithContext(
+		false, ctx, match, "env", []string{"MISSING", "default"},
+	)
+	if result != match {
+		t.Errorf(
+			"expected env with default preserved as %q, got %q",
+			match, result,
+		)
+	}
+}
+
 func TestResolveStringDefaultWithColons(t *testing.T) {
 	replace := func(_, variable string, args []string) string {
 		env := map[string]string{}


### PR DESCRIPTION
## Summary

Per the devcontainer spec, variable substitution only supports `${localEnv:VAR}` and `${containerEnv:VAR}`. The `${env:VAR}` form was incorrectly resolving identically to `${localEnv:VAR}` via a `case "env": fallthrough`. This removes that fallthrough so `${env:VAR}` is now preserved as a literal (matching spec behavior), updates a docs example that used the non-spec form, and adds unit tests for the new behavior.