### PR TITLE
feat(feature): version-aware feature equality

### DIFF
--- a/e2e/tests/up-features/testdata/docker-features-different-versions/.devcontainer.json
+++ b/e2e/tests/up-features/testdata/docker-features-different-versions/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "image": "ghcr.io/devsy-org/test-images/base:alpine",
+  "features": {
+    "./features/versionedFeatureV1": {},
+    "./features/versionedFeatureV2": {}
+  }
+}

--- a/e2e/tests/up-features/testdata/docker-features-different-versions/features/versionedFeatureV1/devcontainer-feature.json
+++ b/e2e/tests/up-features/testdata/docker-features-different-versions/features/versionedFeatureV1/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+  "id": "versionedFeatureV1",
+  "version": "1.0.0",
+  "name": "Versioned Feature V1",
+  "description": "First version of the versioned feature"
+}

--- a/e2e/tests/up-features/testdata/docker-features-different-versions/features/versionedFeatureV1/install.sh
+++ b/e2e/tests/up-features/testdata/docker-features-different-versions/features/versionedFeatureV1/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+echo "v1" >/tmp/versioned-feature-v1.txt

--- a/e2e/tests/up-features/testdata/docker-features-different-versions/features/versionedFeatureV2/devcontainer-feature.json
+++ b/e2e/tests/up-features/testdata/docker-features-different-versions/features/versionedFeatureV2/devcontainer-feature.json
@@ -1,0 +1,6 @@
+{
+  "id": "versionedFeatureV2",
+  "version": "2.0.0",
+  "name": "Versioned Feature V2",
+  "description": "Second version of the versioned feature"
+}

--- a/e2e/tests/up-features/testdata/docker-features-different-versions/features/versionedFeatureV2/install.sh
+++ b/e2e/tests/up-features/testdata/docker-features-different-versions/features/versionedFeatureV2/install.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+echo "v2" >/tmp/versioned-feature-v2.txt

--- a/e2e/tests/up-features/up_features.go
+++ b/e2e/tests/up-features/up_features.go
@@ -650,4 +650,34 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 		},
 		ginkgo.SpecTimeout(framework.TimeoutShort()),
 	)
+
+	ginkgo.It(
+		"should install both versions when same feature has different versions",
+		ginkgo.Label("features", "version-aware"),
+		func(ctx context.Context) {
+			f, err := setupDockerProvider(initialDir+"/bin", "docker")
+			framework.ExpectNoError(err)
+
+			tempDir, err := framework.CopyToTempDir(
+				"tests/up-features/testdata/docker-features-different-versions",
+			)
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+			wsName := filepath.Base(tempDir)
+			ginkgo.DeferCleanup(f.DevsyWorkspaceDelete, wsName)
+
+			err = f.DevsyUp(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			out, err := f.DevsySSH(ctx, wsName, "cat /tmp/versioned-feature-v1.txt")
+			framework.ExpectNoError(err)
+			gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("v1"))
+
+			out, err = f.DevsySSH(ctx, wsName, "cat /tmp/versioned-feature-v2.txt")
+			framework.ExpectNoError(err)
+			gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("v2"))
+		},
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
+	)
 })

--- a/pkg/devcontainer/config/feature.go
+++ b/pkg/devcontainer/config/feature.go
@@ -9,6 +9,7 @@ import (
 
 type FeatureSet struct {
 	ConfigID string
+	Version  string
 	Folder   string
 	Config   *FeatureConfig
 	Options  any

--- a/pkg/devcontainer/feature/extend.go
+++ b/pkg/devcontainer/feature/extend.go
@@ -323,7 +323,8 @@ func getUserFeatures(
 		if err != nil {
 			return nil, fmt.Errorf("process feature %s: %w", featureID, err)
 		}
-		userFeatures[featureSet.ConfigID] = featureSet
+		key := featureDeduplicationKey(featureSet.ConfigID, featureSet.Version)
+		userFeatures[key] = featureSet
 	}
 	return userFeatures, nil
 }
@@ -354,6 +355,7 @@ func (p *featureProcessor) processFeature(
 
 	return &config.FeatureSet{
 		ConfigID: normalizeFeatureID(featureID),
+		Version:  extractVersionFromFeatureID(featureID),
 		Folder:   featureFolder,
 		Config:   featureConfig,
 		Options:  featureOptions,
@@ -366,6 +368,18 @@ type featureDependencyResolver struct {
 	visiting  map[string]bool
 	processor *featureProcessor
 	legacyMap map[string]string
+}
+
+func (r *featureDependencyResolver) findByConfigID(configID string) (string, *config.FeatureSet) {
+	if fs, ok := r.features[configID]; ok {
+		return configID, fs
+	}
+	for key, fs := range r.features {
+		if fs.ConfigID == configID {
+			return key, fs
+		}
+	}
+	return "", nil
 }
 
 func (r *featureDependencyResolver) resolveFeatureDependency(
@@ -385,12 +399,11 @@ func (r *featureDependencyResolver) resolveFeatureDependency(
 
 	for depID, depOptions := range featureSet.Config.DependsOn {
 		normalizedDepID := normalizeFeatureID(depID)
-		depFeatureSet, exists := r.features[normalizedDepID]
-		if !exists {
+		resolvedKey, depFeatureSet := r.findByConfigID(normalizedDepID)
+		if depFeatureSet == nil {
 			if currentID, legacyMatch := r.legacyMap[normalizedDepID]; legacyMatch {
 				log.Debugf("resolved legacy ID %s to current feature %s", depID, currentID)
-				depFeatureSet = r.features[currentID]
-				normalizedDepID = currentID
+				resolvedKey, depFeatureSet = r.findByConfigID(currentID)
 			}
 		}
 		if depFeatureSet == nil {
@@ -400,11 +413,12 @@ func (r *featureDependencyResolver) resolveFeatureDependency(
 			if err != nil {
 				return fmt.Errorf("failed to resolve dependency %s: %w", depID, err)
 			}
-			r.features[normalizedDepID] = depFeatureSet
+			resolvedKey = featureDeduplicationKey(depFeatureSet.ConfigID, depFeatureSet.Version)
+			r.features[resolvedKey] = depFeatureSet
 			r.rebuildLegacyMap()
 		}
 
-		err := r.resolveFeatureDependency(normalizedDepID, depFeatureSet)
+		err := r.resolveFeatureDependency(resolvedKey, depFeatureSet)
 		if err != nil {
 			return err
 		}
@@ -467,6 +481,34 @@ func normalizeFeatureID(featureID string) string {
 	return ref.String()
 }
 
+func extractVersionFromFeatureID(featureID string) string {
+	ref, err := name.ParseReference(featureID)
+	if err != nil {
+		return ""
+	}
+
+	tag, ok := ref.(name.Tag)
+	if !ok {
+		return ""
+	}
+
+	return normalizeVersion(tag.TagStr())
+}
+
+func normalizeVersion(version string) string {
+	if version == "latest" || version == "" {
+		return ""
+	}
+	return strings.TrimPrefix(version, "v")
+}
+
+func featureDeduplicationKey(configID, version string) string {
+	if version == "" {
+		return configID
+	}
+	return configID + ":" + version
+}
+
 func getSortedFeatureSets(
 	devContainer *config.DevContainerConfig,
 	featureSets []*config.FeatureSet,
@@ -496,8 +538,9 @@ func buildOverridePriority(
 			continue
 		}
 		normalizedID := normalizeFeatureID(id)
-		if _, exists := featureLookup[normalizedID]; exists {
-			priority[normalizedID] = i
+		key := findKeyInLookupByConfigID(normalizedID, featureLookup)
+		if key != "" {
+			priority[key] = i
 		}
 	}
 	return priority
@@ -509,17 +552,18 @@ func validateOverrideOrder(
 	featureLookup map[string]*config.FeatureSet,
 ) error {
 	for _, feature := range featureSets {
-		featurePriority, featureHasPriority := priority[feature.ConfigID]
+		featureKey := featureDeduplicationKey(feature.ConfigID, feature.Version)
+		featurePriority, featureHasPriority := priority[featureKey]
 		if !featureHasPriority {
 			continue
 		}
 
 		for depID := range feature.Config.DependsOn {
-			depConfigID := resolveDepConfigID(depID, featureLookup)
-			if depConfigID == "" {
+			depKey := resolveDepConfigID(depID, featureLookup)
+			if depKey == "" {
 				continue
 			}
-			depPriority, depHasPriority := priority[depConfigID]
+			depPriority, depHasPriority := priority[depKey]
 			if !depHasPriority {
 				continue
 			}
@@ -527,9 +571,9 @@ func validateOverrideOrder(
 				return fmt.Errorf(
 					"overrideFeatureInstallOrder places %q (position %d)"+
 						" before its dependency %q (position %d)",
-					feature.ConfigID,
+					featureKey,
 					featurePriority,
-					depConfigID,
+					depKey,
 					depPriority,
 				)
 			}
@@ -543,10 +587,7 @@ func resolveDepConfigID(depID string, featureLookup map[string]*config.FeatureSe
 		return depID
 	}
 	normalizedID := normalizeFeatureID(depID)
-	if _, exists := featureLookup[normalizedID]; exists {
-		return normalizedID
-	}
-	return ""
+	return findKeyInLookupByConfigID(normalizedID, featureLookup)
 }
 
 func getOrderedFeatureSetsWithPriority(
@@ -561,8 +602,11 @@ func getOrderedFeatureSetsWithPriority(
 }
 
 func extractFeatureByID(features []*config.FeatureSet, featureID string) *config.FeatureSet {
+	version := extractVersionFromFeatureID(featureID)
+	normalizedID := normalizeFeatureID(featureID)
 	for _, feature := range features {
-		if feature.ConfigID == featureID {
+		if (feature.ConfigID == featureID || feature.ConfigID == normalizedID) &&
+			feature.Version == version {
 			return feature
 		}
 	}
@@ -570,8 +614,11 @@ func extractFeatureByID(features []*config.FeatureSet, featureID string) *config
 }
 
 func containsFeature(features []*config.FeatureSet, featureID string) bool {
+	version := extractVersionFromFeatureID(featureID)
+	normalizedID := normalizeFeatureID(featureID)
 	for _, feature := range features {
-		if feature.ConfigID == featureID {
+		if (feature.ConfigID == featureID || feature.ConfigID == normalizedID) &&
+			feature.Version == version {
 			return true
 		}
 	}
@@ -609,15 +656,32 @@ func buildFeatureDependencyGraph(
 	return g, nil
 }
 
+func findKeyInLookupByConfigID(
+	configID string,
+	featureLookup map[string]*config.FeatureSet,
+) string {
+	if _, exists := featureLookup[configID]; exists {
+		return configID
+	}
+	for key, fs := range featureLookup {
+		if fs.ConfigID == configID {
+			return key
+		}
+	}
+	return ""
+}
+
 func addHardDependencies(
 	g *graph.Graph[*config.FeatureSet],
 	feature *config.FeatureSet,
 	featureLookup map[string]*config.FeatureSet,
 ) error {
+	featureKey := featureDeduplicationKey(feature.ConfigID, feature.Version)
 	for id := range feature.Config.DependsOn {
 		normalizedID := normalizeFeatureID(id)
-		if _, exists := featureLookup[normalizedID]; exists {
-			if err := g.AddEdge(normalizedID, feature.ConfigID); err != nil {
+		depKey := findKeyInLookupByConfigID(normalizedID, featureLookup)
+		if depKey != "" {
+			if err := g.AddEdge(depKey, featureKey); err != nil {
 				return err
 			}
 		}
@@ -630,17 +694,19 @@ func addSoftDependencies(
 	feature *config.FeatureSet,
 	featureLookup map[string]*config.FeatureSet,
 ) error {
+	featureKey := featureDeduplicationKey(feature.ConfigID, feature.Version)
 	for _, id := range feature.Config.InstallsAfter {
 		normalizedID := normalizeFeatureID(id)
-		if _, exists := featureLookup[normalizedID]; !exists {
+		depKey := findKeyInLookupByConfigID(normalizedID, featureLookup)
+		if depKey == "" {
 			continue
 		}
 
 		if hasHardDependency(feature, id, normalizedID) {
-			continue // already added as hard dependency
+			continue
 		}
 
-		if err := g.AddEdge(normalizedID, feature.ConfigID); err != nil {
+		if err := g.AddEdge(depKey, featureKey); err != nil {
 			return err
 		}
 	}
@@ -650,7 +716,8 @@ func addSoftDependencies(
 func buildFeatureLookupMap(features []*config.FeatureSet) map[string]*config.FeatureSet {
 	lookup := make(map[string]*config.FeatureSet, len(features))
 	for _, feature := range features {
-		lookup[feature.ConfigID] = feature
+		key := featureDeduplicationKey(feature.ConfigID, feature.Version)
+		lookup[key] = feature
 	}
 	return lookup
 }

--- a/pkg/devcontainer/feature/extend_test.go
+++ b/pkg/devcontainer/feature/extend_test.go
@@ -590,3 +590,139 @@ func (suite *ExtendTestSuite) TestResolveDependencies_LegacyIDNotUsedWhenPrimary
 	suite.Len(resolved, 3)
 	suite.NotNil(resolved["feature-b"])
 }
+
+func (suite *ExtendTestSuite) TestVersionAwareDeduplication_SameConfigSameVersion() {
+	featureID := "ghcr.io/devcontainers/features/node" //nolint:goconst
+	features := map[string]*config.FeatureSet{}
+
+	f1 := &config.FeatureSet{
+		ConfigID: featureID,
+		Version:  "1",
+		Config:   &config.FeatureConfig{DependsOn: config.DependsOnField{}},
+	}
+	f2 := &config.FeatureSet{
+		ConfigID: featureID,
+		Version:  "1",
+		Config:   &config.FeatureConfig{DependsOn: config.DependsOnField{}},
+	}
+
+	key := featureDeduplicationKey(featureID, "1")
+	suite.Equal(featureID+":1", key)
+
+	features[featureDeduplicationKey(f1.ConfigID, f1.Version)] = f1
+	features[featureDeduplicationKey(f2.ConfigID, f2.Version)] = f2
+	suite.Len(features, 1)
+}
+
+func (suite *ExtendTestSuite) TestVersionAwareDeduplication_SameConfigDifferentVersion() {
+	featureID := "ghcr.io/devcontainers/features/node"
+	features := map[string]*config.FeatureSet{}
+
+	v1 := &config.FeatureSet{
+		ConfigID: featureID,
+		Version:  "1",
+		Config:   &config.FeatureConfig{DependsOn: config.DependsOnField{}},
+	}
+	v2 := &config.FeatureSet{
+		ConfigID: featureID,
+		Version:  "2",
+		Config:   &config.FeatureConfig{DependsOn: config.DependsOnField{}},
+	}
+
+	features[featureDeduplicationKey(v1.ConfigID, v1.Version)] = v1
+	features[featureDeduplicationKey(v2.ConfigID, v2.Version)] = v2
+	suite.Len(features, 2)
+}
+
+func (suite *ExtendTestSuite) TestVersionAwareDeduplication_EmptyVersionIsDuplicate() {
+	featureID := "ghcr.io/devcontainers/features/node"
+	features := map[string]*config.FeatureSet{}
+
+	f1 := &config.FeatureSet{
+		ConfigID: featureID,
+		Version:  "",
+		Config:   &config.FeatureConfig{DependsOn: config.DependsOnField{}},
+	}
+	f2 := &config.FeatureSet{
+		ConfigID: featureID,
+		Version:  "",
+		Config:   &config.FeatureConfig{DependsOn: config.DependsOnField{}},
+	}
+
+	features[featureDeduplicationKey(f1.ConfigID, f1.Version)] = f1
+	features[featureDeduplicationKey(f2.ConfigID, f2.Version)] = f2
+	suite.Len(features, 1)
+}
+
+func (suite *ExtendTestSuite) TestExtractVersionFromFeatureID() {
+	nodeFeature := "ghcr.io/devcontainers/features/node" //nolint:goconst
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{nodeFeature + ":1", "1"},
+		{nodeFeature + ":2", "2"},
+		{nodeFeature + ":latest", ""},
+		{nodeFeature, ""},
+		{nodeFeature + ":v1", "1"},
+		{nodeFeature + ":v2.3", "2.3"}, //nolint:goconst
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.input, func() {
+			suite.Equal(tc.expected, extractVersionFromFeatureID(tc.input))
+		})
+	}
+}
+
+func (suite *ExtendTestSuite) TestNormalizeVersion() {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"latest", ""},
+		{"", ""},
+		{"1", "1"},
+		{"v1", "1"},
+		{"2.3", "2.3"},
+		{"v2.3", "2.3"},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.input, func() {
+			suite.Equal(tc.expected, normalizeVersion(tc.input))
+		})
+	}
+}
+
+func (suite *ExtendTestSuite) TestContainsFeature_VersionAware() {
+	featureID := "ghcr.io/devcontainers/features/node" //nolint:goconst
+	features := []*config.FeatureSet{
+		{ConfigID: featureID, Version: "1"},
+		{ConfigID: featureID, Version: "2"},
+	}
+
+	suite.True(containsFeature(features, "ghcr.io/devcontainers/features/node:1"))
+	suite.True(containsFeature(features, "ghcr.io/devcontainers/features/node:2"))
+	suite.False(containsFeature(features, "ghcr.io/devcontainers/features/node:3"))
+	suite.False(containsFeature(features, "ghcr.io/devcontainers/features/node:latest"))
+}
+
+func (suite *ExtendTestSuite) TestExtractFeatureByID_VersionAware() {
+	featureID := "ghcr.io/devcontainers/features/node" //nolint:goconst
+	features := []*config.FeatureSet{
+		{ConfigID: featureID, Version: "1"},
+		{ConfigID: featureID, Version: "2"},
+	}
+
+	found := extractFeatureByID(features, "ghcr.io/devcontainers/features/node:1")
+	suite.NotNil(found)
+	suite.Equal("1", found.Version)
+
+	found = extractFeatureByID(features, "ghcr.io/devcontainers/features/node:2")
+	suite.NotNil(found)
+	suite.Equal("2", found.Version)
+
+	notFound := extractFeatureByID(features, "ghcr.io/devcontainers/features/node:3")
+	suite.Nil(notFound)
+}


### PR DESCRIPTION
## Summary

Feature deduplication in `pkg/devcontainer/feature/extend.go` previously compared features by `ConfigID` only, stripping version tags via `normalizeFeatureID`. This caused two features with the same base ID but different versions (e.g., `node:1` and `node:2`) to be treated as duplicates, silently overwriting the first in the dedup map.

This PR adds a `Version` field to `FeatureSet` and uses a composite key (`ConfigID:Version`) for deduplication. Version tags are extracted from OCI references and normalized (strip `v` prefix, treat `latest` as empty). The dependency resolver, graph builder, and feature lookup functions are updated to work with composite keys. `containsFeature` and `extractFeatureByID` now compare both `ConfigID` and `Version`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Devcontainers now support using the same feature at different versions simultaneously within a single configuration, providing greater flexibility for dependency management.

* **Tests**
  * Added comprehensive test coverage for version-aware feature behavior, including deduplication, version parsing and normalization, and version-specific feature lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->