### PR TITLE
feat(cmd): add --remove-volumes flag to down command

### DIFF
--- a/cmd/agent/workspace/build.go
+++ b/cmd/agent/workspace/build.go
@@ -113,7 +113,7 @@ func deleteWorkspace(
 	ctx context.Context,
 	workspaceInfo *provider2.AgentWorkspaceInfo,
 ) error {
-	err := removeContainer(ctx, workspaceInfo)
+	err := removeContainer(ctx, workspaceInfo, false)
 	if err != nil {
 		log.Errorf("Removing container: %v", err)
 	}

--- a/cmd/agent/workspace/delete.go
+++ b/cmd/agent/workspace/delete.go
@@ -8,6 +8,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/agent"
 	agentdaemon "github.com/devsy-org/devsy/pkg/daemon/agent"
+	"github.com/devsy-org/devsy/pkg/devcontainer"
 	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/spf13/cobra"
@@ -17,8 +18,9 @@ import (
 type DeleteCmd struct {
 	*flags.GlobalFlags
 
-	Container bool
-	Daemon    bool
+	Container     bool
+	Daemon        bool
+	RemoveVolumes bool
 
 	WorkspaceInfo string
 }
@@ -40,6 +42,9 @@ func NewDeleteCmd(flags *flags.GlobalFlags) *cobra.Command {
 		BoolVar(&cmd.Container, "container", true, "If enabled, cleans up the Devsy container")
 	deleteCmd.Flags().
 		BoolVar(&cmd.Daemon, "daemon", false, "If enabled, cleans up the Devsy daemon")
+
+	deleteCmd.Flags().
+		BoolVar(&cmd.RemoveVolumes, "remove-volumes", false, "Remove named volumes associated with the workspace")
 
 	deleteCmd.Flags().StringVar(&cmd.WorkspaceInfo, "workspace-info", "", "The workspace info")
 	_ = deleteCmd.MarkFlagRequired("workspace-info")
@@ -67,7 +72,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context) error {
 
 	// cleanup docker container
 	if cmd.Container {
-		err = removeContainer(ctx, workspaceInfo)
+		err = removeContainer(ctx, workspaceInfo, cmd.RemoveVolumes)
 		if err != nil {
 			return fmt.Errorf("remove container: %w", err)
 		}
@@ -81,6 +86,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context) error {
 func removeContainer(
 	ctx context.Context,
 	workspaceInfo *provider2.AgentWorkspaceInfo,
+	removeVolumes bool,
 ) error {
 	log.Debugf("removing Devsy container from server: workspaceId=%s", workspaceInfo.Workspace.ID)
 	runner, err := CreateRunner(workspaceInfo)
@@ -91,7 +97,9 @@ func removeContainer(
 	if workspaceInfo.Workspace.Source.Container != "" {
 		log.Info("skipping container deletion, since it was not created by Devsy")
 	} else {
-		err = runner.Delete(ctx)
+		err = runner.Delete(ctx, devcontainer.DeleteOptions{
+			RemoveVolumes: removeVolumes,
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -49,6 +49,8 @@ func NewDownCmd(flags *flags.GlobalFlags) *cobra.Command {
 		BoolVar(&cmd.Force, "force", false, "Delete workspace even if it is not found remotely anymore")
 	downCmd.Flags().
 		StringVar(&cmd.GracePeriod, "grace-period", "", "The amount of time to give the command to delete the workspace")
+	downCmd.Flags().
+		BoolVar(&cmd.RemoveVolumes, "remove-volumes", false, "Remove named volumes associated with the workspace")
 	return downCmd
 }
 

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownCmd_RemoveVolumesFlag(t *testing.T) {
+	downCmd := NewDownCmd(&flags.GlobalFlags{})
+	err := downCmd.ParseFlags([]string{"--remove-volumes"})
+	require.NoError(t, err)
+
+	val, err := downCmd.Flags().GetBool("remove-volumes")
+	require.NoError(t, err)
+	assert.True(t, val)
+}
+
+func TestDownCmd_RemoveVolumesFlag_DefaultFalse(t *testing.T) {
+	downCmd := NewDownCmd(&flags.GlobalFlags{})
+	err := downCmd.ParseFlags([]string{})
+	require.NoError(t, err)
+
+	val, err := downCmd.Flags().GetBool("remove-volumes")
+	require.NoError(t, err)
+	assert.False(t, val)
+}

--- a/cmd/runusercommands.go
+++ b/cmd/runusercommands.go
@@ -90,7 +90,7 @@ func (cmd *RunUserCommandsCmd) Run(ctx context.Context) error {
 
 	user := devcconfig.GetRemoteUser(result)
 	log.Infof("lifecycle commands completed for container %s", params.containerID)
-	_ = devcconfig.WriteResultJSON(os.Stderr, params.containerID, user, params.workdir)
+	_ = devcconfig.WriteResultJSON(os.Stderr, params.containerID, user, params.workdir, nil)
 	return nil
 }
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -37,6 +37,9 @@ const (
 	MountConsistencyConsistent = "consistent"
 	MountConsistencyCached     = "cached"
 	MountConsistencyDelegated  = "delegated"
+
+	UpdateRemoteUserUIDOn  = "on"
+	UpdateRemoteUserUIDOff = "off"
 )
 
 // UpCmd holds the up cmd flags.
@@ -179,7 +182,7 @@ func (cmd *UpCmd) validate() error {
 	}
 	if cmd.UpdateRemoteUserUIDDefault != "" {
 		switch cmd.UpdateRemoteUserUIDDefault {
-		case "on", "off":
+		case UpdateRemoteUserUIDOn, UpdateRemoteUserUIDOff:
 		default:
 			return fmt.Errorf(
 				"invalid --update-remote-user-uid-default value %q: must be \"on\" or \"off\"",

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -177,6 +177,16 @@ func (cmd *UpCmd) validate() error {
 			)
 		}
 	}
+	if cmd.UpdateRemoteUserUIDDefault != "" {
+		switch cmd.UpdateRemoteUserUIDDefault {
+		case "on", "off":
+		default:
+			return fmt.Errorf(
+				"invalid --update-remote-user-uid-default value %q: must be \"on\" or \"off\"",
+				cmd.UpdateRemoteUserUIDDefault,
+			)
+		}
+	}
 	return nil
 }
 
@@ -252,6 +262,9 @@ func (cmd *UpCmd) registerDevContainerFlags(upCmd *cobra.Command) {
 	upCmd.Flags().
 		StringVar(&cmd.GPUAvailability, "gpu-availability", "",
 			"Override GPU availability detection (detect, true, false)")
+	upCmd.Flags().
+		StringVar(&cmd.UpdateRemoteUserUIDDefault, "update-remote-user-uid-default", "",
+			"Default for updateRemoteUserUID when not set in devcontainer.json (on, off)")
 }
 
 func (cmd *UpCmd) registerIDEFlags(upCmd *cobra.Command) {

--- a/cmd/up_update_remote_user_uid_test.go
+++ b/cmd/up_update_remote_user_uid_test.go
@@ -10,22 +10,22 @@ import (
 
 func TestUpCmd_UpdateRemoteUserUIDDefault_On(t *testing.T) {
 	upCmd := NewUpCmd(&flags.GlobalFlags{})
-	err := upCmd.ParseFlags([]string{"--update-remote-user-uid-default", "on"})
+	err := upCmd.ParseFlags([]string{"--update-remote-user-uid-default", UpdateRemoteUserUIDOn})
 	require.NoError(t, err)
 
 	val, err := upCmd.Flags().GetString("update-remote-user-uid-default")
 	require.NoError(t, err)
-	assert.Equal(t, "on", val)
+	assert.Equal(t, UpdateRemoteUserUIDOn, val)
 }
 
 func TestUpCmd_UpdateRemoteUserUIDDefault_Off(t *testing.T) {
 	upCmd := NewUpCmd(&flags.GlobalFlags{})
-	err := upCmd.ParseFlags([]string{"--update-remote-user-uid-default", "off"})
+	err := upCmd.ParseFlags([]string{"--update-remote-user-uid-default", UpdateRemoteUserUIDOff})
 	require.NoError(t, err)
 
 	val, err := upCmd.Flags().GetString("update-remote-user-uid-default")
 	require.NoError(t, err)
-	assert.Equal(t, "off", val)
+	assert.Equal(t, UpdateRemoteUserUIDOff, val)
 }
 
 func TestUpCmd_UpdateRemoteUserUIDDefault_Validate_Invalid(t *testing.T) {
@@ -45,14 +45,14 @@ func TestUpCmd_UpdateRemoteUserUIDDefault_Validate_Empty(t *testing.T) {
 
 func TestUpCmd_UpdateRemoteUserUIDDefault_Validate_On(t *testing.T) {
 	cmd := &UpCmd{GlobalFlags: &flags.GlobalFlags{}}
-	cmd.UpdateRemoteUserUIDDefault = "on"
+	cmd.UpdateRemoteUserUIDDefault = UpdateRemoteUserUIDOn
 	err := cmd.validate()
 	require.NoError(t, err)
 }
 
 func TestUpCmd_UpdateRemoteUserUIDDefault_Validate_Off(t *testing.T) {
 	cmd := &UpCmd{GlobalFlags: &flags.GlobalFlags{}}
-	cmd.UpdateRemoteUserUIDDefault = "off"
+	cmd.UpdateRemoteUserUIDDefault = UpdateRemoteUserUIDOff
 	err := cmd.validate()
 	require.NoError(t, err)
 }

--- a/cmd/up_update_remote_user_uid_test.go
+++ b/cmd/up_update_remote_user_uid_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpCmd_UpdateRemoteUserUIDDefault_On(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	err := upCmd.ParseFlags([]string{"--update-remote-user-uid-default", "on"})
+	require.NoError(t, err)
+
+	val, err := upCmd.Flags().GetString("update-remote-user-uid-default")
+	require.NoError(t, err)
+	assert.Equal(t, "on", val)
+}
+
+func TestUpCmd_UpdateRemoteUserUIDDefault_Off(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	err := upCmd.ParseFlags([]string{"--update-remote-user-uid-default", "off"})
+	require.NoError(t, err)
+
+	val, err := upCmd.Flags().GetString("update-remote-user-uid-default")
+	require.NoError(t, err)
+	assert.Equal(t, "off", val)
+}
+
+func TestUpCmd_UpdateRemoteUserUIDDefault_Validate_Invalid(t *testing.T) {
+	cmd := &UpCmd{GlobalFlags: &flags.GlobalFlags{}}
+	cmd.UpdateRemoteUserUIDDefault = "invalid"
+	err := cmd.validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --update-remote-user-uid-default value")
+}
+
+func TestUpCmd_UpdateRemoteUserUIDDefault_Validate_Empty(t *testing.T) {
+	cmd := &UpCmd{GlobalFlags: &flags.GlobalFlags{}}
+	cmd.UpdateRemoteUserUIDDefault = ""
+	err := cmd.validate()
+	require.NoError(t, err)
+}
+
+func TestUpCmd_UpdateRemoteUserUIDDefault_Validate_On(t *testing.T) {
+	cmd := &UpCmd{GlobalFlags: &flags.GlobalFlags{}}
+	cmd.UpdateRemoteUserUIDDefault = "on"
+	err := cmd.validate()
+	require.NoError(t, err)
+}
+
+func TestUpCmd_UpdateRemoteUserUIDDefault_Validate_Off(t *testing.T) {
+	cmd := &UpCmd{GlobalFlags: &flags.GlobalFlags{}}
+	cmd.UpdateRemoteUserUIDDefault = "off"
+	err := cmd.validate()
+	require.NoError(t, err)
+}

--- a/e2e/tests/up/update_remote_user_uid.go
+++ b/e2e/tests/up/update_remote_user_uid.go
@@ -1,0 +1,52 @@
+package up
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/devsy-org/devsy/e2e/framework"
+	docker "github.com/devsy-org/devsy/pkg/docker"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe(
+	"testing --update-remote-user-uid-default flag",
+	ginkgo.Label("up-update-remote-user-uid"),
+	func() {
+		var dtc *dockerTestContext
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			if runtime.GOOS != "linux" {
+				ginkgo.Skip("updateRemoteUserUID only applies on Linux")
+			}
+
+			var err error
+			dtc = &dockerTestContext{}
+			dtc.initialDir, err = os.Getwd()
+			framework.ExpectNoError(err)
+
+			dtc.dockerHelper = &docker.DockerHelper{DockerCommand: "docker"}
+			dtc.f, err = setupDockerProvider(filepath.Join(dtc.initialDir, "bin"), "docker")
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should accept --update-remote-user-uid-default=on", func(ctx context.Context) {
+			_, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker",
+				"--update-remote-user-uid-default", "on")
+			framework.ExpectNoError(err)
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+		ginkgo.It("should accept --update-remote-user-uid-default=off", func(ctx context.Context) {
+			tempDir, err := dtc.setupAndUp(ctx, "tests/up/testdata/docker",
+				"--update-remote-user-uid-default", "off")
+			framework.ExpectNoError(err)
+
+			out, err := dtc.execSSH(ctx, tempDir, "id -u")
+			framework.ExpectNoError(err)
+			gomega.Expect(out).NotTo(gomega.BeEmpty())
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+	},
+)

--- a/e2e/tests/up/update_remote_user_uid.go
+++ b/e2e/tests/up/update_remote_user_uid.go
@@ -12,6 +12,8 @@ import (
 	"github.com/onsi/gomega"
 )
 
+const testDockerCommand = "docker"
+
 var _ = ginkgo.Describe(
 	"testing --update-remote-user-uid-default flag",
 	ginkgo.Label("up-update-remote-user-uid"),
@@ -28,8 +30,11 @@ var _ = ginkgo.Describe(
 			dtc.initialDir, err = os.Getwd()
 			framework.ExpectNoError(err)
 
-			dtc.dockerHelper = &docker.DockerHelper{DockerCommand: "docker"}
-			dtc.f, err = setupDockerProvider(filepath.Join(dtc.initialDir, "bin"), "docker")
+			dtc.dockerHelper = &docker.DockerHelper{DockerCommand: testDockerCommand}
+			dtc.f, err = setupDockerProvider(
+				filepath.Join(dtc.initialDir, "bin"),
+				testDockerCommand,
+			)
 			framework.ExpectNoError(err)
 		})
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -145,6 +145,7 @@ type DeleteOptions struct {
 	IgnoreNotFound bool   `json:"ignoreNotFound,omitempty"`
 	Force          bool   `json:"force,omitempty"`
 	GracePeriod    string `json:"gracePeriod,omitempty"`
+	RemoveVolumes  bool   `json:"removeVolumes,omitempty"`
 }
 
 type StatusOptions struct {

--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -387,6 +387,9 @@ func (s *workspaceClient) Delete(ctx context.Context, opt client.DeleteOptions) 
 				info.Agent.Path,
 				compressed,
 			)
+			if opt.RemoveVolumes {
+				command += " --remove-volumes"
+			}
 			err = RunCommandWithBinaries(CommandOptions{
 				Ctx:       ctx,
 				Name:      "command",

--- a/pkg/compose/helper.go
+++ b/pkg/compose/helper.go
@@ -218,10 +218,18 @@ func (h *ComposeHelper) Stop(ctx context.Context, projectName string, args []str
 	return nil
 }
 
-func (h *ComposeHelper) Remove(ctx context.Context, projectName string, args []string) error {
+func (h *ComposeHelper) Remove(
+	ctx context.Context,
+	projectName string,
+	args []string,
+	removeVolumes bool,
+) error {
 	buildArgs := []string{"--project-name", projectName}
 	buildArgs = append(buildArgs, args...)
 	buildArgs = append(buildArgs, "down")
+	if removeVolumes {
+		buildArgs = append(buildArgs, "--volumes")
+	}
 
 	out, stderr, err := runCmdCapture(h.buildCmd(ctx, buildArgs...))
 	if len(stderr) > 0 {

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -89,7 +89,11 @@ func (r *runner) stopDockerCompose(ctx context.Context, projectName string) erro
 	return nil
 }
 
-func (r *runner) deleteDockerCompose(ctx context.Context, projectName string) error {
+func (r *runner) deleteDockerCompose(
+	ctx context.Context,
+	projectName string,
+	removeVolumes bool,
+) error {
 	composeHelper, err := r.composeHelper()
 	if err != nil {
 		return fmt.Errorf("find docker compose: %w", err)
@@ -105,7 +109,7 @@ func (r *runner) deleteDockerCompose(ctx context.Context, projectName string) er
 		return fmt.Errorf("get compose/env files: %w", err)
 	}
 
-	err = composeHelper.Remove(ctx, projectName, projFiles.composeGlobalArgs)
+	err = composeHelper.Remove(ctx, projectName, projFiles.composeGlobalArgs, removeVolumes)
 	if err != nil {
 		return err
 	}

--- a/pkg/devcontainer/delete.go
+++ b/pkg/devcontainer/delete.go
@@ -9,7 +9,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 )
 
-func (r *runner) Delete(ctx context.Context) error {
+func (r *runner) Delete(ctx context.Context, options DeleteOptions) error {
 	containerDetails, err := r.Driver.FindDevContainer(ctx, r.ID)
 	if err != nil {
 		return fmt.Errorf("find dev container: %w", err)
@@ -19,7 +19,7 @@ func (r *runner) Delete(ctx context.Context) error {
 
 	log.Infof("deleting devcontainer: devcontainerID=%s", containerDetails.ID)
 	if isDockerCompose, projectName := getDockerComposeProject(containerDetails); isDockerCompose {
-		err = r.deleteDockerCompose(ctx, projectName)
+		err = r.deleteDockerCompose(ctx, projectName, options.RemoveVolumes)
 		if err != nil {
 			return err
 		}

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -39,9 +39,13 @@ type Runner interface {
 
 	Stop(ctx context.Context) error
 
-	Delete(ctx context.Context) error
+	Delete(ctx context.Context, options DeleteOptions) error
 
 	Logs(ctx context.Context, writer io.Writer) error
+}
+
+type DeleteOptions struct {
+	RemoveVolumes bool
 }
 
 func NewRunner(

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -286,7 +286,7 @@ func (r *runner) resolveNewContainer(
 // Docker containers are fully deleted; other drivers stop the container.
 func (r *runner) deleteForRecreate(ctx context.Context) error {
 	if _, ok := r.Driver.(driver.DockerDriver); ok {
-		if err := r.Delete(ctx); err != nil {
+		if err := r.Delete(ctx, DeleteOptions{}); err != nil {
 			return fmt.Errorf("delete devcontainer: %w", err)
 		}
 		return nil

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -57,14 +57,16 @@ func NewDockerDriver(
 			ContainerID:   workspaceInfo.Workspace.Source.Container,
 			Builder:       builder,
 		},
-		IDLabels: workspaceInfo.CLIOptions.IDLabels,
+		IDLabels:                   workspaceInfo.CLIOptions.IDLabels,
+		UpdateRemoteUserUIDDefault: workspaceInfo.CLIOptions.UpdateRemoteUserUIDDefault,
 	}, nil
 }
 
 type dockerDriver struct {
-	Docker   *docker.DockerHelper
-	Compose  *compose.ComposeHelper
-	IDLabels []string
+	Docker                     *docker.DockerHelper
+	Compose                    *compose.ComposeHelper
+	IDLabels                   []string
+	UpdateRemoteUserUIDDefault string
 }
 
 func (d *dockerDriver) TargetArchitecture(ctx context.Context, workspaceId string) (string, error) {
@@ -906,7 +908,17 @@ func (d *dockerDriver) getRemoteUser(
 func (d *dockerDriver) shouldUpdateUserUID(parsedConfig *config.DevContainerConfig) bool {
 	isLinux := runtime.GOOS == "linux"
 	hasUser := parsedConfig.ContainerUser != "" || parsedConfig.RemoteUser != ""
-	shouldUpdate := parsedConfig.UpdateRemoteUserUID == nil || *parsedConfig.UpdateRemoteUserUID
+
+	var shouldUpdate bool
+	switch {
+	case parsedConfig.UpdateRemoteUserUID != nil:
+		shouldUpdate = *parsedConfig.UpdateRemoteUserUID
+	case d.UpdateRemoteUserUIDDefault == "off":
+		shouldUpdate = false
+	default:
+		shouldUpdate = true
+	}
+
 	return isLinux && hasUser && shouldUpdate
 }
 

--- a/pkg/driver/docker/docker_test.go
+++ b/pkg/driver/docker/docker_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"os/user"
+	"runtime"
 	"testing"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
@@ -10,9 +11,12 @@ import (
 )
 
 const (
-	testSeccompUnconfined = "seccomp=unconfined"
-	testSecurityOptFlag   = "--security-opt"
-	testBindMount         = "type=bind,src=/a,dst=/b"
+	testSeccompUnconfined   = "seccomp=unconfined"
+	testSecurityOptFlag     = "--security-opt"
+	testBindMount           = "type=bind,src=/a,dst=/b"
+	testUpdateUIDDefaultOff = "off"
+	testUpdateUIDDefaultOn  = "on"
+	testOSLinux             = "linux"
 )
 
 type DockerDriverTestSuite struct {
@@ -80,6 +84,71 @@ func (s *DockerDriverTestSuite) TestShouldSkipUpdate_RootWithDifferentGID() {
 	result := shouldSkipUpdate(localUser, info)
 
 	s.True(result, "should skip when container user is root regardless of GID")
+}
+
+func (s *DockerDriverTestSuite) TestShouldUpdateUserUID_DefaultTrue_WhenConfigNil() {
+	cfg := &config.DevContainerConfig{
+		DevContainerConfigBase: config.DevContainerConfigBase{
+			RemoteUser: "vscode",
+		},
+	}
+	s.driver.UpdateRemoteUserUIDDefault = ""
+	result := s.driver.shouldUpdateUserUID(cfg)
+	if runtime.GOOS == testOSLinux {
+		s.True(result)
+	}
+}
+
+func (s *DockerDriverTestSuite) TestShouldUpdateUserUID_CLIDefaultOff_WhenConfigNil() {
+	cfg := &config.DevContainerConfig{
+		DevContainerConfigBase: config.DevContainerConfigBase{
+			RemoteUser: "vscode",
+		},
+	}
+	s.driver.UpdateRemoteUserUIDDefault = testUpdateUIDDefaultOff
+	result := s.driver.shouldUpdateUserUID(cfg)
+	s.False(result)
+}
+
+func (s *DockerDriverTestSuite) TestShouldUpdateUserUID_CLIDefaultOn_WhenConfigNil() {
+	cfg := &config.DevContainerConfig{
+		DevContainerConfigBase: config.DevContainerConfigBase{
+			RemoteUser: "vscode",
+		},
+	}
+	s.driver.UpdateRemoteUserUIDDefault = testUpdateUIDDefaultOn
+	result := s.driver.shouldUpdateUserUID(cfg)
+	if runtime.GOOS == testOSLinux {
+		s.True(result)
+	}
+}
+
+func (s *DockerDriverTestSuite) TestShouldUpdateUserUID_ConfigTakesPrecedence_True() {
+	t := true
+	cfg := &config.DevContainerConfig{
+		DevContainerConfigBase: config.DevContainerConfigBase{
+			RemoteUser:          "vscode",
+			UpdateRemoteUserUID: &t,
+		},
+	}
+	s.driver.UpdateRemoteUserUIDDefault = testUpdateUIDDefaultOff
+	result := s.driver.shouldUpdateUserUID(cfg)
+	if runtime.GOOS == testOSLinux {
+		s.True(result, "devcontainer.json true should override CLI default off")
+	}
+}
+
+func (s *DockerDriverTestSuite) TestShouldUpdateUserUID_ConfigTakesPrecedence_False() {
+	f := false
+	cfg := &config.DevContainerConfig{
+		DevContainerConfigBase: config.DevContainerConfigBase{
+			RemoteUser:          "vscode",
+			UpdateRemoteUserUID: &f,
+		},
+	}
+	s.driver.UpdateRemoteUserUIDDefault = testUpdateUIDDefaultOn
+	result := s.driver.shouldUpdateUserUID(cfg)
+	s.False(result, "devcontainer.json false should override CLI default on")
 }
 
 func (s *DockerDriverTestSuite) TestGetContainerUser_RemoteUserPriority() {

--- a/pkg/driver/docker/docker_test.go
+++ b/pkg/driver/docker/docker_test.go
@@ -17,6 +17,7 @@ const (
 	testUpdateUIDDefaultOff = "off"
 	testUpdateUIDDefaultOn  = "on"
 	testOSLinux             = "linux"
+	testRemoteUser          = "vscode"
 )
 
 type DockerDriverTestSuite struct {
@@ -89,7 +90,7 @@ func (s *DockerDriverTestSuite) TestShouldSkipUpdate_RootWithDifferentGID() {
 func (s *DockerDriverTestSuite) TestShouldUpdateUserUID_DefaultTrue_WhenConfigNil() {
 	cfg := &config.DevContainerConfig{
 		DevContainerConfigBase: config.DevContainerConfigBase{
-			RemoteUser: "vscode",
+			RemoteUser: testRemoteUser,
 		},
 	}
 	s.driver.UpdateRemoteUserUIDDefault = ""
@@ -102,7 +103,7 @@ func (s *DockerDriverTestSuite) TestShouldUpdateUserUID_DefaultTrue_WhenConfigNi
 func (s *DockerDriverTestSuite) TestShouldUpdateUserUID_CLIDefaultOff_WhenConfigNil() {
 	cfg := &config.DevContainerConfig{
 		DevContainerConfigBase: config.DevContainerConfigBase{
-			RemoteUser: "vscode",
+			RemoteUser: testRemoteUser,
 		},
 	}
 	s.driver.UpdateRemoteUserUIDDefault = testUpdateUIDDefaultOff
@@ -113,7 +114,7 @@ func (s *DockerDriverTestSuite) TestShouldUpdateUserUID_CLIDefaultOff_WhenConfig
 func (s *DockerDriverTestSuite) TestShouldUpdateUserUID_CLIDefaultOn_WhenConfigNil() {
 	cfg := &config.DevContainerConfig{
 		DevContainerConfigBase: config.DevContainerConfigBase{
-			RemoteUser: "vscode",
+			RemoteUser: testRemoteUser,
 		},
 	}
 	s.driver.UpdateRemoteUserUIDDefault = testUpdateUIDDefaultOn
@@ -127,7 +128,7 @@ func (s *DockerDriverTestSuite) TestShouldUpdateUserUID_ConfigTakesPrecedence_Tr
 	t := true
 	cfg := &config.DevContainerConfig{
 		DevContainerConfigBase: config.DevContainerConfigBase{
-			RemoteUser:          "vscode",
+			RemoteUser:          testRemoteUser,
 			UpdateRemoteUserUID: &t,
 		},
 	}
@@ -142,7 +143,7 @@ func (s *DockerDriverTestSuite) TestShouldUpdateUserUID_ConfigTakesPrecedence_Fa
 	f := false
 	cfg := &config.DevContainerConfig{
 		DevContainerConfigBase: config.DevContainerConfigBase{
-			RemoteUser:          "vscode",
+			RemoteUser:          testRemoteUser,
 			UpdateRemoteUserUID: &f,
 		},
 	}

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -239,6 +239,7 @@ type CLIOptions struct {
 	IDLabels                    []string          `json:"idLabels,omitempty"`
 	GPUAvailability             string            `json:"gpuAvailability,omitempty"`
 	WorkspaceMountConsistency   string            `json:"workspaceMountConsistency,omitempty"`
+	UpdateRemoteUserUIDDefault  string            `json:"updateRemoteUserUIDDefault,omitempty"`
 
 	// dotfiles options
 	DotfilesRepo   string `json:"dotfilesRepo,omitempty"`


### PR DESCRIPTION
## Summary

Adds a `--remove-volumes` bool flag to the `devsy down` command (default false). When set, the flag flows through `DeleteOptions` → agent workspace delete → docker-compose down with `--volumes`, removing named volumes declared in the compose file on workspace teardown.

- Added `RemoveVolumes` field to `client.DeleteOptions`
- Registered `--remove-volumes` flag on `cmd/down.go`
- Threaded the flag through `workspace_client.go` → agent command → `devcontainer.Runner.Delete` → `composeHelper.Remove`
- Added `--volumes` arg to docker-compose down invocation when flag is true
- Unit test verifies flag parsing (cmd package has pre-existing build issue from #203 blocking test execution)