### PR TITLE
fix(e2e): replace external devcontainer image with own registry test container

### DIFF
--- a/e2e/tests/extends/extends.go
+++ b/e2e/tests/extends/extends.go
@@ -47,7 +47,7 @@ var _ = ginkgo.Describe("extends property", ginkgo.Label("extends"), func() {
 		config := parseConfigFromOutput(stdout)
 		gomega.Expect(config).To(gomega.HaveKeyWithValue("name", "Single Level Child"))
 		gomega.Expect(config).To(
-			gomega.HaveKeyWithValue("image", "mcr.microsoft.com/devcontainers/base:ubuntu"),
+			gomega.HaveKeyWithValue("image", "ghcr.io/devsy-org/test-images/base:ubuntu"),
 		)
 		gomega.Expect(config).To(gomega.HaveKeyWithValue("remoteUser", "vscode"))
 	}, ginkgo.SpecTimeout(framework.TimeoutShort()))
@@ -92,7 +92,7 @@ var _ = ginkgo.Describe("extends property", ginkgo.Label("extends"), func() {
 		config := parseConfigFromOutput(stdout)
 		gomega.Expect(config).To(gomega.HaveKeyWithValue("name", "Array Replace Child"))
 		gomega.Expect(config).To(
-			gomega.HaveKeyWithValue("image", "mcr.microsoft.com/devcontainers/base:ubuntu"),
+			gomega.HaveKeyWithValue("image", "ghcr.io/devsy-org/test-images/base:ubuntu"),
 		)
 
 		forwardPorts, ok := config["forwardPorts"].([]any)
@@ -120,7 +120,7 @@ var _ = ginkgo.Describe("extends property", ginkgo.Label("extends"), func() {
 		config := parseConfigFromOutput(stdout)
 		gomega.Expect(config).To(gomega.HaveKeyWithValue("name", "Multi Level Child"))
 		gomega.Expect(config).To(
-			gomega.HaveKeyWithValue("image", "mcr.microsoft.com/devcontainers/base:ubuntu"),
+			gomega.HaveKeyWithValue("image", "ghcr.io/devsy-org/test-images/base:ubuntu"),
 		)
 		gomega.Expect(config).To(gomega.HaveKeyWithValue("remoteUser", "vscode"))
 
@@ -157,7 +157,7 @@ var _ = ginkgo.Describe("extends property", ginkgo.Label("extends"), func() {
 		config := parseConfigFromOutput(stdout)
 		gomega.Expect(config).To(gomega.HaveKeyWithValue("name", "Array Extends Child"))
 		gomega.Expect(config).To(
-			gomega.HaveKeyWithValue("image", "mcr.microsoft.com/devcontainers/base:ubuntu"),
+			gomega.HaveKeyWithValue("image", "ghcr.io/devsy-org/test-images/base:ubuntu"),
 		)
 		gomega.Expect(config).To(gomega.HaveKeyWithValue("remoteUser", "vscode"))
 
@@ -242,7 +242,7 @@ var _ = ginkgo.Describe("extends property", ginkgo.Label("extends"), func() {
 			regHost := strings.TrimPrefix(srv.URL, "http://")
 
 			parentJSON := `{
-			"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+			"image": "ghcr.io/devsy-org/test-images/base:ubuntu",
 			"containerEnv": {"PARENT_KEY": "parent-value", "SHARED": "from-parent"},
 			"features": {"ghcr.io/devcontainers/features/node:1": {}}
 		}`
@@ -277,7 +277,7 @@ var _ = ginkgo.Describe("extends property", ginkgo.Label("extends"), func() {
 			gomega.Expect(config).To(
 				gomega.HaveKeyWithValue(
 					"image",
-					"mcr.microsoft.com/devcontainers/base:ubuntu",
+					"ghcr.io/devsy-org/test-images/base:ubuntu",
 				),
 			)
 

--- a/e2e/tests/extends/testdata/array-extends/.devcontainer/base.json
+++ b/e2e/tests/extends/testdata/array-extends/.devcontainer/base.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
   "containerEnv": {
     "FROM_BASE": "base-value",
     "SHARED": "from-base"

--- a/e2e/tests/extends/testdata/array-replace/.devcontainer/base.json
+++ b/e2e/tests/extends/testdata/array-replace/.devcontainer/base.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
   "forwardPorts": [3000, 4000],
   "capAdd": ["SYS_PTRACE"]
 }

--- a/e2e/tests/extends/testdata/deep-merge/.devcontainer/base.json
+++ b/e2e/tests/extends/testdata/deep-merge/.devcontainer/base.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
   "containerEnv": {
     "SHARED_KEY": "from-base",
     "BASE_ONLY": "base-value"

--- a/e2e/tests/extends/testdata/multi-level/.devcontainer/grandparent.json
+++ b/e2e/tests/extends/testdata/multi-level/.devcontainer/grandparent.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
   "remoteUser": "vscode",
   "containerEnv": {
     "LEVEL": "grandparent",

--- a/e2e/tests/extends/testdata/single-level/.devcontainer/base.json
+++ b/e2e/tests/extends/testdata/single-level/.devcontainer/base.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
   "remoteUser": "vscode",
   "containerEnv": {
     "BASE_VAR": "from-base"

--- a/e2e/tests/readconfiguration/readconfiguration.go
+++ b/e2e/tests/readconfiguration/readconfiguration.go
@@ -46,7 +46,7 @@ var _ = ginkgo.Describe("read-configuration command", ginkgo.Label("read-configu
 		gomega.Expect(ok).To(gomega.BeTrue(), "configuration should be an object")
 		gomega.Expect(config).To(gomega.HaveKeyWithValue("name", "Test Read Configuration"))
 		gomega.Expect(config).To(
-			gomega.HaveKeyWithValue("image", "mcr.microsoft.com/devcontainers/base:ubuntu"),
+			gomega.HaveKeyWithValue("image", "ghcr.io/devsy-org/test-images/base:ubuntu"),
 		)
 		gomega.Expect(config).To(gomega.HaveKey("features"))
 		gomega.Expect(config).To(
@@ -117,7 +117,7 @@ var _ = ginkgo.Describe("read-configuration command", ginkgo.Label("read-configu
 				gomega.HaveKeyWithValue("remoteUser", "vscode"),
 			)
 			gomega.Expect(merged).To(
-				gomega.HaveKeyWithValue("image", "mcr.microsoft.com/devcontainers/base:ubuntu"),
+				gomega.HaveKeyWithValue("image", "ghcr.io/devsy-org/test-images/base:ubuntu"),
 			)
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
@@ -313,7 +313,7 @@ var _ = ginkgo.Describe("read-configuration command", ginkgo.Label("read-configu
 			metadataLabel := `[{"remoteUser":"testuser","customizations":{"vscode":{"extensions":["ms-python.python"]}}}]`
 			out, err := exec.CommandContext(ctx, "docker", "run", "-d",
 				"--label", "devcontainer.metadata="+metadataLabel,
-				"mcr.microsoft.com/devcontainers/base:ubuntu",
+				"ghcr.io/devsy-org/test-images/base:ubuntu",
 				"sleep", "infinity",
 			).Output()
 			framework.ExpectNoError(err)

--- a/e2e/tests/readconfiguration/testdata-container-env/.devcontainer/devcontainer.json
+++ b/e2e/tests/readconfiguration/testdata-container-env/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
   "containerEnv": {
     "TEST_META_VAR": "meta-test-value",
     "ANOTHER_VAR": "another-value"

--- a/e2e/tests/readconfiguration/testdata-host-requirements/.devcontainer/devcontainer.json
+++ b/e2e/tests/readconfiguration/testdata-host-requirements/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Host Requirements Test",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
   "hostRequirements": {
     "cpus": 4,
     "memory": "8gb",

--- a/e2e/tests/readconfiguration/testdata-port-attributes/.devcontainer/devcontainer.json
+++ b/e2e/tests/readconfiguration/testdata-port-attributes/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Port Attributes Test",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
   "forwardPorts": [8080, 9090],
   "portsAttributes": {
     "8080": {

--- a/e2e/tests/readconfiguration/testdata-port-range/.devcontainer/devcontainer.json
+++ b/e2e/tests/readconfiguration/testdata-port-range/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
   "name": "Port Range Test",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
   "forwardPorts": [8080, "3000-3005"]
 }

--- a/e2e/tests/readconfiguration/testdata/.devcontainer/devcontainer.json
+++ b/e2e/tests/readconfiguration/testdata/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Test Read Configuration",
-  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "18"


### PR DESCRIPTION
## Summary

- Replace all `mcr.microsoft.com/devcontainers/base:ubuntu` references in E2E tests with `ghcr.io/devsy-org/test-images/base:ubuntu`
- Eliminates dependency on external Microsoft Container Registry which causes timeout flakes in CI
- Updated 10 testdata JSON files and 2 Go test files with assertion string changes