### PR TITLE
feat(feature): implement collection.json consumption from OCI registries

### DIFF
--- a/cmd/features/features.go
+++ b/cmd/features/features.go
@@ -1,0 +1,16 @@
+package features
+
+import (
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/spf13/cobra"
+)
+
+func NewFeaturesCmd(flags *flags.GlobalFlags) *cobra.Command {
+	featuresCmd := &cobra.Command{
+		Use:   "features",
+		Short: "Devcontainer feature commands",
+	}
+
+	featuresCmd.AddCommand(NewListCollectionCmd(flags))
+	return featuresCmd
+}

--- a/cmd/features/list_collection.go
+++ b/cmd/features/list_collection.go
@@ -1,0 +1,105 @@
+package features
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/devsy-org/devsy/pkg/devcontainer/feature"
+	"github.com/devsy-org/devsy/pkg/table"
+	"github.com/spf13/cobra"
+)
+
+type ListCollectionCmd struct {
+	*flags.GlobalFlags
+
+	Output string
+}
+
+func NewListCollectionCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &ListCollectionCmd{
+		GlobalFlags: globalFlags,
+	}
+	listCollectionCmd := &cobra.Command{
+		Use:   "list-collection <registry/namespace>",
+		Short: "List features in a devcontainer feature collection",
+		Long: `Lists all features available in a devcontainer feature collection
+published as an OCI artifact. The argument should be in the format
+"registry/namespace" (e.g., "ghcr.io/devcontainers/features").`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			return cmd.Run(args[0])
+		},
+	}
+
+	listCollectionCmd.Flags().
+		StringVar(&cmd.Output, "output", "plain", "The output format to use. Can be json or plain")
+	return listCollectionCmd
+}
+
+func (cmd *ListCollectionCmd) Run(ref string) error {
+	registry, namespace, err := parseCollectionRef(ref)
+	if err != nil {
+		return err
+	}
+
+	features, err := feature.ListCollectionFeatures(registry, namespace)
+	if err != nil {
+		return fmt.Errorf("fetch collection: %w", err)
+	}
+
+	switch cmd.Output {
+	case "json":
+		return printFeaturesJSON(features)
+	case "plain":
+		printFeaturesTable(features)
+	default:
+		return fmt.Errorf(
+			"unexpected output format, choose either json or plain. Got %s",
+			cmd.Output,
+		)
+	}
+
+	return nil
+}
+
+func printFeaturesJSON(features []feature.CollectionFeature) error {
+	out, err := json.MarshalIndent(features, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, _ = os.Stdout.WriteString(string(out) + "\n")
+	return nil
+}
+
+func printFeaturesTable(features []feature.CollectionFeature) {
+	rows := make([][]string, 0, len(features))
+	for _, f := range features {
+		deprecated := ""
+		if f.Deprecated {
+			deprecated = "yes"
+		}
+		rows = append(rows, []string{
+			f.ID,
+			f.Version,
+			f.Name,
+			f.Description,
+			deprecated,
+		})
+	}
+	table.Print([]string{"ID", "Version", "Name", "Description", "Deprecated"}, rows)
+}
+
+func parseCollectionRef(ref string) (string, string, error) {
+	parts := strings.SplitN(ref, "/", 2)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf(
+			"invalid collection reference %q: expected format \"registry/namespace\" "+
+				"(e.g., \"ghcr.io/devcontainers/features\")",
+			ref,
+		)
+	}
+	return parts[0], parts[1], nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/agent"
 	"github.com/devsy-org/devsy/cmd/completion"
 	"github.com/devsy-org/devsy/cmd/context"
+	"github.com/devsy-org/devsy/cmd/features"
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/cmd/helper"
 	"github.com/devsy-org/devsy/cmd/ide"
@@ -105,6 +106,7 @@ func BuildRoot() *cobra.Command {
 	_ = completion.RegisterFlagCompletionFuns(rootCmd, globalFlags)
 
 	rootCmd.AddCommand(agent.NewAgentCmd(globalFlags))
+	rootCmd.AddCommand(features.NewFeaturesCmd(globalFlags))
 	rootCmd.AddCommand(provider.NewProviderCmd(globalFlags))
 	rootCmd.AddCommand(use.NewUseCmd(globalFlags))
 	rootCmd.AddCommand(helper.NewHelperCmd(globalFlags))

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/devsy-org/devsy/e2e/framework"
 	// Register tests.
 	_ "github.com/devsy-org/devsy/e2e/tests/build"
+	_ "github.com/devsy-org/devsy/e2e/tests/collection"
 	_ "github.com/devsy-org/devsy/e2e/tests/context"
 	_ "github.com/devsy-org/devsy/e2e/tests/dockerinstall"
 	_ "github.com/devsy-org/devsy/e2e/tests/down"

--- a/e2e/tests/collection/collection.go
+++ b/e2e/tests/collection/collection.go
@@ -1,0 +1,111 @@
+package collection
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"strings"
+
+	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/devsy-org/devsy/pkg/devcontainer/feature"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("features list-collection", ginkgo.Label("collection", "suite"), func() {
+	var initialDir string
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		initialDir, err = os.Getwd()
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.It("lists features from a collection registry", func(ctx context.Context) {
+		f := framework.NewDefaultFramework(initialDir + "/bin")
+
+		srv := httptest.NewServer(registry.New())
+		ginkgo.DeferCleanup(func() { srv.Close() })
+
+		regHost := strings.TrimPrefix(srv.URL, "http://")
+
+		col := feature.Collection{
+			SourceInformation: feature.SourceInformation{
+				Repository: "https://github.com/devcontainers/features",
+				Type:       "github",
+			},
+			Features: []feature.CollectionFeature{
+				{
+					ID:          "go",
+					Version:     "1.2.0",
+					Name:        "Go",
+					Description: "Installs Go and common Go tools",
+				},
+				{
+					ID:          "node",
+					Version:     "1.5.0",
+					Name:        "Node.js",
+					Description: "Installs Node.js, nvm, and yarn",
+					Deprecated:  true,
+				},
+			},
+		}
+
+		pushCollectionImage(regHost, "devcontainers/features", col)
+
+		stdout, err := f.ExecCommandOutput(ctx, []string{
+			"features", "list-collection",
+			regHost + "/devcontainers/features",
+			"--output", "json",
+		})
+		framework.ExpectNoError(err)
+
+		var features []feature.CollectionFeature
+		err = json.Unmarshal([]byte(stdout), &features)
+		framework.ExpectNoError(err)
+
+		gomega.Expect(features).To(gomega.HaveLen(2))
+		gomega.Expect(features[0].ID).To(gomega.Equal("go"))
+		gomega.Expect(features[0].Version).To(gomega.Equal("1.2.0"))
+		gomega.Expect(features[1].ID).To(gomega.Equal("node"))
+		gomega.Expect(features[1].Deprecated).To(gomega.BeTrue())
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("returns error for non-existent collection", func(ctx context.Context) {
+		f := framework.NewDefaultFramework(initialDir + "/bin")
+
+		srv := httptest.NewServer(registry.New())
+		ginkgo.DeferCleanup(func() { srv.Close() })
+
+		regHost := strings.TrimPrefix(srv.URL, "http://")
+
+		_, err := f.ExecCommandOutput(ctx, []string{
+			"features", "list-collection",
+			regHost + "/nonexistent/collection",
+		})
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+})
+
+func pushCollectionImage(regHost, namespace string, col feature.Collection) {
+	raw, err := json.Marshal(col)
+	framework.ExpectNoError(err)
+
+	layer := static.NewLayer(raw, types.MediaType(feature.CollectionLayerMediaType))
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	framework.ExpectNoError(err)
+
+	refStr := regHost + "/" + namespace + "/devcontainer-collection:latest"
+	ref, err := name.ParseReference(refStr, name.Insecure)
+	framework.ExpectNoError(err)
+
+	framework.ExpectNoError(remote.Write(ref, img))
+}

--- a/pkg/devcontainer/feature/collection.go
+++ b/pkg/devcontainer/feature/collection.go
@@ -1,0 +1,135 @@
+package feature
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/devsy-org/devsy/pkg/image"
+	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+)
+
+const CollectionLayerMediaType = "application/vnd.devcontainers.collection.layer.v1+json"
+
+type Collection struct {
+	SourceInformation SourceInformation   `json:"sourceInformation,omitzero"`
+	Features          []CollectionFeature `json:"features"`
+}
+
+type SourceInformation struct {
+	Repository string `json:"repository,omitempty"`
+	Type       string `json:"type,omitempty"`
+}
+
+type CollectionFeature struct {
+	ID               string                        `json:"id"`
+	Version          string                        `json:"version"`
+	Name             string                        `json:"name"`
+	Description      string                        `json:"description"`
+	DocumentationURL string                        `json:"documentationURL,omitempty"`
+	Options          map[string]FeatureOptionEntry `json:"options,omitempty"`
+	Deprecated       bool                          `json:"deprecated,omitempty"`
+}
+
+type FeatureOptionEntry struct {
+	Type        string   `json:"type,omitempty"`
+	Default     any      `json:"default,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Enum        []string `json:"enum,omitempty"`
+	Proposals   []string `json:"proposals,omitempty"`
+}
+
+func FetchCollectionJSON(registry, namespace string) (*Collection, error) {
+	ref, err := buildCollectionRef(registry, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("parse collection reference: %w", err)
+	}
+
+	img, err := pullCollectionImage(ref)
+	if err != nil {
+		return nil, err
+	}
+
+	return extractCollectionJSON(img)
+}
+
+func ListCollectionFeatures(registry, namespace string) ([]CollectionFeature, error) {
+	col, err := FetchCollectionJSON(registry, namespace)
+	if err != nil {
+		return nil, err
+	}
+	return col.Features, nil
+}
+
+func buildCollectionRef(registry, namespace string) (name.Reference, error) {
+	refStr := fmt.Sprintf("%s/%s/devcontainer-collection:latest", registry, namespace)
+	return name.ParseReference(refStr)
+}
+
+func pullCollectionImage(ref name.Reference) (v1.Image, error) {
+	var img v1.Image
+	err := retryOCIPull(func() error {
+		log.Debugf("fetching collection image: reference=%s", ref.String())
+		var fetchErr error
+		img, fetchErr = remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+		return fetchErr
+	})
+	if err != nil {
+		err = image.SanitizeRegistryError(err)
+		registry := sanitizeURL(ref.Context().RegistryStr())
+		return nil, fmt.Errorf("pull collection from %s: %w", registry, err)
+	}
+	return img, nil
+}
+
+func extractCollectionJSON(img v1.Image) (*Collection, error) {
+	layer, err := findCollectionLayer(img)
+	if err != nil {
+		return nil, fmt.Errorf("find collection layer: %w", err)
+	}
+
+	data, err := layer.Uncompressed()
+	if err != nil {
+		return nil, fmt.Errorf("uncompress collection layer: %w", err)
+	}
+	defer func() { _ = data.Close() }()
+
+	return parseCollection(data)
+}
+
+func findCollectionLayer(img v1.Image) (v1.Layer, error) {
+	manifest, err := img.Manifest()
+	if err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+
+	if len(manifest.Layers) == 0 {
+		return nil, fmt.Errorf("image has no layers")
+	}
+
+	for _, desc := range manifest.Layers {
+		if string(desc.MediaType) == CollectionLayerMediaType {
+			return img.LayerByDigest(desc.Digest)
+		}
+	}
+
+	return img.LayerByDigest(manifest.Layers[0].Digest)
+}
+
+func parseCollection(r io.Reader) (*Collection, error) {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read collection data: %w", err)
+	}
+
+	var col Collection
+	if err := json.Unmarshal(raw, &col); err != nil {
+		return nil, fmt.Errorf("parse collection JSON: %w", err)
+	}
+
+	return &col, nil
+}

--- a/pkg/devcontainer/feature/collection_test.go
+++ b/pkg/devcontainer/feature/collection_test.go
@@ -1,0 +1,231 @@
+package feature
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/stretchr/testify/suite"
+)
+
+type CollectionTestSuite struct {
+	suite.Suite
+}
+
+func TestCollectionTestSuite(t *testing.T) {
+	suite.Run(t, new(CollectionTestSuite))
+}
+
+func (s *CollectionTestSuite) TestParseCollection_HappyPath() {
+	col := Collection{
+		SourceInformation: SourceInformation{
+			Repository: "https://github.com/devcontainers/features",
+			Type:       "github",
+		},
+		Features: []CollectionFeature{
+			{
+				ID:          "go",
+				Version:     "1.2.0",
+				Name:        "Go",
+				Description: "Installs Go and common Go tools",
+			},
+			{
+				ID:          "node",
+				Version:     "1.5.0",
+				Name:        "Node.js",
+				Description: "Installs Node.js, nvm, and yarn",
+				Deprecated:  true,
+			},
+		},
+	}
+
+	raw, err := json.Marshal(col)
+	s.Require().NoError(err)
+
+	parsed, err := parseCollection(bytes.NewReader(raw))
+	s.Require().NoError(err)
+	s.Equal("https://github.com/devcontainers/features", parsed.SourceInformation.Repository)
+	s.Equal("github", parsed.SourceInformation.Type)
+	s.Len(parsed.Features, 2)
+	s.Equal("go", parsed.Features[0].ID)
+	s.Equal("1.2.0", parsed.Features[0].Version)
+	s.Equal("Go", parsed.Features[0].Name)
+	s.Equal("Installs Go and common Go tools", parsed.Features[0].Description)
+	s.False(parsed.Features[0].Deprecated)
+	s.Equal("node", parsed.Features[1].ID)
+	s.True(parsed.Features[1].Deprecated)
+}
+
+func (s *CollectionTestSuite) TestParseCollection_EmptyFeatures() {
+	col := Collection{Features: []CollectionFeature{}}
+	raw, err := json.Marshal(col)
+	s.Require().NoError(err)
+
+	parsed, err := parseCollection(bytes.NewReader(raw))
+	s.Require().NoError(err)
+	s.Empty(parsed.Features)
+}
+
+func (s *CollectionTestSuite) TestParseCollection_InvalidJSON() {
+	_, err := parseCollection(bytes.NewReader([]byte("not json")))
+	s.Error(err)
+	s.Contains(err.Error(), "parse collection JSON")
+}
+
+func (s *CollectionTestSuite) TestParseCollection_WithOptions() {
+	col := Collection{
+		Features: []CollectionFeature{
+			{
+				ID:      "python",
+				Version: "2.0.0",
+				Name:    "Python",
+				Options: map[string]FeatureOptionEntry{
+					"version": {
+						Type:        "string",
+						Default:     "3.11",
+						Description: "Python version to install",
+						Proposals:   []string{"3.10", "3.11", "3.12"},
+					},
+				},
+			},
+		},
+	}
+
+	raw, err := json.Marshal(col)
+	s.Require().NoError(err)
+
+	parsed, err := parseCollection(bytes.NewReader(raw))
+	s.Require().NoError(err)
+	s.Len(parsed.Features, 1)
+	s.Contains(parsed.Features[0].Options, "version")
+	s.Equal("string", parsed.Features[0].Options["version"].Type)
+	s.Equal("3.11", parsed.Features[0].Options["version"].Default)
+}
+
+func (s *CollectionTestSuite) TestExtractCollectionJSON_TypedLayer() {
+	col := Collection{
+		Features: []CollectionFeature{
+			{ID: "rust", Version: "1.0.0", Name: "Rust"},
+		},
+	}
+	raw, err := json.Marshal(col)
+	s.Require().NoError(err)
+
+	layer := static.NewLayer(raw, types.MediaType(CollectionLayerMediaType))
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	s.Require().NoError(err)
+
+	parsed, err := extractCollectionJSON(img)
+	s.Require().NoError(err)
+	s.Len(parsed.Features, 1)
+	s.Equal("rust", parsed.Features[0].ID)
+}
+
+func (s *CollectionTestSuite) TestExtractCollectionJSON_FallbackToFirstLayer() {
+	col := Collection{
+		Features: []CollectionFeature{
+			{ID: "java", Version: "2.1.0", Name: "Java"},
+		},
+	}
+	raw, err := json.Marshal(col)
+	s.Require().NoError(err)
+
+	layer := static.NewLayer(raw, types.OCIUncompressedLayer)
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	s.Require().NoError(err)
+
+	parsed, err := extractCollectionJSON(img)
+	s.Require().NoError(err)
+	s.Len(parsed.Features, 1)
+	s.Equal("java", parsed.Features[0].ID)
+}
+
+func (s *CollectionTestSuite) TestFindCollectionLayer_NoLayers() {
+	_, err := findCollectionLayer(empty.Image)
+	s.Error(err)
+	s.Contains(err.Error(), "no layers")
+}
+
+func (s *CollectionTestSuite) TestBuildCollectionRef() {
+	ref, err := buildCollectionRef("ghcr.io", "devcontainers/features")
+	s.Require().NoError(err)
+	s.Equal("ghcr.io/devcontainers/features/devcontainer-collection:latest", ref.String())
+}
+
+func (s *CollectionTestSuite) TestBuildCollectionRef_InvalidRegistry() {
+	_, err := buildCollectionRef("", "INVALID@@@REF")
+	s.Error(err)
+}
+
+func (s *CollectionTestSuite) TestListCollectionFeatures_FromImage() {
+	col := Collection{
+		Features: []CollectionFeature{
+			{ID: "go", Version: "1.2.0", Name: "Go", Description: "Go language"},
+			{ID: "node", Version: "1.5.0", Name: "Node.js", Description: "Node runtime"},
+		},
+	}
+	raw, err := json.Marshal(col)
+	s.Require().NoError(err)
+
+	layer := static.NewLayer(raw, types.MediaType(CollectionLayerMediaType))
+	img, err := mutate.AppendLayers(empty.Image, layer)
+	s.Require().NoError(err)
+
+	parsed, err := extractCollectionJSON(img)
+	s.Require().NoError(err)
+	s.Len(parsed.Features, 2)
+	s.Equal("go", parsed.Features[0].ID)
+	s.Equal("node", parsed.Features[1].ID)
+}
+
+func (s *CollectionTestSuite) TestFindCollectionLayer_PrefersTypedLayer() {
+	untyped := static.NewLayer([]byte("garbage"), types.OCIUncompressedLayer)
+
+	col := Collection{Features: []CollectionFeature{{ID: "correct"}}}
+	raw, _ := json.Marshal(col)
+	typed := static.NewLayer(raw, types.MediaType(CollectionLayerMediaType))
+
+	img, err := mutate.AppendLayers(empty.Image, untyped, typed)
+	s.Require().NoError(err)
+
+	layer, err := findCollectionLayer(img)
+	s.Require().NoError(err)
+
+	mt, err := layer.MediaType()
+	s.Require().NoError(err)
+	s.Equal(types.MediaType(CollectionLayerMediaType), mt)
+
+	// Verify the layer content is the typed one
+	data, err := layer.Uncompressed()
+	s.Require().NoError(err)
+	defer func() { _ = data.Close() }()
+
+	var result Collection
+	buf := new(bytes.Buffer)
+	_, _ = buf.ReadFrom(data)
+	_ = json.Unmarshal(buf.Bytes(), &result)
+	s.Equal("correct", result.Features[0].ID)
+}
+
+func (s *CollectionTestSuite) TestExtractCollectionJSON_EmptyManifest() {
+	img := emptyImageWithLayers(0)
+	_, err := extractCollectionJSON(img)
+	s.Error(err)
+}
+
+func emptyImageWithLayers(n int) v1.Image {
+	if n == 0 {
+		return empty.Image
+	}
+	img := empty.Image
+	for range n {
+		layer := static.NewLayer([]byte("{}"), types.OCIUncompressedLayer)
+		img, _ = mutate.AppendLayers(img, layer)
+	}
+	return img
+}

--- a/pkg/devcontainer/feature/collection_test.go
+++ b/pkg/devcontainer/feature/collection_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const testFeatureNode = "node"
+
 type CollectionTestSuite struct {
 	suite.Suite
 }
@@ -35,7 +37,7 @@ func (s *CollectionTestSuite) TestParseCollection_HappyPath() {
 				Description: "Installs Go and common Go tools",
 			},
 			{
-				ID:          "node",
+				ID:          testFeatureNode,
 				Version:     "1.5.0",
 				Name:        "Node.js",
 				Description: "Installs Node.js, nvm, and yarn",
@@ -57,7 +59,7 @@ func (s *CollectionTestSuite) TestParseCollection_HappyPath() {
 	s.Equal("Go", parsed.Features[0].Name)
 	s.Equal("Installs Go and common Go tools", parsed.Features[0].Description)
 	s.False(parsed.Features[0].Deprecated)
-	s.Equal("node", parsed.Features[1].ID)
+	s.Equal(testFeatureNode, parsed.Features[1].ID)
 	s.True(parsed.Features[1].Deprecated)
 }
 
@@ -166,7 +168,7 @@ func (s *CollectionTestSuite) TestListCollectionFeatures_FromImage() {
 	col := Collection{
 		Features: []CollectionFeature{
 			{ID: "go", Version: "1.2.0", Name: "Go", Description: "Go language"},
-			{ID: "node", Version: "1.5.0", Name: "Node.js", Description: "Node runtime"},
+			{ID: testFeatureNode, Version: "1.5.0", Name: "Node.js", Description: "Node runtime"},
 		},
 	}
 	raw, err := json.Marshal(col)
@@ -180,7 +182,7 @@ func (s *CollectionTestSuite) TestListCollectionFeatures_FromImage() {
 	s.Require().NoError(err)
 	s.Len(parsed.Features, 2)
 	s.Equal("go", parsed.Features[0].ID)
-	s.Equal("node", parsed.Features[1].ID)
+	s.Equal(testFeatureNode, parsed.Features[1].ID)
 }
 
 func (s *CollectionTestSuite) TestFindCollectionLayer_PrefersTypedLayer() {


### PR DESCRIPTION
## Summary

- Adds `Collection`, `CollectionFeature`, and `SourceInformation` types matching the devcontainer collection.json spec
- Implements `FetchCollectionJSON()` and `ListCollectionFeatures()` to pull and parse collection manifests from OCI registries, using existing retry and auth patterns
- Adds `devsy features list-collection <registry/namespace>` CLI command with plain table and JSON output modes
- Includes comprehensive unit tests (layer discovery, fallback, parsing) and e2e test using an in-memory OCI registry