### PR TITLE
fix(e2e): replace mcr.microsoft.com references with ghcr.io/devsy-org test images

### DIFF
--- a/examples/build-multi-stage/Dockerfile
+++ b/examples/build-multi-stage/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1.22-bullseye AS go
+FROM ghcr.io/devsy-org/test-images/go:1 AS go
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/examples/build/Dockerfile
+++ b/examples/build/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM mcr.microsoft.com/devcontainers/go:1.22-bullseye
+FROM ghcr.io/devsy-org/test-images/go:1
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/examples/compose/Dockerfile
+++ b/examples/compose/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM mcr.microsoft.com/devcontainers/go:1.22-bullseye AS go
+FROM ghcr.io/devsy-org/test-images/go:1 AS go
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/examples/compose/devcontainer.Dockerfile
+++ b/examples/compose/devcontainer.Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1.22-bullseye AS go
+FROM ghcr.io/devsy-org/test-images/go:1 AS go
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/examples/compose/devcontainer.Dockerfile2
+++ b/examples/compose/devcontainer.Dockerfile2
@@ -1,2 +1,2 @@
-FROM mcr.microsoft.com/devcontainers/base:ubuntu
+FROM ghcr.io/devsy-org/test-images/base:ubuntu
 RUN echo test

--- a/examples/multi-devcontainer/.devcontainer.json
+++ b/examples/multi-devcontainer/.devcontainer.json
@@ -1,1 +1,1 @@
-{ "image": "mcr.microsoft.com/devcontainers/base:ubuntu", "build": {} }
+{ "image": "ghcr.io/devsy-org/test-images/base:ubuntu", "build": {} }

--- a/examples/multi-devcontainer/proj1/.devcontainer.json
+++ b/examples/multi-devcontainer/proj1/.devcontainer.json
@@ -1,4 +1,4 @@
 {
   "name": "Python 3",
-  "image": "mcr.microsoft.com/vscode/devcontainers/python:0-3"
+  "image": "ghcr.io/devsy-org/test-images/python:latest"
 }

--- a/examples/multi-devcontainer/proj2/.devcontainer.json
+++ b/examples/multi-devcontainer/proj2/.devcontainer.json
@@ -1,4 +1,4 @@
 {
   "name": "Go",
-  "image": "mcr.microsoft.com/vscode/devcontainers/go:0-1.19-bullseye"
+  "image": "ghcr.io/devsy-org/test-images/go:1"
 }

--- a/examples/object-lifecycle-hooks/.devcontainer.json
+++ b/examples/object-lifecycle-hooks/.devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Object-Lifecycle",
-  "image": "mcr.microsoft.com/vscode/devcontainers/go:1",
+  "image": "ghcr.io/devsy-org/test-images/go:1",
   "postStartCommand": {
     "cobra-install": "go install github.com/spf13/cobra-cli@latest",
     "golangci-lint": "go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest",

--- a/examples/simple/.devcontainer.json
+++ b/examples/simple/.devcontainer.json
@@ -3,7 +3,7 @@
 {
   "name": "C# (.NET)",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/dotnet:1-8.0",
+  "image": "ghcr.io/devsy-org/test-images/go:1",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {

--- a/examples/simple/.devcontainer.json
+++ b/examples/simple/.devcontainer.json
@@ -1,9 +1,9 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/dotnet
 {
-  "name": "C# (.NET)",
+  "name": "Simple Example",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "ghcr.io/devsy-org/test-images/go:1",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   "features": {

--- a/pkg/dockerfile/test_Dockerfile
+++ b/pkg/dockerfile/test_Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/go:1.22-bullseye
+FROM ghcr.io/devsy-org/test-images/go:1
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/pkg/image/error_test.go
+++ b/pkg/image/error_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func makeTransportErrorWithBody(statusCode int, body string) error {
-	req, _ := http.NewRequest("GET", "https://mcr.microsoft.com/v2/", nil)
+	req, _ := http.NewRequest("GET", "https://ghcr.io/v2/devsy-org/test-images/", nil)
 	resp := &http.Response{
 		StatusCode: statusCode,
 		Body:       io.NopCloser(strings.NewReader(body)),
@@ -24,7 +24,7 @@ func makeTransportErrorWithBody(statusCode int, body string) error {
 func TestSanitizeRegistryError_HTMLBody(t *testing.T) {
 	htmlBody := `<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"><html><body><h1>403 Forbidden</h1></body></html>`
 	inner := makeTransportErrorWithBody(http.StatusForbidden, htmlBody)
-	wrapped := fmt.Errorf("retrieve image mcr.microsoft.com/devcontainers/base:ubuntu: %w", inner)
+	wrapped := fmt.Errorf("retrieve image ghcr.io/devsy-org/test-images/base:ubuntu: %w", inner)
 
 	sanitized := SanitizeRegistryError(wrapped)
 	if sanitized == wrapped {


### PR DESCRIPTION
## Summary

Replaces all `mcr.microsoft.com` container image references in E2E test fixtures (examples/ and pkg/ test files) with `ghcr.io/devsy-org/test-images/*` equivalents. This removes dependency on Microsoft Container Registry for test execution. No production code changes.