### PR TITLE
fix(inject): chmod binary before mv to prevent entrypoint race on Alpine

### DIFF
--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -142,12 +142,19 @@ func Inject(opts InjectOptions) (bool, error) {
 	}
 	log.Debugf("injection: payload delivered elapsed=%s", time.Since(start))
 
-	// prefer result error
 	if result.err != nil {
 		return result.wasExecuted, result.err
-	} else if err != nil && result.wasExecuted {
+	}
+
+	// Exec EOF during binary injection is expected: the container entrypoint
+	// may exec the daemon (killing the docker exec process) before inject.sh
+	// prints its final response. Only surface exec errors when a command was
+	// actually executed through the script.
+	if err != nil && result.wasExecuted {
 		return result.wasExecuted, err
-	} else if result.wasExecuted || opts.ScriptParams.Command == "" {
+	}
+
+	if result.wasExecuted || opts.ScriptParams.Command == "" {
 		return result.wasExecuted, nil
 	}
 

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -145,7 +145,7 @@ func Inject(opts InjectOptions) (bool, error) {
 	// prefer result error
 	if result.err != nil {
 		return result.wasExecuted, result.err
-	} else if err != nil {
+	} else if err != nil && result.wasExecuted {
 		return result.wasExecuted, err
 	} else if result.wasExecuted || opts.ScriptParams.Command == "" {
 		return result.wasExecuted, nil

--- a/pkg/inject/inject.sh
+++ b/pkg/inject/inject.sh
@@ -47,6 +47,14 @@ inject_binary() {
         return 1
     fi
 
+    if [ "$CHMOD_PATH" = "true" ]; then
+        $sh_c "chmod +x \"$temp_file\"" || {
+            >&2 echo "Error: Failed to make $temp_file executable"
+            $sh_c "rm -f \"$temp_file\"" 2>/dev/null || true
+            return 1
+        }
+    fi
+
     if ! $sh_c "mv \"$temp_file\" \"$INSTALL_PATH\""; then
         >&2 echo "Error: Failed to move binary to $INSTALL_PATH"
         $sh_c "rm -f \"$temp_file\"" 2>/dev/null || true
@@ -95,6 +103,14 @@ download_binary() {
     if [ "$iteration" -gt "$max_iteration" ]; then
         >&2 echo "Error: Failed to download devsy after $max_iteration attempts"
         return 1
+    fi
+
+    if [ "$CHMOD_PATH" = "true" ]; then
+        $sh_c "chmod +x \"$temp_file\"" || {
+            >&2 echo "Error: Failed to make $temp_file executable"
+            $sh_c "rm -f \"$temp_file\"" 2>/dev/null || true
+            return 1
+        }
     fi
 
     if ! $sh_c "mv \"$temp_file\" \"$INSTALL_PATH\""; then
@@ -146,13 +162,6 @@ install_agent() {
                 exit 1
             }
         fi
-    fi
-
-    if [ "$CHMOD_PATH" = "true" ]; then
-        $sh_c "chmod +x \"$INSTALL_PATH\"" || {
-            >&2 echo "Error: Failed to make $INSTALL_PATH executable"
-            exit 1
-        }
     fi
 }
 


### PR DESCRIPTION
## Summary

- Fixes flaky e2e test `should handle dependsOn with options` caused by a race condition between the inject script and container entrypoint on Alpine/BusyBox
- BusyBox `command -v` returns true for non-executable files, creating a window between `mv` and `chmod +x` where the entrypoint detects the binary, tries to exec it, fails (not executable), and crashes the container (PID 1 dies → docker exec EOF)
- Fix: chmod +x the temp file BEFORE mv'ing to final path in `pkg/inject/inject.sh`, making the binary atomically executable when it appears. Also adds defense-in-depth EOF handling in `pkg/inject/inject.go` to not propagate expected exec EOF during binary injection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined error handling in injection workflows to better distinguish between execution errors and injection failures, enabling more appropriate recovery and retry logic in specific scenarios
  * Enhanced file permission management during binary operations with improved error detection and cleanup handling

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/264)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->