### PR TITLE
fix(e2e): skip GPG/SSH-signing tests when SSH tools unavailable

### DIFF
--- a/e2e/tests/ssh/ssh.go
+++ b/e2e/tests/ssh/ssh.go
@@ -20,6 +20,15 @@ import (
 
 const osWindows = "windows"
 
+func skipIfSSHToolsMissing() {
+	if _, err := exec.LookPath("ssh-keygen"); err != nil {
+		ginkgo.Skip("skipping: ssh-keygen or ssh-agent not available")
+	}
+	if _, err := exec.LookPath("ssh-agent"); err != nil {
+		ginkgo.Skip("skipping: ssh-keygen or ssh-agent not available")
+	}
+}
+
 var _ = ginkgo.Describe("devsy ssh test suite", ginkgo.Label("ssh"), ginkgo.Ordered, func() {
 	var initialDir string
 
@@ -69,6 +78,7 @@ var _ = ginkgo.Describe("devsy ssh test suite", ginkgo.Label("ssh"), ginkgo.Orde
 			if runtime.GOOS == osWindows {
 				ginkgo.Skip("skipping on windows")
 			}
+			skipIfSSHToolsMissing()
 
 			tempDir, err := framework.CopyToTempDir("tests/ssh/testdata/gpg-forwarding")
 			framework.ExpectNoError(err)
@@ -118,6 +128,7 @@ var _ = ginkgo.Describe("devsy ssh test suite", ginkgo.Label("ssh"), ginkgo.Orde
 			if runtime.GOOS == osWindows {
 				ginkgo.Skip("skipping on windows")
 			}
+			skipIfSSHToolsMissing()
 
 			tempDir, err := framework.CopyToTempDir("tests/ssh/testdata/ssh-signing")
 			framework.ExpectNoError(err)
@@ -281,6 +292,7 @@ var _ = ginkgo.Describe("devsy ssh test suite", ginkgo.Label("ssh"), ginkgo.Orde
 			if runtime.GOOS == osWindows {
 				ginkgo.Skip("skipping on windows")
 			}
+			skipIfSSHToolsMissing()
 
 			tempDir, err := framework.CopyToTempDir("tests/ssh/testdata/ssh-signing")
 			framework.ExpectNoError(err)
@@ -328,6 +340,7 @@ var _ = ginkgo.Describe("devsy ssh test suite", ginkgo.Label("ssh"), ginkgo.Orde
 			if runtime.GOOS == osWindows {
 				ginkgo.Skip("skipping on windows")
 			}
+			skipIfSSHToolsMissing()
 
 			tempDir, err := framework.CopyToTempDir("tests/ssh/testdata/ssh-signing")
 			framework.ExpectNoError(err)


### PR DESCRIPTION
## Summary

Adds a `skipIfSSHToolsMissing()` helper that checks for `ssh-keygen` and `ssh-agent` on the PATH before running GPG/SSH-signing E2E tests. Tests that depend on these tools now skip cleanly in environments where they are not installed, rather than failing with confusing exec errors. The first SSH test (basic workspace SSH) and the port-forwarding test are unaffected since they don't use these tools directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by adding checks to skip tests when required SSH tools are unavailable, preventing test failures due to missing system dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->