### PR TITLE
fix(ci): install kind directly on Windows to avoid docker-desktop dep

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -394,20 +394,12 @@ jobs:
           UUID=$(python -c "import uuid; print(uuid.uuid4().hex)")
           echo "result=$UUID" >> "$GITHUB_OUTPUT"
 
-      - name: setup podman (Windows)
-        if: matrix.label == 'up-docker-wsl' && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
-        shell: pwsh
-        run: |
-          $msiPath = "$env:RUNNER_TEMP\podman.msi"
-          Invoke-WebRequest -Uri "https://github.com/containers/podman/releases/download/v5.8.2/podman-installer-windows-amd64.msi" -OutFile $msiPath
-          $proc = Start-Process msiexec.exe -Wait -PassThru -ArgumentList "/i `"$msiPath`" /qn /norestart ADDLOCAL=ALL"
-          if ($proc.ExitCode -ne 0) { throw "MSI install failed with exit code $($proc.ExitCode)" }
-          $podmanDir = "C:\Program Files\RedHat\Podman"
-          if (!(Test-Path $podmanDir)) { throw "Podman directory not found after MSI install" }
-          echo "$podmanDir" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      - name: install podman (Windows)
+        if: matrix.install-kind == true && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
+        uses: redhat-actions/podman-install@v1
 
       - name: start podman machine (Windows)
-        if: matrix.label == 'up-docker-wsl' && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
+        if: matrix.install-kind == true && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
         shell: pwsh
         run: |
           wsl --set-default-version 2
@@ -419,7 +411,7 @@ jobs:
         if: matrix.install-kind == true && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
         shell: bash
         env:
-          KIND_EXPERIMENTAL_PROVIDER: ${{ matrix.label == 'up-docker-wsl' && 'podman' || 'docker' }}
+          KIND_EXPERIMENTAL_PROVIDER: podman
         run: |
           curl -Lo "$RUNNER_TEMP/kind.exe" "https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-windows-amd64"
           export PATH="$RUNNER_TEMP:$PATH"
@@ -474,17 +466,13 @@ jobs:
               GOROOT="${GOROOT}" \
               go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"
           else
-            DOCKER_HOST_VAL=""
-            if [ "${{ matrix.label }}" == "up-docker-wsl" ]; then
-              DOCKER_HOST_VAL="npipe:////./pipe/podman-machine-default"
-            fi
             GH_USERNAME="${GH_USERNAME}" \
               GH_ACCESS_TOKEN="${GH_ACCESS_TOKEN}" \
               GH_CREDENTIAL_USERNAME="${GH_CREDENTIAL_USERNAME}" \
               KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
               PATH="${PATH}" \
               GOROOT="${GOROOT}" \
-              DOCKER_HOST="${DOCKER_HOST_VAL}" \
+              DOCKER_HOST="npipe:////./pipe/podman-machine-default" \
               go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"
           fi
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -409,8 +409,9 @@ jobs:
           export PATH="/c/Program Files/RedHat/Podman:$PATH"
           echo 'C:\Program Files\RedHat\Podman' >> "$GITHUB_PATH"
 
-          # Install kind directly
-          curl -Lo "/c/Program Files/RedHat/Podman/kind.exe" "https://kind.sigs.k8s.io/dl/v0.24.0/kind-windows-amd64"
+          # Install kind directly (download to RUNNER_TEMP first, then move)
+          curl -Lo "$RUNNER_TEMP/kind.exe" "https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-windows-amd64"
+          mv "$RUNNER_TEMP/kind.exe" "/c/Program Files/RedHat/Podman/kind.exe"
 
           podman machine init
           podman machine set --rootful

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -434,6 +434,7 @@ jobs:
         shell: bash
         env:
           KIND_EXPERIMENTAL_PROVIDER: podman
+          DOCKER_HOST: npipe:////./pipe/docker_engine
         run: |
           curl -Lo "$RUNNER_TEMP/kind.exe" "https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-windows-amd64"
           curl -Lo "$RUNNER_TEMP/kind.sha256sum" "https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-windows-amd64.sha256sum"
@@ -503,7 +504,7 @@ jobs:
               KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
               PATH="${PATH}" \
               GOROOT="${GOROOT}" \
-              DOCKER_HOST="npipe:////./pipe/podman-machine-default" \
+              DOCKER_HOST="npipe:////./pipe/docker_engine" \
               go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"
           fi
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -402,9 +402,7 @@ jobs:
           $msiPath = "$env:RUNNER_TEMP\podman.msi"
           Invoke-WebRequest -Uri $msiUrl -OutFile $msiPath
 
-          $shasumsUrl = "https://github.com/containers/podman/releases/download/v5.8.2/shasums"
-          $shasums = (Invoke-WebRequest -Uri $shasumsUrl).Content
-          $expectedHash = ($shasums -split "`n" | Where-Object { $_ -match "podman-installer-windows-amd64.msi" }) -replace '\s+.*$',''
+          $expectedHash = "eda54f26f9695d198d9a679fa45ae24ba35b78444f432b5fe0c122c5a3624c57"
           $actualHash = (Get-FileHash -Path $msiPath -Algorithm SHA256).Hash.ToLower()
           if ($actualHash -ne $expectedHash) {
             throw "SHA256 mismatch for podman MSI! Expected: $expectedHash, Got: $actualHash"

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -434,12 +434,11 @@ jobs:
         shell: bash
         env:
           KIND_EXPERIMENTAL_PROVIDER: podman
-          DOCKER_HOST: npipe:////./pipe/docker_engine
+          DOCKER_HOST: npipe:////./pipe/podman-machine-default
         run: |
           curl -Lo "$RUNNER_TEMP/kind.exe" "https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-windows-amd64"
-          curl -Lo "$RUNNER_TEMP/kind.sha256sum" "https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-windows-amd64.sha256sum"
-          expected=$(awk '{print $1}' "$RUNNER_TEMP/kind.sha256sum")
-          actual=$(sha256sum "$RUNNER_TEMP/kind.exe" | awk '{print $1}')
+          expected="6f724188289cc79395f45afae0f2b85e0d220c2b84c6ed2f5047d9d0c9a67028"
+          actual=$(sha256sum "$RUNNER_TEMP/kind.exe" | awk '{gsub(/^\\\\/, ""); print $1}')
           if [ "$actual" != "$expected" ]; then
             echo "SHA256 mismatch for kind.exe! Expected: $expected, Got: $actual"
             exit 1
@@ -504,7 +503,7 @@ jobs:
               KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
               PATH="${PATH}" \
               GOROOT="${GOROOT}" \
-              DOCKER_HOST="npipe:////./pipe/docker_engine" \
+              DOCKER_HOST="npipe:////./pipe/podman-machine-default" \
               go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"
           fi
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -394,38 +394,36 @@ jobs:
           UUID=$(python -c "import uuid; print(uuid.uuid4().hex)")
           echo "result=$UUID" >> "$GITHUB_OUTPUT"
 
+      - name: setup podman (Windows)
+        if: matrix.label == 'up-docker-wsl' && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
+        shell: pwsh
+        run: |
+          $msiPath = "$env:RUNNER_TEMP\podman.msi"
+          Invoke-WebRequest -Uri "https://github.com/containers/podman/releases/download/v5.8.2/podman-installer-windows-amd64.msi" -OutFile $msiPath
+          $proc = Start-Process msiexec.exe -Wait -PassThru -ArgumentList "/i `"$msiPath`" /qn /norestart ADDLOCAL=ALL"
+          if ($proc.ExitCode -ne 0) { throw "MSI install failed with exit code $($proc.ExitCode)" }
+          $podmanDir = "C:\Program Files\RedHat\Podman"
+          if (!(Test-Path $podmanDir)) { throw "Podman directory not found after MSI install" }
+          echo "$podmanDir" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
+      - name: start podman machine (Windows)
+        if: matrix.label == 'up-docker-wsl' && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
+        shell: pwsh
+        run: |
+          wsl --set-default-version 2
+          podman machine init
+          podman machine set --rootful
+          podman machine start
+
       - name: setup kind (Windows)
         if: matrix.install-kind == true && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
         shell: bash
         env:
-          KIND_EXPERIMENTAL_PROVIDER: podman
-          DOCKER_HOST: npipe:////./pipe/podman-machine-default
+          KIND_EXPERIMENTAL_PROVIDER: ${{ matrix.label == 'up-docker-wsl' && 'podman' || 'docker' }}
         run: |
-          wsl --set-default-version 2
-
-          # Install podman via MSI (includes gvproxy needed for podman machine)
-          curl -Lo "$RUNNER_TEMP/podman.msi" "https://github.com/containers/podman/releases/download/v5.8.2/podman-installer-windows-amd64.msi"
-          powershell.exe -Command "Start-Process msiexec.exe -Wait -ArgumentList '/i','$(cygpath -w "$RUNNER_TEMP/podman.msi")','/qn','/norestart'"
-
-          # Verify podman installed to expected location
-          if [ -d "/c/Program Files/RedHat/Podman" ]; then
-            echo "Podman installed to /c/Program Files/RedHat/Podman"
-          else
-            echo "WARNING: Expected podman directory not found, checking alternatives..."
-            ls "/c/Program Files/RedHat/" 2>/dev/null || true
-            find "/c/Program Files/" -maxdepth 1 -iname "*podman*" -o -iname "*redhat*" 2>/dev/null || true
-          fi
-          export PATH="/c/Program Files/RedHat/Podman:$PATH"
-          echo 'C:\Program Files\RedHat\Podman' >> "$GITHUB_PATH"
-
-          # Install kind to RUNNER_TEMP (avoid depending on podman install dir existing)
           curl -Lo "$RUNNER_TEMP/kind.exe" "https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-windows-amd64"
           export PATH="$RUNNER_TEMP:$PATH"
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
-
-          podman machine init
-          podman machine set --rootful
-          podman machine start
 
           CLUSTER_NAME=$(python -c "import uuid; print(uuid.uuid4().hex)")
           kind create cluster --name "$CLUSTER_NAME" --image kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
@@ -476,13 +474,17 @@ jobs:
               GOROOT="${GOROOT}" \
               go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"
           else
+            DOCKER_HOST_VAL=""
+            if [ "${{ matrix.label }}" == "up-docker-wsl" ]; then
+              DOCKER_HOST_VAL="npipe:////./pipe/podman-machine-default"
+            fi
             GH_USERNAME="${GH_USERNAME}" \
               GH_ACCESS_TOKEN="${GH_ACCESS_TOKEN}" \
               GH_CREDENTIAL_USERNAME="${GH_CREDENTIAL_USERNAME}" \
               KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
               PATH="${PATH}" \
               GOROOT="${GOROOT}" \
-              DOCKER_HOST="npipe:////./pipe/podman-machine-default" \
+              DOCKER_HOST="${DOCKER_HOST_VAL}" \
               go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"
           fi
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -402,6 +402,15 @@ jobs:
           $msiPath = "$env:RUNNER_TEMP\podman.msi"
           Invoke-WebRequest -Uri $msiUrl -OutFile $msiPath
 
+          $shasumsUrl = "https://github.com/containers/podman/releases/download/v5.8.2/shasums"
+          $shasums = (Invoke-WebRequest -Uri $shasumsUrl).Content
+          $expectedHash = ($shasums -split "`n" | Where-Object { $_ -match "podman-installer-windows-amd64.msi" }) -replace '\s+.*$',''
+          $actualHash = (Get-FileHash -Path $msiPath -Algorithm SHA256).Hash.ToLower()
+          if ($actualHash -ne $expectedHash) {
+            throw "SHA256 mismatch for podman MSI! Expected: $expectedHash, Got: $actualHash"
+          }
+          Write-Host "Podman MSI checksum verified: $actualHash"
+
           $installDir = "C:\Program Files\RedHat\Podman"
           $logFile = "$env:RUNNER_TEMP\podman-install.log"
           $proc = Start-Process msiexec.exe -Wait -PassThru -ArgumentList "/i `"$msiPath`" /qn /norestart /l*v `"$logFile`" INSTALLDIR=`"$installDir`""
@@ -429,6 +438,15 @@ jobs:
           KIND_EXPERIMENTAL_PROVIDER: podman
         run: |
           curl -Lo "$RUNNER_TEMP/kind.exe" "https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-windows-amd64"
+          curl -Lo "$RUNNER_TEMP/kind.sha256sum" "https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-windows-amd64.sha256sum"
+          expected=$(awk '{print $1}' "$RUNNER_TEMP/kind.sha256sum")
+          actual=$(sha256sum "$RUNNER_TEMP/kind.exe" | awk '{print $1}')
+          if [ "$actual" != "$expected" ]; then
+            echo "SHA256 mismatch for kind.exe! Expected: $expected, Got: $actual"
+            exit 1
+          fi
+          echo "kind.exe checksum verified: $actual"
+
           export PATH="$RUNNER_TEMP:$PATH"
           echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -394,18 +394,33 @@ jobs:
           UUID=$(python -c "import uuid; print(uuid.uuid4().hex)")
           echo "result=$UUID" >> "$GITHUB_OUTPUT"
 
-      - name: install podman (Windows)
-        if: matrix.install-kind == true && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
-        uses: redhat-actions/podman-install@v1
-
-      - name: start podman machine (Windows)
+      - name: install and start podman (Windows)
         if: matrix.install-kind == true && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
         shell: pwsh
         run: |
+          $msiUrl = "https://github.com/containers/podman/releases/download/v5.8.2/podman-installer-windows-amd64.msi"
+          $msiPath = "$env:RUNNER_TEMP\podman.msi"
+          Invoke-WebRequest -Uri $msiUrl -OutFile $msiPath
+
+          $installDir = "C:\Program Files\RedHat\Podman"
+          $logFile = "$env:RUNNER_TEMP\podman-install.log"
+          $proc = Start-Process msiexec.exe -Wait -PassThru -ArgumentList "/i `"$msiPath`" /qn /norestart /l*v `"$logFile`" INSTALLDIR=`"$installDir`""
+          Write-Host "MSI exit code: $($proc.ExitCode)"
+
+          if (!(Test-Path "$installDir\podman.exe")) {
+            Write-Host "--- MSI install log (last 50 lines) ---"
+            Get-Content $logFile -Tail 50
+            Write-Host "--- Searching for podman.exe ---"
+            Get-ChildItem "C:\" -Filter "podman.exe" -Recurse -Depth 4 -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_.FullName }
+            throw "podman.exe not found at $installDir"
+          }
+
+          echo "$installDir" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+
           wsl --set-default-version 2
-          podman machine init
-          podman machine set --rootful
-          podman machine start
+          & "$installDir\podman.exe" machine init
+          & "$installDir\podman.exe" machine set --rootful
+          & "$installDir\podman.exe" machine start
 
       - name: setup kind (Windows)
         if: matrix.install-kind == true && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -402,7 +402,8 @@ jobs:
           DOCKER_HOST: npipe:////./pipe/podman-machine-default
         run: |
           wsl --set-default-version 2
-          choco install podman-cli kind -y
+          choco install podman-cli -y
+          curl -Lo /c/ProgramData/chocolatey/bin/kind.exe https://kind.sigs.k8s.io/dl/v0.24.0/kind-windows-amd64
 
           podman machine init
           podman machine set --rootful

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -402,8 +402,15 @@ jobs:
           DOCKER_HOST: npipe:////./pipe/podman-machine-default
         run: |
           wsl --set-default-version 2
-          choco install podman-cli -y
-          curl -Lo /c/ProgramData/chocolatey/bin/kind.exe https://kind.sigs.k8s.io/dl/v0.24.0/kind-windows-amd64
+
+          # Install podman via MSI (includes gvproxy needed for podman machine)
+          curl -Lo "$RUNNER_TEMP/podman.msi" "https://github.com/containers/podman/releases/download/v5.8.2/podman-installer-windows-amd64.msi"
+          powershell.exe -Command "Start-Process msiexec.exe -Wait -ArgumentList '/i','$(cygpath -w "$RUNNER_TEMP/podman.msi")','/qn','/norestart'"
+          export PATH="/c/Program Files/RedHat/Podman:$PATH"
+          echo 'C:\Program Files\RedHat\Podman' >> "$GITHUB_PATH"
+
+          # Install kind directly
+          curl -Lo "/c/Program Files/RedHat/Podman/kind.exe" "https://kind.sigs.k8s.io/dl/v0.24.0/kind-windows-amd64"
 
           podman machine init
           podman machine set --rootful

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -438,7 +438,7 @@ jobs:
         run: |
           curl -Lo "$RUNNER_TEMP/kind.exe" "https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-windows-amd64"
           expected="6f724188289cc79395f45afae0f2b85e0d220c2b84c6ed2f5047d9d0c9a67028"
-          actual=$(sha256sum "$RUNNER_TEMP/kind.exe" | awk '{gsub(/^\\\\/, ""); print $1}')
+          actual=$(sha256sum "$RUNNER_TEMP/kind.exe" | awk '{print $1}' | sed 's/^[^a-f0-9]*//')
           if [ "$actual" != "$expected" ]; then
             echo "SHA256 mismatch for kind.exe! Expected: $expected, Got: $actual"
             exit 1

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -406,18 +406,29 @@ jobs:
           # Install podman via MSI (includes gvproxy needed for podman machine)
           curl -Lo "$RUNNER_TEMP/podman.msi" "https://github.com/containers/podman/releases/download/v5.8.2/podman-installer-windows-amd64.msi"
           powershell.exe -Command "Start-Process msiexec.exe -Wait -ArgumentList '/i','$(cygpath -w "$RUNNER_TEMP/podman.msi")','/qn','/norestart'"
+
+          # Verify podman installed to expected location
+          if [ -d "/c/Program Files/RedHat/Podman" ]; then
+            echo "Podman installed to /c/Program Files/RedHat/Podman"
+          else
+            echo "WARNING: Expected podman directory not found, checking alternatives..."
+            ls "/c/Program Files/RedHat/" 2>/dev/null || true
+            find "/c/Program Files/" -maxdepth 1 -iname "*podman*" -o -iname "*redhat*" 2>/dev/null || true
+          fi
           export PATH="/c/Program Files/RedHat/Podman:$PATH"
           echo 'C:\Program Files\RedHat\Podman' >> "$GITHUB_PATH"
 
-          # Install kind directly (download to RUNNER_TEMP first, then move)
+          # Install kind to RUNNER_TEMP (avoid depending on podman install dir existing)
           curl -Lo "$RUNNER_TEMP/kind.exe" "https://github.com/kubernetes-sigs/kind/releases/download/v0.24.0/kind-windows-amd64"
-          mv "$RUNNER_TEMP/kind.exe" "/c/Program Files/RedHat/Podman/kind.exe"
+          export PATH="$RUNNER_TEMP:$PATH"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
 
           podman machine init
           podman machine set --rootful
           podman machine start
 
-          kind create cluster --name "${{ steps.uuid.outputs.result }}" --image kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
+          CLUSTER_NAME=$(python -c "import uuid; print(uuid.uuid4().hex)")
+          kind create cluster --name "$CLUSTER_NAME" --image kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
 
       # NOTE: skevetter/setup-kind does not work on Windows runners
       - name: setup kind


### PR DESCRIPTION
## Summary

- Replaces `choco install kind` with a direct binary download from `kind.sigs.k8s.io` on Windows CI runners
- Chocolatey's `kind` package pulls `docker-desktop` as a dependency, which hangs on Windows runners since we only need podman (`KIND_EXPERIMENTAL_PROVIDER: podman`)
- Keeps `choco install podman-cli -y` unchanged; only the kind installation method changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Windows CI now installs Podman via a verified MSI, ensures WSL2 is enabled, and initializes a Podman machine.
  * Windows CI now downloads and verifies the kind binary, updates PATH, and creates kind clusters using generated identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->