### PR TITLE
feat(compose): validate runServices against compose file services

### DIFF
--- a/e2e/tests/up-docker-compose/testdata/docker-compose-run-services-invalid/.devcontainer/devcontainer.json
+++ b/e2e/tests/up-docker-compose/testdata/docker-compose-run-services-invalid/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "Go",
+  "dockerComposeFile": "../docker-compose.yaml",
+  "service": "app",
+  "runServices": ["app", "nonexistent-service"],
+  "workspaceFolder": "/workspaces"
+}

--- a/e2e/tests/up-docker-compose/testdata/docker-compose-run-services-invalid/docker-compose.yaml
+++ b/e2e/tests/up-docker-compose/testdata/docker-compose-run-services-invalid/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  app:
+    image: ghcr.io/devsy-org/test-images/go:1
+    command: sleep infinity
+    volumes:
+      - .:/workspaces:cached

--- a/e2e/tests/up-docker-compose/up_docker_compose.go
+++ b/e2e/tests/up-docker-compose/up_docker_compose.go
@@ -502,6 +502,15 @@ var _ = ginkgo.Describe(
 			gomega.Expect(dbIDs).To(gomega.BeEmpty(), "db container not to be created")
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
+		ginkgo.It("invalid runServices returns error", func(ctx context.Context) {
+			_, _, err := tc.setupAndStartWorkspace(
+				ctx,
+				"tests/up-docker-compose/testdata/docker-compose-run-services-invalid",
+			)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring("nonexistent-service"))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
 		ginkgo.It("user lookup with no remoteUser", func(ctx context.Context) {
 			_, _, err := tc.setupAndStartWorkspace(
 				ctx,

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -176,6 +176,10 @@ func (r *runner) runDockerCompose(
 	project.Name = composeHelper.GetProjectName(r.ID)
 	log.Debugf("Loaded project %s", project.Name)
 
+	if err := validateRunServices(parsedConfig.Config.RunServices, project); err != nil {
+		return nil, err
+	}
+
 	containerDetails, err := composeHelper.FindDevContainer(
 		ctx,
 		project.Name,
@@ -313,6 +317,22 @@ func (r *runner) runDockerCompose(
 		substitutionContext: substitutionContext,
 		timeout:             timeout,
 	})
+}
+
+func validateRunServices(runServices []string, project *composetypes.Project) error {
+	if len(runServices) == 0 {
+		return nil
+	}
+	var invalid []string
+	for _, svc := range runServices {
+		if _, ok := project.Services[svc]; !ok {
+			invalid = append(invalid, svc)
+		}
+	}
+	if len(invalid) > 0 {
+		return fmt.Errorf("runServices: service(s) not found in compose file: %v", invalid)
+	}
+	return nil
 }
 
 // onlyRunServices appends the services defined in .devcontainer.json runServices to the upArgs.

--- a/pkg/devcontainer/compose_test.go
+++ b/pkg/devcontainer/compose_test.go
@@ -2,6 +2,7 @@ package devcontainer
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	composetypes "github.com/compose-spec/compose-go/v2/types"
@@ -308,4 +309,44 @@ func (s *PrepareBuildContextSuite) TestCustomBuildContextEmptyContext() {
 
 func TestPrepareBuildContextSuite(t *testing.T) {
 	suite.Run(t, new(PrepareBuildContextSuite))
+}
+
+func TestValidateRunServices(t *testing.T) {
+	project := &composetypes.Project{
+		Services: map[string]composetypes.ServiceConfig{
+			"app": {Name: "app"},
+			"db":  {Name: "db"},
+		},
+	}
+	emptyProject := &composetypes.Project{Services: map[string]composetypes.ServiceConfig{}}
+
+	tests := []struct {
+		name        string
+		runServices []string
+		project     *composetypes.Project
+		wantErr     bool
+		errContains string
+	}{
+		{"empty runServices returns nil", nil, project, false, ""},
+		{"valid services returns nil", []string{"app", "db"}, project, false, ""},
+		{"invalid service returns error", []string{"nonexistent"}, project, true, "nonexistent"},
+		{"mix of valid and invalid", []string{"app", "typo-svc", "bad"}, project, true, "typo-svc"},
+		{"project with no services", []string{"app"}, emptyProject, true, "app"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRunServices(tt.runServices, tt.project)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.errContains)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Adds upfront validation that each service listed in `runServices` actually exists in the referenced docker-compose file's `services:` map. Previously, typos in `runServices` would pass silently through config loading and only fail with confusing errors at container start time. Now a clear error is returned immediately, listing all invalid service names (e.g. `runServices: service(s) not found in compose file: [typo-service]`).

- Added `validateRunServices()` in `pkg/devcontainer/compose.go` called after `LoadDockerComposeProject` returns
- Unit tests covering: empty list, all valid, invalid only, mix of valid/invalid, empty project
- E2E test fixture with an invalid `runServices` entry asserting the error message