### PR TITLE
refactor(cmd): extract up command into cmd/up subpackage

### DIFF
--- a/cmd/flag_aliases_test.go
+++ b/cmd/flag_aliases_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/devsy-org/devsy/cmd/up"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -22,7 +23,7 @@ const (
 )
 
 func TestUpCmd_ConfigAlias(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{flagConfig, ".devcontainer/custom.json"})
 	require.NoError(t, err)
 
@@ -50,7 +51,7 @@ func TestGlobalFlags_LogFormatAlias(t *testing.T) {
 }
 
 func TestConfigAlias_IsHidden(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	f := upCmd.Flags().Lookup("config")
 	require.NotNil(t, f)
 	assert.True(t, f.Hidden, flagConfig+" alias should be hidden")
@@ -71,7 +72,7 @@ func TestConfigAlias_E2E(t *testing.T) {
 }
 
 func TestUpCmd_OverrideConfigAlias(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{flagOverrideConfig, "/tmp/override.json"})
 	require.NoError(t, err)
 
@@ -81,14 +82,14 @@ func TestUpCmd_OverrideConfigAlias(t *testing.T) {
 }
 
 func TestOverrideConfigAlias_IsHidden(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	f := upCmd.Flags().Lookup("override-config")
 	require.NotNil(t, f)
 	assert.True(t, f.Hidden, flagOverrideConfig+" alias should be hidden")
 }
 
 func TestUpCmd_DotfilesRepositoryAlias(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{flagDotfilesRepository, "https://github.com/user/dotfiles"})
 	require.NoError(t, err)
 
@@ -98,14 +99,14 @@ func TestUpCmd_DotfilesRepositoryAlias(t *testing.T) {
 }
 
 func TestDotfilesRepositoryAlias_IsHidden(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	f := upCmd.Flags().Lookup("dotfiles-repository")
 	require.NotNil(t, f)
 	assert.True(t, f.Hidden, flagDotfilesRepository+" alias should be hidden")
 }
 
 func TestUpCmd_RemoveExistingContainerAlias(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{flagRemoveExistingContainer})
 	require.NoError(t, err)
 
@@ -115,7 +116,7 @@ func TestUpCmd_RemoveExistingContainerAlias(t *testing.T) {
 }
 
 func TestRemoveExistingContainerAlias_IsHidden(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	f := upCmd.Flags().Lookup("remove-existing-container")
 	require.NotNil(t, f)
 	assert.True(t, f.Hidden, flagRemoveExistingContainer+" alias should be hidden")

--- a/cmd/minor_flags_test.go
+++ b/cmd/minor_flags_test.go
@@ -4,19 +4,20 @@ import (
 	"testing"
 
 	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/devsy-org/devsy/cmd/up"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestUpCmd_ContainerDataFolderFlag(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	flag := upCmd.Flags().Lookup("container-data-folder")
 	require.NotNil(t, flag)
 	assert.Equal(t, "", flag.DefValue)
 }
 
 func TestUpCmd_ContainerDataFolderFlagParsesValue(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{"--container-data-folder", "/tmp/data"})
 	require.NoError(t, err)
 	val, err := upCmd.Flags().GetString("container-data-folder")
@@ -25,14 +26,14 @@ func TestUpCmd_ContainerDataFolderFlagParsesValue(t *testing.T) {
 }
 
 func TestUpCmd_MountWorkspaceGitRootFlag(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	flag := upCmd.Flags().Lookup("mount-workspace-git-root")
 	require.NotNil(t, flag)
 	assert.Equal(t, "true", flag.DefValue)
 }
 
 func TestUpCmd_MountWorkspaceGitRootFlagParsesValue(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{"--mount-workspace-git-root=false"})
 	require.NoError(t, err)
 	val, err := upCmd.Flags().GetBool("mount-workspace-git-root")
@@ -41,14 +42,14 @@ func TestUpCmd_MountWorkspaceGitRootFlagParsesValue(t *testing.T) {
 }
 
 func TestUpCmd_TerminalColumnsFlag(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	flag := upCmd.Flags().Lookup("terminal-columns")
 	require.NotNil(t, flag)
 	assert.Equal(t, "0", flag.DefValue)
 }
 
 func TestUpCmd_TerminalColumnsFlagParsesValue(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{"--terminal-columns", "120"})
 	require.NoError(t, err)
 	val, err := upCmd.Flags().GetInt("terminal-columns")
@@ -57,14 +58,14 @@ func TestUpCmd_TerminalColumnsFlagParsesValue(t *testing.T) {
 }
 
 func TestUpCmd_TerminalRowsFlag(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	flag := upCmd.Flags().Lookup("terminal-rows")
 	require.NotNil(t, flag)
 	assert.Equal(t, "0", flag.DefValue)
 }
 
 func TestUpCmd_TerminalRowsFlagParsesValue(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{"--terminal-rows", "40"})
 	require.NoError(t, err)
 	val, err := upCmd.Flags().GetInt("terminal-rows")
@@ -73,7 +74,7 @@ func TestUpCmd_TerminalRowsFlagParsesValue(t *testing.T) {
 }
 
 func TestUpCmd_SkipPostCreateFlagParsesValue(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{flagSkipPostCreate})
 	require.NoError(t, err)
 	val, err := upCmd.Flags().GetBool("skip-post-create")
@@ -82,14 +83,14 @@ func TestUpCmd_SkipPostCreateFlagParsesValue(t *testing.T) {
 }
 
 func TestUpCmd_SkipNonBlockingCommandsFlag(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	flag := upCmd.Flags().Lookup("skip-non-blocking-commands")
 	require.NotNil(t, flag)
 	assert.Equal(t, "false", flag.DefValue)
 }
 
 func TestUpCmd_SkipNonBlockingCommandsFlagParsesValue(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{"--skip-non-blocking-commands"})
 	require.NoError(t, err)
 	val, err := upCmd.Flags().GetBool("skip-non-blocking-commands")
@@ -98,14 +99,14 @@ func TestUpCmd_SkipNonBlockingCommandsFlagParsesValue(t *testing.T) {
 }
 
 func TestUpCmd_DotfilesTargetPathFlag(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	flag := upCmd.Flags().Lookup("dotfiles-target-path")
 	require.NotNil(t, flag)
 	assert.Equal(t, "", flag.DefValue)
 }
 
 func TestUpCmd_DotfilesTargetPathFlagParsesValue(t *testing.T) {
-	upCmd := NewUpCmd(&flags.GlobalFlags{})
+	upCmd := up.NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{"--dotfiles-target-path", "~/dotfiles"})
 	require.NoError(t, err)
 	val, err := upCmd.Flags().GetString("dotfiles-target-path")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/devsy-org/devsy/cmd/pro"
 	"github.com/devsy-org/devsy/cmd/provider"
 	"github.com/devsy-org/devsy/cmd/templates"
+	"github.com/devsy-org/devsy/cmd/up"
 	"github.com/devsy-org/devsy/cmd/use"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
@@ -114,7 +115,7 @@ func BuildRoot() *cobra.Command {
 	rootCmd.AddCommand(machine.NewMachineCmd(globalFlags))
 	rootCmd.AddCommand(context.NewContextCmd(globalFlags))
 	rootCmd.AddCommand(pro.NewProCmd(globalFlags))
-	rootCmd.AddCommand(NewUpCmd(globalFlags))
+	rootCmd.AddCommand(up.NewUpCmd(globalFlags))
 	rootCmd.AddCommand(NewDeleteCmd(globalFlags))
 	rootCmd.AddCommand(NewSSHCmd(globalFlags))
 	rootCmd.AddCommand(NewVersionCmd())

--- a/cmd/up/agent.go
+++ b/cmd/up/agent.go
@@ -1,4 +1,4 @@
-package cmd
+package up
 
 import (
 	"context"

--- a/cmd/up/configure.go
+++ b/cmd/up/configure.go
@@ -1,4 +1,4 @@
-package cmd
+package up
 
 import (
 	"context"

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -1,4 +1,4 @@
-package cmd
+package up
 
 import (
 	"context"

--- a/cmd/up/up_client.go
+++ b/cmd/up/up_client.go
@@ -1,4 +1,4 @@
-package cmd
+package up
 
 import (
 	"context"

--- a/cmd/up/up_flags.go
+++ b/cmd/up/up_flags.go
@@ -1,4 +1,4 @@
-package cmd
+package up
 
 import "github.com/spf13/cobra"
 

--- a/cmd/up/up_test.go
+++ b/cmd/up/up_test.go
@@ -1,4 +1,4 @@
-package cmd
+package up
 
 import (
 	"testing"
@@ -137,7 +137,7 @@ func TestUpCmd_SkipPostAttachFlag(t *testing.T) {
 func TestUpCmd_SkipFlagsParseValues(t *testing.T) {
 	upCmd := NewUpCmd(&flags.GlobalFlags{})
 	err := upCmd.ParseFlags([]string{
-		flagSkipPostCreate,
+		"--skip-post-create",
 		"--skip-post-start",
 		"--skip-post-attach",
 	})

--- a/cmd/up/up_update_remote_user_uid_test.go
+++ b/cmd/up/up_update_remote_user_uid_test.go
@@ -1,4 +1,4 @@
-package cmd
+package up
 
 import (
 	"testing"

--- a/cmd/up/up_validate.go
+++ b/cmd/up/up_validate.go
@@ -1,4 +1,4 @@
-package cmd
+package up
 
 import (
 	"fmt"


### PR DESCRIPTION
## Summary

Moves all `cmd/up*.go` source and test files into a dedicated `cmd/up/` subpackage (`package up`), following the existing pattern used by `cmd/machine/`, `cmd/ide/`, `cmd/flags/`, etc.

This isolates the up command's implementation (4 source files + 2 test files) for better maintainability and navigability. The root `cmd/root.go` now imports `cmd/up` and calls `up.NewUpCmd(globalFlags)` — no behavioral changes, same CLI interface.

- `cmd/up.go`, `up_flags.go`, `up_validate.go`, `up_client.go` → `cmd/up/`
- `cmd/up_test.go`, `up_update_remote_user_uid_test.go` → `cmd/up/`
- Updated `cmd/root.go`, `cmd/minor_flags_test.go`, `cmd/flag_aliases_test.go` to import `cmd/up`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code reorganization with no user-facing changes or impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->