### PR TITLE
fix(config): make shutdownAction defaults explicit in config resolution

### DIFF
--- a/e2e/tests/readconfiguration/readconfiguration.go
+++ b/e2e/tests/readconfiguration/readconfiguration.go
@@ -470,4 +470,46 @@ var _ = ginkgo.Describe("read-configuration command", ginkgo.Label("read-configu
 			})
 			framework.ExpectError(err)
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.DescribeTable("resolves shutdownAction per devcontainer spec",
+		ginkgo.Label("read-configuration"),
+		func(ctx context.Context, testdataDir, expected string) {
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+			tempDir, err := framework.CopyToTempDirWithoutChdir(testdataDir)
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
+
+			stdout, _, err := f.ExecCommandCapture(ctx, []string{
+				"read-configuration",
+				"--workspace-folder", tempDir,
+				"--include-merged-configuration",
+			})
+			framework.ExpectNoError(err)
+
+			var result map[string]any
+			err = json.Unmarshal([]byte(stdout), &result)
+			framework.ExpectNoError(err)
+
+			merged, ok := result["mergedConfiguration"].(map[string]any)
+			gomega.Expect(ok).To(gomega.BeTrue(), "mergedConfiguration should be an object")
+			gomega.Expect(merged).To(
+				gomega.HaveKeyWithValue("shutdownAction", expected),
+			)
+		},
+		ginkgo.Entry("defaults to stopContainer for image-based config",
+			"tests/readconfiguration/testdata-shutdown-action",
+			"stopContainer",
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
+		),
+		ginkgo.Entry("defaults to stopCompose for docker-compose config",
+			"tests/readconfiguration/testdata-shutdown-action-compose",
+			"stopCompose",
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
+		),
+		ginkgo.Entry("preserves explicit none",
+			"tests/readconfiguration/testdata-shutdown-action-explicit",
+			"none",
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
+		),
+	)
 })

--- a/e2e/tests/readconfiguration/testdata-shutdown-action-compose/.devcontainer.json
+++ b/e2e/tests/readconfiguration/testdata-shutdown-action-compose/.devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app"
+}

--- a/e2e/tests/readconfiguration/testdata-shutdown-action-compose/docker-compose.yml
+++ b/e2e/tests/readconfiguration/testdata-shutdown-action-compose/docker-compose.yml
@@ -1,0 +1,4 @@
+version: "3"
+services:
+  app:
+    image: ghcr.io/devsy-org/test-images/base:ubuntu

--- a/e2e/tests/readconfiguration/testdata-shutdown-action-explicit/.devcontainer.json
+++ b/e2e/tests/readconfiguration/testdata-shutdown-action-explicit/.devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu",
+  "shutdownAction": "none"
+}

--- a/e2e/tests/readconfiguration/testdata-shutdown-action/.devcontainer.json
+++ b/e2e/tests/readconfiguration/testdata-shutdown-action/.devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu"
+}

--- a/pkg/devcontainer/config/merge.go
+++ b/pkg/devcontainer/config/merge.go
@@ -140,6 +140,17 @@ func MergeConfiguration(
 	)
 	mergedConfig.HostRequirements = mergeHostRequirements(reversed)
 
+	if mergedConfig.ShutdownAction == "" {
+		switch {
+		case copiedConfig.ShutdownAction != "":
+			mergedConfig.ShutdownAction = copiedConfig.ShutdownAction
+		case len(copiedConfig.DockerComposeFile) > 0:
+			mergedConfig.ShutdownAction = ShutdownActionStopCompose
+		default:
+			mergedConfig.ShutdownAction = ShutdownActionStopContainer
+		}
+	}
+
 	return mergedConfig, nil
 }
 

--- a/pkg/devcontainer/config/merge_test.go
+++ b/pkg/devcontainer/config/merge_test.go
@@ -516,3 +516,51 @@ func TestMergeLifestyleHooks_MultipleFeatures(t *testing.T) {
 		t.Errorf("expected image hook last, got %v", got[2])
 	}
 }
+
+func TestMergeConfiguration_ShutdownActionDefault_ImageConfig(t *testing.T) {
+	cfg := &DevContainerConfig{
+		ImageContainer: ImageContainer{Image: "ubuntu:latest"},
+	}
+	merged, err := MergeConfiguration(cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if merged.ShutdownAction != ShutdownActionStopContainer {
+		t.Errorf("ShutdownAction = %q, want %q", merged.ShutdownAction, ShutdownActionStopContainer)
+	}
+}
+
+func TestMergeConfiguration_ShutdownActionDefault_ComposeConfig(t *testing.T) {
+	cfg := &DevContainerConfig{
+		ComposeContainer: ComposeContainer{
+			DockerComposeFile: []string{"docker-compose.yml"},
+			Service:           "app",
+		},
+	}
+	merged, err := MergeConfiguration(cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if merged.ShutdownAction != ShutdownActionStopCompose {
+		t.Errorf("ShutdownAction = %q, want %q", merged.ShutdownAction, ShutdownActionStopCompose)
+	}
+}
+
+func TestMergeConfiguration_ShutdownActionExplicit_NotOverridden(t *testing.T) {
+	cfg := &DevContainerConfig{
+		DevContainerConfigBase: DevContainerConfigBase{
+			ShutdownAction: ShutdownActionNone,
+		},
+		ComposeContainer: ComposeContainer{
+			DockerComposeFile: []string{"docker-compose.yml"},
+			Service:           "app",
+		},
+	}
+	merged, err := MergeConfiguration(cfg, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if merged.ShutdownAction != ShutdownActionNone {
+		t.Errorf("ShutdownAction = %q, want %q", merged.ShutdownAction, ShutdownActionNone)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds explicit spec-compliant default assignment for `shutdownAction` in `MergeConfiguration`: `"stopCompose"` for Docker Compose-based configs, `"stopContainer"` for image/Dockerfile-based configs
- Preserves explicit config-level `shutdownAction` values that were previously lost when image metadata provided no override
- Adds unit tests verifying all three cases: image default, compose default, and explicit value preservation
- Adds e2e tests (via `read-configuration --include-merged-configuration`) validating defaults and explicit preservation

## Spec Reference

Per the [devcontainer JSON reference](https://containers.dev/implementors/json_reference/):

> **shutdownAction**: Action to take when the user disconnects from the container in their editor. The default is `"stopContainer"` for non-Docker Compose configurations and `"stopCompose"` for Docker Compose configurations.

Valid values: `"none"`, `"stopContainer"`, `"stopCompose"`

The implementation in `merge.go:143-152` matches this spec exactly:
1. If an explicit `shutdownAction` is set in the devcontainer config, it is preserved
2. If no explicit value is set and `dockerComposeFile` is configured, defaults to `"stopCompose"`
3. Otherwise defaults to `"stopContainer"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent default shutdown behavior based on container configuration type. Image-based containers default to stopping the container directly, while Docker Compose configurations default to stopping the entire compose stack. Explicit shutdown action settings are always respected.

* **Tests**
  * Added comprehensive unit and end-to-end test coverage for shutdown action configuration defaults and explicit overrides.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/259)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->