### PR TITLE
feat(cli): add --docker-path flag to read-configuration command

### DIFF
--- a/cmd/readconfiguration.go
+++ b/cmd/readconfiguration.go
@@ -22,6 +22,7 @@ type ReadConfigurationCmd struct {
 	Config                       string
 	ContainerID                  string
 	IDLabels                     []string
+	DockerPath                   string
 	IncludeFeaturesConfiguration bool
 	IncludeMergedConfiguration   bool
 }
@@ -48,6 +49,13 @@ func NewReadConfigurationCmd(f *flags.GlobalFlags) *cobra.Command {
 			"container-id",
 			"",
 			"Read configuration from a running container with the given ID",
+		)
+	readConfigCmd.Flags().
+		StringVar(
+			&cmd.DockerPath,
+			"docker-path",
+			"",
+			"Path to the docker/podman executable (defaults to 'docker')",
 		)
 	readConfigCmd.Flags().
 		StringVar(
@@ -207,7 +215,11 @@ func (cmd *ReadConfigurationCmd) resolveConfigFromContainer(ctx context.Context)
 	string,
 	error,
 ) {
-	helper := &docker.DockerHelper{DockerCommand: defaultDockerCommand}
+	dockerCommand := defaultDockerCommand
+	if cmd.DockerPath != "" {
+		dockerCommand = cmd.DockerPath
+	}
+	helper := &docker.DockerHelper{DockerCommand: dockerCommand}
 
 	details, err := helper.InspectContainers(ctx, []string{cmd.ContainerID})
 	if err != nil {

--- a/e2e/tests/readconfiguration/readconfiguration.go
+++ b/e2e/tests/readconfiguration/readconfiguration.go
@@ -380,4 +380,94 @@ var _ = ginkgo.Describe("read-configuration command", ginkgo.Label("read-configu
 			gomega.Expect(ok).To(gomega.BeTrue(), "workspace should be an object")
 			gomega.Expect(ws).To(gomega.HaveKey("workspaceFolder"))
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("fails with --container-id when container does not exist",
+		func(ctx context.Context) {
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+
+			_, _, err := f.ExecCommandCapture(ctx, []string{
+				"read-configuration",
+				"--container-id", "nonexistent-container-id-12345",
+			})
+			framework.ExpectError(err)
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("fails with --container-id when container has no metadata label",
+		func(ctx context.Context) {
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+
+			out, err := exec.CommandContext(ctx, "docker", "run", "-d",
+				"ghcr.io/devsy-org/test-images/base:ubuntu",
+				"sleep", "infinity",
+			).Output()
+			framework.ExpectNoError(err)
+			containerID := strings.TrimSpace(string(out))
+			ginkgo.DeferCleanup(func() {
+				args := []string{"rm", "-f", containerID}
+				cmd := exec.Command("docker", args...) // #nosec G204
+				_ = cmd.Run()
+			})
+
+			stdout, _, err := f.ExecCommandCapture(ctx, []string{
+				"read-configuration",
+				"--container-id", containerID,
+			})
+			if err == nil {
+				var result map[string]any
+				unmarshalErr := json.Unmarshal([]byte(stdout), &result)
+				framework.ExpectNoError(unmarshalErr)
+				config, ok := result["configuration"].(map[string]any)
+				gomega.Expect(ok).To(gomega.BeTrue())
+				gomega.Expect(config).To(gomega.BeEmpty(),
+					"configuration should be empty when no metadata label exists")
+			}
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("respects --docker-path flag with valid docker path",
+		func(ctx context.Context) {
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+
+			metadataLabel := `[{"remoteUser":"dockerpathuser"}]`
+			out, err := exec.CommandContext(ctx, "docker", "run", "-d",
+				"--label", "devcontainer.metadata="+metadataLabel,
+				"ghcr.io/devsy-org/test-images/base:ubuntu",
+				"sleep", "infinity",
+			).Output()
+			framework.ExpectNoError(err)
+			containerID := strings.TrimSpace(string(out))
+			ginkgo.DeferCleanup(func() {
+				args := []string{"rm", "-f", containerID}
+				cmd := exec.Command("docker", args...) // #nosec G204
+				_ = cmd.Run()
+			})
+
+			stdout, _, err := f.ExecCommandCapture(ctx, []string{
+				"read-configuration",
+				"--container-id", containerID,
+				"--docker-path", "docker",
+			})
+			framework.ExpectNoError(err)
+
+			var result map[string]any
+			err = json.Unmarshal([]byte(stdout), &result)
+			framework.ExpectNoError(err, "output should be valid JSON")
+
+			config, ok := result["configuration"].(map[string]any)
+			gomega.Expect(ok).To(gomega.BeTrue())
+			gomega.Expect(config).To(
+				gomega.HaveKeyWithValue("remoteUser", "dockerpathuser"),
+			)
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("fails with --docker-path pointing to invalid executable",
+		func(ctx context.Context) {
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+
+			_, _, err := f.ExecCommandCapture(ctx, []string{
+				"read-configuration",
+				"--container-id", "any-container",
+				"--docker-path", "/nonexistent/path/to/docker",
+			})
+			framework.ExpectError(err)
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 })


### PR DESCRIPTION
## Summary

Adds `--docker-path` flag to the `read-configuration` command, allowing users to specify a custom docker/podman executable path when reading configuration from a running container via `--container-id`. Previously the command hardcoded `"docker"` as the container runtime binary. This aligns `read-configuration` with the `exec` command which already supports `--docker-path`.

Per the [devcontainer CLI reference spec](https://containers.dev/implementors/reference/), the `read-configuration` command supports `--docker-path` as an optional flag for specifying the Docker CLI path (or Docker-compatible CLI) to use.

**Changes:**
- Added `DockerPath` field to `ReadConfigurationCmd` struct
- Registered `--docker-path` flag in `NewReadConfigurationCmd()` following the same pattern as `cmd/exec.go`
- Updated `resolveConfigFromContainer()` to use the custom docker path when specified (defaults to "docker" if empty)
- Added E2E tests: nonexistent container error, container without metadata label, valid `--docker-path` usage, and invalid `--docker-path` error