### PR TITLE
fix(test): isolate GPG signing key unit tests from host git config

### DIFF
--- a/cmd/ssh_test.go
+++ b/cmd/ssh_test.go
@@ -14,7 +14,11 @@ func writeGitConfig(t *testing.T, content string) {
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", home)
 	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(home, ".gitconfig"))
-	err := os.WriteFile(filepath.Join(home, ".gitconfig"), []byte(content), 0o600)
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+	t.Setenv("GIT_DIR", filepath.Join(home, ".git"))
+	err := os.MkdirAll(filepath.Join(home, ".git"), 0o750)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(home, ".gitconfig"), []byte(content), 0o600)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
## Summary

The `writeGitConfig()` test helper in `cmd/ssh_test.go` sets `HOME`, `XDG_CONFIG_HOME`, and `GIT_CONFIG_GLOBAL` to isolate tests from host git configuration, but does not block system-level or local repository git config from leaking through. On hosts with a GPG signing key configured (in `/etc/gitconfig` or the repo's `.git/config`), the host key corrupts test assertions.

This adds `GIT_CONFIG_SYSTEM` pointed to `/dev/null` and `GIT_DIR` pointed to a fresh empty `.git` directory in the temp home, fully isolating all six `TestGpgSigningKey_*` tests from any host git configuration.