### PR TITLE
fix(delivery): support rootless Podman in volume direct copy

### DIFF
--- a/pkg/agent/delivery/local_docker.go
+++ b/pkg/agent/delivery/local_docker.go
@@ -177,8 +177,7 @@ func (d *LocalDockerDelivery) populateVolumeViaUnshare(
 	destPath string,
 	data []byte,
 ) error {
-	script := fmt.Sprintf("cat > %s && chmod 755 %s", destPath, destPath)
-	cmd := d.cmd(ctx, "unshare", "sh", "-c", script)
+	cmd := d.cmd(ctx, "unshare", "sh", "-c", `cat > "$1" && chmod 755 "$1"`, "--", destPath)
 	cmd.Stdin = bytes.NewReader(data)
 
 	out, err := cmd.CombinedOutput()

--- a/pkg/agent/delivery/local_docker.go
+++ b/pkg/agent/delivery/local_docker.go
@@ -19,6 +19,7 @@ var _ AgentDelivery = (*LocalDockerDelivery)(nil)
 
 const (
 	defaultDockerCmd   = "docker"
+	podmanCmd          = "podman"
 	volumePrefix       = "devsy-agent-"
 	volumeMountPath    = "/opt/devsy"
 	defaultHelperImage = "busybox:latest"
@@ -156,6 +157,10 @@ func (d *LocalDockerDelivery) populateVolumeDirectCopy(
 
 	destPath := filepath.Join(mountpoint, binaryName())
 
+	if d.isPodman() {
+		return d.populateVolumeViaUnshare(ctx, destPath, data)
+	}
+
 	if err := os.WriteFile(destPath, data, 0o600); err != nil {
 		return fmt.Errorf("write binary to volume: %w", err)
 	}
@@ -165,6 +170,26 @@ func (d *LocalDockerDelivery) populateVolumeDirectCopy(
 	}
 
 	return nil
+}
+
+func (d *LocalDockerDelivery) populateVolumeViaUnshare(
+	ctx context.Context,
+	destPath string,
+	data []byte,
+) error {
+	script := fmt.Sprintf("cat > %s && chmod 755 %s", destPath, destPath)
+	cmd := d.cmd(ctx, "unshare", "sh", "-c", script)
+	cmd.Stdin = bytes.NewReader(data)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("podman unshare write failed: %s: %w", string(out), err)
+	}
+	return nil
+}
+
+func (d *LocalDockerDelivery) isPodman() bool {
+	return filepath.Base(d.dockerCommand()) == podmanCmd
 }
 
 func (d *LocalDockerDelivery) volumeMountpoint(

--- a/pkg/agent/delivery/local_docker_test.go
+++ b/pkg/agent/delivery/local_docker_test.go
@@ -124,3 +124,101 @@ func TestPopulateVolume_FallbackToDirectCopy(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
 }
+
+func TestIsPodman(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{"default docker", "", false},
+		{"explicit docker", "docker", false},
+		{"explicit podman", podmanCmd, true},
+		{"full path podman", "/usr/bin/podman", true},
+		{"full path docker", "/usr/bin/docker", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &LocalDockerDelivery{DockerCommand: tt.cmd}
+			assert.Equal(t, tt.want, d.isPodman())
+		})
+	}
+}
+
+func TestPopulateVolumeDirectCopy_PodmanUsesUnshare(t *testing.T) {
+	tmpDir := t.TempDir()
+	mountDir := filepath.Join(tmpDir, "mount")
+	require.NoError(t, os.MkdirAll(mountDir, 0o750))
+
+	destPath := filepath.Join(mountDir, binaryName())
+	binaryContent := []byte("fake-agent-binary-content")
+
+	scriptPath := filepath.Join(tmpDir, "podman")
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"  unshare) shift; exec \"$@\" ;;\n" +
+		"  volume) echo \"" + mountDir + "\" ;;\n" +
+		"  *) exit 1 ;;\n" +
+		"esac\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+	// #nosec G302 -- test script must be executable
+	require.NoError(t, os.Chmod(scriptPath, 0o755))
+
+	d := &LocalDockerDelivery{DockerCommand: scriptPath}
+	err := d.populateVolumeDirectCopy(context.Background(), "test-vol", binaryContent)
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(destPath) //nolint:gosec // test reads from a temp directory we control
+	require.NoError(t, err)
+	assert.Equal(t, binaryContent, data)
+
+	info, err := os.Stat(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}
+
+func TestPopulateVolumeDirectCopy_DockerUsesDirectWrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	mountDir := filepath.Join(tmpDir, "mount")
+	require.NoError(t, os.MkdirAll(mountDir, 0o750))
+
+	binaryContent := []byte("fake-agent-binary-content")
+
+	scriptPath := filepath.Join(tmpDir, "fake-docker.sh")
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"  volume) echo \"" + mountDir + "\" ;;\n" +
+		"  *) exit 1 ;;\n" +
+		"esac\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+	// #nosec G302 -- test script must be executable
+	require.NoError(t, os.Chmod(scriptPath, 0o755))
+
+	d := &LocalDockerDelivery{DockerCommand: scriptPath}
+	err := d.populateVolumeDirectCopy(context.Background(), "test-vol", binaryContent)
+	require.NoError(t, err)
+
+	destPath := filepath.Join(mountDir, binaryName())
+	data, err := os.ReadFile(destPath) //nolint:gosec // test reads from a temp directory we control
+	require.NoError(t, err)
+	assert.Equal(t, binaryContent, data)
+
+	info, err := os.Stat(destPath)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o755), info.Mode().Perm())
+}
+
+func TestPopulateVolumeViaUnshare_FailureReturnsError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	scriptPath := filepath.Join(tmpDir, "podman")
+	script := "#!/bin/sh\necho 'unshare failed: permission denied' >&2; exit 1\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+	// #nosec G302 -- test script must be executable
+	require.NoError(t, os.Chmod(scriptPath, 0o755))
+
+	d := &LocalDockerDelivery{DockerCommand: scriptPath}
+	err := d.populateVolumeViaUnshare(context.Background(), "/fake/path/devsy", []byte("data"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "podman unshare write failed")
+}


### PR DESCRIPTION
## Summary

- Add `podman unshare` fallback in `populateVolumeDirectCopy` so the direct-copy path works with rootless Podman volumes whose mountpoints are inside a user namespace
- Detect Podman runtime via `filepath.Base(dockerCommand())` and route to `populateVolumeViaUnshare` which pipes binary data through `podman unshare sh -c 'cat > "$1" && chmod 755 "$1"' -- <path>`
- Docker direct-copy path is completely unchanged
- Uses positional argument passing (`$1`) to prevent shell injection from volume mountpoint paths