### PR TITLE
ci: split test matrix into privileged and non-privileged groups

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -129,9 +129,6 @@ jobs:
           - label: context
             runner: ubuntu-latest
 
-          - label: ide
-            runner: ubuntu-latest
-
           - label: readconfiguration
             runner: ubuntu-latest
 
@@ -142,9 +139,6 @@ jobs:
             runner: ubuntu-latest
 
           - label: machine
-            runner: ubuntu-latest
-
-          - label: machineprovider
             runner: ubuntu-latest
 
     runs-on: ${{ matrix.runner }}
@@ -198,6 +192,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - label: ide
+            runner: ubuntu-latest
+            free-disk-space: false
+            install-kind: false
+            requires-secret: false
+
+          - label: machineprovider
+            runner: ubuntu-latest
+            free-disk-space: false
+            install-kind: false
+            requires-secret: false
+
           - label: integration
             runner: ubuntu-latest
             free-disk-space: false

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -119,6 +119,78 @@ jobs:
           name: devsy-${{ steps.os.outputs.runner_os }}
           path: dist/devsy-${{ steps.os.outputs.runner_os }}_*/devsy-${{ steps.os.outputs.runner_os }}-*
 
+  integration-tests-unprivileged:
+    name: Test ${{ matrix.label }} on ${{ matrix.runner }}
+    needs: [build-cli]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: context
+            runner: ubuntu-latest
+
+          - label: ide
+            runner: ubuntu-latest
+
+          - label: readconfiguration
+            runner: ubuntu-latest
+
+          - label: extends
+            runner: ubuntu-latest
+
+          - label: outdated
+            runner: ubuntu-latest
+
+          - label: machine
+            runner: ubuntu-latest
+
+          - label: machineprovider
+            runner: ubuntu-latest
+
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: get operating system lowercase
+        id: os
+        shell: bash
+        run: |
+          OS=$(echo "${{ runner.os }}" | tr '[:upper:]' '[:lower:]')
+          echo "runner_os=$OS" >> "$GITHUB_OUTPUT"
+
+      - name: download CLI artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: devsy-${{ steps.os.outputs.runner_os }}
+          path: ${{ runner.temp }}/devsy-bin/
+          merge-multiple: true
+
+      - name: setup executable
+        shell: bash
+        working-directory: ./e2e
+        run: |
+          TEMP_DIR="${{ runner.temp }}"
+          ls -R "$TEMP_DIR/devsy-bin/"
+          mkdir -p ./bin/
+          find "$TEMP_DIR/devsy-bin/" -type f -name "devsy-*" -exec cp {} ./bin \;
+          find ./bin -name "devsy-*" -exec chmod +x {} \;
+          ls -R ./bin/
+
+      - name: run test
+        shell: bash
+        working-directory: ./e2e
+        env:
+          GH_USERNAME: ${{ github.repository_owner }}
+          GH_ACCESS_TOKEN: ${{ github.token }}
+          GH_CREDENTIAL_USERNAME: x-access-token
+        run: |
+          go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"
+
   integration-tests:
     name: Test ${{ matrix.label }} on ${{ matrix.runner }}
     needs: [can-read-secret, build-cli]
@@ -126,31 +198,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: context
-            runner: ubuntu-latest
-            free-disk-space: false
-            install-kind: false
-            requires-secret: false
-
-          - label: ide
-            runner: ubuntu-latest
-            free-disk-space: false
-            install-kind: false
-            requires-secret: false
-
           - label: integration
-            runner: ubuntu-latest
-            free-disk-space: false
-            install-kind: false
-            requires-secret: false
-
-          - label: machine
-            runner: ubuntu-latest
-            free-disk-space: false
-            install-kind: false
-            requires-secret: false
-
-          - label: machineprovider
             runner: ubuntu-latest
             free-disk-space: false
             install-kind: false
@@ -186,25 +234,7 @@ jobs:
             install-kind: false
             requires-secret: false
 
-          - label: readconfiguration
-            runner: ubuntu-latest
-            free-disk-space: false
-            install-kind: false
-            requires-secret: false
-
-          - label: extends
-            runner: ubuntu-latest
-            free-disk-space: false
-            install-kind: false
-            requires-secret: false
-
           - label: extends-up
-            runner: ubuntu-latest
-            free-disk-space: false
-            install-kind: false
-            requires-secret: false
-
-          - label: outdated
             runner: ubuntu-latest
             free-disk-space: false
             install-kind: false


### PR DESCRIPTION
## Summary

- Splits the CI integration-tests matrix into two jobs: `integration-tests-unprivileged` (no sudo) and `integration-tests` (keeps sudo for Docker-dependent tests)
- Non-privileged tests (context, ide, readconfiguration, extends, outdated, machine, machineprovider) now run as the runner user without root, reducing the sudo surface by ~25% of Linux test entries
- Job name pattern (`Test <label> on <runner>`) is preserved for branch protection compatibility
- Based on DEVSY-105 investigation that found ~60% of test labels have zero Docker dependency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal test infrastructure configuration to streamline end-to-end test execution across different test categories.

---

**Note:** This release contains no user-facing changes or feature updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/272)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->