### PR TITLE
chore: pin Go version in renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,11 @@
       "prPriority": 3
     },
     {
+      "matchDatasources": ["golang-version"],
+      "enabled": false,
+      "description": "Pin Go toolchain version — do not auto-update or auto-merge"
+    },
+    {
       "matchManagers": ["npm"],
       "automerge": true,
       "prPriority": 2


### PR DESCRIPTION
## Summary
- Pins the Go toolchain version in renovate.json to prevent Renovate from automatically updating or auto-merging Go version changes
- Adds a `packageRules` entry with `matchDatasources: ["golang-version"]` and `enabled: false`