### PR TITLE
feat(cmd): add JSON result envelope on stdout for up/build/exec

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -222,7 +222,7 @@ func (cmd *BuildCmd) build(
 	}
 
 	containerID := ""
-	workdir := ""
+	workdir := "" // uses substituted path directly; build doesn't support git subpath overrides
 	if result != nil {
 		if result.ContainerDetails != nil {
 			containerID = result.ContainerDetails.ID

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -9,6 +9,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
+	devcconfig "github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/image"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
@@ -207,7 +208,7 @@ func (cmd *BuildCmd) build(
 		log.Debugf("done building devcontainer")
 		log.Infof("cleaning up temporary workspace")
 	}()
-	_, err = clientimplementation.BuildAgentClient(
+	result, err := clientimplementation.BuildAgentClient(
 		ctx,
 		clientimplementation.BuildAgentClientOptions{
 			WorkspaceClient: workspaceClient,
@@ -215,5 +216,22 @@ func (cmd *BuildCmd) build(
 			AgentCommand:    "build",
 		},
 	)
-	return err
+	if err != nil {
+		_ = devcconfig.WriteErrorJSON(os.Stdout, err.Error())
+		return err
+	}
+
+	containerID := ""
+	workdir := ""
+	if result != nil {
+		if result.ContainerDetails != nil {
+			containerID = result.ContainerDetails.ID
+		}
+		if result.SubstitutionContext != nil {
+			workdir = result.SubstitutionContext.ContainerWorkspaceFolder
+		}
+	}
+	user := devcconfig.GetRemoteUser(result)
+	_ = devcconfig.WriteResultJSON(os.Stdout, containerID, user, workdir)
+	return nil
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -123,11 +123,18 @@ func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
 	probedEnv := probeContainerEnv(ctx, target, userEnvProbe)
 	envMap := buildExecEnv(result, cmd.RemoteEnv, probedEnv)
 
-	return cmd.execInContainer(ctx, execOpts{
+	err = cmd.execInContainer(ctx, execOpts{
 		target:  target,
 		workdir: workdir,
 		envMap:  envMap,
 	}, args)
+	if err != nil {
+		_ = devcconfig.WriteErrorJSON(os.Stderr, err.Error())
+		return err
+	}
+
+	_ = devcconfig.WriteResultJSON(os.Stderr, containerDetails.ID, user, workdir)
+	return nil
 }
 
 func (cmd *ExecCmd) validateRemoteEnv() error {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -86,21 +86,26 @@ func (cmd *UpCmd) Run(
 		return nil // Platform mode
 	}
 
-	containerID := ""
-	if wctx.result != nil && wctx.result.ContainerDetails != nil {
-		containerID = wctx.result.ContainerDetails.ID
-	}
-	_ = config2.WriteResultJSON(os.Stdout, containerID, wctx.user, wctx.workdir)
-
 	if cmd.Prebuild {
 		return nil
 	}
 
 	if err := cmd.configureWorkspace(devsyConfig, client, wctx); err != nil {
+		_ = config2.WriteErrorJSON(os.Stdout, err.Error())
 		return err
 	}
 
-	return cmd.openIDE(ctx, devsyConfig, client, wctx)
+	if err := cmd.openIDE(ctx, devsyConfig, client, wctx); err != nil {
+		_ = config2.WriteErrorJSON(os.Stdout, err.Error())
+		return err
+	}
+
+	containerID := ""
+	if wctx.result != nil && wctx.result.ContainerDetails != nil {
+		containerID = wctx.result.ContainerDetails.ID
+	}
+	_ = config2.WriteResultJSON(os.Stdout, containerID, wctx.user, wctx.workdir)
+	return nil
 }
 
 func (cmd *UpCmd) execute(cobraCmd *cobra.Command, args []string) error {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -79,11 +79,18 @@ func (cmd *UpCmd) Run(
 
 	wctx, err := cmd.executeDevsyUp(ctx, devsyConfig, client)
 	if err != nil {
+		_ = config2.WriteErrorJSON(os.Stdout, err.Error())
 		return err
 	}
 	if wctx == nil {
 		return nil // Platform mode
 	}
+
+	containerID := ""
+	if wctx.result != nil && wctx.result.ContainerDetails != nil {
+		containerID = wctx.result.ContainerDetails.ID
+	}
+	_ = config2.WriteResultJSON(os.Stdout, containerID, wctx.user, wctx.workdir)
 
 	if cmd.Prebuild {
 		return nil

--- a/pkg/devcontainer/config/envelope.go
+++ b/pkg/devcontainer/config/envelope.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+type ResultEnvelope struct {
+	Outcome               string `json:"outcome"`
+	ContainerID           string `json:"containerId"`
+	RemoteUser            string `json:"remoteUser"`
+	RemoteWorkspaceFolder string `json:"remoteWorkspaceFolder"`
+}
+
+type ErrorEnvelope struct {
+	Outcome string `json:"outcome"`
+	Message string `json:"message"`
+}
+
+func WriteResultJSON(w io.Writer, containerID, user, workdir string) error {
+	env := ResultEnvelope{
+		Outcome:               "success",
+		ContainerID:           containerID,
+		RemoteUser:            user,
+		RemoteWorkspaceFolder: workdir,
+	}
+	data, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "%s\n", data)
+	return err
+}
+
+func WriteErrorJSON(w io.Writer, msg string) error {
+	env := ErrorEnvelope{
+		Outcome: "error",
+		Message: msg,
+	}
+	data, err := json.Marshal(env)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "%s\n", data)
+	return err
+}

--- a/pkg/devcontainer/config/envelope_test.go
+++ b/pkg/devcontainer/config/envelope_test.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+//nolint:goconst,cyclop,funlen // test table values
+func TestWriteResultJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		containerID string
+		user        string
+		workdir     string
+	}{
+		{
+			name:        "typical values",
+			containerID: "abc123def456",
+			user:        "vscode",
+			workdir:     "/workspaces/project",
+		},
+		{
+			name:        "root user",
+			containerID: "sha256:abcdef1234567890",
+			user:        "root",
+			workdir:     "/workspaces/my-app",
+		},
+		{
+			name:        "empty strings",
+			containerID: "",
+			user:        "",
+			workdir:     "",
+		},
+		{
+			name:        "special characters in container ID",
+			containerID: "container:with/special-chars_123",
+			user:        "dev-user",
+			workdir:     "/workspaces/my project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := WriteResultJSON(&buf, tt.containerID, tt.user, tt.workdir)
+			if err != nil {
+				t.Fatalf("WriteResultJSON returned error: %v", err)
+			}
+
+			output := buf.Bytes()
+			if output[len(output)-1] != '\n' {
+				t.Fatal("output must be newline-terminated")
+			}
+
+			var envelope ResultEnvelope
+			if err := json.Unmarshal(output, &envelope); err != nil {
+				t.Fatalf("output is not valid JSON: %v", err)
+			}
+
+			if envelope.Outcome != "success" {
+				t.Errorf("outcome = %q, want %q", envelope.Outcome, "success")
+			}
+			if envelope.ContainerID != tt.containerID {
+				t.Errorf("containerId = %q, want %q", envelope.ContainerID, tt.containerID)
+			}
+			if envelope.RemoteUser != tt.user {
+				t.Errorf("remoteUser = %q, want %q", envelope.RemoteUser, tt.user)
+			}
+			if envelope.RemoteWorkspaceFolder != tt.workdir {
+				t.Errorf("remoteWorkspaceFolder = %q, want %q",
+					envelope.RemoteWorkspaceFolder, tt.workdir)
+			}
+
+			if bytes.Contains(output[:len(output)-1], []byte("\n")) {
+				t.Error("JSON must be single-line (no embedded newlines)")
+			}
+		})
+	}
+}
+
+func TestWriteErrorJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		message string
+	}{
+		{
+			name:    "simple error",
+			message: "container failed to start",
+		},
+		{
+			name:    "empty message",
+			message: "",
+		},
+		{
+			name:    "message with quotes",
+			message: `failed to parse "devcontainer.json": unexpected token`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := WriteErrorJSON(&buf, tt.message)
+			if err != nil {
+				t.Fatalf("WriteErrorJSON returned error: %v", err)
+			}
+
+			output := buf.Bytes()
+			if output[len(output)-1] != '\n' {
+				t.Fatal("output must be newline-terminated")
+			}
+
+			var envelope ErrorEnvelope
+			if err := json.Unmarshal(output, &envelope); err != nil {
+				t.Fatalf("output is not valid JSON: %v", err)
+			}
+
+			if envelope.Outcome != "error" {
+				t.Errorf("outcome = %q, want %q", envelope.Outcome, "error")
+			}
+			if envelope.Message != tt.message {
+				t.Errorf("message = %q, want %q", envelope.Message, tt.message)
+			}
+
+			if bytes.Contains(output[:len(output)-1], []byte("\n")) {
+				t.Error("JSON must be single-line (no embedded newlines)")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds structured JSON result output to `up`, `build`, and `exec` commands matching the official devcontainer CLI envelope format (`{"outcome":"success","containerId":"...","remoteUser":"...","remoteWorkspaceFolder":"..."}`).

- `up` and `build` emit the envelope to stdout on success (error envelope on failure)
- `exec` emits to stderr since stdout is reserved for the executed command's output
- Includes unit tests for envelope marshaling with edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI commands now output structured JSON responses, including container ID, remote user, and workspace information on success and detailed error messages on failure, enabling better programmatic integration and automation.

* **Tests**
  * Added comprehensive test coverage for JSON output formatting and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->