### PR TITLE
feat(compose): validate hostRequirements in Docker Compose path

### DIFF
--- a/e2e/tests/up-docker-compose/host_requirements.go
+++ b/e2e/tests/up-docker-compose/host_requirements.go
@@ -1,0 +1,69 @@
+//go:build linux || darwin || unix
+
+package up
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe(
+	"testing up docker-compose command host requirements warnings",
+	ginkgo.Label("up-docker-compose-host-requirements"),
+	func() {
+		var btc *baseTestContext
+
+		ginkgo.BeforeEach(func(ctx context.Context) {
+			var err error
+			btc = &baseTestContext{}
+			btc.initialDir, err = os.Getwd()
+			framework.ExpectNoError(err)
+
+			btc.f, err = setupDockerProvider(
+				filepath.Join(btc.initialDir, "bin"), "docker",
+			)
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("surfaces hostRequirements warnings in JSON envelope", func(ctx context.Context) {
+			tempDir, err := setupWorkspace(
+				"tests/up-docker-compose/testdata/compose-host-requirements",
+				btc.initialDir,
+				btc.f,
+			)
+			framework.ExpectNoError(err)
+
+			stdout, _, err := btc.f.DevsyUpStreams(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			lines := strings.Split(strings.TrimSpace(stdout), "\n")
+			gomega.Expect(lines).NotTo(gomega.BeEmpty())
+
+			lastLine := lines[len(lines)-1]
+			var envelope config.ResultEnvelope
+			err = json.Unmarshal([]byte(lastLine), &envelope)
+			framework.ExpectNoError(err)
+
+			gomega.Expect(envelope.Outcome).To(gomega.Equal("success"))
+			gomega.Expect(envelope.Warnings).NotTo(gomega.BeEmpty())
+
+			found := false
+			for _, w := range envelope.Warnings {
+				if strings.Contains(w, "cpus:") {
+					found = true
+					break
+				}
+			}
+			gomega.Expect(found).To(gomega.BeTrue(),
+				"expected a cpus warning in %v", envelope.Warnings)
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+	},
+)

--- a/e2e/tests/up-docker-compose/testdata/compose-host-requirements/.devcontainer.json
+++ b/e2e/tests/up-docker-compose/testdata/compose-host-requirements/.devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "name": "ComposeHostRequirements",
+  "dockerComposeFile": "./docker-compose.yaml",
+  "service": "app",
+  "workspaceFolder": "/workspaces",
+  "hostRequirements": {
+    "cpus": 128
+  }
+}

--- a/e2e/tests/up-docker-compose/testdata/compose-host-requirements/docker-compose.yaml
+++ b/e2e/tests/up-docker-compose/testdata/compose-host-requirements/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  app:
+    image: ghcr.io/devsy-org/test-images/go:1
+    command: sleep infinity
+    volumes:
+      - .:/workspaces:cached

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -309,13 +309,20 @@ func (r *runner) runDockerCompose(
 	composeAlias := project.Name
 	mergedConfig.RemoteEnv["COMPOSE_PROJECT_NAME"] = &composeAlias
 
-	// setup container
+	// validate host requirements (advisory only — warnings never block creation)
+	hostWarnings := config.ValidateHostRequirements(
+		parsedConfig.Config.HostRequirements,
+		config.SystemHostInfo{},
+		substitutionContext.LocalWorkspaceFolder,
+	)
+
 	return r.setupContainer(ctx, &setupContainerParams{
 		rawConfig:           parsedConfig.Raw,
 		containerDetails:    containerDetails,
 		mergedConfig:        mergedConfig,
 		substitutionContext: substitutionContext,
 		timeout:             timeout,
+		hostWarnings:        hostWarnings,
 	})
 }
 


### PR DESCRIPTION
## Summary

- Adds `ValidateHostRequirements()` call to the Docker Compose container creation path (`pkg/devcontainer/compose.go`), matching the existing behavior in the single-container path (`single.go:225-229`).
- Warnings are advisory only and never block container creation — they propagate through `setupContainerParams.hostWarnings` into the JSON result envelope.
- Adds E2E test (`up-docker-compose-host-requirements` label) that verifies CPU warnings appear in the JSON envelope when using Docker Compose with `hostRequirements.cpus` set above host capacity.

Reference: https://containers.dev/implementors/reference/ (hostRequirements section)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker Compose setup now validates host requirements and surfaces warnings (including CPU requirements) during container initialization to inform users of system prerequisites.

* **Tests**
  * Added end-to-end test validating host requirements warnings are properly displayed in Docker Compose workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->