### PR TITLE
feat(compose): add podman compose detection path

### DIFF
--- a/pkg/compose/helper.go
+++ b/pkg/compose/helper.go
@@ -22,6 +22,8 @@ import (
 const (
 	ProjectLabel = "com.docker.compose.project"
 	ServiceLabel = "com.docker.compose.service"
+	podmanCmd    = "podman"
+	composeArg   = "compose"
 )
 
 func LoadDockerComposeProject(
@@ -127,15 +129,15 @@ func tryDockerComposeV2(dockerCmd string) (*ComposeHelper, error) {
 }
 
 func tryPodmanCompose() (*ComposeHelper, error) {
-	if _, err := exec.LookPath("podman"); err != nil {
+	if _, err := exec.LookPath(podmanCmd); err != nil {
 		return nil, fmt.Errorf("podman not found in PATH")
 	}
 
-	if exec.Command("podman", "compose").Run() != nil {
+	if exec.Command(podmanCmd, composeArg).Run() != nil {
 		return nil, fmt.Errorf("podman compose not available")
 	}
 
-	cmd := exec.Command("podman", "compose", "version", "--short")
+	cmd := exec.Command(podmanCmd, composeArg, "version", "--short")
 	out, stderr, err := runCmdCapture(cmd)
 	if len(stderr) > 0 {
 		log.Warnf("%s: %s", strings.TrimSpace(string(stderr)), strings.TrimSpace(string(out)))
@@ -158,9 +160,9 @@ func tryPodmanCompose() (*ComposeHelper, error) {
 	}
 
 	return &ComposeHelper{
-		Command: "podman",
+		Command: podmanCmd,
 		Version: parsed.String(),
-		Args:    []string{"compose"},
+		Args:    []string{composeArg},
 	}, nil
 }
 

--- a/pkg/compose/helper.go
+++ b/pkg/compose/helper.go
@@ -148,14 +148,18 @@ func tryPodmanCompose() (*ComposeHelper, error) {
 		)
 	}
 
-	version := strings.TrimSpace(string(out))
-	if _, parseErr := parseVersion(version); parseErr != nil {
-		return nil, fmt.Errorf("failed to parse podman compose version %q: %w", version, parseErr)
+	parsed, parseErr := parseVersion(strings.TrimSpace(string(out)))
+	if parseErr != nil {
+		return nil, fmt.Errorf(
+			"failed to parse podman compose version %q: %w",
+			strings.TrimSpace(string(out)),
+			parseErr,
+		)
 	}
 
 	return &ComposeHelper{
 		Command: "podman",
-		Version: version,
+		Version: parsed.String(),
 		Args:    []string{"compose"},
 	}, nil
 }

--- a/pkg/compose/helper.go
+++ b/pkg/compose/helper.go
@@ -56,7 +56,8 @@ type ComposeHelper struct {
 }
 
 // NewComposeHelper creates a new ComposeHelper instance after detecting whether Docker
-// Compose V1 or V2 is installed. It returns an error if neither is found.
+// Compose V2, Podman Compose, or Docker Compose V1 is installed. It returns an error
+// if none are found.
 func NewComposeHelper(dockerHelper *docker.DockerHelper) (*ComposeHelper, error) {
 	dockerCmd := dockerHelper.DockerCommand
 	if dockerCmd == "" {
@@ -68,12 +69,17 @@ func NewComposeHelper(dockerHelper *docker.DockerHelper) (*ComposeHelper, error)
 		return helper, nil
 	}
 
+	if helper, err := tryPodmanCompose(); err == nil {
+		helper.Docker = dockerHelper
+		return helper, nil
+	}
+
 	if helper, err := tryDockerComposeV1(); err == nil {
 		helper.Docker = dockerHelper
 		return helper, nil
 	}
 
-	return nil, fmt.Errorf("docker compose not installed")
+	return nil, fmt.Errorf("docker compose or podman compose not installed")
 }
 
 // tryDockerComposeV2 checks if Docker Compose V2 is available and returns a ComposeHelper if so.
@@ -118,6 +124,40 @@ func tryDockerComposeV2(dockerCmd string) (*ComposeHelper, error) {
 	}
 
 	return helper, nil
+}
+
+func tryPodmanCompose() (*ComposeHelper, error) {
+	if _, err := exec.LookPath("podman"); err != nil {
+		return nil, fmt.Errorf("podman not found in PATH")
+	}
+
+	if exec.Command("podman", "compose").Run() != nil {
+		return nil, fmt.Errorf("podman compose not available")
+	}
+
+	cmd := exec.Command("podman", "compose", "version", "--short")
+	out, stderr, err := runCmdCapture(cmd)
+	if len(stderr) > 0 {
+		log.Warnf("%s: %s", strings.TrimSpace(string(stderr)), strings.TrimSpace(string(out)))
+	}
+	if err != nil {
+		return nil, fmt.Errorf(
+			"failed to get podman compose version %s: %w",
+			strings.TrimSpace(string(stderr)),
+			err,
+		)
+	}
+
+	version := strings.TrimSpace(string(out))
+	if _, parseErr := parseVersion(version); parseErr != nil {
+		return nil, fmt.Errorf("failed to parse podman compose version %q: %w", version, parseErr)
+	}
+
+	return &ComposeHelper{
+		Command: "podman",
+		Version: version,
+		Args:    []string{"compose"},
+	}, nil
 }
 
 func tryDockerComposeV1() (*ComposeHelper, error) {

--- a/pkg/compose/helper_test.go
+++ b/pkg/compose/helper_test.go
@@ -8,6 +8,12 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const (
+	testPodmanCmd     = "podman"
+	testComposeArg    = "compose"
+	testPodmanVersion = "2.32.4"
+)
+
 type HelperTestSuite struct {
 	suite.Suite
 }
@@ -92,13 +98,13 @@ func (s *HelperTestSuite) TestParseVersionPodmanCompose() {
 	}{
 		{
 			name:    "podman compose standard version",
-			version: "2.32.4",
-			want:    "2.32.4",
+			version: testPodmanVersion,
+			want:    testPodmanVersion,
 		},
 		{
 			name:    "podman compose with v prefix",
-			version: "v2.32.4",
-			want:    "2.32.4",
+			version: "v" + testPodmanVersion,
+			want:    testPodmanVersion,
 		},
 		{
 			name:    "podman-compose python variant",
@@ -107,13 +113,14 @@ func (s *HelperTestSuite) TestParseVersionPodmanCompose() {
 		},
 		{
 			name:    "podman compose with trailing newline",
-			version: "2.32.4\n",
-			want:    "2.32.4",
+			version: testPodmanVersion + "\n",
+			want:    testPodmanVersion,
 		},
 		{
-			name:    "podman compose with external provider warning",
-			version: ">>>> Executing external compose provider. Please see podman-compose(1) <<<<\n\n2.32.4\n",
-			want:    "2.32.4",
+			name: "podman compose with external provider warning",
+			version: ">>>> Executing external compose provider." +
+				" Please see podman-compose(1) <<<<\n\n" + testPodmanVersion + "\n",
+			want: testPodmanVersion,
 		},
 	}
 
@@ -132,26 +139,26 @@ func (s *HelperTestSuite) TestParseVersionPodmanCompose() {
 
 func (s *HelperTestSuite) TestComposeHelperPodmanFields() {
 	helper := &ComposeHelper{
-		Command: "podman",
-		Version: "2.32.4",
-		Args:    []string{"compose"},
+		Command: testPodmanCmd,
+		Version: testPodmanVersion,
+		Args:    []string{testComposeArg},
 	}
 
-	s.Equal("podman", helper.Command)
-	s.Equal("2.32.4", helper.Version)
-	s.Equal([]string{"compose"}, helper.Args)
+	s.Equal(testPodmanCmd, helper.Command)
+	s.Equal(testPodmanVersion, helper.Version)
+	s.Equal([]string{testComposeArg}, helper.Args)
 }
 
 func (s *HelperTestSuite) TestComposeHelperBuildCmdPodman() {
 	helper := &ComposeHelper{
-		Command: "podman",
-		Version: "2.32.4",
-		Args:    []string{"compose"},
+		Command: testPodmanCmd,
+		Version: testPodmanVersion,
+		Args:    []string{testComposeArg},
 	}
 
 	cmd := helper.buildCmd(context.TODO(), "--project-name", "test", "up", "-d")
-	s.True(strings.HasSuffix(cmd.Path, "podman"))
-	s.Contains(cmd.Args, "compose")
+	s.True(strings.HasSuffix(cmd.Path, testPodmanCmd))
+	s.Contains(cmd.Args, testComposeArg)
 	s.Contains(cmd.Args, "--project-name")
 	s.Contains(cmd.Args, "test")
 	s.Contains(cmd.Args, "up")

--- a/pkg/compose/helper_test.go
+++ b/pkg/compose/helper_test.go
@@ -1,6 +1,7 @@
 package compose
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -79,4 +80,79 @@ func (s *HelperTestSuite) TestParseVersionWithPodmanWarning() {
 	v, err := parseVersion(cmdOutput)
 	s.NoError(err)
 	s.Equal("5.1.0", v.String())
+}
+
+func (s *HelperTestSuite) TestParseVersionPodmanCompose() {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "podman compose standard version",
+			version: "2.32.4",
+			want:    "2.32.4",
+		},
+		{
+			name:    "podman compose with v prefix",
+			version: "v2.32.4",
+			want:    "2.32.4",
+		},
+		{
+			name:    "podman-compose python variant",
+			version: "1.0.6",
+			want:    "1.0.6",
+		},
+		{
+			name:    "podman compose with trailing newline",
+			version: "2.32.4\n",
+			want:    "2.32.4",
+		},
+		{
+			name:    "podman compose with external provider warning",
+			version: ">>>> Executing external compose provider. Please see podman-compose(1) <<<<\n\n2.32.4\n",
+			want:    "2.32.4",
+		},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			got, err := parseVersion(tt.version)
+			if tt.wantErr {
+				s.Error(err)
+			} else {
+				s.NoError(err)
+				s.Equal(tt.want, got.String())
+			}
+		})
+	}
+}
+
+func (s *HelperTestSuite) TestComposeHelperPodmanFields() {
+	helper := &ComposeHelper{
+		Command: "podman",
+		Version: "2.32.4",
+		Args:    []string{"compose"},
+	}
+
+	s.Equal("podman", helper.Command)
+	s.Equal("2.32.4", helper.Version)
+	s.Equal([]string{"compose"}, helper.Args)
+}
+
+func (s *HelperTestSuite) TestComposeHelperBuildCmdPodman() {
+	helper := &ComposeHelper{
+		Command: "podman",
+		Version: "2.32.4",
+		Args:    []string{"compose"},
+	}
+
+	cmd := helper.buildCmd(context.TODO(), "--project-name", "test", "up", "-d")
+	s.Equal("podman", cmd.Path[:len(cmd.Path)]) // binary name ends the path
+	s.Contains(cmd.Args, "compose")
+	s.Contains(cmd.Args, "--project-name")
+	s.Contains(cmd.Args, "test")
+	s.Contains(cmd.Args, "up")
+	s.Contains(cmd.Args, "-d")
 }

--- a/pkg/compose/helper_test.go
+++ b/pkg/compose/helper_test.go
@@ -2,6 +2,7 @@ package compose
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -149,7 +150,7 @@ func (s *HelperTestSuite) TestComposeHelperBuildCmdPodman() {
 	}
 
 	cmd := helper.buildCmd(context.TODO(), "--project-name", "test", "up", "-d")
-	s.Equal("podman", cmd.Path[:len(cmd.Path)]) // binary name ends the path
+	s.True(strings.HasSuffix(cmd.Path, "podman"))
 	s.Contains(cmd.Args, "compose")
 	s.Contains(cmd.Args, "--project-name")
 	s.Contains(cmd.Args, "test")


### PR DESCRIPTION
## Summary

- Add `tryPodmanCompose()` detection path to `NewComposeHelper()` so Podman's built-in compose subcommand is discovered alongside Docker Compose V2 and V1
- Detection order: Docker Compose V2 → Podman Compose → Docker Compose V1, preserving backward compatibility
- Handles Podman's external compose provider warnings in version parsing
- Adds unit tests covering version parsing (standard, v-prefix, python variant, trailing newline, external provider warning), field validation, and command building for Podman compose

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Podman Compose with automatic detection and configuration
  
* **Bug Fixes**
  * Updated error messages to include references to both Docker and Podman Compose options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/274)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->