### PR TITLE
fix(cmd): add missing warnings param to WriteResultJSON call

### DIFF
--- a/cmd/runusercommands.go
+++ b/cmd/runusercommands.go
@@ -90,7 +90,7 @@ func (cmd *RunUserCommandsCmd) Run(ctx context.Context) error {
 
 	user := devcconfig.GetRemoteUser(result)
 	log.Infof("lifecycle commands completed for container %s", params.containerID)
-	_ = devcconfig.WriteResultJSON(os.Stderr, params.containerID, user, params.workdir)
+	_ = devcconfig.WriteResultJSON(os.Stderr, params.containerID, user, params.workdir, nil)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

PR #204 added a `warnings []string` parameter to `WriteResultJSON()` but PR #203's call site in `cmd/runusercommands.go` was not updated, causing a build failure on main. This passes `nil` since `run-user-commands` doesn't evaluate hostRequirements. Matches the pattern used in `cmd/exec.go` and `cmd/build.go`.