### PR TITLE
fix(e2e): correct runServices error assertion

### DIFF
--- a/e2e/tests/up-docker-compose/up_docker_compose.go
+++ b/e2e/tests/up-docker-compose/up_docker_compose.go
@@ -503,12 +503,16 @@ var _ = ginkgo.Describe(
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("invalid runServices returns error", func(ctx context.Context) {
-			_, _, err := tc.setupAndStartWorkspace(
-				ctx,
+			tempDir, err := setupWorkspace(
 				"tests/up-docker-compose/testdata/docker-compose-run-services-invalid",
+				tc.initialDir, tc.f,
 			)
+			framework.ExpectNoError(err)
+			_, stderr, err := tc.f.ExecCommandCapture(ctx, []string{
+				"up", "--debug", "--ide", "none", tempDir,
+			})
 			gomega.Expect(err).To(gomega.HaveOccurred())
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring("nonexistent-service"))
+			gomega.Expect(stderr).To(gomega.ContainSubstring("nonexistent-service"))
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 		ginkgo.It("user lookup with no remoteUser", func(ctx context.Context) {


### PR DESCRIPTION
## Summary

- Fix broken E2E test assertion for invalid runServices validation
- The test was checking `err.Error()` which only contains the exit code ("exit status 1"), not the validation message
- The runServices validation error is written to stderr by the CLI, so the test now checks stderr directly for "nonexistent-service"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved error validation for service initialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->