### PR TITLE
feat(cli): add --result-format flag for JSON envelope control (DEVSY-022)

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -12,6 +12,7 @@ import (
 	devcconfig "github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/image"
 	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/output"
 	"github.com/devsy-org/devsy/pkg/provider"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
@@ -225,6 +226,8 @@ func (cmd *BuildCmd) build(
 		log.Debugf("done building devcontainer")
 		log.Infof("cleaning up temporary workspace")
 	}()
+	emitJSON := output.ResolveMode(cmd.ResultFormat) == output.ModeJSON
+
 	result, err := clientimplementation.BuildAgentClient(
 		ctx,
 		clientimplementation.BuildAgentClientOptions{
@@ -234,12 +237,18 @@ func (cmd *BuildCmd) build(
 		},
 	)
 	if err != nil {
-		_ = devcconfig.WriteErrorJSON(os.Stdout, err.Error())
+		if emitJSON {
+			_ = devcconfig.WriteErrorJSON(os.Stdout, err.Error())
+		}
 		return err
 	}
 
+	if !emitJSON {
+		return nil
+	}
+
 	containerID := ""
-	workdir := "" // uses substituted path directly; build doesn't support git subpath overrides
+	workdir := ""
 	if result != nil {
 		if result.ContainerDetails != nil {
 			containerID = result.ContainerDetails.ID

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -16,6 +16,7 @@ import (
 	devcconfig "github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/output"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
@@ -169,17 +170,23 @@ func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
 	probedEnv := probeContainerEnv(ctx, target, userEnvProbe)
 	envMap := buildExecEnv(result, cmd.RemoteEnv, probedEnv)
 
+	emitJSON := output.ResolveMode(cmd.ResultFormat) == output.ModeJSON
+
 	err = cmd.execInContainer(ctx, execOpts{
 		target:  target,
 		workdir: workdir,
 		envMap:  envMap,
 	}, args)
 	if err != nil {
-		_ = devcconfig.WriteErrorJSON(os.Stderr, err.Error())
+		if emitJSON {
+			_ = devcconfig.WriteErrorJSON(os.Stderr, err.Error())
+		}
 		return err
 	}
 
-	_ = devcconfig.WriteResultJSON(os.Stderr, containerDetails.ID, user, workdir, nil)
+	if emitJSON {
+		_ = devcconfig.WriteResultJSON(os.Stderr, containerDetails.ID, user, workdir, nil)
+	}
 	return nil
 }
 
@@ -218,17 +225,23 @@ func (cmd *ExecCmd) runWithContainerID(ctx context.Context, args []string) error
 
 	workdir := containerDetails.Config.WorkingDir
 
+	emitJSON := output.ResolveMode(cmd.ResultFormat) == output.ModeJSON
+
 	err = cmd.execInContainer(ctx, execOpts{
 		target:  target,
 		workdir: workdir,
 		envMap:  envMap,
 	}, args)
 	if err != nil {
-		_ = devcconfig.WriteErrorJSON(os.Stderr, err.Error())
+		if emitJSON {
+			_ = devcconfig.WriteErrorJSON(os.Stderr, err.Error())
+		}
 		return err
 	}
 
-	_ = devcconfig.WriteResultJSON(os.Stderr, containerDetails.ID, "", workdir, nil)
+	if emitJSON {
+		_ = devcconfig.WriteResultJSON(os.Stderr, containerDetails.ID, "", workdir, nil)
+	}
 	return nil
 }
 

--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -14,10 +14,11 @@ type GlobalFlags struct {
 	UID       string
 	Owner     platform.OwnerFilter
 
-	LogOutput string
-	Verbosity int
-	Quiet     bool
-	Debug     bool
+	LogOutput    string
+	ResultFormat string
+	Verbosity    int
+	Quiet        bool
+	Debug        bool
 }
 
 // SetGlobalFlags applies the global flags.
@@ -29,6 +30,12 @@ func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 		config.BinaryName+"-home",
 		"",
 		"If defined will override the default devsy home",
+	)
+	flags.StringVar(
+		&globalFlags.ResultFormat,
+		"result-format",
+		"json",
+		"The result output format. Can be json, plain, or auto",
 	)
 	flags.StringVar(
 		&globalFlags.LogOutput,

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -14,6 +14,7 @@ import (
 	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/ide"
 	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/output"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/telemetry"
 	"github.com/devsy-org/devsy/pkg/util"
@@ -66,9 +67,13 @@ func (cmd *UpCmd) Run(
 ) error {
 	cmd.prepareWorkspace(client)
 
+	emitJSON := output.ResolveMode(cmd.ResultFormat) == output.ModeJSON
+
 	wctx, err := cmd.executeDevsyUp(ctx, devsyConfig, client)
 	if err != nil {
-		_ = config2.WriteErrorJSON(os.Stdout, err.Error())
+		if emitJSON {
+			_ = config2.WriteErrorJSON(os.Stdout, err.Error())
+		}
 		return err
 	}
 	if wctx == nil {
@@ -80,24 +85,30 @@ func (cmd *UpCmd) Run(
 	}
 
 	if err := cmd.configureWorkspace(devsyConfig, client, wctx); err != nil {
-		_ = config2.WriteErrorJSON(os.Stdout, err.Error())
+		if emitJSON {
+			_ = config2.WriteErrorJSON(os.Stdout, err.Error())
+		}
 		return err
 	}
 
 	if err := cmd.openIDE(ctx, devsyConfig, client, wctx); err != nil {
-		_ = config2.WriteErrorJSON(os.Stdout, err.Error())
+		if emitJSON {
+			_ = config2.WriteErrorJSON(os.Stdout, err.Error())
+		}
 		return err
 	}
 
-	containerID := ""
-	var warnings []string
-	if wctx.result != nil {
-		if wctx.result.ContainerDetails != nil {
-			containerID = wctx.result.ContainerDetails.ID
+	if emitJSON {
+		containerID := ""
+		var warnings []string
+		if wctx.result != nil {
+			if wctx.result.ContainerDetails != nil {
+				containerID = wctx.result.ContainerDetails.ID
+			}
+			warnings = wctx.result.HostWarnings
 		}
-		warnings = wctx.result.HostWarnings
+		_ = config2.WriteResultJSON(os.Stdout, containerID, wctx.user, wctx.workdir, warnings)
 	}
-	_ = config2.WriteResultJSON(os.Stdout, containerID, wctx.user, wctx.workdir, warnings)
 	return nil
 }
 

--- a/e2e/tests/exec/exec.go
+++ b/e2e/tests/exec/exec.go
@@ -2,10 +2,12 @@ package exec
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"strings"
 
 	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -177,5 +179,28 @@ var _ = ginkgo.Describe("devsy exec test suite", ginkgo.Label("exec"), ginkgo.Or
 			})
 			framework.ExpectNoError(err)
 			gomega.Expect(stdout).To(gomega.Equal("found"))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("should emit JSON envelope on stderr with --result-format json",
+		func(ctx context.Context) {
+			tempDir, f, err := setupWorkspaceAndUp(ctx, "tests/exec/testdata/exec", initialDir)
+			framework.ExpectNoError(err)
+
+			stdout, stderr, err := f.ExecCommandCapture(ctx, []string{
+				execCommand,
+				"--result-format", "json",
+				workspaceFolderFlag, tempDir,
+				"--", echoCommand, "-n", "hello",
+			})
+			framework.ExpectNoError(err)
+			gomega.Expect(stdout).To(gomega.Equal("hello"))
+
+			lines := strings.Split(strings.TrimSpace(stderr), "\n")
+			gomega.Expect(lines).NotTo(gomega.BeEmpty())
+			lastLine := lines[len(lines)-1]
+			var envelope config.ResultEnvelope
+			err = json.Unmarshal([]byte(lastLine), &envelope)
+			framework.ExpectNoError(err)
+			gomega.Expect(envelope.Outcome).To(gomega.Equal("success"))
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 })

--- a/e2e/tests/exec/exec.go
+++ b/e2e/tests/exec/exec.go
@@ -203,4 +203,27 @@ var _ = ginkgo.Describe("devsy exec test suite", ginkgo.Label("exec"), ginkgo.Or
 			framework.ExpectNoError(err)
 			gomega.Expect(envelope.Outcome).To(gomega.Equal("success"))
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("should suppress JSON envelope on stderr with --result-format plain",
+		func(ctx context.Context) {
+			tempDir, f, err := setupWorkspaceAndUp(ctx, "tests/exec/testdata/exec", initialDir)
+			framework.ExpectNoError(err)
+
+			stdout, stderr, err := f.ExecCommandCapture(ctx, []string{
+				execCommand,
+				"--result-format", "plain",
+				workspaceFolderFlag, tempDir,
+				"--", echoCommand, "-n", "hello",
+			})
+			framework.ExpectNoError(err)
+			gomega.Expect(stdout).To(gomega.Equal("hello"))
+
+			for line := range strings.SplitSeq(stderr, "\n") {
+				var envelope config.ResultEnvelope
+				if json.Unmarshal([]byte(line), &envelope) == nil {
+					gomega.Expect(envelope.Outcome).To(gomega.BeEmpty(),
+						"expected no JSON envelope on stderr, but found one: %s", line)
+				}
+			}
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 })

--- a/e2e/tests/up/json_envelope.go
+++ b/e2e/tests/up/json_envelope.go
@@ -1,0 +1,103 @@
+package up
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe(
+	"testing up command --result-format flag",
+	ginkgo.Label("up-result-format"),
+	func() {
+		var dtc *dockerTestContext
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			var err error
+			dtc = &dockerTestContext{}
+			dtc.initialDir, err = os.Getwd()
+			framework.ExpectNoError(err)
+
+			dtc.f, err = setupDockerProvider(
+				filepath.Join(dtc.initialDir, "bin"), "docker",
+			)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("emits JSON envelope with --result-format json", func(ctx context.Context) {
+			tempDir, err := setupWorkspace(
+				"tests/up/testdata/docker",
+				dtc.initialDir,
+				dtc.f,
+			)
+			framework.ExpectNoError(err)
+
+			stdout, _, err := dtc.f.DevsyUpStreams(ctx, tempDir, "--result-format", "json")
+			framework.ExpectNoError(err)
+
+			lines := strings.Split(strings.TrimSpace(stdout), "\n")
+			gomega.Expect(lines).NotTo(gomega.BeEmpty())
+
+			lastLine := lines[len(lines)-1]
+			var envelope config.ResultEnvelope
+			err = json.Unmarshal([]byte(lastLine), &envelope)
+			framework.ExpectNoError(err)
+
+			gomega.Expect(envelope.Outcome).To(gomega.Equal("success"))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+		ginkgo.It("suppresses JSON envelope with --result-format plain", func(ctx context.Context) {
+			tempDir, err := setupWorkspace(
+				"tests/up/testdata/docker",
+				dtc.initialDir,
+				dtc.f,
+			)
+			framework.ExpectNoError(err)
+
+			stdout, _, err := dtc.f.DevsyUpStreams(ctx, tempDir, "--result-format", "plain")
+			framework.ExpectNoError(err)
+
+			for line := range strings.SplitSeq(strings.TrimSpace(stdout), "\n") {
+				var envelope config.ResultEnvelope
+				if json.Unmarshal([]byte(line), &envelope) == nil {
+					gomega.Expect(envelope.Outcome).To(gomega.BeEmpty(),
+						"expected no JSON envelope in stdout, but found one: %s", line)
+				}
+			}
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+		ginkgo.It(
+			"emits error envelope with --result-format json on failure",
+			func(ctx context.Context) {
+				tempDir, err := setupWorkspace(
+					"tests/up/testdata/docker-invalid-bind-mount",
+					dtc.initialDir,
+					dtc.f,
+				)
+				framework.ExpectNoError(err)
+
+				stdout, _, err := dtc.f.DevsyUpStreams(ctx, tempDir, "--result-format", "json")
+				gomega.Expect(err).To(gomega.HaveOccurred())
+
+				lines := strings.Split(strings.TrimSpace(stdout), "\n")
+				gomega.Expect(lines).NotTo(gomega.BeEmpty())
+
+				lastLine := lines[len(lines)-1]
+				var envelope config.ErrorEnvelope
+				err = json.Unmarshal([]byte(lastLine), &envelope)
+				framework.ExpectNoError(err)
+
+				gomega.Expect(envelope.Outcome).To(gomega.Equal("error"))
+				gomega.Expect(envelope.Message).NotTo(gomega.BeEmpty())
+			},
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
+		)
+	},
+)

--- a/pkg/output/mode.go
+++ b/pkg/output/mode.go
@@ -1,0 +1,22 @@
+package output
+
+import "github.com/devsy-org/devsy/pkg/terminal"
+
+const (
+	ModeJSON  = "json"
+	ModePlain = "plain"
+)
+
+func ResolveMode(flagValue string) string {
+	switch flagValue {
+	case ModeJSON:
+		return ModeJSON
+	case ModePlain:
+		return ModePlain
+	default:
+		if !terminal.IsTerminalOut {
+			return ModeJSON
+		}
+		return ModePlain
+	}
+}

--- a/pkg/output/mode.go
+++ b/pkg/output/mode.go
@@ -13,10 +13,12 @@ func ResolveMode(flagValue string) string {
 		return ModeJSON
 	case ModePlain:
 		return ModePlain
-	default:
+	case "auto":
 		if !terminal.IsTerminalOut {
 			return ModeJSON
 		}
 		return ModePlain
+	default:
+		return ModeJSON
 	}
 }

--- a/pkg/output/mode_test.go
+++ b/pkg/output/mode_test.go
@@ -41,3 +41,10 @@ func TestResolveMode_Auto_TTY(t *testing.T) {
 		t.Errorf("ResolveMode(\"auto\") with TTY = %q, want %q", got, ModePlain)
 	}
 }
+
+func TestResolveMode_InvalidValue(t *testing.T) {
+	got := ResolveMode("bogus")
+	if got != ModeJSON {
+		t.Errorf("ResolveMode(\"bogus\") = %q, want %q", got, ModeJSON)
+	}
+}

--- a/pkg/output/mode_test.go
+++ b/pkg/output/mode_test.go
@@ -1,0 +1,43 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/terminal"
+)
+
+func TestResolveMode_JSON(t *testing.T) {
+	got := ResolveMode("json")
+	if got != ModeJSON {
+		t.Errorf("ResolveMode(\"json\") = %q, want %q", got, ModeJSON)
+	}
+}
+
+func TestResolveMode_Plain(t *testing.T) {
+	got := ResolveMode("plain")
+	if got != ModePlain {
+		t.Errorf("ResolveMode(\"plain\") = %q, want %q", got, ModePlain)
+	}
+}
+
+func TestResolveMode_Auto_NonTTY(t *testing.T) {
+	orig := terminal.IsTerminalOut
+	terminal.IsTerminalOut = false
+	defer func() { terminal.IsTerminalOut = orig }()
+
+	got := ResolveMode("auto")
+	if got != ModeJSON {
+		t.Errorf("ResolveMode(\"auto\") with non-TTY = %q, want %q", got, ModeJSON)
+	}
+}
+
+func TestResolveMode_Auto_TTY(t *testing.T) {
+	orig := terminal.IsTerminalOut
+	terminal.IsTerminalOut = true
+	defer func() { terminal.IsTerminalOut = orig }()
+
+	got := ResolveMode("auto")
+	if got != ModePlain {
+		t.Errorf("ResolveMode(\"auto\") with TTY = %q, want %q", got, ModePlain)
+	}
+}

--- a/pkg/terminal/tty.go
+++ b/pkg/terminal/tty.go
@@ -7,7 +7,10 @@ import (
 	dockerterm "github.com/moby/term"
 )
 
-var IsTerminalIn = IsTerminal(os.Stdin)
+var (
+	IsTerminalIn  = IsTerminal(os.Stdin)
+	IsTerminalOut = IsTerminal(os.Stdout)
+)
 
 // IsTerminal returns whether the passed object is a terminal or not.
 func IsTerminal(stdin io.Reader) bool {


### PR DESCRIPTION
## Summary
- Add global `--result-format json|plain|auto` flag (default: "json") for controlling JSON envelope output
- When "json" (default): emit envelope unconditionally (backward compatible)
- When "plain": suppress envelope output
- When "auto": emit JSON only when stdout is not a TTY
- Exec command always writes envelope to stderr (preserving stdout for command output)
- Add E2E tests covering all modes

Spec reference: https://containers.dev/implementors/spec/ — Output section (JSON result envelope format)