### PR TITLE
fix(ci): disable rust-cache bin caching to fix macOS cargo resolution

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -637,6 +637,7 @@ jobs:
         with:
           workspaces: "./desktop/src-tauri -> target"
           shared-key: "desktop-${{ matrix.runner }}"
+          cache-bin: "false"
 
       - name: get operating system lowercase
         id: os

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,7 @@ jobs:
         with:
           workspaces: "./desktop/src-tauri -> target"
           shared-key: "desktop-${{ matrix.runner }}"
+          cache-bin: "false"
 
       - name: get operating system lowercase
         id: os


### PR DESCRIPTION
## Summary

- Disables binary caching (`cache-bin: false`) in `swatinem/rust-cache` for both `pr-ci.yml` and `release.yml` desktop build jobs
- Fixes deterministic CI failure where `cargo` resolves to Homebrew's broken `rustup-init` shim on macOS runners (image `20260511.0048+`), causing `cargo metadata` to fail with `Usage: rustup-init[EXE] [OPTIONS]`
- Root cause: `rust-cache` restores cached `/opt/homebrew/bin/cargo` (a `rustup-init` shim) which shadows `~/.cargo/bin/cargo` (the real binary from `dtolnay/rust-toolchain`)

Upstream refs: actions/runner-images#14097, actions/runner-images#14099, Swatinem/rust-cache#341