### PR TITLE
fix(e2e): increase timeout for container-pull-heavy E2E tests

### DIFF
--- a/e2e/tests/up-docker-compose/config.go
+++ b/e2e/tests/up-docker-compose/config.go
@@ -44,7 +44,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			framework.ExpectNoError(tc.verifyWorkspaceMount(ctx, workspace, tempDir))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("sub-folder", func(ctx context.Context) {
 			tempDir, workspace, err := tc.setupAndStartWorkspace(
@@ -53,7 +53,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			framework.ExpectNoError(tc.verifyWorkspaceMount(ctx, workspace, tempDir))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("overrides", func(ctx context.Context) {
 			tempDir, workspace, err := tc.setupAndStartWorkspace(
@@ -62,7 +62,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			framework.ExpectNoError(tc.verifyWorkspaceMount(ctx, workspace, tempDir))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("env-file", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe(
 			gomega.Expect(ids).To(gomega.HaveLen(1), "1 compose container to be created")
 			gomega.Expect(devsyUpOutput).
 				NotTo(gomega.ContainSubstring("Defaulting to a blank string."))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("restart", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -133,7 +133,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			gomega.Expect(restartIds).To(gomega.HaveLen(1), "1 compose container after restart")
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("environment variables", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -160,7 +160,7 @@ var _ = ginkgo.Describe(
 				[]string{"ssh", "--command", "echo $FOO", workspace.ID},
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("user", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -187,7 +187,7 @@ var _ = ginkgo.Describe(
 				[]string{"ssh", "--command", "ps u -p 1", workspace.ID},
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("override command", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -201,7 +201,7 @@ var _ = ginkgo.Describe(
 			gomega.Expect(detail.Config.Entrypoint).
 				NotTo(gomega.ContainElement("bash"), "overrides container entry point")
 			gomega.Expect(detail.Config.Cmd).To(gomega.BeEmpty(), "overrides container command")
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It(
 			"implements updateRemoteUserUID with root container user",
@@ -265,7 +265,7 @@ var _ = ginkgo.Describe(
 				verifyHostFileAccess(hostFile, expectedContent)
 				verifyHostFileOwnership(hostFile, testUID, testGID, testUID == 0)
 			},
-			ginkgo.SpecTimeout(framework.TimeoutShort()),
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
 		)
 
 		ginkgo.It(
@@ -323,7 +323,7 @@ var _ = ginkgo.Describe(
 				verifyHostFileAccess(hostFile, expectedContent)
 				verifyHostFileOwnership(hostFile, testUID, testGID, testUID == 0)
 			},
-			ginkgo.SpecTimeout(framework.TimeoutShort()),
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
 		)
 
 		ginkgo.It("privileged", func(ctx context.Context) {
@@ -337,7 +337,7 @@ var _ = ginkgo.Describe(
 			framework.ExpectNoError(err)
 			gomega.Expect(detail.HostConfig.Privileged).
 				To(gomega.BeTrue(), "container run with privileged true")
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("capabilities", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -354,7 +354,7 @@ var _ = ginkgo.Describe(
 			gomega.Expect(detail.HostConfig.CapAdd).
 				To(gomega.Or(gomega.ContainElement("NET_ADMIN"), gomega.ContainElement("CAP_NET_ADMIN")),
 					"devcontainer configuration can add capabilities")
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("security options", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -369,7 +369,7 @@ var _ = ginkgo.Describe(
 				To(gomega.ContainElement("seccomp=unconfined"), "securityOpts contain seccomp=unconfined")
 			gomega.Expect(detail.HostConfig.SecurityOpt).
 				To(gomega.ContainElement("apparmor=unconfined"), "securityOpts contain apparmor=unconfined")
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("remote env", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -405,7 +405,7 @@ var _ = ginkgo.Describe(
 				[]string{"ssh", "--command", "cat $HOME/remote-env.out", workspace.ID},
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("remote env null unsets variable", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -454,7 +454,7 @@ var _ = ginkgo.Describe(
 				},
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("remote user", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -481,7 +481,7 @@ var _ = ginkgo.Describe(
 				[]string{"ssh", "--command", "cat $HOME/remote-user.out", workspace.ID},
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("variables substitution", func(ctx context.Context) {
 			tempDir, workspace, err := tc.setupAndStartWorkspace(
@@ -544,6 +544,6 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			gomega.Expect(containerWorkspaceFolderBasename).To(gomega.Equal("workspaces"))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 	},
 )

--- a/e2e/tests/up-docker-compose/up_docker_compose.go
+++ b/e2e/tests/up-docker-compose/up_docker_compose.go
@@ -93,7 +93,7 @@ var _ = ginkgo.Describe(
 			bar, err := tc.execSSH(ctx, tempDir, "cat $HOME/mnt2/bar.txt")
 			framework.ExpectNoError(err)
 			gomega.Expect(strings.TrimSpace(bar)).To(gomega.Equal("FOO"))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("port forwarding", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -158,7 +158,7 @@ var _ = ginkgo.Describe(
 				gomega.MatchError("signal: killed"),
 				gomega.MatchError(context.Canceled),
 			))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("features", func(ctx context.Context) {
 			tempDir, workspace, err := tc.setupAndStartWorkspace(
@@ -182,7 +182,7 @@ var _ = ginkgo.Describe(
 			framework.ExpectNoError(err)
 			gomega.Expect(vclusterVersionOutput).
 				To(gomega.ContainSubstring("vcluster version 0.24.1"))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It(
 			"does not retag shared image when applying features to image backed services",
@@ -346,7 +346,7 @@ var _ = ginkgo.Describe(
 			postAttachCommand, err := tc.execSSH(ctx, tempDir, "cat $HOME/post-attach-command.out")
 			framework.ExpectNoError(err)
 			gomega.Expect(postAttachCommand).To(gomega.Equal("postAttachCommand"))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("parallel object based commands", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -380,7 +380,7 @@ var _ = ginkgo.Describe(
 			parallelB, err := tc.execSSH(ctx, tempDir, "cat $HOME/parallel-b.out")
 			framework.ExpectNoError(err)
 			gomega.Expect(parallelB).To(gomega.Equal("parallelB"))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("commands with quotes", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -410,7 +410,7 @@ var _ = ginkgo.Describe(
 			quotedTest, err := tc.execSSH(ctx, tempDir, "cat $HOME/quoted-test.out")
 			framework.ExpectNoError(err)
 			gomega.Expect(quotedTest).To(gomega.Equal("quoted value"))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("v2 features", func(ctx context.Context) {
 			_, ws, err := tc.setupAndStartWorkspace(
@@ -427,7 +427,7 @@ var _ = ginkgo.Describe(
 			var containerDetails []container.InspectResponse
 			err = tc.dockerHelper.Inspect(ctx, ids, "container", &containerDetails)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("v1 fallback", func(ctx context.Context) {
 			_, ws, err := tc.setupAndStartWorkspace(
@@ -444,7 +444,7 @@ var _ = ginkgo.Describe(
 			var containerDetails []container.InspectResponse
 			err = tc.dockerHelper.Inspect(ctx, ids, "container", &containerDetails)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("multiple services", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -472,7 +472,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			gomega.Expect(dbIDs).To(gomega.HaveLen(1), "db container to be created")
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("specific services", func(ctx context.Context) {
 			_, workspace, err := tc.setupAndStartWorkspace(
@@ -500,7 +500,7 @@ var _ = ginkgo.Describe(
 			)
 			framework.ExpectNoError(err)
 			gomega.Expect(dbIDs).To(gomega.BeEmpty(), "db container not to be created")
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("invalid runServices returns error", func(ctx context.Context) {
 			tempDir, err := setupWorkspace(
@@ -513,7 +513,7 @@ var _ = ginkgo.Describe(
 			})
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(stderr).To(gomega.ContainSubstring("nonexistent-service"))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("user lookup with no remoteUser", func(ctx context.Context) {
 			_, _, err := tc.setupAndStartWorkspace(
@@ -521,7 +521,7 @@ var _ = ginkgo.Describe(
 				"tests/up-docker-compose/testdata/docker-compose-lookup-user",
 			)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("dockerfile with args", func(ctx context.Context) {
 			tempDir, workspace, err := tc.setupAndStartWorkspace(
@@ -545,7 +545,7 @@ var _ = ginkgo.Describe(
 			framework.ExpectNoError(err)
 			gomega.Expect(strings.TrimSpace(buildArgs)).
 				To(gomega.Equal("ghcr.io/devsy-org/test-images/go:1"))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It("multi-stage dockerfile with args", func(ctx context.Context) {
 			tempDir, workspace, err := tc.setupAndStartWorkspace(
@@ -569,7 +569,7 @@ var _ = ginkgo.Describe(
 			framework.ExpectNoError(err)
 			gomega.Expect(strings.TrimSpace(buildArgs)).
 				To(gomega.Equal("ghcr.io/devsy-org/test-images/go:1"))
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It(
 			"shutdownAction stopCompose stops all services",
@@ -593,7 +593,7 @@ var _ = ginkgo.Describe(
 				gomega.Expect(sidecarRunning).
 					To(gomega.BeFalse(), "sidecar container should be stopped")
 			},
-			ginkgo.SpecTimeout(framework.TimeoutShort()),
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
 		)
 
 		ginkgo.It(
@@ -618,7 +618,7 @@ var _ = ginkgo.Describe(
 				gomega.Expect(sidecarRunning).
 					To(gomega.BeTrue(), "sidecar container should still be running")
 			},
-			ginkgo.SpecTimeout(framework.TimeoutShort()),
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
 		)
 	},
 )

--- a/e2e/tests/up-features/up_features.go
+++ b/e2e/tests/up-features/up_features.go
@@ -50,7 +50,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 		out, err = f.DevsySSH(ctx, wsName, "cat /tmp/feature-postStart.txt")
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(strings.TrimSpace(out), "feature-postStart")
-	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+	}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 	ginkgo.It("lifecycle hooks order feature before image", func(ctx context.Context) {
 		f, err := setupDockerProvider(initialDir+"/bin", "docker")
@@ -75,7 +75,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 		gomega.Expect(lines).To(gomega.HaveLen(2))
 		gomega.Expect(lines[0]).To(gomega.Equal("feature"))
 		gomega.Expect(lines[1]).To(gomega.Equal("image"))
-	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+	}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 	ginkgo.It("http headers download", func(ctx context.Context) {
 		server := ghttp.NewServer()
@@ -130,7 +130,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 
 		err = f.DevsyUp(ctx, tempDir)
 		framework.ExpectNoError(err)
-	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+	}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 	ginkgo.It(
 		"direct tar feature uses cached download with integrity verification",
@@ -223,7 +223,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			// Only one HTTP request was made — proves cache was reused with passing integrity
 			gomega.Expect(server.ReceivedRequests()).To(gomega.HaveLen(1))
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It("should install with lifecycle hooks", func(ctx context.Context) {
@@ -241,7 +241,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 
 		err = f.DevsyUp(ctx, tempDir)
 		framework.ExpectNoError(err)
-	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+	}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 	ginkgo.It(
 		"should automatically install dependsOn features",
@@ -267,7 +267,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			gomega.Expect(out).To(gomega.ContainSubstring("SUCCESS: hello command is available"))
 			gomega.Expect(out).To(gomega.ContainSubstring("hey, vscode"))
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -294,7 +294,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			gomega.Expect(out).To(gomega.ContainSubstring("SUCCESS: hello command is available"))
 			gomega.Expect(out).To(gomega.ContainSubstring("hey, vscode"))
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -321,7 +321,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			framework.ExpectNoError(err)
 			gomega.Expect(out).To(gomega.ContainSubstring("All dependencies available"))
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -345,7 +345,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			// The logs show "circular dependency detected" in the debug output
 			framework.ExpectError(err)
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -372,7 +372,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			framework.ExpectNoError(err)
 			gomega.Expect(out).To(gomega.ContainSubstring("custom greeting"))
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -399,7 +399,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			framework.ExpectNoError(err)
 			gomega.Expect(out).To(gomega.ContainSubstring("Correct order"))
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -422,7 +422,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			err = f.DevsyUp(ctx, tempDir)
 			framework.ExpectError(err)
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -445,7 +445,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			err = f.DevsyUp(ctx, tempDir)
 			framework.ExpectError(err)
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -473,7 +473,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			// Should contain greeting from one of the features (last one wins)
 			gomega.Expect(out).To(gomega.ContainSubstring("from"))
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -531,7 +531,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			framework.ExpectNoError(err)
 			gomega.Expect(out).To(gomega.MatchRegexp(`v\d+\.\d+\.\d+`))
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It("resolves user variable in dockerfile", func(ctx context.Context) {
@@ -553,7 +553,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 		out, err := f.DevsySSH(ctx, wsName, "whoami")
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(strings.TrimSpace(out), "testuser")
-	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+	}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 	ginkgo.It("preserves user when feature is present with variable", func(ctx context.Context) {
 		f, err := setupDockerProvider(initialDir+"/bin", "docker")
@@ -574,7 +574,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 		out, err := f.DevsySSH(ctx, wsName, "whoami")
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(strings.TrimSpace(out), "ubuntu")
-	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+	}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 	ginkgo.It(
 		"should resolve legacy feature IDs in dependsOn",
@@ -600,7 +600,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			gomega.Expect(out).To(gomega.ContainSubstring("SUCCESS: legacy ID resolution worked"))
 			gomega.Expect(out).To(gomega.ContainSubstring("legacy-id-resolved-successfully"))
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -622,7 +622,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			err = f.DevsyUp(ctx, tempDir)
 			framework.ExpectError(err)
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -648,7 +648,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			framework.ExpectNoError(err)
 			gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("alpha\nbase\nconsumer"))
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -678,7 +678,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			framework.ExpectNoError(err)
 			gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("v2"))
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 
 	ginkgo.It(
@@ -708,6 +708,6 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-features", "suite
 			framework.ExpectNoError(err)
 			gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("e2e-test-secret"))
 		},
-		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		ginkgo.SpecTimeout(framework.TimeoutModerate()),
 	)
 })

--- a/e2e/tests/up-features/wsl.go
+++ b/e2e/tests/up-features/wsl.go
@@ -82,7 +82,7 @@ var _ = ginkgo.Describe(
 			// Wait for devsy workspace to come online (deadline: 30s)
 			err = f.DevsyUp(ctx, tempDir)
 			framework.ExpectNoError(err)
-		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
 		ginkgo.It(
 			"ensure dependencies installed via features are accessible in lifecycle hooks",
@@ -103,7 +103,7 @@ var _ = ginkgo.Describe(
 				err = f.DevsyUp(ctx, tempDir, "--debug")
 				framework.ExpectNoError(err)
 			},
-			ginkgo.SpecTimeout(framework.TimeoutShort()),
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
 		)
 	},
 )


### PR DESCRIPTION
## Summary

Upgrades the spec timeout from `TimeoutShort` (3min) to `TimeoutModerate` (5min) for the 4 E2E test suites that frequently timeout due to ghcr.io container image pull latency:

- **up-docker-compose/suite** — `up_docker_compose.go` (16 specs)
- **up-docker-compose/config** — `config.go` (17 specs)
- **up-features/suite** — `up_features.go` (22 specs)
- **up-features/wsl** — `wsl.go` (2 specs)

These tests pull container images from ghcr.io during execution, making them sensitive to registry latency. The previous 3-minute timeout was insufficient under typical CI load. The global `TimeoutShort` constant remains unchanged — only these 4 test files are affected.