### PR TITLE
ci: pre-install gnupg2 in e2e test setup steps

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -354,6 +354,10 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: install gnupg2
+        if: runner.os == 'Linux' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
+        run: sudo apt-get install -y gnupg2
+
       - name: get operating system lowercase
         if: matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true'
         id: os


### PR DESCRIPTION
## Summary

- Adds an explicit `gnupg2` installation step to the integration-tests job in `pr-ci.yml`, running before test execution on Linux runners
- Eliminates the runtime `sudo apt-get install gnupg2 -y` fallback in `e2e/framework/command.go:352`, reducing unexpected sudo calls during test runs
- gnupg2 is already available on ubuntu-latest runners, so this makes the dependency explicit rather than relying on the framework fallback