### PR TITLE
feat(cmd): add hidden flag aliases for devcontainer CLI compat

### DIFF
--- a/cmd/flag_aliases_test.go
+++ b/cmd/flag_aliases_test.go
@@ -9,10 +9,16 @@ import (
 )
 
 const (
-	flagConfig           = "--config"
-	flagDevcontainerPath = "devcontainer-path"
-	flagLogFormat        = "--log-format"
-	formatJSON           = "json"
+	flagConfig                  = "--config"
+	flagDevcontainerPath        = "devcontainer-path"
+	flagLogFormat               = "--log-format"
+	flagOverrideConfig          = "--override-config"
+	flagExtraDevContainerPath   = "extra-devcontainer-path"
+	flagDotfilesRepository      = "--dotfiles-repository"
+	flagDotfiles                = "dotfiles"
+	flagRemoveExistingContainer = "--remove-existing-container"
+	flagRecreate                = "recreate"
+	formatJSON                  = "json"
 )
 
 func TestUpCmd_ConfigAlias(t *testing.T) {
@@ -62,4 +68,55 @@ func TestConfigAlias_E2E(t *testing.T) {
 	rootCmd.SetArgs([]string{"up", flagConfig, "/tmp/test.json", "--help"})
 	err := rootCmd.Execute()
 	require.NoError(t, err)
+}
+
+func TestUpCmd_OverrideConfigAlias(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	err := upCmd.ParseFlags([]string{flagOverrideConfig, "/tmp/override.json"})
+	require.NoError(t, err)
+
+	val, err := upCmd.Flags().GetString(flagExtraDevContainerPath)
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/override.json", val)
+}
+
+func TestOverrideConfigAlias_IsHidden(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	f := upCmd.Flags().Lookup("override-config")
+	require.NotNil(t, f)
+	assert.True(t, f.Hidden, flagOverrideConfig+" alias should be hidden")
+}
+
+func TestUpCmd_DotfilesRepositoryAlias(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	err := upCmd.ParseFlags([]string{flagDotfilesRepository, "https://github.com/user/dotfiles"})
+	require.NoError(t, err)
+
+	val, err := upCmd.Flags().GetString(flagDotfiles)
+	require.NoError(t, err)
+	assert.Equal(t, "https://github.com/user/dotfiles", val)
+}
+
+func TestDotfilesRepositoryAlias_IsHidden(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	f := upCmd.Flags().Lookup("dotfiles-repository")
+	require.NotNil(t, f)
+	assert.True(t, f.Hidden, flagDotfilesRepository+" alias should be hidden")
+}
+
+func TestUpCmd_RemoveExistingContainerAlias(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	err := upCmd.ParseFlags([]string{flagRemoveExistingContainer})
+	require.NoError(t, err)
+
+	val, err := upCmd.Flags().GetBool(flagRecreate)
+	require.NoError(t, err)
+	assert.True(t, val)
+}
+
+func TestRemoveExistingContainerAlias_IsHidden(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	f := upCmd.Flags().Lookup("remove-existing-container")
+	require.NotNil(t, f)
+	assert.True(t, f.Hidden, flagRemoveExistingContainer+" alias should be hidden")
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -190,6 +190,8 @@ func (cmd *UpCmd) registerSSHFlags(upCmd *cobra.Command) {
 func (cmd *UpCmd) registerDotfilesFlags(upCmd *cobra.Command) {
 	upCmd.Flags().
 		StringVar(&cmd.DotfilesSource, "dotfiles", "", "The path or url to the dotfiles to use in the container")
+	upCmd.Flags().StringVar(&cmd.DotfilesSource, "dotfiles-repository", "", "Alias for --dotfiles")
+	_ = upCmd.Flags().MarkHidden("dotfiles-repository")
 	upCmd.Flags().
 		StringVar(&cmd.DotfilesScript, "dotfiles-script", "",
 			"The path in dotfiles directory to use to install the dotfiles, if empty will try to guess")
@@ -216,6 +218,9 @@ func (cmd *UpCmd) registerDevContainerFlags(upCmd *cobra.Command) {
 	upCmd.Flags().
 		StringVar(&cmd.ExtraDevContainerPath, "extra-devcontainer-path", "",
 			"The path to an additional devcontainer.json file to override original devcontainer.json")
+	upCmd.Flags().
+		StringVar(&cmd.ExtraDevContainerPath, "override-config", "", "Alias for --extra-devcontainer-path")
+	_ = upCmd.Flags().MarkHidden("override-config")
 	upCmd.Flags().
 		StringVar(&cmd.FallbackImage, "fallback-image", "",
 			"The fallback image to use if no devcontainer configuration has been detected")
@@ -289,6 +294,8 @@ func (cmd *UpCmd) registerWorkspaceFlags(upCmd *cobra.Command) {
 			"If true will only run the prebuild lifecycle (onCreateCommand + updateContentCommand) then stop")
 	upCmd.Flags().
 		BoolVar(&cmd.Recreate, "recreate", false, "If true will remove any existing containers and recreate them")
+	upCmd.Flags().BoolVar(&cmd.Recreate, "remove-existing-container", false, "Alias for --recreate")
+	_ = upCmd.Flags().MarkHidden("remove-existing-container")
 	upCmd.Flags().
 		BoolVar(&cmd.Reset, "reset", false,
 			"If true will remove any existing containers including sources, and recreate them")


### PR DESCRIPTION
## Summary

Adds hidden cobra flag aliases on the `up` command to match the official devcontainer CLI naming conventions, improving compatibility for users migrating from or scripting against the standard CLI.

**Aliases added:**
- `--override-config` → alias for `--extra-devcontainer-path` (matches `devcontainer up --override-config`)
- `--dotfiles-repository` → alias for `--dotfiles` (matches `devcontainer up --dotfiles-repository`)
- `--remove-existing-container` → alias for `--recreate` (matches `devcontainer up --remove-existing-container`)

**Aliases skipped (with reasons):**
- `--workspace-folder` on `up`: Currently a positional arg (`up [workspace-path]`). Adding as a flag would conflict with positional arg semantics. The `exec` command already uses `--workspace-folder` as an explicit flag.
- `--remote-env` on `up`: The official CLI only has `--remote-env` on `exec` (not `up`). Our `--workspace-env` on `up` has different semantics (injected during workspace creation, not remote container env).
- `--container-data-folder` / `--container-system-data-folder`: No equivalent flags exist in our CLI.
- `--mount`: Not an official devcontainer CLI flag. The official CLI has `--mount-workspace-git-root` instead, which is semantically different from our `--workspace-mount-consistency`.
- `--id-label`: Already uses the same name as the official CLI — no alias needed.

All aliases are hidden (don't appear in `--help`) and bind to the same variable as the primary flag. Unit tests cover both value binding and hidden status for each alias.