### PR TITLE
feat(cmd): add minor CLI flags

### DIFF
--- a/cmd/agent/container/deferred_hooks.go
+++ b/cmd/agent/container/deferred_hooks.go
@@ -69,7 +69,7 @@ func (cmd *DeferredHooksCmd) Run(ctx context.Context) error {
 		Repository:    cmd.DotfilesRepo,
 		InstallScript: cmd.DotfilesScript,
 		RemoteUser:    config.GetRemoteUser(setupInfo),
-	}, cmd.SecretsEnv)
+	}, cmd.SecretsEnv, setup.SkipPhases{})
 	if err != nil {
 		return fmt.Errorf("deferred hooks setup: %w", err)
 	}

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -193,6 +193,9 @@ func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
 		PlatformOptions:   &sctx.workspaceInfo.CLIOptions.Platform,
 		TunnelClient:      sctx.tunnelClient,
 		Prebuild:          cmd.Prebuild,
+		SkipPostCreate:    sctx.workspaceInfo.CLIOptions.SkipPostCreate,
+		SkipPostStart:     sctx.workspaceInfo.CLIOptions.SkipPostStart,
+		SkipPostAttach:    sctx.workspaceInfo.CLIOptions.SkipPostAttach,
 		Dotfiles: setup.DotfilesConfig{
 			Repository:    cmd.DotfilesRepo,
 			InstallScript: cmd.DotfilesScript,

--- a/cmd/agent/workspace/build.go
+++ b/cmd/agent/workspace/build.go
@@ -89,10 +89,12 @@ func (cmd *BuildCmd) Run(ctx context.Context) error {
 	for _, platform := range platforms {
 		// build the image
 		imageName, err := runner.Build(ctx, provider2.BuildOptions{
-			CLIOptions:    workspaceInfo.CLIOptions,
-			RegistryCache: workspaceInfo.RegistryCache,
-			Platform:      platform,
-			ExportCache:   true,
+			CLIOptions:      workspaceInfo.CLIOptions,
+			RegistryCache:   workspaceInfo.RegistryCache,
+			Platform:        platform,
+			ExportCache:     true,
+			NoBuild:         workspaceInfo.CLIOptions.NoBuild,
+			PushDuringBuild: workspaceInfo.CLIOptions.PushDuringBuild,
 		})
 		if err != nil {
 			log.Errorf("Error building image: %v", err)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -160,9 +160,9 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 		StringSliceVar(&cmd.Platforms, "platform", []string{}, "Set target platform for build")
 	buildCmd.Flags().
 		BoolVar(&cmd.SkipPush, "skip-push", false, "If true will not push the image to the repository, useful for testing")
-	buildCmd.Flags().BoolVar(&cmd.PushDuringBuild, "push", false,
-		"Push image directly to registry during build, skipping load to local daemon.",
-	)
+	buildCmd.Flags().
+		BoolVar(&cmd.PushDuringBuild, "push", false,
+			"Push image directly to registry during build, skipping load to local daemon")
 	buildCmd.Flags().
 		StringArrayVar(&cmd.CacheFrom, "cache-from", []string{},
 			"Cache sources for the build (e.g., myregistry.io/cache:latest or type=registry,ref=...). "+

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -187,6 +187,11 @@ func NewBuildCmd(flags *flags.GlobalFlags) *cobra.Command {
 		BoolVar(&cmd.GitCloneRecursiveSubmodules, "git-clone-recursive-submodules", false,
 			"If true will clone git submodule repositories recursively")
 
+	buildCmd.Flags().
+		StringVar(&cmd.ImageName, "image-name", "", "Alternative name for the built image")
+	buildCmd.Flags().
+		BoolVar(&cmd.NoBuild, "no-build", false, "Fail if the image must be built (enforce pre-built images only)")
+
 	// TESTING
 	buildCmd.Flags().BoolVar(&cmd.ForceBuild, "force-build", false, "TESTING ONLY")
 	buildCmd.Flags().

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCmd_NoCacheFlag(t *testing.T) {
+	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
+	flag := buildCmd.Flags().Lookup("no-cache")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestBuildCmd_NoCacheFlagParsesValue(t *testing.T) {
+	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
+	err := buildCmd.ParseFlags([]string{"--no-cache"})
+	require.NoError(t, err)
+
+	val, err := buildCmd.Flags().GetBool("no-cache")
+	require.NoError(t, err)
+	assert.True(t, val)
+}
+
+func TestBuildCmd_ImageNameFlag(t *testing.T) {
+	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
+	flag := buildCmd.Flags().Lookup("image-name")
+	require.NotNil(t, flag)
+	assert.Equal(t, "", flag.DefValue)
+}
+
+func TestBuildCmd_ImageNameFlagParsesValue(t *testing.T) {
+	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
+	err := buildCmd.ParseFlags([]string{"--image-name", "my-custom-image:latest"})
+	require.NoError(t, err)
+
+	flag := buildCmd.Flags().Lookup("image-name")
+	assert.Equal(t, "my-custom-image:latest", flag.Value.String())
+}
+
+func TestBuildCmd_NoBuildFlag(t *testing.T) {
+	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
+	flag := buildCmd.Flags().Lookup("no-build")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestBuildCmd_NoBuildFlagParsesValue(t *testing.T) {
+	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
+	err := buildCmd.ParseFlags([]string{"--no-build"})
+	require.NoError(t, err)
+
+	val, err := buildCmd.Flags().GetBool("no-build")
+	require.NoError(t, err)
+	assert.True(t, val)
+}
+
+func TestBuildCmd_NoCacheDefaultFalse(t *testing.T) {
+	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
+	err := buildCmd.ParseFlags([]string{})
+	require.NoError(t, err)
+
+	val, err := buildCmd.Flags().GetBool("no-cache")
+	require.NoError(t, err)
+	assert.False(t, val)
+}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -33,6 +33,8 @@ type ExecCmd struct {
 	RemoteEnv           []string
 	DefaultUserEnvProbe string
 	IDLabels            []string
+	ContainerDataFolder string
+	SkipPostCreate      bool
 }
 
 func NewExecCmd(f *flags.GlobalFlags) *cobra.Command {
@@ -88,6 +90,20 @@ func NewExecCmd(f *flags.GlobalFlags) *cobra.Command {
 			"id-label",
 			[]string{},
 			"Override the default container identification labels (format: key=value, can be specified multiple times)",
+		)
+	execCmd.Flags().
+		StringVar(
+			&cmd.ContainerDataFolder,
+			"container-data-folder",
+			"",
+			"Override the default container data folder path",
+		)
+	execCmd.Flags().
+		BoolVar(
+			&cmd.SkipPostCreate,
+			"skip-post-create",
+			false,
+			"Skip running postCreateCommand",
 		)
 
 	return execCmd

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -110,6 +110,13 @@ func NewExecCmd(f *flags.GlobalFlags) *cobra.Command {
 }
 
 func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
+	if cmd.ContainerDataFolder != "" {
+		log.Warnf("--container-data-folder is accepted but not yet implemented for exec")
+	}
+	if cmd.SkipPostCreate {
+		log.Warnf("--skip-post-create is accepted but not yet implemented for exec")
+	}
+
 	if cmd.WorkspaceFolder == "" && cmd.ContainerID == "" {
 		return fmt.Errorf("either --workspace-folder or --container-id must be provided")
 	}

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -95,3 +95,42 @@ func TestExecCmd_NonExistentContainerID(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "nonexistent-container-id-12345")
 }
+
+func TestExecCmd_ContainerDataFolderFlag(t *testing.T) {
+	execCmd := NewExecCmd(&flags.GlobalFlags{})
+	flag := execCmd.Flags().Lookup("container-data-folder")
+	require.NotNil(t, flag)
+	assert.Equal(t, "", flag.DefValue)
+}
+
+func TestExecCmd_ContainerDataFolderFlagParsesValue(t *testing.T) {
+	execCmd := NewExecCmd(&flags.GlobalFlags{})
+	err := execCmd.ParseFlags([]string{
+		"--workspace-folder", "/tmp",
+		"--container-data-folder", "/custom/data",
+	})
+	require.NoError(t, err)
+
+	flag := execCmd.Flags().Lookup("container-data-folder")
+	assert.Equal(t, "/custom/data", flag.Value.String())
+}
+
+func TestExecCmd_SkipPostCreateFlag(t *testing.T) {
+	execCmd := NewExecCmd(&flags.GlobalFlags{})
+	flag := execCmd.Flags().Lookup("skip-post-create")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestExecCmd_SkipPostCreateFlagParsesValue(t *testing.T) {
+	execCmd := NewExecCmd(&flags.GlobalFlags{})
+	err := execCmd.ParseFlags([]string{
+		"--workspace-folder", "/tmp",
+		"--skip-post-create",
+	})
+	require.NoError(t, err)
+
+	val, err := execCmd.Flags().GetBool("skip-post-create")
+	require.NoError(t, err)
+	assert.True(t, val)
+}

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -8,6 +8,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	flagSkipPostCreate  = "--skip-post-create"
+	flagWorkspaceFolder = "--workspace-folder"
+	testTmpDir          = "/tmp"
+)
+
 func TestValidateRemoteEnv_Valid(t *testing.T) {
 	cmd := &ExecCmd{
 		GlobalFlags: &flags.GlobalFlags{},
@@ -54,7 +60,7 @@ func TestNewExecCmd_RequiresWorkspaceFolderOrContainerID(t *testing.T) {
 
 func TestNewExecCmd_RequiresArgs(t *testing.T) {
 	execCmd := NewExecCmd(&flags.GlobalFlags{})
-	execCmd.SetArgs([]string{"--workspace-folder", "/tmp/test"})
+	execCmd.SetArgs([]string{flagWorkspaceFolder, testTmpDir + "/test"})
 	err := execCmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires at least 1 arg")
@@ -106,7 +112,7 @@ func TestExecCmd_ContainerDataFolderFlag(t *testing.T) {
 func TestExecCmd_ContainerDataFolderFlagParsesValue(t *testing.T) {
 	execCmd := NewExecCmd(&flags.GlobalFlags{})
 	err := execCmd.ParseFlags([]string{
-		"--workspace-folder", "/tmp",
+		flagWorkspaceFolder, testTmpDir,
 		"--container-data-folder", "/custom/data",
 	})
 	require.NoError(t, err)
@@ -125,8 +131,8 @@ func TestExecCmd_SkipPostCreateFlag(t *testing.T) {
 func TestExecCmd_SkipPostCreateFlagParsesValue(t *testing.T) {
 	execCmd := NewExecCmd(&flags.GlobalFlags{})
 	err := execCmd.ParseFlags([]string{
-		"--workspace-folder", "/tmp",
-		"--skip-post-create",
+		flagWorkspaceFolder, testTmpDir,
+		flagSkipPostCreate,
 	})
 	require.NoError(t, err)
 

--- a/cmd/minor_flags_test.go
+++ b/cmd/minor_flags_test.go
@@ -72,13 +72,6 @@ func TestUpCmd_TerminalRowsFlagParsesValue(t *testing.T) {
 	assert.Equal(t, 40, val)
 }
 
-func TestUpCmd_SkipPostCreateFlag(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
-	flag := upCmd.Flags().Lookup("skip-post-create")
-	require.NotNil(t, flag)
-	assert.Equal(t, "false", flag.DefValue)
-}
-
 func TestUpCmd_SkipPostCreateFlagParsesValue(t *testing.T) {
 	upCmd := NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{"--skip-post-create"})
@@ -118,22 +111,6 @@ func TestUpCmd_DotfilesTargetPathFlagParsesValue(t *testing.T) {
 	val, err := upCmd.Flags().GetString("dotfiles-target-path")
 	require.NoError(t, err)
 	assert.Equal(t, "~/dotfiles", val)
-}
-
-func TestBuildCmd_NoCacheFlag(t *testing.T) {
-	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
-	flag := buildCmd.Flags().Lookup("no-cache")
-	require.NotNil(t, flag)
-	assert.Equal(t, "false", flag.DefValue)
-}
-
-func TestBuildCmd_NoCacheFlagParsesValue(t *testing.T) {
-	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
-	err := buildCmd.ParseFlags([]string{"--no-cache"})
-	require.NoError(t, err)
-	val, err := buildCmd.Flags().GetBool("no-cache")
-	require.NoError(t, err)
-	assert.True(t, val)
 }
 
 func TestBuildCmd_LabelFlag(t *testing.T) {

--- a/cmd/minor_flags_test.go
+++ b/cmd/minor_flags_test.go
@@ -74,7 +74,7 @@ func TestUpCmd_TerminalRowsFlagParsesValue(t *testing.T) {
 
 func TestUpCmd_SkipPostCreateFlagParsesValue(t *testing.T) {
 	upCmd := NewUpCmd(&flags.GlobalFlags{})
-	err := upCmd.ParseFlags([]string{"--skip-post-create"})
+	err := upCmd.ParseFlags([]string{flagSkipPostCreate})
 	require.NoError(t, err)
 	val, err := upCmd.Flags().GetBool("skip-post-create")
 	require.NoError(t, err)

--- a/cmd/runusercommands.go
+++ b/cmd/runusercommands.go
@@ -21,8 +21,13 @@ import (
 type RunUserCommandsCmd struct {
 	*flags.GlobalFlags
 
-	WorkspaceFolder string
-	IDLabels        []string
+	WorkspaceFolder   string
+	IDLabels          []string
+	SkipPostCreate    bool
+	SkipPostStart     bool
+	SkipPostAttach    bool
+	SkipOnCreate      bool
+	SkipUpdateContent bool
 }
 
 // NewRunUserCommandsCmd creates a new run-user-commands command.
@@ -53,6 +58,16 @@ func NewRunUserCommandsCmd(f *flags.GlobalFlags) *cobra.Command {
 			[]string{},
 			"Override the default container identification labels (format: key=value, can be specified multiple times)",
 		)
+	runCmd.Flags().
+		BoolVar(&cmd.SkipPostCreate, "skip-post-create", false, "Skip running postCreateCommand")
+	runCmd.Flags().
+		BoolVar(&cmd.SkipPostStart, "skip-post-start", false, "Skip running postStartCommand")
+	runCmd.Flags().
+		BoolVar(&cmd.SkipPostAttach, "skip-post-attach", false, "Skip running postAttachCommand")
+	runCmd.Flags().
+		BoolVar(&cmd.SkipOnCreate, "skip-on-create", false, "Skip running onCreateCommand")
+	runCmd.Flags().
+		BoolVar(&cmd.SkipUpdateContent, "skip-update-content", false, "Skip running updateContentCommand")
 
 	return runCmd
 }
@@ -149,13 +164,20 @@ func (cmd *RunUserCommandsCmd) runLifecycleHooks(
 	hooks := []struct {
 		name string
 		cmds []types.LifecycleHook
+		skip bool
 	}{
-		{"postCreateCommand", result.MergedConfig.PostCreateCommands},
-		{"postStartCommand", result.MergedConfig.PostStartCommands},
-		{"postAttachCommand", result.MergedConfig.PostAttachCommands},
+		{"onCreateCommand", result.MergedConfig.OnCreateCommands, cmd.SkipOnCreate},
+		{"updateContentCommand", result.MergedConfig.UpdateContentCommands, cmd.SkipUpdateContent},
+		{"postCreateCommand", result.MergedConfig.PostCreateCommands, cmd.SkipPostCreate},
+		{"postStartCommand", result.MergedConfig.PostStartCommands, cmd.SkipPostStart},
+		{"postAttachCommand", result.MergedConfig.PostAttachCommands, cmd.SkipPostAttach},
 	}
 
 	for _, hook := range hooks {
+		if hook.skip {
+			log.Infof("skipping %s (--skip flag set)", hook.name)
+			continue
+		}
 		for _, h := range hook.cmds {
 			if err := execLifecycleHook(params, hook.name, h); err != nil {
 				_ = devcconfig.WriteErrorJSON(os.Stderr, err.Error())

--- a/cmd/runusercommands_test.go
+++ b/cmd/runusercommands_test.go
@@ -154,8 +154,8 @@ func TestRunUserCommandsCmd_SkipUpdateContentFlag(t *testing.T) {
 func TestRunUserCommandsCmd_SkipFlagsParseValues(t *testing.T) {
 	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
 	err := cmd.ParseFlags([]string{
-		"--workspace-folder", "/tmp",
-		"--skip-post-create",
+		flagWorkspaceFolder, testTmpDir,
+		flagSkipPostCreate,
 		"--skip-post-start",
 		"--skip-post-attach",
 		"--skip-on-create",

--- a/cmd/runusercommands_test.go
+++ b/cmd/runusercommands_test.go
@@ -115,3 +115,71 @@ func TestRunUserCommandsCmd_RegisteredInRoot(t *testing.T) {
 	}
 	assert.True(t, found, "run-user-commands should be registered in root")
 }
+
+func TestRunUserCommandsCmd_SkipPostCreateFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("skip-post-create")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestRunUserCommandsCmd_SkipPostStartFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("skip-post-start")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestRunUserCommandsCmd_SkipPostAttachFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("skip-post-attach")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestRunUserCommandsCmd_SkipOnCreateFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("skip-on-create")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestRunUserCommandsCmd_SkipUpdateContentFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("skip-update-content")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestRunUserCommandsCmd_SkipFlagsParseValues(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	err := cmd.ParseFlags([]string{
+		"--workspace-folder", "/tmp",
+		"--skip-post-create",
+		"--skip-post-start",
+		"--skip-post-attach",
+		"--skip-on-create",
+		"--skip-update-content",
+	})
+	require.NoError(t, err)
+
+	val, err := cmd.Flags().GetBool("skip-post-create")
+	require.NoError(t, err)
+	assert.True(t, val)
+
+	val, err = cmd.Flags().GetBool("skip-post-start")
+	require.NoError(t, err)
+	assert.True(t, val)
+
+	val, err = cmd.Flags().GetBool("skip-post-attach")
+	require.NoError(t, err)
+	assert.True(t, val)
+
+	val, err = cmd.Flags().GetBool("skip-on-create")
+	require.NoError(t, err)
+	assert.True(t, val)
+
+	val, err = cmd.Flags().GetBool("skip-update-content")
+	require.NoError(t, err)
+	assert.True(t, val)
+}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -293,6 +293,18 @@ func (cmd *UpCmd) registerDevContainerFlags(upCmd *cobra.Command) {
 	upCmd.Flags().
 		BoolVar(&cmd.SkipNonBlockingCommands, "skip-non-blocking-commands", false,
 			"Skip non-blocking lifecycle commands")
+	upCmd.Flags().
+		BoolVar(&cmd.SkipPostStart, "skip-post-start", false,
+			"Skip running postStartCommand")
+	upCmd.Flags().
+		BoolVar(&cmd.SkipPostAttach, "skip-post-attach", false,
+			"Skip running postAttachCommand")
+	upCmd.Flags().
+		StringVar(&cmd.ContainerUser, "container-user", "",
+			"Override the user in the container")
+	upCmd.Flags().
+		StringVar(&cmd.RemoteUser, "remote-user", "",
+			"Override the remoteUser setting")
 }
 
 func (cmd *UpCmd) registerIDEFlags(upCmd *cobra.Command) {

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -112,3 +112,78 @@ func TestUpCmd_ValidateWorkspaceMountConsistency(t *testing.T) {
 		})
 	}
 }
+
+func TestUpCmd_SkipPostCreateFlag(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	flag := upCmd.Flags().Lookup("skip-post-create")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestUpCmd_SkipPostStartFlag(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	flag := upCmd.Flags().Lookup("skip-post-start")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestUpCmd_SkipPostAttachFlag(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	flag := upCmd.Flags().Lookup("skip-post-attach")
+	require.NotNil(t, flag)
+	assert.Equal(t, "false", flag.DefValue)
+}
+
+func TestUpCmd_SkipFlagsParseValues(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	err := upCmd.ParseFlags([]string{
+		"--skip-post-create",
+		"--skip-post-start",
+		"--skip-post-attach",
+	})
+	require.NoError(t, err)
+
+	val, err := upCmd.Flags().GetBool("skip-post-create")
+	require.NoError(t, err)
+	assert.True(t, val)
+
+	val, err = upCmd.Flags().GetBool("skip-post-start")
+	require.NoError(t, err)
+	assert.True(t, val)
+
+	val, err = upCmd.Flags().GetBool("skip-post-attach")
+	require.NoError(t, err)
+	assert.True(t, val)
+}
+
+func TestUpCmd_ContainerUserFlag(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	flag := upCmd.Flags().Lookup("container-user")
+	require.NotNil(t, flag)
+	assert.Equal(t, "", flag.DefValue)
+}
+
+func TestUpCmd_ContainerUserFlagParsesValue(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	err := upCmd.ParseFlags([]string{"--container-user", "devuser"})
+	require.NoError(t, err)
+
+	flag := upCmd.Flags().Lookup("container-user")
+	assert.Equal(t, "devuser", flag.Value.String())
+}
+
+func TestUpCmd_RemoteUserFlag(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	flag := upCmd.Flags().Lookup("remote-user")
+	require.NotNil(t, flag)
+	assert.Equal(t, "", flag.DefValue)
+}
+
+func TestUpCmd_RemoteUserFlagParsesValue(t *testing.T) {
+	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	err := upCmd.ParseFlags([]string{"--remote-user", "vscode"})
+	require.NoError(t, err)
+
+	flag := upCmd.Flags().Lookup("remote-user")
+	assert.Equal(t, "vscode", flag.Value.String())
+}

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -137,7 +137,7 @@ func TestUpCmd_SkipPostAttachFlag(t *testing.T) {
 func TestUpCmd_SkipFlagsParseValues(t *testing.T) {
 	upCmd := NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{
-		"--skip-post-create",
+		flagSkipPostCreate,
 		"--skip-post-start",
 		"--skip-post-attach",
 	})

--- a/pkg/devcontainer/build/options.go
+++ b/pkg/devcontainer/build/options.go
@@ -52,6 +52,8 @@ type BuildOptions struct {
 	Push bool
 	// Upload controls whether to upload the build context. Used for remote builds.
 	Upload bool
+	// NoCache disables the Docker build cache entirely.
+	NoCache bool
 }
 
 // NewOptionsParams contains the parameters needed to create BuildOptions.
@@ -92,7 +94,8 @@ func NewOptions(params NewOptionsParams) (*BuildOptions, error) {
 		// Push controls whether BuildKit pushes directly to the registry during build.
 		// When true, BuildKit uses the --push flag instead of --load, streaming the image
 		// directly to the registry. This is mutually exclusive with Load.
-		Push: params.Options.PushDuringBuild,
+		Push:    params.Options.PushDuringBuild,
+		NoCache: params.Options.NoCache,
 	}
 
 	// get build args and target

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -126,6 +126,12 @@ func (r *runner) buildResult(params *setupContainerParams) *config.Result {
 	if r.WorkspaceConfig.CLIOptions.DefaultUserEnvProbe != "" {
 		result.MergedConfig.UserEnvProbe = r.WorkspaceConfig.CLIOptions.DefaultUserEnvProbe
 	}
+	if r.WorkspaceConfig.CLIOptions.ContainerUser != "" {
+		result.MergedConfig.ContainerUser = r.WorkspaceConfig.CLIOptions.ContainerUser
+	}
+	if r.WorkspaceConfig.CLIOptions.RemoteUser != "" {
+		result.MergedConfig.RemoteUser = r.WorkspaceConfig.CLIOptions.RemoteUser
+	}
 
 	if r.WorkspaceConfig.Agent.Local == stringTrue &&
 		r.WorkspaceConfig.CLIOptions.Platform.Enabled {

--- a/pkg/devcontainer/setup/lifecyclehooks.go
+++ b/pkg/devcontainer/setup/lifecyclehooks.go
@@ -224,6 +224,13 @@ type phaseHook struct {
 	runFunc func() error
 }
 
+// SkipPhases controls which lifecycle phases should be skipped.
+type SkipPhases struct {
+	PostCreate bool
+	PostStart  bool
+	PostAttach bool
+}
+
 // RunPreAttachHooks runs lifecycle hooks up to and including the waitFor phase
 // synchronously and returns a slice of deferred phases that should run in the
 // background. Dotfiles are installed between postCreateCommand and
@@ -237,6 +244,7 @@ func RunPreAttachHooks(
 	prebuild bool,
 	dotfiles DotfilesConfig,
 	secretsEnv []string,
+	skip SkipPhases,
 ) (DeferredHooks, error) {
 	env := resolveLifecycleEnv(ctx, setupInfo)
 	mergeSecretsEnv(env.remoteEnv, secretsEnv)
@@ -245,6 +253,9 @@ func RunPreAttachHooks(
 	// Insert the dotfiles phase between postCreate and postStart.
 	created := setupInfo.ContainerDetails.Created
 	all = insertDotfilesPhase(ctx, all, dotfiles, created)
+
+	// Remove skipped phases.
+	all = filterSkippedPhases(all, skip)
 
 	if prebuild {
 		return DeferredHooks{}, runPrebuildHooks(all)
@@ -262,6 +273,24 @@ func RunPreAttachHooks(
 
 	deferred, err := runWithWaitFor(all, waitFor)
 	return DeferredHooks{hooks: deferred}, err
+}
+
+func filterSkippedPhases(all []phaseHook, skip SkipPhases) []phaseHook {
+	skipped := map[LifecyclePhase]bool{
+		PhasePostCreate: skip.PostCreate,
+		PhasePostStart:  skip.PostStart,
+		PhasePostAttach: skip.PostAttach,
+	}
+
+	filtered := make([]phaseHook, 0, len(all))
+	for _, ph := range all {
+		if skipped[ph.phase] {
+			log.Infof("skipping %s (--skip flag set)", ph.phase)
+			continue
+		}
+		filtered = append(filtered, ph)
+	}
+	return filtered
 }
 
 // insertDotfilesPhase splices a dotfiles phaseHook after postCreateCommand
@@ -388,7 +417,16 @@ func (d DeferredHooks) Run() error {
 
 // RunPostAttachHooks runs postAttachCommand only.
 // These run after the IDE has been opened and can be long-running.
-func RunPostAttachHooks(ctx context.Context, setupInfo *config.Result, secretsEnv []string) error {
+func RunPostAttachHooks(
+	ctx context.Context,
+	setupInfo *config.Result,
+	secretsEnv []string,
+	skipPostAttach ...bool,
+) error {
+	if len(skipPostAttach) > 0 && skipPostAttach[0] {
+		log.Infof("skipping postAttachCommand (--skip-post-attach set)")
+		return nil
+	}
 	env := resolveLifecycleEnv(ctx, setupInfo)
 	mergeSecretsEnv(env.remoteEnv, secretsEnv)
 

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -100,7 +100,7 @@ func (s *LifecycleHookTestSuite) TestLifecycleHooksNoOpWithEmptyConfig() {
 	}
 
 	// Both functions should return nil with empty config (no commands to run)
-	deferred, err := RunPreAttachHooks(ctx, result, false, DotfilesConfig{}, nil)
+	deferred, err := RunPreAttachHooks(ctx, result, false, DotfilesConfig{}, nil, SkipPhases{})
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), deferred.Empty())
 
@@ -252,7 +252,7 @@ func (s *LifecycleHookTestSuite) TestPrebuildIgnoresWaitFor() {
 	}
 
 	// In prebuild mode, no deferred hooks are returned regardless of waitFor.
-	deferred, err := RunPreAttachHooks(ctx, result, true, DotfilesConfig{}, nil)
+	deferred, err := RunPreAttachHooks(ctx, result, true, DotfilesConfig{}, nil, SkipPhases{})
 	assert.NoError(s.T(), err)
 	assert.True(s.T(), deferred.Empty())
 }

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -45,6 +45,9 @@ type ContainerSetupConfig struct {
 	PlatformOptions   *devsy.PlatformOptions
 	TunnelClient      tunnel.TunnelClient
 	Dotfiles          DotfilesConfig
+	SkipPostCreate    bool
+	SkipPostStart     bool
+	SkipPostAttach    bool
 }
 
 // SetupContainerPreAttach runs container setup up to and including the waitFor
@@ -77,6 +80,11 @@ func SetupContainerPreAttach(
 		cfg.Prebuild,
 		cfg.Dotfiles,
 		cfg.SecretsEnv,
+		SkipPhases{
+			PostCreate: cfg.SkipPostCreate,
+			PostStart:  cfg.SkipPostStart,
+			PostAttach: cfg.SkipPostAttach,
+		},
 	)
 	if err != nil {
 		return DeferredHooks{}, fmt.Errorf("lifecycle hooks pre-attach: %w", err)
@@ -90,7 +98,12 @@ func SetupContainerPreAttach(
 // Called after the IDE has been opened.
 func SetupContainerPostAttach(ctx context.Context, cfg *ContainerSetupConfig) error {
 	log.Debugf("running post-attach lifecycle hooks")
-	if err := RunPostAttachHooks(ctx, cfg.SetupInfo, cfg.SecretsEnv); err != nil {
+	if err := RunPostAttachHooks(
+		ctx,
+		cfg.SetupInfo,
+		cfg.SecretsEnv,
+		cfg.SkipPostAttach,
+	); err != nil {
 		return fmt.Errorf("lifecycle hooks post-attach: %w", err)
 	}
 

--- a/pkg/driver/docker/build.go
+++ b/pkg/driver/docker/build.go
@@ -23,6 +23,9 @@ func (d *dockerDriver) BuildDevContainer(
 	req driver.BuildRequest,
 ) (*config.BuildInfo, error) {
 	imageName := build.GetImageName(req.LocalWorkspaceFolder, req.PrebuildHash)
+	if req.Options.ImageName != "" {
+		imageName = req.Options.ImageName
+	}
 	orchestrator := &buildOrchestrator{
 		driver:   d,
 		resolver: &imageResolver{driver: d},
@@ -95,6 +98,9 @@ func (s *dockerBuildxStrategy) name() string {
 func buildDockerBuildxArgs(options *build.BuildOptions, platform string) []string {
 	args := []string{"buildx", "build", "-f", options.Dockerfile}
 	args = appendBuildFlags(args, options.Load, options.Push)
+	if options.NoCache {
+		args = append(args, "--no-cache")
+	}
 	args = appendImageTags(args, options.Images)
 	args = appendBuildArgsAndContexts(args, options.BuildArgs, options.Contexts)
 	args = appendLabels(args, options.Labels)

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -250,11 +250,9 @@ type CLIOptions struct {
 	RemoteUser                  string            `json:"remoteUser,omitempty"`
 
 	// skip lifecycle hook options
-	SkipPostCreate    bool `json:"skipPostCreate,omitempty"`
-	SkipPostStart     bool `json:"skipPostStart,omitempty"`
-	SkipPostAttach    bool `json:"skipPostAttach,omitempty"`
-	SkipOnCreate      bool `json:"skipOnCreate,omitempty"`
-	SkipUpdateContent bool `json:"skipUpdateContent,omitempty"`
+	SkipPostCreate bool `json:"skipPostCreate,omitempty"`
+	SkipPostStart  bool `json:"skipPostStart,omitempty"`
+	SkipPostAttach bool `json:"skipPostAttach,omitempty"`
 
 	// dotfiles options
 	DotfilesRepo       string `json:"dotfilesRepo,omitempty"`

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -245,8 +245,16 @@ type CLIOptions struct {
 	MountWorkspaceGitRoot       *bool             `json:"mountWorkspaceGitRoot,omitempty"`
 	TerminalColumns             int               `json:"terminalColumns,omitempty"`
 	TerminalRows                int               `json:"terminalRows,omitempty"`
-	SkipPostCreate              bool              `json:"skipPostCreate,omitempty"`
 	SkipNonBlockingCommands     bool              `json:"skipNonBlockingCommands,omitempty"`
+	ContainerUser               string            `json:"containerUser,omitempty"`
+	RemoteUser                  string            `json:"remoteUser,omitempty"`
+
+	// skip lifecycle hook options
+	SkipPostCreate    bool `json:"skipPostCreate,omitempty"`
+	SkipPostStart     bool `json:"skipPostStart,omitempty"`
+	SkipPostAttach    bool `json:"skipPostAttach,omitempty"`
+	SkipOnCreate      bool `json:"skipOnCreate,omitempty"`
+	SkipUpdateContent bool `json:"skipUpdateContent,omitempty"`
 
 	// dotfiles options
 	DotfilesRepo       string `json:"dotfilesRepo,omitempty"`
@@ -277,6 +285,10 @@ type CLIOptions struct {
 	Labels               []string `json:"labels,omitempty"`
 	Output               string   `json:"output,omitempty"`
 	ExperimentalLockfile string   `json:"experimentalLockfile,omitempty"`
+	// ImageName specifies an alternative name for the built image.
+	ImageName string `json:"imageName,omitempty"`
+	// NoBuild prevents building; the command will fail if the image does not exist.
+	NoBuild bool `json:"noBuild,omitempty"`
 
 	// ForceBuild forces a rebuild even if a cached image exists.
 	ForceBuild bool `json:"forceBuild,omitempty"`


### PR DESCRIPTION
## Summary

Adds 15 missing CLI flags across the up, build, exec, and run-user-commands commands to reach devcontainer CLI parity:

- **up**: `--skip-post-create`, `--skip-post-start`, `--skip-post-attach`, `--container-user`, `--remote-user`
- **build**: `--no-cache`, `--image-name`, `--no-build`
- **exec**: `--container-data-folder`, `--skip-post-create`
- **run-user-commands**: `--skip-post-create`, `--skip-post-start`, `--skip-post-attach`, `--skip-on-create`, `--skip-update-content`

Skip flags are wired through the lifecycle hook execution pipeline so skipped phases are logged and excluded. Container-user and remote-user override the devcontainer.json values when specified. No-cache passes through to docker buildx. Image-name overrides the computed image tag. No-build prevents image building entirely.