### PR TITLE
feat(provider): add built-in Podman provider

### DIFF
--- a/providers/podman/provider.yaml
+++ b/providers/podman/provider.yaml
@@ -1,0 +1,32 @@
+name: podman
+version: v0.0.1
+icon: https://devsy.sh/assets/podman.svg
+home: https://github.com/devsy-org/devsy
+description: |-
+  Devsy on Podman
+optionGroups:
+  - options:
+      - PODMAN_PATH
+      - PODMAN_HOST
+      - INACTIVITY_TIMEOUT
+    name: "Advanced Options"
+options:
+  INACTIVITY_TIMEOUT:
+    description: "If defined, will automatically stop the container after the inactivity period. Examples: 10m, 1h"
+  PODMAN_PATH:
+    description: The path where to find the podman binary.
+    default: podman
+  PODMAN_HOST:
+    global: true
+    description: The podman host to use.
+agent:
+  containerInactivityTimeout: ${INACTIVITY_TIMEOUT}
+  local: true
+  docker:
+    path: ${PODMAN_PATH}
+    install: false
+    env:
+      DOCKER_HOST: ${PODMAN_HOST}
+exec:
+  command: |-
+    "${DEVSY}" helper sh -c "${COMMAND}"

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -10,6 +10,9 @@ var DockerProvider string
 //go:embed kubernetes/provider.yaml
 var KubernetesProvider string
 
+//go:embed podman/provider.yaml
+var PodmanProvider string
+
 //go:embed pro/provider.yaml
 var ProProvider string
 
@@ -18,6 +21,7 @@ func GetBuiltInProviders() map[string]string {
 	return map[string]string{
 		"docker":     DockerProvider,
 		"kubernetes": KubernetesProvider,
+		"podman":     PodmanProvider,
 		"pro":        ProProvider,
 	}
 }


### PR DESCRIPTION
## Summary

- Add `providers/podman/provider.yaml` as a first-party Podman provider mirroring the Docker provider with Podman-specific defaults
- Uses `podman` as the default binary path, omits BuildKit builder option (not applicable to Podman)
- Maps `PODMAN_HOST` to `DOCKER_HOST` env var for Podman's Docker-compatible API socket
- Registered in `providers/providers.go` via `GetBuiltInProviders()`