### PR TITLE
feat(cmd): add --container-id flag to read-configuration

### DIFF
--- a/cmd/readconfiguration.go
+++ b/cmd/readconfiguration.go
@@ -86,10 +86,10 @@ type readConfigurationWorkspace struct {
 
 // Run executes the read-configuration command.
 func (cmd *ReadConfigurationCmd) Run(
-	_ *cobra.Command,
+	c *cobra.Command,
 	_ []string,
 ) error {
-	parsedConfig, workspaceFolder, err := cmd.resolve()
+	parsedConfig, workspaceFolder, err := cmd.resolve(c.Context())
 	if err != nil {
 		return err
 	}
@@ -124,7 +124,7 @@ func (cmd *ReadConfigurationCmd) Run(
 	return nil
 }
 
-func (cmd *ReadConfigurationCmd) resolve() (
+func (cmd *ReadConfigurationCmd) resolve(ctx context.Context) (
 	*config2.DevContainerConfig,
 	string,
 	error,
@@ -135,7 +135,7 @@ func (cmd *ReadConfigurationCmd) resolve() (
 		)
 	}
 	if cmd.ContainerID != "" {
-		return cmd.resolveConfigFromContainer()
+		return cmd.resolveConfigFromContainer(ctx)
 	}
 	return cmd.resolveConfig()
 }
@@ -187,13 +187,12 @@ func (cmd *ReadConfigurationCmd) resolveConfig() (
 	return parsedConfig, workspaceFolder, nil
 }
 
-func (cmd *ReadConfigurationCmd) resolveConfigFromContainer() (
+func (cmd *ReadConfigurationCmd) resolveConfigFromContainer(ctx context.Context) (
 	*config2.DevContainerConfig,
 	string,
 	error,
 ) {
-	ctx := context.TODO()
-	helper := &docker.DockerHelper{DockerCommand: "docker"}
+	helper := &docker.DockerHelper{DockerCommand: defaultDockerCommand}
 
 	details, err := helper.InspectContainers(ctx, []string{cmd.ContainerID})
 	if err != nil {

--- a/cmd/readconfiguration.go
+++ b/cmd/readconfiguration.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -8,6 +9,8 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/devcontainer/metadata"
+	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +20,7 @@ type ReadConfigurationCmd struct {
 
 	WorkspaceFolder              string
 	Config                       string
+	ContainerID                  string
 	IncludeFeaturesConfiguration bool
 	IncludeMergedConfiguration   bool
 }
@@ -37,7 +41,13 @@ func NewReadConfigurationCmd(f *flags.GlobalFlags) *cobra.Command {
 			"",
 			"Path to the workspace folder",
 		)
-	_ = readConfigCmd.MarkFlagRequired("workspace-folder")
+	readConfigCmd.Flags().
+		StringVar(
+			&cmd.ContainerID,
+			"container-id",
+			"",
+			"Read configuration from a running container with the given ID",
+		)
 	readConfigCmd.Flags().
 		StringVar(
 			&cmd.Config,
@@ -79,7 +89,7 @@ func (cmd *ReadConfigurationCmd) Run(
 	_ *cobra.Command,
 	_ []string,
 ) error {
-	parsedConfig, workspaceFolder, err := cmd.resolveConfig()
+	parsedConfig, workspaceFolder, err := cmd.resolve()
 	if err != nil {
 		return err
 	}
@@ -112,6 +122,22 @@ func (cmd *ReadConfigurationCmd) Run(
 	_, _ = os.Stdout.WriteString("\n")
 
 	return nil
+}
+
+func (cmd *ReadConfigurationCmd) resolve() (
+	*config2.DevContainerConfig,
+	string,
+	error,
+) {
+	if cmd.ContainerID == "" && cmd.WorkspaceFolder == "" {
+		return nil, "", fmt.Errorf(
+			"either --workspace-folder or --container-id must be provided",
+		)
+	}
+	if cmd.ContainerID != "" {
+		return cmd.resolveConfigFromContainer()
+	}
+	return cmd.resolveConfig()
 }
 
 func (cmd *ReadConfigurationCmd) resolveConfig() (
@@ -156,6 +182,49 @@ func (cmd *ReadConfigurationCmd) resolveConfig() (
 			"no devcontainer configuration found in %s",
 			workspaceFolder,
 		)
+	}
+
+	return parsedConfig, workspaceFolder, nil
+}
+
+func (cmd *ReadConfigurationCmd) resolveConfigFromContainer() (
+	*config2.DevContainerConfig,
+	string,
+	error,
+) {
+	ctx := context.TODO()
+	helper := &docker.DockerHelper{DockerCommand: "docker"}
+
+	details, err := helper.InspectContainers(ctx, []string{cmd.ContainerID})
+	if err != nil {
+		return nil, "", fmt.Errorf("inspect container %s: %w", cmd.ContainerID, err)
+	}
+	if len(details) == 0 {
+		return nil, "", fmt.Errorf("container %s not found", cmd.ContainerID)
+	}
+
+	containerDetails := &details[0]
+	subCtx := &config2.SubstitutionContext{}
+
+	imageMetadata, err := metadata.GetImageMetadataFromContainer(
+		containerDetails,
+		subCtx,
+	)
+	if err != nil {
+		return nil, "", fmt.Errorf("get image metadata from container: %w", err)
+	}
+
+	parsedConfig := &config2.DevContainerConfig{}
+	if len(imageMetadata.Config) > 0 {
+		last := imageMetadata.Config[len(imageMetadata.Config)-1]
+		parsedConfig.DevContainerConfigBase = last.DevContainerConfigBase
+		parsedConfig.DevContainerActions = last.DevContainerActions
+		parsedConfig.NonComposeBase = last.NonComposeBase
+	}
+
+	workspaceFolder := containerDetails.Config.WorkingDir
+	if workspaceFolder == "" {
+		workspaceFolder = "/"
 	}
 
 	return parsedConfig, workspaceFolder, nil

--- a/cmd/runusercommands.go
+++ b/cmd/runusercommands.go
@@ -90,7 +90,7 @@ func (cmd *RunUserCommandsCmd) Run(ctx context.Context) error {
 
 	user := devcconfig.GetRemoteUser(result)
 	log.Infof("lifecycle commands completed for container %s", params.containerID)
-	_ = devcconfig.WriteResultJSON(os.Stderr, params.containerID, user, params.workdir)
+	_ = devcconfig.WriteResultJSON(os.Stderr, params.containerID, user, params.workdir, nil)
 	return nil
 }
 

--- a/e2e/tests/readconfiguration/readconfiguration.go
+++ b/e2e/tests/readconfiguration/readconfiguration.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/devsy-org/devsy/e2e/framework"
 	"github.com/onsi/ginkgo/v2"
@@ -303,4 +305,42 @@ var _ = ginkgo.Describe("read-configuration command", ginkgo.Label("read-configu
 		gomega.Expect(hr["memory"]).To(gomega.Equal("8gb"))
 		gomega.Expect(hr["storage"]).To(gomega.Equal("32gb"))
 	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("reads configuration from a running container via --container-id",
+		func(ctx context.Context) {
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+
+			metadataLabel := `[{"remoteUser":"testuser","customizations":{"vscode":{"extensions":["ms-python.python"]}}}]`
+			out, err := exec.CommandContext(ctx, "docker", "run", "-d",
+				"--label", "devcontainer.metadata="+metadataLabel,
+				"mcr.microsoft.com/devcontainers/base:ubuntu",
+				"sleep", "infinity",
+			).Output()
+			framework.ExpectNoError(err)
+			containerID := strings.TrimSpace(string(out))
+			ginkgo.DeferCleanup(func() {
+				_ = exec.Command("docker", "rm", "-f", containerID).Run() //nolint:gosec // G204
+			})
+
+			stdout, _, err := f.ExecCommandCapture(ctx, []string{
+				"read-configuration",
+				"--container-id", containerID,
+			})
+			framework.ExpectNoError(err)
+
+			var result map[string]any
+			err = json.Unmarshal([]byte(stdout), &result)
+			framework.ExpectNoError(err, "output should be valid JSON")
+
+			gomega.Expect(result).To(gomega.HaveKey("configuration"))
+			gomega.Expect(result).To(gomega.HaveKey("workspace"))
+
+			config, ok := result["configuration"].(map[string]any)
+			gomega.Expect(ok).To(gomega.BeTrue(), "configuration should be an object")
+			gomega.Expect(config).To(gomega.HaveKeyWithValue("remoteUser", "testuser"))
+
+			ws, ok := result["workspace"].(map[string]any)
+			gomega.Expect(ok).To(gomega.BeTrue(), "workspace should be an object")
+			gomega.Expect(ws).To(gomega.HaveKey("workspaceFolder"))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 })


### PR DESCRIPTION
## Summary

- Adds `--container-id` flag to `read-configuration` command that reads devcontainer configuration from a running container's metadata labels instead of from disk
- Makes `--workspace-folder` no longer required when `--container-id` is provided (runtime validation ensures at least one is given)
- Adds E2E test covering the happy path (launches a container with metadata labels, reads config via `--container-id`, verifies JSON output)
- Fixes pre-existing build error in `runusercommands.go` (missing `warnings` parameter after `WriteResultJSON` signature change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `read-configuration` command now supports the `--container-id` flag to read devcontainer configuration from running containers
  * Automatically derives configuration and workspace settings from the running container's environment and metadata

* **Tests**
  * Added end-to-end test validating configuration retrieval from Docker containers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->