### PR TITLE
fix(devcontainer): include feature containerEnv in metadata label and warn on parse failure

### DIFF
--- a/pkg/devcontainer/metadata/metadata.go
+++ b/pkg/devcontainer/metadata/metadata.go
@@ -73,11 +73,12 @@ func FeatureConfigToImageMetadata(feature *config.FeatureConfig) *config.ImageMe
 			Customizations:       feature.Customizations,
 		},
 		NonComposeBase: config.NonComposeBase{
-			Mounts:      feature.Mounts,
-			Init:        feature.Init,
-			Privileged:  feature.Privileged,
-			CapAdd:      feature.CapAdd,
-			SecurityOpt: feature.SecurityOpt,
+			ContainerEnv: feature.ContainerEnv,
+			Mounts:       feature.Mounts,
+			Init:         feature.Init,
+			Privileged:   feature.Privileged,
+			CapAdd:       feature.CapAdd,
+			SecurityOpt:  feature.SecurityOpt,
 		},
 	}
 }
@@ -133,7 +134,7 @@ func GetImageMetadataFromContainer(
 		single := &config.ImageMetadata{}
 		err = json.Unmarshal([]byte(containerDetails.Config.Labels[ImageMetadataLabel]), single)
 		if err != nil {
-			log.Errorf("Error parsing image metadata: %v", err)
+			log.Warnf("Error parsing image metadata: %v", err)
 			return &config.ImageMetadataConfig{}, nil
 		}
 
@@ -169,7 +170,7 @@ func GetImageMetadata(
 		single := &config.ImageMetadata{}
 		err = json.Unmarshal([]byte(imageDetails.Config.Labels[ImageMetadataLabel]), single)
 		if err != nil {
-			log.Errorf("Error parsing image metadata: %v", err)
+			log.Warnf("Error parsing image metadata: %v", err)
 			return &config.ImageMetadataConfig{}, nil
 		}
 

--- a/pkg/devcontainer/metadata/metadata_test.go
+++ b/pkg/devcontainer/metadata/metadata_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 )
 
-func TestFeatureConfigToImageMetadata_ExcludesContainerEnv(t *testing.T) {
+func TestFeatureConfigToImageMetadata_IncludesContainerEnv(t *testing.T) {
 	feature := &config.FeatureConfig{
 		ContainerEnv: map[string]string{
 			"FOO": "bar",
@@ -18,11 +18,29 @@ func TestFeatureConfigToImageMetadata_ExcludesContainerEnv(t *testing.T) {
 
 	got := FeatureConfigToImageMetadata(feature)
 
-	if got.ContainerEnv != nil {
-		t.Fatalf(
-			"expected ContainerEnv to be nil in per-feature metadata, got %v",
-			got.ContainerEnv,
-		)
+	if got.ContainerEnv == nil {
+		t.Fatal("expected ContainerEnv to be included in per-feature metadata, got nil")
+	}
+	if got.ContainerEnv["FOO"] != "bar" || got.ContainerEnv["BAZ"] != "qux" {
+		t.Fatalf("expected ContainerEnv to contain FOO=bar and BAZ=qux, got %v", got.ContainerEnv)
+	}
+}
+
+func TestGetImageMetadataFromContainer_WarnsOnParseFailure(t *testing.T) {
+	details := &config.ContainerDetails{
+		Config: config.ContainerDetailsConfig{
+			Labels: map[string]string{
+				ImageMetadataLabel: "not valid json {{{",
+			},
+		},
+	}
+
+	result, err := GetImageMetadataFromContainer(details, &config.SubstitutionContext{})
+	if err != nil {
+		t.Fatalf("expected no error on corrupt metadata, got: %v", err)
+	}
+	if len(result.Raw) != 0 {
+		t.Fatalf("expected empty Raw slice for corrupt metadata, got %d entries", len(result.Raw))
 	}
 }
 


### PR DESCRIPTION
## Summary

- `FeatureConfigToImageMetadata` now includes `ContainerEnv` in the `NonComposeBase` struct, matching the behavior already present in `DevContainerConfigToImageMetadata`. Previously feature-level container environment variables were silently dropped from the image metadata label.
- Downgrades metadata parse failure log level from `Errorf` to `Warnf` in both `GetImageMetadataFromContainer` and `GetImageMetadata`, since both functions already gracefully degrade by returning an empty config rather than propagating the error.
- Adds a unit test verifying graceful degradation on corrupt metadata JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Container environment variables are now captured and included in metadata for non-Docker Compose configurations.

* **Bug Fixes**
  * Image metadata parsing failures now generate warnings instead of errors, improving system resilience when handling malformed metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->