### PR TITLE
feat(cli): add spec-required flags to run-user-commands (DEVSY-027)

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -23,7 +23,10 @@ import (
 	"golang.org/x/term"
 )
 
-const defaultDockerCommand = "docker"
+const (
+	defaultDockerCommand   = "docker"
+	containerStatusRunning = "running"
+)
 
 type ExecCmd struct {
 	*flags.GlobalFlags
@@ -206,7 +209,7 @@ func (cmd *ExecCmd) runWithContainerID(ctx context.Context, args []string) error
 	}
 
 	containerDetails := &details[0]
-	if strings.ToLower(containerDetails.State.Status) != "running" {
+	if !strings.EqualFold(containerDetails.State.Status, containerStatusRunning) {
 		return fmt.Errorf(
 			"container %s is not running (status: %s)",
 			cmd.ContainerID,
@@ -302,7 +305,7 @@ func findRunningContainer(
 		)
 	}
 
-	if strings.ToLower(container.State.Status) != "running" {
+	if !strings.EqualFold(container.State.Status, containerStatusRunning) {
 		return nil, fmt.Errorf(
 			"container %s is not running (status: %s)",
 			container.ID,

--- a/cmd/runusercommands.go
+++ b/cmd/runusercommands.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -244,7 +245,7 @@ func (cmd *RunUserCommandsCmd) inspectRunningContainer(
 	if len(details) == 0 {
 		errMsg := fmt.Sprintf("container %s not found", cmd.ContainerID)
 		_ = devcconfig.WriteErrorJSON(os.Stderr, errMsg)
-		return nil, fmt.Errorf("%s", errMsg)
+		return nil, errors.New(errMsg)
 	}
 
 	containerDetails := &details[0]
@@ -255,7 +256,7 @@ func (cmd *RunUserCommandsCmd) inspectRunningContainer(
 			containerDetails.State.Status,
 		)
 		_ = devcconfig.WriteErrorJSON(os.Stderr, errMsg)
-		return nil, fmt.Errorf("%s", errMsg)
+		return nil, errors.New(errMsg)
 	}
 	return containerDetails, nil
 }
@@ -276,7 +277,7 @@ func (cmd *RunUserCommandsCmd) loadContainerIDConfig(
 	if devContainerConfig == nil {
 		errMsg := "no devcontainer configuration found"
 		_ = devcconfig.WriteErrorJSON(os.Stderr, errMsg)
-		return nil, fmt.Errorf("%s", errMsg)
+		return nil, errors.New(errMsg)
 	}
 
 	mergedConfig, err := devcconfig.MergeConfiguration(devContainerConfig, nil)
@@ -355,6 +356,7 @@ func (cmd *RunUserCommandsCmd) resolveContainer(
 			result.MergedConfig,
 			cmd.OverrideConfig,
 		); err != nil {
+			_ = devcconfig.WriteErrorJSON(os.Stderr, err.Error())
 			return nil, nil, fmt.Errorf("apply override config: %w", err)
 		}
 	}

--- a/cmd/runusercommands.go
+++ b/cmd/runusercommands.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
@@ -21,13 +22,20 @@ import (
 type RunUserCommandsCmd struct {
 	*flags.GlobalFlags
 
-	WorkspaceFolder   string
-	IDLabels          []string
-	SkipPostCreate    bool
-	SkipPostStart     bool
-	SkipPostAttach    bool
-	SkipOnCreate      bool
-	SkipUpdateContent bool
+	WorkspaceFolder         string
+	ContainerID             string
+	DockerPath              string
+	Config                  string
+	OverrideConfig          string
+	RemoteEnv               []string
+	IDLabels                []string
+	Prebuild                bool
+	SkipNonBlockingCommands bool
+	SkipPostCreate          bool
+	SkipPostStart           bool
+	SkipPostAttach          bool
+	SkipOnCreate            bool
+	SkipUpdateContent       bool
 }
 
 // NewRunUserCommandsCmd creates a new run-user-commands command.
@@ -50,7 +58,41 @@ func NewRunUserCommandsCmd(f *flags.GlobalFlags) *cobra.Command {
 			"",
 			"Path to the workspace folder",
 		)
-	_ = runCmd.MarkFlagRequired("workspace-folder")
+	runCmd.Flags().
+		StringVar(
+			&cmd.ContainerID,
+			"container-id",
+			"",
+			"Target a specific container by ID",
+		)
+	runCmd.Flags().
+		StringVar(
+			&cmd.DockerPath,
+			"docker-path",
+			"",
+			"Path to the docker/podman executable (defaults to 'docker')",
+		)
+	runCmd.Flags().
+		StringVar(
+			&cmd.Config,
+			"config",
+			"",
+			"Path to the devcontainer.json configuration file",
+		)
+	runCmd.Flags().
+		StringVar(
+			&cmd.OverrideConfig,
+			"override-config",
+			"",
+			"Path to an additional devcontainer.json file to override the primary configuration",
+		)
+	runCmd.Flags().
+		StringArrayVar(
+			&cmd.RemoteEnv,
+			"remote-env",
+			[]string{},
+			"Environment variables to set in the container (KEY=VALUE format, can be specified multiple times)",
+		)
 	runCmd.Flags().
 		StringArrayVar(
 			&cmd.IDLabels,
@@ -58,6 +100,12 @@ func NewRunUserCommandsCmd(f *flags.GlobalFlags) *cobra.Command {
 			[]string{},
 			"Override the default container identification labels (format: key=value, can be specified multiple times)",
 		)
+	runCmd.Flags().
+		BoolVar(&cmd.Prebuild, "prebuild", false,
+			"Stop lifecycle execution after onCreateCommand and updateContentCommand")
+	runCmd.Flags().
+		BoolVar(&cmd.SkipNonBlockingCommands, "skip-non-blocking-commands", false,
+			"Skip non-blocking lifecycle commands (stop after the waitFor-configured command)")
 	runCmd.Flags().
 		BoolVar(&cmd.SkipPostCreate, "skip-post-create", false, "Skip running postCreateCommand")
 	runCmd.Flags().
@@ -90,8 +138,12 @@ type lifecycleExecParams struct {
 
 // Run executes the run-user-commands logic.
 func (cmd *RunUserCommandsCmd) Run(ctx context.Context) error {
-	if err := devcconfig.ValidateIDLabels(cmd.IDLabels); err != nil {
+	if err := cmd.validate(); err != nil {
 		return err
+	}
+
+	if cmd.ContainerID != "" {
+		return cmd.runWithContainerID(ctx)
 	}
 
 	params, result, err := cmd.resolveContainer(ctx)
@@ -107,6 +159,154 @@ func (cmd *RunUserCommandsCmd) Run(ctx context.Context) error {
 	log.Infof("lifecycle commands completed for container %s", params.containerID)
 	_ = devcconfig.WriteResultJSON(os.Stderr, params.containerID, user, params.workdir, nil)
 	return nil
+}
+
+func (cmd *RunUserCommandsCmd) validate() error {
+	if cmd.WorkspaceFolder == "" && cmd.ContainerID == "" {
+		return fmt.Errorf("either --workspace-folder or --container-id must be provided")
+	}
+	if cmd.ContainerID != "" && cmd.WorkspaceFolder == "" && cmd.Config == "" {
+		return fmt.Errorf(
+			"--config is required when --container-id is used without --workspace-folder",
+		)
+	}
+	if err := cmd.validateRemoteEnv(); err != nil {
+		return err
+	}
+	return devcconfig.ValidateIDLabels(cmd.IDLabels)
+}
+
+func (cmd *RunUserCommandsCmd) validateRemoteEnv() error {
+	for _, env := range cmd.RemoteEnv {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 || parts[0] == "" {
+			return fmt.Errorf("invalid remote-env value %q: must be KEY=VALUE format", env)
+		}
+	}
+	return nil
+}
+
+func (cmd *RunUserCommandsCmd) runWithContainerID(ctx context.Context) error {
+	helper := &docker.DockerHelper{DockerCommand: cmd.resolveDockerPath()}
+
+	containerDetails, err := cmd.inspectRunningContainer(ctx, helper)
+	if err != nil {
+		return err
+	}
+
+	result, err := cmd.loadContainerIDConfig(containerDetails)
+	if err != nil {
+		return err
+	}
+
+	workdir := containerDetails.Config.WorkingDir
+	if result.MergedConfig.WorkspaceFolder != "" {
+		workdir = result.MergedConfig.WorkspaceFolder
+	}
+
+	envArgs := buildLifecycleEnvArgs(result)
+	envArgs = append(envArgs, cmd.buildCLIRemoteEnvArgs()...)
+
+	params := &lifecycleExecParams{
+		ctx:         ctx,
+		helper:      helper,
+		containerID: containerDetails.ID,
+		envArgs:     envArgs,
+		workdir:     workdir,
+	}
+
+	if err := cmd.runLifecycleHooks(params, result); err != nil {
+		return err
+	}
+
+	user := devcconfig.GetRemoteUser(result)
+	log.Infof("lifecycle commands completed for container %s", params.containerID)
+	_ = devcconfig.WriteResultJSON(os.Stderr, params.containerID, user, params.workdir, nil)
+	return nil
+}
+
+func (cmd *RunUserCommandsCmd) resolveDockerPath() string {
+	if cmd.DockerPath != "" {
+		return cmd.DockerPath
+	}
+	return defaultDockerCommand
+}
+
+func (cmd *RunUserCommandsCmd) inspectRunningContainer(
+	ctx context.Context,
+	helper *docker.DockerHelper,
+) (*devcconfig.ContainerDetails, error) {
+	details, err := helper.InspectContainers(ctx, []string{cmd.ContainerID})
+	if err != nil {
+		_ = devcconfig.WriteErrorJSON(os.Stderr, err.Error())
+		return nil, fmt.Errorf("inspect container %s: %w", cmd.ContainerID, err)
+	}
+	if len(details) == 0 {
+		errMsg := fmt.Sprintf("container %s not found", cmd.ContainerID)
+		_ = devcconfig.WriteErrorJSON(os.Stderr, errMsg)
+		return nil, fmt.Errorf("%s", errMsg)
+	}
+
+	containerDetails := &details[0]
+	if !strings.EqualFold(containerDetails.State.Status, containerStatusRunning) {
+		errMsg := fmt.Sprintf(
+			"container %s is not running (status: %s)",
+			cmd.ContainerID,
+			containerDetails.State.Status,
+		)
+		_ = devcconfig.WriteErrorJSON(os.Stderr, errMsg)
+		return nil, fmt.Errorf("%s", errMsg)
+	}
+	return containerDetails, nil
+}
+
+func (cmd *RunUserCommandsCmd) loadContainerIDConfig(
+	containerDetails *devcconfig.ContainerDetails,
+) (*devcconfig.Result, error) {
+	configFolder := cmd.WorkspaceFolder
+	if configFolder == "" {
+		configFolder = "."
+	}
+
+	devContainerConfig, err := devcconfig.ParseDevContainerJSON(configFolder, cmd.Config)
+	if err != nil {
+		_ = devcconfig.WriteErrorJSON(os.Stderr, err.Error())
+		return nil, fmt.Errorf("parse devcontainer config: %w", err)
+	}
+	if devContainerConfig == nil {
+		errMsg := "no devcontainer configuration found"
+		_ = devcconfig.WriteErrorJSON(os.Stderr, errMsg)
+		return nil, fmt.Errorf("%s", errMsg)
+	}
+
+	mergedConfig, err := devcconfig.MergeConfiguration(devContainerConfig, nil)
+	if err != nil {
+		_ = devcconfig.WriteErrorJSON(os.Stderr, err.Error())
+		return nil, fmt.Errorf("merge configuration: %w", err)
+	}
+
+	if cmd.OverrideConfig != "" {
+		if err := devcconfig.MergeExtraRemoteEnv(mergedConfig, cmd.OverrideConfig); err != nil {
+			_ = devcconfig.WriteErrorJSON(os.Stderr, err.Error())
+			return nil, fmt.Errorf("apply override config: %w", err)
+		}
+	}
+
+	return &devcconfig.Result{
+		MergedConfig:     mergedConfig,
+		ContainerDetails: containerDetails,
+	}, nil
+}
+
+func (cmd *RunUserCommandsCmd) buildCLIRemoteEnvArgs() []string {
+	if len(cmd.RemoteEnv) == 0 {
+		return nil
+	}
+	args := make([]string, 0, len(cmd.RemoteEnv)*2)
+	for _, env := range cmd.RemoteEnv {
+		args = append(args, "-e", env)
+	}
+	return args
 }
 
 func (cmd *RunUserCommandsCmd) resolveContainer(
@@ -129,6 +329,9 @@ func (cmd *RunUserCommandsCmd) resolveContainer(
 
 	workspaceConfig := client.WorkspaceConfig()
 	dockerCommand := resolveDockerCommand(workspaceConfig)
+	if cmd.DockerPath != "" {
+		dockerCommand = cmd.DockerPath
+	}
 
 	containerDetails, err := findRunningContainer(
 		ctx, dockerCommand, devcontainer.GetRunnerIDFromWorkspace(workspaceConfig), cmd.IDLabels,
@@ -147,11 +350,23 @@ func (cmd *RunUserCommandsCmd) resolveContainer(
 		return nil, nil, fmt.Errorf("no workspace result found; lifecycle commands unavailable")
 	}
 
+	if cmd.OverrideConfig != "" {
+		if err := devcconfig.MergeExtraRemoteEnv(
+			result.MergedConfig,
+			cmd.OverrideConfig,
+		); err != nil {
+			return nil, nil, fmt.Errorf("apply override config: %w", err)
+		}
+	}
+
+	envArgs := buildLifecycleEnvArgs(result)
+	envArgs = append(envArgs, cmd.buildCLIRemoteEnvArgs()...)
+
 	params := &lifecycleExecParams{
 		ctx:         ctx,
 		helper:      &docker.DockerHelper{DockerCommand: dockerCommand},
 		containerID: containerDetails.ID,
-		envArgs:     buildLifecycleEnvArgs(result),
+		envArgs:     envArgs,
 		workdir:     resolveExecWorkdir(result, client.Workspace()),
 	}
 	return params, result, nil
@@ -173,7 +388,20 @@ func (cmd *RunUserCommandsCmd) runLifecycleHooks(
 		{"postAttachCommand", result.MergedConfig.PostAttachCommands, cmd.SkipPostAttach},
 	}
 
-	for _, hook := range hooks {
+	waitForBoundary := resolveWaitForBoundary(result)
+
+	for i, hook := range hooks {
+		if cmd.Prebuild && i >= 2 {
+			log.Infof("stopping lifecycle execution (--prebuild: after updateContentCommand)")
+			return nil
+		}
+		if cmd.SkipNonBlockingCommands && i > waitForBoundary {
+			log.Infof(
+				"stopping lifecycle execution (--skip-non-blocking-commands: after %s)",
+				hooks[waitForBoundary].name,
+			)
+			return nil
+		}
 		if hook.skip {
 			log.Infof("skipping %s (--skip flag set)", hook.name)
 			continue
@@ -186,6 +414,29 @@ func (cmd *RunUserCommandsCmd) runLifecycleHooks(
 		}
 	}
 	return nil
+}
+
+func resolveWaitForBoundary(result *devcconfig.Result) int {
+	if result == nil || result.MergedConfig == nil {
+		return 1
+	}
+	hookNames := []string{
+		"onCreateCommand",
+		"updateContentCommand",
+		"postCreateCommand",
+		"postStartCommand",
+		"postAttachCommand",
+	}
+	waitFor := result.MergedConfig.WaitFor
+	if waitFor == "" {
+		waitFor = "updateContentCommand"
+	}
+	for i, name := range hookNames {
+		if name == waitFor {
+			return i
+		}
+	}
+	return 1
 }
 
 func execLifecycleHook(params *lifecycleExecParams, name string, hook types.LifecycleHook) error {

--- a/cmd/runusercommands_test.go
+++ b/cmd/runusercommands_test.go
@@ -9,6 +9,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	flagContainerID   = "--container-id"
+	testContainerID   = "abc"
+	hookOnCreate      = "onCreateCommand"
+	hookUpdateContent = "updateContentCommand"
+	hookPostCreate    = "postCreateCommand"
+	hookPostStart     = "postStartCommand"
+	hookPostAttach    = "postAttachCommand"
+)
+
 func TestNewRunUserCommandsCmd_CommandName(t *testing.T) {
 	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
 	assert.Equal(t, "run-user-commands", cmd.Use)
@@ -43,7 +53,7 @@ func TestNewRunUserCommandsCmd_RequiresWorkspaceFolderOrContainerID(t *testing.T
 
 func TestNewRunUserCommandsCmd_ContainerIDWithoutConfigFails(t *testing.T) {
 	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
-	cmd.SetArgs([]string{"--container-id", "abc123"})
+	cmd.SetArgs([]string{flagContainerID, "abc123"})
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(),
@@ -181,11 +191,11 @@ func TestRunUserCommandsCmd_NewFlagsParseValues(t *testing.T) {
 		"--docker-path", "/usr/local/bin/podman",
 		"--config", ".devcontainer/devcontainer.json",
 		"--override-config", "/tmp/override.json",
-		"--remote-env", "FOO=bar",
-		"--remote-env", "BAZ=qux",
+		"--remote-env", testEnvFoo,
+		"--remote-env", testEnvBaz,
 		"--prebuild",
 		"--skip-non-blocking-commands",
-		"--container-id", "abc123",
+		flagContainerID, "abc123",
 	})
 	require.NoError(t, err)
 
@@ -203,7 +213,7 @@ func TestRunUserCommandsCmd_NewFlagsParseValues(t *testing.T) {
 
 	remoteEnv, err := cmd.Flags().GetStringArray("remote-env")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"FOO=bar", "BAZ=qux"}, remoteEnv)
+	assert.Equal(t, []string{testEnvFoo, testEnvBaz}, remoteEnv)
 
 	prebuild, err := cmd.Flags().GetBool("prebuild")
 	require.NoError(t, err)
@@ -225,7 +235,7 @@ func TestRunUserCommandsCmd_ValidateRemoteEnv(t *testing.T) {
 		wantErr   bool
 		errSubstr string
 	}{
-		{"valid", []string{"FOO=bar", "BAZ=qux=extra"}, false, ""},
+		{"valid", []string{testEnvFoo, "BAZ=qux=extra"}, false, ""},
 		{"empty", []string{}, false, ""},
 		{"missing equals", []string{"INVALID"}, true, "must be KEY=VALUE format"},
 		{"empty key", []string{"=value"}, true, "must be KEY=VALUE format"},
@@ -256,14 +266,14 @@ func TestRunUserCommandsCmd_Validate(t *testing.T) {
 	}{
 		{
 			"workspace-folder only",
-			&RunUserCommandsCmd{GlobalFlags: &flags.GlobalFlags{}, WorkspaceFolder: "/tmp"},
+			&RunUserCommandsCmd{GlobalFlags: &flags.GlobalFlags{}, WorkspaceFolder: testTmpDir},
 			false, "",
 		},
 		{
 			"container-id with config",
 			&RunUserCommandsCmd{
 				GlobalFlags: &flags.GlobalFlags{},
-				ContainerID: "abc",
+				ContainerID: testContainerID,
 				Config:      "path",
 			},
 			false,
@@ -273,8 +283,8 @@ func TestRunUserCommandsCmd_Validate(t *testing.T) {
 			"container-id with workspace-folder",
 			&RunUserCommandsCmd{
 				GlobalFlags:     &flags.GlobalFlags{},
-				ContainerID:     "abc",
-				WorkspaceFolder: "/tmp",
+				ContainerID:     testContainerID,
+				WorkspaceFolder: testTmpDir,
 			},
 			false,
 			"",
@@ -286,7 +296,7 @@ func TestRunUserCommandsCmd_Validate(t *testing.T) {
 		},
 		{
 			"container-id without config or workspace",
-			&RunUserCommandsCmd{GlobalFlags: &flags.GlobalFlags{}, ContainerID: "abc"},
+			&RunUserCommandsCmd{GlobalFlags: &flags.GlobalFlags{}, ContainerID: testContainerID},
 			true, "--config is required",
 		},
 	}
@@ -310,11 +320,11 @@ func TestResolveWaitForBoundary(t *testing.T) {
 		want    int
 	}{
 		{"default (empty)", "", 1},
-		{"onCreateCommand", "onCreateCommand", 0},
-		{"updateContentCommand", "updateContentCommand", 1},
-		{"postCreateCommand", "postCreateCommand", 2},
-		{"postStartCommand", "postStartCommand", 3},
-		{"postAttachCommand", "postAttachCommand", 4},
+		{hookOnCreate, hookOnCreate, 0},
+		{hookUpdateContent, hookUpdateContent, 1},
+		{hookPostCreate, hookPostCreate, 2},
+		{hookPostStart, hookPostStart, 3},
+		{hookPostAttach, hookPostAttach, 4},
 		{"unknown falls back to 1", "unknownHook", 1},
 	}
 	for _, tt := range tests {
@@ -371,7 +381,7 @@ func TestBuildLifecycleEnvArgs_WithValues(t *testing.T) {
 		},
 	}
 	args := buildLifecycleEnvArgs(result)
-	assert.Equal(t, []string{"-e", "FOO=bar"}, args)
+	assert.Equal(t, []string{"-e", testEnvFoo}, args)
 }
 
 func TestBuildLifecycleEnvArgs_NilValueSkipped(t *testing.T) {
@@ -407,10 +417,10 @@ func TestRunUserCommandsCmd_RegisteredInRoot(t *testing.T) {
 func TestRunUserCommandsCmd_BuildCLIRemoteEnvArgs(t *testing.T) {
 	cmd := &RunUserCommandsCmd{
 		GlobalFlags: &flags.GlobalFlags{},
-		RemoteEnv:   []string{"FOO=bar", "BAZ=qux"},
+		RemoteEnv:   []string{testEnvFoo, testEnvBaz},
 	}
 	args := cmd.buildCLIRemoteEnvArgs()
-	assert.Equal(t, []string{"-e", "FOO=bar", "-e", "BAZ=qux"}, args)
+	assert.Equal(t, []string{"-e", testEnvFoo, "-e", testEnvBaz}, args)
 }
 
 func TestRunUserCommandsCmd_BuildCLIRemoteEnvArgs_Empty(t *testing.T) {

--- a/cmd/runusercommands_test.go
+++ b/cmd/runusercommands_test.go
@@ -33,12 +33,28 @@ func TestNewRunUserCommandsCmdAlias_RegisteredInRoot(t *testing.T) {
 	assert.True(t, found, "runUserCommands alias should be registered in root")
 }
 
-func TestNewRunUserCommandsCmd_WorkspaceFolderRequired(t *testing.T) {
+func TestNewRunUserCommandsCmd_RequiresWorkspaceFolderOrContainerID(t *testing.T) {
 	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
 	cmd.SetArgs([]string{})
 	err := cmd.Execute()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "required flag")
+	assert.Contains(t, err.Error(), "either --workspace-folder or --container-id must be provided")
+}
+
+func TestNewRunUserCommandsCmd_ContainerIDWithoutConfigFails(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	cmd.SetArgs([]string{"--container-id", "abc123"})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(),
+		"--config is required when --container-id is used without --workspace-folder")
+}
+
+func TestNewRunUserCommandsCmd_ContainerIDWithWorkspaceFolderNoConfigOK(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("container-id")
+	require.NotNil(t, f)
+	assert.Equal(t, "", f.DefValue)
 }
 
 func TestNewRunUserCommandsCmd_IDLabelFlag(t *testing.T) {
@@ -46,6 +62,278 @@ func TestNewRunUserCommandsCmd_IDLabelFlag(t *testing.T) {
 	f := cmd.Flags().Lookup("id-label")
 	require.NotNil(t, f)
 	assert.Equal(t, "stringArray", f.Value.Type())
+}
+
+func TestNewRunUserCommandsCmd_DockerPathFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("docker-path")
+	require.NotNil(t, f)
+	assert.Equal(t, "", f.DefValue)
+}
+
+func TestNewRunUserCommandsCmd_ConfigFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("config")
+	require.NotNil(t, f)
+	assert.Equal(t, "", f.DefValue)
+}
+
+func TestNewRunUserCommandsCmd_OverrideConfigFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("override-config")
+	require.NotNil(t, f)
+	assert.Equal(t, "", f.DefValue)
+}
+
+func TestNewRunUserCommandsCmd_RemoteEnvFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("remote-env")
+	require.NotNil(t, f)
+	assert.Equal(t, "stringArray", f.Value.Type())
+}
+
+func TestNewRunUserCommandsCmd_PrebuildFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("prebuild")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestNewRunUserCommandsCmd_SkipNonBlockingCommandsFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("skip-non-blocking-commands")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestRunUserCommandsCmd_SkipPostCreateFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("skip-post-create")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestRunUserCommandsCmd_SkipPostStartFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("skip-post-start")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestRunUserCommandsCmd_SkipPostAttachFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("skip-post-attach")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestRunUserCommandsCmd_SkipOnCreateFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("skip-on-create")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestRunUserCommandsCmd_SkipUpdateContentFlag(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	f := cmd.Flags().Lookup("skip-update-content")
+	require.NotNil(t, f)
+	assert.Equal(t, "false", f.DefValue)
+}
+
+func TestRunUserCommandsCmd_SkipFlagsParseValues(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	err := cmd.ParseFlags([]string{
+		flagWorkspaceFolder, testTmpDir,
+		flagSkipPostCreate,
+		"--skip-post-start",
+		"--skip-post-attach",
+		"--skip-on-create",
+		"--skip-update-content",
+	})
+	require.NoError(t, err)
+
+	val, err := cmd.Flags().GetBool("skip-post-create")
+	require.NoError(t, err)
+	assert.True(t, val)
+
+	val, err = cmd.Flags().GetBool("skip-post-start")
+	require.NoError(t, err)
+	assert.True(t, val)
+
+	val, err = cmd.Flags().GetBool("skip-post-attach")
+	require.NoError(t, err)
+	assert.True(t, val)
+
+	val, err = cmd.Flags().GetBool("skip-on-create")
+	require.NoError(t, err)
+	assert.True(t, val)
+
+	val, err = cmd.Flags().GetBool("skip-update-content")
+	require.NoError(t, err)
+	assert.True(t, val)
+}
+
+func TestRunUserCommandsCmd_NewFlagsParseValues(t *testing.T) {
+	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
+	err := cmd.ParseFlags([]string{
+		flagWorkspaceFolder, testTmpDir,
+		"--docker-path", "/usr/local/bin/podman",
+		"--config", ".devcontainer/devcontainer.json",
+		"--override-config", "/tmp/override.json",
+		"--remote-env", "FOO=bar",
+		"--remote-env", "BAZ=qux",
+		"--prebuild",
+		"--skip-non-blocking-commands",
+		"--container-id", "abc123",
+	})
+	require.NoError(t, err)
+
+	dockerPath, err := cmd.Flags().GetString("docker-path")
+	require.NoError(t, err)
+	assert.Equal(t, "/usr/local/bin/podman", dockerPath)
+
+	configPath, err := cmd.Flags().GetString("config")
+	require.NoError(t, err)
+	assert.Equal(t, ".devcontainer/devcontainer.json", configPath)
+
+	overridePath, err := cmd.Flags().GetString("override-config")
+	require.NoError(t, err)
+	assert.Equal(t, "/tmp/override.json", overridePath)
+
+	remoteEnv, err := cmd.Flags().GetStringArray("remote-env")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"FOO=bar", "BAZ=qux"}, remoteEnv)
+
+	prebuild, err := cmd.Flags().GetBool("prebuild")
+	require.NoError(t, err)
+	assert.True(t, prebuild)
+
+	skipNonBlocking, err := cmd.Flags().GetBool("skip-non-blocking-commands")
+	require.NoError(t, err)
+	assert.True(t, skipNonBlocking)
+
+	containerID, err := cmd.Flags().GetString("container-id")
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", containerID)
+}
+
+func TestRunUserCommandsCmd_ValidateRemoteEnv(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       []string
+		wantErr   bool
+		errSubstr string
+	}{
+		{"valid", []string{"FOO=bar", "BAZ=qux=extra"}, false, ""},
+		{"empty", []string{}, false, ""},
+		{"missing equals", []string{"INVALID"}, true, "must be KEY=VALUE format"},
+		{"empty key", []string{"=value"}, true, "must be KEY=VALUE format"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &RunUserCommandsCmd{
+				GlobalFlags: &flags.GlobalFlags{},
+				RemoteEnv:   tt.env,
+			}
+			err := cmd.validateRemoteEnv()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRunUserCommandsCmd_Validate(t *testing.T) {
+	tests := []struct {
+		name      string
+		cmd       *RunUserCommandsCmd
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			"workspace-folder only",
+			&RunUserCommandsCmd{GlobalFlags: &flags.GlobalFlags{}, WorkspaceFolder: "/tmp"},
+			false, "",
+		},
+		{
+			"container-id with config",
+			&RunUserCommandsCmd{
+				GlobalFlags: &flags.GlobalFlags{},
+				ContainerID: "abc",
+				Config:      "path",
+			},
+			false,
+			"",
+		},
+		{
+			"container-id with workspace-folder",
+			&RunUserCommandsCmd{
+				GlobalFlags:     &flags.GlobalFlags{},
+				ContainerID:     "abc",
+				WorkspaceFolder: "/tmp",
+			},
+			false,
+			"",
+		},
+		{
+			"neither provided",
+			&RunUserCommandsCmd{GlobalFlags: &flags.GlobalFlags{}},
+			true, "either --workspace-folder or --container-id",
+		},
+		{
+			"container-id without config or workspace",
+			&RunUserCommandsCmd{GlobalFlags: &flags.GlobalFlags{}, ContainerID: "abc"},
+			true, "--config is required",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cmd.validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errSubstr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestResolveWaitForBoundary(t *testing.T) {
+	tests := []struct {
+		name    string
+		waitFor string
+		want    int
+	}{
+		{"default (empty)", "", 1},
+		{"onCreateCommand", "onCreateCommand", 0},
+		{"updateContentCommand", "updateContentCommand", 1},
+		{"postCreateCommand", "postCreateCommand", 2},
+		{"postStartCommand", "postStartCommand", 3},
+		{"postAttachCommand", "postAttachCommand", 4},
+		{"unknown falls back to 1", "unknownHook", 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &devcconfig.Result{
+				MergedConfig: &devcconfig.MergedDevContainerConfig{
+					DevContainerConfigBase: devcconfig.DevContainerConfigBase{
+						WaitFor: tt.waitFor,
+					},
+				},
+			}
+			got := resolveWaitForBoundary(result)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveWaitForBoundary_NilResult(t *testing.T) {
+	assert.Equal(t, 1, resolveWaitForBoundary(nil))
 }
 
 func TestBuildLifecycleEnvArgs_Nil(t *testing.T) {
@@ -116,70 +404,20 @@ func TestRunUserCommandsCmd_RegisteredInRoot(t *testing.T) {
 	assert.True(t, found, "run-user-commands should be registered in root")
 }
 
-func TestRunUserCommandsCmd_SkipPostCreateFlag(t *testing.T) {
-	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
-	f := cmd.Flags().Lookup("skip-post-create")
-	require.NotNil(t, f)
-	assert.Equal(t, "false", f.DefValue)
+func TestRunUserCommandsCmd_BuildCLIRemoteEnvArgs(t *testing.T) {
+	cmd := &RunUserCommandsCmd{
+		GlobalFlags: &flags.GlobalFlags{},
+		RemoteEnv:   []string{"FOO=bar", "BAZ=qux"},
+	}
+	args := cmd.buildCLIRemoteEnvArgs()
+	assert.Equal(t, []string{"-e", "FOO=bar", "-e", "BAZ=qux"}, args)
 }
 
-func TestRunUserCommandsCmd_SkipPostStartFlag(t *testing.T) {
-	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
-	f := cmd.Flags().Lookup("skip-post-start")
-	require.NotNil(t, f)
-	assert.Equal(t, "false", f.DefValue)
-}
-
-func TestRunUserCommandsCmd_SkipPostAttachFlag(t *testing.T) {
-	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
-	f := cmd.Flags().Lookup("skip-post-attach")
-	require.NotNil(t, f)
-	assert.Equal(t, "false", f.DefValue)
-}
-
-func TestRunUserCommandsCmd_SkipOnCreateFlag(t *testing.T) {
-	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
-	f := cmd.Flags().Lookup("skip-on-create")
-	require.NotNil(t, f)
-	assert.Equal(t, "false", f.DefValue)
-}
-
-func TestRunUserCommandsCmd_SkipUpdateContentFlag(t *testing.T) {
-	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
-	f := cmd.Flags().Lookup("skip-update-content")
-	require.NotNil(t, f)
-	assert.Equal(t, "false", f.DefValue)
-}
-
-func TestRunUserCommandsCmd_SkipFlagsParseValues(t *testing.T) {
-	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
-	err := cmd.ParseFlags([]string{
-		flagWorkspaceFolder, testTmpDir,
-		flagSkipPostCreate,
-		"--skip-post-start",
-		"--skip-post-attach",
-		"--skip-on-create",
-		"--skip-update-content",
-	})
-	require.NoError(t, err)
-
-	val, err := cmd.Flags().GetBool("skip-post-create")
-	require.NoError(t, err)
-	assert.True(t, val)
-
-	val, err = cmd.Flags().GetBool("skip-post-start")
-	require.NoError(t, err)
-	assert.True(t, val)
-
-	val, err = cmd.Flags().GetBool("skip-post-attach")
-	require.NoError(t, err)
-	assert.True(t, val)
-
-	val, err = cmd.Flags().GetBool("skip-on-create")
-	require.NoError(t, err)
-	assert.True(t, val)
-
-	val, err = cmd.Flags().GetBool("skip-update-content")
-	require.NoError(t, err)
-	assert.True(t, val)
+func TestRunUserCommandsCmd_BuildCLIRemoteEnvArgs_Empty(t *testing.T) {
+	cmd := &RunUserCommandsCmd{
+		GlobalFlags: &flags.GlobalFlags{},
+		RemoteEnv:   []string{},
+	}
+	args := cmd.buildCLIRemoteEnvArgs()
+	assert.Nil(t, args)
 }

--- a/cmd/runusercommands_test.go
+++ b/cmd/runusercommands_test.go
@@ -50,7 +50,7 @@ func TestNewRunUserCommandsCmd_ContainerIDWithoutConfigFails(t *testing.T) {
 		"--config is required when --container-id is used without --workspace-folder")
 }
 
-func TestNewRunUserCommandsCmd_ContainerIDWithWorkspaceFolderNoConfigOK(t *testing.T) {
+func TestNewRunUserCommandsCmd_ContainerIDFlagExists(t *testing.T) {
 	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
 	f := cmd.Flags().Lookup("container-id")
 	require.NotNil(t, f)

--- a/cmd/runusercommands_test.go
+++ b/cmd/runusercommands_test.go
@@ -10,13 +10,14 @@ import (
 )
 
 const (
-	flagContainerID   = "--container-id"
-	testContainerID   = "abc"
-	hookOnCreate      = "onCreateCommand"
-	hookUpdateContent = "updateContentCommand"
-	hookPostCreate    = "postCreateCommand"
-	hookPostStart     = "postStartCommand"
-	hookPostAttach    = "postAttachCommand"
+	flagContainerID    = "--container-id"
+	testContainerID    = "abc"
+	testContainerIDHex = "abc123"
+	hookOnCreate       = "onCreateCommand"
+	hookUpdateContent  = "updateContentCommand"
+	hookPostCreate     = "postCreateCommand"
+	hookPostStart      = "postStartCommand"
+	hookPostAttach     = "postAttachCommand"
 )
 
 func TestNewRunUserCommandsCmd_CommandName(t *testing.T) {
@@ -53,7 +54,7 @@ func TestNewRunUserCommandsCmd_RequiresWorkspaceFolderOrContainerID(t *testing.T
 
 func TestNewRunUserCommandsCmd_ContainerIDWithoutConfigFails(t *testing.T) {
 	cmd := NewRunUserCommandsCmd(&flags.GlobalFlags{})
-	cmd.SetArgs([]string{flagContainerID, "abc123"})
+	cmd.SetArgs([]string{flagContainerID, testContainerIDHex})
 	err := cmd.Execute()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(),
@@ -195,7 +196,7 @@ func TestRunUserCommandsCmd_NewFlagsParseValues(t *testing.T) {
 		"--remote-env", testEnvBaz,
 		"--prebuild",
 		"--skip-non-blocking-commands",
-		flagContainerID, "abc123",
+		flagContainerID, testContainerIDHex,
 	})
 	require.NoError(t, err)
 
@@ -225,7 +226,7 @@ func TestRunUserCommandsCmd_NewFlagsParseValues(t *testing.T) {
 
 	containerID, err := cmd.Flags().GetString("container-id")
 	require.NoError(t, err)
-	assert.Equal(t, "abc123", containerID)
+	assert.Equal(t, testContainerIDHex, containerID)
 }
 
 func TestRunUserCommandsCmd_ValidateRemoteEnv(t *testing.T) {

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -24,6 +24,7 @@ import (
 	_ "github.com/devsy-org/devsy/e2e/tests/outdated"
 	_ "github.com/devsy-org/devsy/e2e/tests/provider"
 	_ "github.com/devsy-org/devsy/e2e/tests/readconfiguration"
+	_ "github.com/devsy-org/devsy/e2e/tests/runusercommands"
 	_ "github.com/devsy-org/devsy/e2e/tests/selfupdate"
 	_ "github.com/devsy-org/devsy/e2e/tests/ssh"
 	_ "github.com/devsy-org/devsy/e2e/tests/templates"

--- a/e2e/tests/runusercommands/helper.go
+++ b/e2e/tests/runusercommands/helper.go
@@ -1,0 +1,37 @@
+package runusercommands
+
+import (
+	"context"
+
+	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/onsi/ginkgo/v2"
+)
+
+func setupWorkspace(testdataPath, initialDir string) (string, *framework.Framework, error) {
+	tempDir, err := framework.CopyToTempDir(testdataPath)
+	if err != nil {
+		return "", nil, err
+	}
+
+	f, err := framework.SetupDockerProvider(initialDir+"/bin", "docker")
+	if err != nil {
+		return "", nil, err
+	}
+
+	ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+	ginkgo.DeferCleanup(f.DevsyWorkspaceDelete, tempDir)
+
+	return tempDir, f, nil
+}
+
+func setupWorkspaceAndUp(
+	ctx context.Context,
+	testdataPath, initialDir string,
+) (string, *framework.Framework, error) {
+	tempDir, f, err := setupWorkspace(testdataPath, initialDir)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return tempDir, f, f.DevsyUp(ctx, tempDir)
+}

--- a/e2e/tests/runusercommands/runusercommands.go
+++ b/e2e/tests/runusercommands/runusercommands.go
@@ -1,0 +1,52 @@
+package runusercommands
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe(
+	"devsy run-user-commands test suite",
+	ginkgo.Label("run-user-commands"),
+	ginkgo.Ordered,
+	func() {
+		var initialDir string
+
+		ginkgo.BeforeEach(func() {
+			var err error
+			initialDir, err = os.Getwd()
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should execute lifecycle hooks via run-user-commands",
+			func(ctx context.Context) {
+				tempDir, f, err := setupWorkspaceAndUp(
+					ctx,
+					"tests/runusercommands/testdata/lifecycle",
+					initialDir,
+				)
+				framework.ExpectNoError(err)
+
+				_, _, err = f.ExecCommandCapture(ctx, []string{
+					"run-user-commands",
+					"--workspace-folder", tempDir,
+				})
+				framework.ExpectNoError(err)
+
+				stdout, _, err := f.ExecCommandCapture(ctx, []string{
+					"exec",
+					"--workspace-folder", tempDir,
+					"--", "cat", "/tmp/lifecycle-test.txt",
+				})
+				framework.ExpectNoError(err)
+				gomega.Expect(strings.TrimSpace(stdout)).To(gomega.ContainSubstring("oncreate-ran"))
+				gomega.Expect(strings.TrimSpace(stdout)).
+					To(gomega.ContainSubstring("postcreate-ran"))
+			}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+	},
+)

--- a/e2e/tests/runusercommands/testdata/lifecycle/.devcontainer/devcontainer.json
+++ b/e2e/tests/runusercommands/testdata/lifecycle/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "Run User Commands Test",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
+  "onCreateCommand": "echo oncreate-ran > /tmp/lifecycle-test.txt",
+  "postCreateCommand": "echo postcreate-ran >> /tmp/lifecycle-test.txt"
+}


### PR DESCRIPTION
## Summary

Adds 7 devcontainer spec-required flags to the `run-user-commands` command for full spec compliance per https://containers.dev/implementors/reference/:

- **--docker-path** — Override docker/podman executable path for container operations
- **--container-id** — Target a specific container directly without workspace resolution
- **--config** — Specify devcontainer.json path (required with --container-id when --workspace-folder is absent)
- **--override-config** — Additional devcontainer.json to overlay on the primary config
- **--remote-env** — Repeatable KEY=VALUE env vars injected into lifecycle exec commands
- **--prebuild** — Stop lifecycle execution after onCreateCommand + updateContentCommand (first 2 hooks)
- **--skip-non-blocking-commands** — Stop after the waitFor-configured command boundary

Also removes the hard `--workspace-folder` requirement — the command now accepts either `--workspace-folder` or `--container-id` (+ `--config`), matching the devcontainer CLI spec behavior.

Includes:
- Comprehensive unit tests for all new flags (validation, parsing, boundary resolution)
- E2E test verifying lifecycle hooks execute via `run-user-commands` against a running container
- Extraction of `containerStatusRunning` constant to satisfy linter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added container-centric execution mode supporting container ID, Docker path override, config override, remote environment variables, and lifecycle hook control flags.
  * Enabled lifecycle hook execution within containerized environments.

* **Bug Fixes**
  * Enhanced container running-state validation with stricter case-insensitive checks.

* **Tests**
  * Added comprehensive end-to-end test coverage and CLI flag validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->