### PR TITLE
refactor(cli): rename pkg/upgrade to pkg/selfupdate

### DIFF
--- a/cmd/self_update.go
+++ b/cmd/self_update.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/devsy-org/devsy/pkg/upgrade"
+	"github.com/devsy-org/devsy/pkg/selfupdate"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +22,7 @@ func NewSelfUpdateCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			ctx := cobraCmd.Context()
-			if err := upgrade.Upgrade(ctx, cmd.Version, cmd.DryRun); err != nil {
+			if err := selfupdate.Upgrade(ctx, cmd.Version, cmd.DryRun); err != nil {
 				return fmt.Errorf("unable to update: %w", err)
 			}
 			return nil

--- a/pkg/selfupdate/selfupdate.go
+++ b/pkg/selfupdate/selfupdate.go
@@ -1,4 +1,4 @@
-package upgrade
+package selfupdate
 
 import (
 	"context"


### PR DESCRIPTION
## Summary

Renames the internal Go package `pkg/upgrade` to `pkg/selfupdate` to free the `upgrade` namespace for the devcontainer spec's feature upgrade command (see https://containers.dev/implementors/reference/). The devcontainer spec reserves `upgrade` for feature version upgrades, so the binary self-update logic moves to `pkg/selfupdate` to avoid a name collision. No behavior change — the CLI command remains `self-update`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated self-update command implementation through code reorganization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->