### PR TITLE
fix(e2e): increase TimeoutShort from 2min to 3min

### DIFF
--- a/e2e/framework/timeouts.go
+++ b/e2e/framework/timeouts.go
@@ -11,7 +11,7 @@ func TimeoutShort() time.Duration {
 	if runtime.GOOS == osWindows {
 		return 10 * time.Minute
 	}
-	return 2 * time.Minute
+	return 3 * time.Minute
 }
 
 func TimeoutModerate() time.Duration {


### PR DESCRIPTION
## Summary

- E2E tests doing Docker builds with `apt-get install` consistently timeout at 2 minutes on GitHub Actions due to slow Ubuntu apt mirror response times
- This caused 4 consecutive CI failures on main (commits d2ca8330b through ba9fbb925) despite the underlying code being correct
- Increases `TimeoutShort()` from 2 minutes to 3 minutes to accommodate realistic Docker build times on CI runners
- The original semantic merge conflict (WriteResultJSON missing `warnings` param from PR #204 vs PR #203) was already fixed in PR #207

Resolves consistent "Test up-features && suite" and "Test up-docker-compose && config" CI failures on main.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted test framework timeout configuration on non-Windows platforms to improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->