### PR TITLE
fix(e2e): stabilize feature dependency ordering tests

### DIFF
--- a/pkg/devcontainer/feature/oci_retry.go
+++ b/pkg/devcontainer/feature/oci_retry.go
@@ -11,9 +11,9 @@ import (
 )
 
 var ociBackoff = wait.Backoff{
-	Duration: 1 * time.Second,
+	Duration: 2 * time.Second,
 	Factor:   2.0,
-	Steps:    3,
+	Steps:    4,
 }
 
 func isTransientError(err error) bool {
@@ -23,7 +23,9 @@ func isTransientError(err error) bool {
 
 	var terr *transport.Error
 	if errors.As(err, &terr) {
-		return terr.StatusCode >= http.StatusInternalServerError
+		return terr.StatusCode >= http.StatusInternalServerError ||
+			terr.StatusCode == http.StatusTooManyRequests ||
+			terr.StatusCode == http.StatusRequestTimeout
 	}
 
 	return true

--- a/pkg/devcontainer/feature/oci_retry_test.go
+++ b/pkg/devcontainer/feature/oci_retry_test.go
@@ -32,6 +32,34 @@ func (s *OCIRetryTestSuite) TestRetrySucceedsOnThirdAttempt() {
 	s.Equal(3, attempts)
 }
 
+func (s *OCIRetryTestSuite) TestRetryOn429() {
+	attempts := 0
+	err := retryOCIPull(func() error {
+		attempts++
+		if attempts < 3 {
+			return &transport.Error{StatusCode: http.StatusTooManyRequests}
+		}
+		return nil
+	})
+
+	s.NoError(err)
+	s.Equal(3, attempts)
+}
+
+func (s *OCIRetryTestSuite) TestRetryOn408() {
+	attempts := 0
+	err := retryOCIPull(func() error {
+		attempts++
+		if attempts < 2 {
+			return &transport.Error{StatusCode: http.StatusRequestTimeout}
+		}
+		return nil
+	})
+
+	s.NoError(err)
+	s.Equal(2, attempts)
+}
+
 func (s *OCIRetryTestSuite) TestRetryGivesUpAfterMaxAttempts() {
 	attempts := 0
 	err := retryOCIPull(func() error {
@@ -109,8 +137,8 @@ func (s *OCIRetryTestSuite) TestExponentialBackoff() {
 	firstGap := timestamps[1].Sub(timestamps[0])
 	secondGap := timestamps[2].Sub(timestamps[1])
 
-	s.GreaterOrEqual(firstGap.Milliseconds(), int64(900))
-	s.GreaterOrEqual(secondGap.Milliseconds(), int64(1800))
+	s.GreaterOrEqual(firstGap.Milliseconds(), int64(1800))
+	s.GreaterOrEqual(secondGap.Milliseconds(), int64(3600))
 }
 
 func (s *OCIRetryTestSuite) TestIsTransientError_Nil() {


### PR DESCRIPTION
## Summary

Fixes intermittent E2E test failures in feature dependency ordering tests (`should not fail if same feature exists in dependsOn and installsAfter`, `should handle forward reference dependencies`, `should handle same feature in dependsOn and installsAfter`).

The root cause is that `isTransientError` in `pkg/devcontainer/feature/oci_retry.go` only treated HTTP 5xx as retryable, causing 429 (Too Many Requests) and 408 (Request Timeout) from container registries to fail immediately without retry. These tests download features from `ghcr.io/devcontainers/` and are more vulnerable to rate limiting than tests using only local/cached features.

- Treat 429 and 408 as retryable transport errors in `retryOCIPull`
- Increase backoff from 1s×3 to 2s×4 attempts for better rate-limit recovery
- Add unit tests for 429 and 408 retry behavior