### PR TITLE
ci: add Linux rootless and rootful Podman to e2e test matrix

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -533,8 +533,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y podman
-          sudo podman system service --time=0 unix:///run/podman/podman.sock &
-          timeout 10 bash -c 'until [ -S /run/podman/podman.sock ]; do sleep 0.5; done'
+          sudo systemctl enable --now podman.socket
+          timeout 30 bash -c 'until sudo podman info >/dev/null 2>&1; do sleep 1; done'
           echo "DOCKER_HOST=unix:///run/podman/podman.sock" >> "$GITHUB_ENV"
           sudo podman info
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -186,7 +186,7 @@ jobs:
           go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"
 
   integration-tests:
-    name: Test ${{ matrix.label }} on ${{ matrix.runner }}
+    name: Test ${{ matrix.label }}${{ matrix.install-podman && format(' ({0})', matrix.install-podman) || '' }} on ${{ matrix.runner }}
     needs: [can-read-secret, build-cli]
     strategy:
       fail-fast: false
@@ -534,7 +534,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y podman
           sudo podman system service --time=0 unix:///run/podman/podman.sock &
-          sleep 2
+          timeout 10 bash -c 'until [ -S /run/podman/podman.sock ]; do sleep 0.5; done'
           echo "DOCKER_HOST=unix:///run/podman/podman.sock" >> "$GITHUB_ENV"
           sudo podman info
 
@@ -570,6 +570,7 @@ jobs:
               GH_ACCESS_TOKEN="${GH_ACCESS_TOKEN}" \
               GH_CREDENTIAL_USERNAME="${GH_CREDENTIAL_USERNAME}" \
               KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
+              ${DOCKER_HOST:+DOCKER_HOST="${DOCKER_HOST}"} \
               PATH="${PATH}" \
               GOROOT="${GOROOT}" \
               go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -305,8 +305,16 @@ jobs:
           - label: up-provider-podman
             runner: ubuntu-latest
             free-disk-space: true
-            install-kind: true
+            install-kind: false
             requires-secret: false
+            install-podman: rootless
+
+          - label: up-provider-podman
+            runner: ubuntu-latest
+            free-disk-space: true
+            install-kind: false
+            requires-secret: false
+            install-podman: rootful
 
           - label: up-provider-docker
             runner: ubuntu-latest
@@ -512,6 +520,23 @@ jobs:
           version: v0.24.0
           image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
           skipClusterLogsExport: true
+
+      - name: Install Podman (Linux rootless)
+        if: matrix.install-podman == 'rootless' && runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+          podman info
+
+      - name: Install Podman (Linux rootful)
+        if: matrix.install-podman == 'rootful' && runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y podman
+          sudo podman system service --time=0 unix:///run/podman/podman.sock &
+          sleep 2
+          echo "DOCKER_HOST=unix:///run/podman/podman.sock" >> "$GITHUB_ENV"
+          sudo podman info
 
       - name: remove docker
         if: matrix.label == 'docker-install' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')


### PR DESCRIPTION
## Summary

- Add two Linux Podman entries to the e2e CI matrix: rootless and rootful modes
- Rootless: installs Podman via apt, runs as current user
- Rootful: installs Podman, starts root socket service, sets `DOCKER_HOST` and forwards it through `sudo` env passthrough
- Job name template includes Podman mode for distinct CI display names (e.g., "Test up-provider-podman (rootless) on ubuntu-latest")
- Uses socket poll instead of `sleep` for rootful service readiness

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to enhance testing capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/278)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->