### PR TITLE
fix(daemon): remove hardcoded ShutdownAction fallback, trust merge layer

### DIFF
--- a/pkg/daemon/agent/daemon.go
+++ b/pkg/daemon/agent/daemon.go
@@ -61,10 +61,7 @@ func BuildWorkspaceDaemonConfig(
 	// build info isn't required in the workspace and can be omitted
 	platformOptions.Build = nil
 
-	shutdownAction := config.ShutdownActionStopContainer
-	if mergedConfig.ShutdownAction != "" {
-		shutdownAction = mergedConfig.ShutdownAction
-	}
+	shutdownAction := mergedConfig.ShutdownAction
 
 	daemonConfig := &DaemonConfig{
 		Platform: platformOptions,

--- a/pkg/daemon/agent/daemon_test.go
+++ b/pkg/daemon/agent/daemon_test.go
@@ -15,9 +15,9 @@ func TestBuildWorkspaceDaemonConfig_ShutdownAction(t *testing.T) {
 		want           string
 	}{
 		{
-			name:           "defaults to stopContainer when empty",
+			name:           "passes through empty value from merged config",
 			shutdownAction: "",
-			want:           config.ShutdownActionStopContainer,
+			want:           "",
 		},
 		{
 			name:           "preserves none",


### PR DESCRIPTION
## Summary
- Removed the hardcoded `ShutdownActionStopContainer` fallback in `pkg/daemon/agent/daemon.go:64` that overrode the merge layer's context-dependent default
- The merge layer (`pkg/devcontainer/config/merge.go:143-152`) already correctly differentiates: compose workspaces → `stopCompose`, image workspaces → `stopContainer`, explicit user config → respected
- The daemon now trusts the merge layer's value directly instead of re-defaulting
- Updated unit test to reflect pass-through behavior