### PR TITLE
ci: add Linux rootless and rootful Podman to e2e test matrix

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -308,6 +308,22 @@ jobs:
             install-kind: true
             requires-secret: false
 
+          - label: up-provider-podman
+            runner: ubuntu-latest
+            free-disk-space: false
+            install-kind: false
+            install-podman-linux: true
+            podman-rootless: true
+            requires-secret: false
+
+          - label: up-provider-podman
+            runner: ubuntu-latest
+            free-disk-space: false
+            install-kind: false
+            install-podman-linux: true
+            podman-rootless: false
+            requires-secret: false
+
           - label: up-provider-docker
             runner: ubuntu-latest
             free-disk-space: false
@@ -481,6 +497,22 @@ jobs:
           & "$installDir\podman.exe" machine set --rootful
           & "$installDir\podman.exe" machine start
 
+      - name: install and start podman (Linux rootless)
+        if: matrix.install-podman-linux == true && matrix.podman-rootless == true && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
+        run: |
+          sudo apt-get update && sudo apt-get install -y podman
+          systemctl --user start podman.socket
+          podman info
+          echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+
+      - name: install and start podman (Linux rootful)
+        if: matrix.install-podman-linux == true && matrix.podman-rootless == false && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
+        run: |
+          sudo apt-get update && sudo apt-get install -y podman
+          sudo systemctl start podman.socket
+          podman info
+          echo "DOCKER_HOST=unix:///run/podman/podman.sock" >> "$GITHUB_ENV"
+
       - name: setup kind (Windows)
         if: matrix.install-kind == true && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
         shell: bash
@@ -547,6 +579,7 @@ jobs:
               KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
               PATH="${PATH}" \
               GOROOT="${GOROOT}" \
+              ${DOCKER_HOST:+DOCKER_HOST="${DOCKER_HOST}"} \
               go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"
           else
             GH_USERNAME="${GH_USERNAME}" \

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -186,7 +186,7 @@ jobs:
           go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"
 
   integration-tests:
-    name: Test ${{ matrix.label }} on ${{ matrix.runner }}
+    name: Test ${{ matrix.label }}${{ matrix.variant && format(' ({0})', matrix.variant) || '' }} on ${{ matrix.runner }}
     needs: [can-read-secret, build-cli]
     strategy:
       fail-fast: false
@@ -309,6 +309,7 @@ jobs:
             requires-secret: false
 
           - label: up-provider-podman
+            variant: rootless
             runner: ubuntu-latest
             free-disk-space: false
             install-kind: false
@@ -317,6 +318,7 @@ jobs:
             requires-secret: false
 
           - label: up-provider-podman
+            variant: rootful
             runner: ubuntu-latest
             free-disk-space: false
             install-kind: false
@@ -502,7 +504,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y podman
           systemctl --user start podman.socket
-          podman info
+          timeout 10 bash -c "until [ -S /run/user/$(id -u)/podman/podman.sock ]; do sleep 0.5; done"
           echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
 
       - name: install and start podman (Linux rootful)
@@ -510,7 +512,7 @@ jobs:
         run: |
           sudo apt-get update && sudo apt-get install -y podman
           sudo systemctl start podman.socket
-          podman info
+          timeout 10 bash -c 'until [ -S /run/podman/podman.sock ]; do sleep 0.5; done'
           echo "DOCKER_HOST=unix:///run/podman/podman.sock" >> "$GITHUB_ENV"
 
       - name: setup kind (Windows)
@@ -579,7 +581,7 @@ jobs:
               KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
               PATH="${PATH}" \
               GOROOT="${GOROOT}" \
-              ${DOCKER_HOST:+DOCKER_HOST="${DOCKER_HOST}"} \
+              DOCKER_HOST="${DOCKER_HOST:-}" \
               go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"
           else
             GH_USERNAME="${GH_USERNAME}" \


### PR DESCRIPTION
## Summary

- Adds Linux rootless and rootful Podman entries to the e2e test matrix in `.github/workflows/pr-ci.yml`
- Installs Podman via apt, starts appropriate socket (user for rootless, system for rootful)
- Forwards `DOCKER_HOST` through sudo to test process for rootful mode
- Uses socket readiness polling instead of sleep for reliability
- Distinct job display names: "Test up-provider-podman (rootless)" and "Test up-provider-podman (rootful)"
- All existing CI entries unchanged (purely additive)