### PR TITLE
fix(graph): use round-based topological sort in sortNodeIDsWithPriority

### DIFF
--- a/pkg/devcontainer/graph/graph.go
+++ b/pkg/devcontainer/graph/graph.go
@@ -445,17 +445,16 @@ func processNeighbors(
 
 func (g *Graph[T]) sortNodeIDsWithPriority(priority map[string]int) ([]string, error) {
 	workingInDegree := copyInDegreeMap(g.inDegree)
-	ready := initializeQueue(workingInDegree)
 	sortedResult := make([]string, 0, len(g.nodes))
 
-	for len(ready) > 0 {
-		sortByPriority(ready, priority)
-
-		current := ready[0]
-		ready = ready[1:]
-		sortedResult = append(sortedResult, current)
-
-		processNeighborsUnordered(g.edges, current, workingInDegree, &ready)
+	for {
+		round := collectZeroInDegree(workingInDegree)
+		if len(round) == 0 {
+			break
+		}
+		sortByPriority(round, priority)
+		sortedResult = append(sortedResult, round...)
+		advanceRound(round, g.edges, workingInDegree)
 	}
 
 	if len(sortedResult) != len(g.nodes) {
@@ -481,20 +480,6 @@ func comparePriority(a, b string, priority map[string]int) bool {
 		return pa < pb
 	}
 	return a < b
-}
-
-func processNeighborsUnordered(
-	edges map[string][]string,
-	currentNode string,
-	inDegree map[string]int,
-	queue *[]string,
-) {
-	for _, neighbor := range edges[currentNode] {
-		inDegree[neighbor]--
-		if inDegree[neighbor] == 0 {
-			*queue = append(*queue, neighbor)
-		}
-	}
 }
 
 func circularDependencyError(inDegree map[string]int) error {

--- a/pkg/devcontainer/graph/graph_test.go
+++ b/pkg/devcontainer/graph/graph_test.go
@@ -668,6 +668,12 @@ func (suite *GraphTestSuite) TestSortWithPriorityRoundBased() {
 			expected: []string{"Z", "X", "Y"},
 		},
 		{
+			name:     "mid-round promotion prevented by round boundary",
+			setup:    suite.buildMidRoundPromotion,
+			priority: map[string]int{"A": 1, "C": 2, "B": 3},
+			expected: []string{"A", "B", "C"},
+		},
+		{
 			name:     "circular dependency returns error",
 			setup:    suite.buildCycle,
 			priority: map[string]int{"A": 1},
@@ -716,6 +722,13 @@ func (suite *GraphTestSuite) buildIndependentXYZ() {
 	suite.Require().NoError(suite.graph.AddNode("X", "dataX"))
 	suite.Require().NoError(suite.graph.AddNode("Y", "dataY"))
 	suite.Require().NoError(suite.graph.AddNode("Z", "dataZ"))
+}
+
+func (suite *GraphTestSuite) buildMidRoundPromotion() {
+	suite.Require().NoError(suite.graph.AddNode("A", "dataA"))
+	suite.Require().NoError(suite.graph.AddNode("B", "dataB"))
+	suite.Require().NoError(suite.graph.AddNode("C", "dataC"))
+	suite.Require().NoError(suite.graph.AddEdge("A", "C"))
 }
 
 func (suite *GraphTestSuite) buildCycle() {

--- a/pkg/devcontainer/graph/graph_test.go
+++ b/pkg/devcontainer/graph/graph_test.go
@@ -641,3 +641,86 @@ func (suite *GraphTestSuite) TestTopologicalSortAdvanced() {
 		})
 	}
 }
+
+func (suite *GraphTestSuite) TestSortWithPriorityRoundBased() {
+	testCases := []struct {
+		name     string
+		setup    func()
+		priority map[string]int
+		expected []string
+	}{
+		{
+			name:     "round-based emits all zero-in-degree before advancing",
+			setup:    suite.buildParallelChains,
+			priority: map[string]int{"B": 1, "A": 2},
+			expected: []string{"B", "A", "C", "D"},
+		},
+		{
+			name:     "diamond graph groups siblings in same round",
+			setup:    suite.buildDiamond,
+			priority: map[string]int{"C": 1, "B": 2},
+			expected: []string{"A", "C", "B", "D"},
+		},
+		{
+			name:     "nodes without priority sort alphabetically after prioritized nodes",
+			setup:    suite.buildIndependentXYZ,
+			priority: map[string]int{"Z": 1},
+			expected: []string{"Z", "X", "Y"},
+		},
+		{
+			name:     "circular dependency returns error",
+			setup:    suite.buildCycle,
+			priority: map[string]int{"A": 1},
+			expected: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(tc.name, func() {
+			suite.SetupTest()
+			tc.setup()
+
+			result, err := suite.graph.sortNodeIDsWithPriority(tc.priority)
+			if tc.expected == nil {
+				suite.Error(err)
+				suite.Contains(err.Error(), "circular dependency")
+			} else {
+				suite.NoError(err)
+				suite.Equal(tc.expected, result)
+			}
+		})
+	}
+}
+
+func (suite *GraphTestSuite) buildParallelChains() {
+	suite.Require().NoError(suite.graph.AddNode("A", "dataA"))
+	suite.Require().NoError(suite.graph.AddNode("B", "dataB"))
+	suite.Require().NoError(suite.graph.AddNode("C", "dataC"))
+	suite.Require().NoError(suite.graph.AddNode("D", "dataD"))
+	suite.Require().NoError(suite.graph.AddEdge("A", "C"))
+	suite.Require().NoError(suite.graph.AddEdge("B", "D"))
+}
+
+func (suite *GraphTestSuite) buildDiamond() {
+	suite.Require().NoError(suite.graph.AddNode("A", "dataA"))
+	suite.Require().NoError(suite.graph.AddNode("B", "dataB"))
+	suite.Require().NoError(suite.graph.AddNode("C", "dataC"))
+	suite.Require().NoError(suite.graph.AddNode("D", "dataD"))
+	suite.Require().NoError(suite.graph.AddEdge("A", "B"))
+	suite.Require().NoError(suite.graph.AddEdge("A", "C"))
+	suite.Require().NoError(suite.graph.AddEdge("B", "D"))
+	suite.Require().NoError(suite.graph.AddEdge("C", "D"))
+}
+
+func (suite *GraphTestSuite) buildIndependentXYZ() {
+	suite.Require().NoError(suite.graph.AddNode("X", "dataX"))
+	suite.Require().NoError(suite.graph.AddNode("Y", "dataY"))
+	suite.Require().NoError(suite.graph.AddNode("Z", "dataZ"))
+}
+
+func (suite *GraphTestSuite) buildCycle() {
+	suite.Require().NoError(suite.graph.AddNode("A", "dataA"))
+	suite.Require().NoError(suite.graph.AddNode("B", "dataB"))
+	suite.Require().NoError(suite.graph.AddEdge("A", "B"))
+	suite.Require().NoError(suite.graph.AddEdge("B", "A"))
+}


### PR DESCRIPTION
## Summary

Rewrites `sortNodeIDsWithPriority()` to use the same round-based collection pattern as `sortNodeIDs()`. The previous single-queue Kahn's algorithm processed one node at a time, which could emit nodes from later topological levels before all same-level siblings were emitted. The fix collects all zero-in-degree nodes per round, sorts them by priority within the round, and emits the entire round before advancing — matching the spec-required behavior for feature installation ordering.

## Spec Reference

The [devcontainer Features specification](https://containers.dev/implementors/features/) describes how features must be installed in dependency order using a round-based topological sort. Specifically, `installsAfter` is used to declare explicit ordering constraints between features, and compliant implementations must resolve these dependencies such that all features in a given topological level are processed before advancing to the next. This PR aligns `sortNodeIDsWithPriority()` with that required round-based behavior.