### PR TITLE
feat(feature): add interactive prompting for secret options

### DIFF
--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -587,8 +587,9 @@ func cleanupBuildInformation(c *config.DevContainerConfig) {
 }
 
 func featureSecretOpts(options provider.BuildOptions) *feature.SecretOptions {
-	if options.FeatureSecretsFile == "" {
-		return nil
+	opts := &feature.SecretOptions{
+		SecretsFile: options.FeatureSecretsFile,
+		Prompter:    &feature.TerminalSecretPrompter{},
 	}
-	return &feature.SecretOptions{SecretsFile: options.FeatureSecretsFile}
+	return opts
 }

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -688,9 +688,9 @@ func (r *runner) buildAndExtendDockerCompose(
 	dockerfileContents = buildInfo.dockerfileContents
 	buildTarget = buildInfo.buildTarget
 
-	var secretOpts *feature.SecretOptions
-	if featureSecretsFile != "" {
-		secretOpts = &feature.SecretOptions{SecretsFile: featureSecretsFile}
+	secretOpts := &feature.SecretOptions{
+		SecretsFile: featureSecretsFile,
+		Prompter:    &feature.TerminalSecretPrompter{},
 	}
 	extendImageBuildInfo, err := feature.GetExtendedBuildInfo(&feature.ExtendedBuildParams{
 		Ctx:                substitutionContext,

--- a/pkg/devcontainer/feature/options.go
+++ b/pkg/devcontainer/feature/options.go
@@ -17,9 +17,17 @@ const (
 	optionTypeSecret  = "secret"
 )
 
+// SecretPrompter prompts the user for a secret value. Implementations should
+// mask input when running interactively, or handle non-interactive mode
+// (e.g. emit a warning and return an empty string).
+type SecretPrompter interface {
+	PromptSecret(featureID, optionName string) (string, error)
+}
+
 // SecretOptions holds configuration for resolving secret-typed feature options.
 type SecretOptions struct {
 	SecretsFile string
+	Prompter    SecretPrompter
 }
 
 // ResolveSecretOptions resolves secret-typed options for a feature. For each option
@@ -64,6 +72,7 @@ type secretResolver struct {
 	featureID     string
 	featureSafeID string
 	fileData      map[string]map[string]string
+	prompter      SecretPrompter
 }
 
 func newSecretResolver(featureID string, opts *SecretOptions) (*secretResolver, error) {
@@ -71,12 +80,15 @@ func newSecretResolver(featureID string, opts *SecretOptions) (*secretResolver, 
 		featureID:     featureID,
 		featureSafeID: getFeatureSafeID(featureID),
 	}
-	if opts != nil && opts.SecretsFile != "" {
-		var err error
-		r.fileData, err = parseFeatureSecretsFile(opts.SecretsFile)
-		if err != nil {
-			return nil, err
+	if opts != nil {
+		if opts.SecretsFile != "" {
+			var err error
+			r.fileData, err = parseFeatureSecretsFile(opts.SecretsFile)
+			if err != nil {
+				return nil, err
+			}
 		}
+		r.prompter = opts.Prompter
 	}
 	return r, nil
 }
@@ -93,6 +105,19 @@ func (r *secretResolver) resolve(name string, option config.FeatureConfigOption)
 
 	if string(option.Default) != "" {
 		return string(option.Default), nil
+	}
+
+	if r.prompter != nil {
+		val, err := r.prompter.PromptSecret(r.featureID, name)
+		if err != nil {
+			return "", fmt.Errorf(
+				"feature %q: prompt for secret option %q: %w",
+				r.featureID, name, err,
+			)
+		}
+		if val != "" {
+			return val, nil
+		}
 	}
 
 	return "", fmt.Errorf(

--- a/pkg/devcontainer/feature/options.go
+++ b/pkg/devcontainer/feature/options.go
@@ -122,7 +122,8 @@ func (r *secretResolver) resolve(name string, option config.FeatureConfigOption)
 
 	return "", fmt.Errorf(
 		"feature %q: secret option %q is required but no value was provided. "+
-			"Set via devcontainer.json options, environment variable %s, or --feature-secrets-file",
+			"Set via devcontainer.json options, environment variable %s, "+
+			"--feature-secrets-file, or run in an interactive terminal to be prompted",
 		r.featureID, name, envVarName,
 	)
 }

--- a/pkg/devcontainer/feature/options_secret_test.go
+++ b/pkg/devcontainer/feature/options_secret_test.go
@@ -1,6 +1,7 @@
 package feature
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,7 +10,25 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-const testOptionToken = "token"
+type mockPrompter struct {
+	called     bool
+	featureID  string
+	optionName string
+	returnVal  string
+	returnErr  error
+}
+
+func (m *mockPrompter) PromptSecret(featureID, optionName string) (string, error) {
+	m.called = true
+	m.featureID = featureID
+	m.optionName = optionName
+	return m.returnVal, m.returnErr
+}
+
+const (
+	testOptionToken   = "token"
+	prompterUnusedVal = "should-not-be-used"
+)
 
 type SecretOptionsTestSuite struct {
 	suite.Suite
@@ -237,4 +256,124 @@ func (s *SecretOptionsTestSuite) TestEmptyOptionsMapReturnsEarly() {
 	resolved, err := ResolveSecretOptions(testFeatureID, cfg, userOpts, nil)
 	s.NoError(err)
 	s.Equal(userOpts, resolved)
+}
+
+func (s *SecretOptionsTestSuite) TestPrompterCalledWhenNoValueProvided() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionToken: {Type: optionTypeSecret},
+		},
+	}
+	p := &mockPrompter{returnVal: "prompted-secret"}
+	opts := &SecretOptions{Prompter: p}
+
+	resolved, err := ResolveSecretOptions(testFeatureID, cfg, map[string]any{}, opts)
+	s.NoError(err)
+	s.True(p.called)
+	s.Equal(testFeatureID, p.featureID)
+	s.Equal(testOptionToken, p.optionName)
+	s.Equal("prompted-secret", resolved[testOptionToken])
+}
+
+func (s *SecretOptionsTestSuite) TestSecretsFileTakesPrecedenceOverPrompter() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionToken: {Type: optionTypeSecret},
+		},
+	}
+
+	secretsFile := filepath.Join(s.T().TempDir(), "secrets.json")
+	content := `{"` + testFeatureID + `": {"` + testOptionToken + `": "file-value"}}`
+	err := os.WriteFile(secretsFile, []byte(content), 0o600)
+	s.Require().NoError(err)
+
+	p := &mockPrompter{returnVal: "prompted-value"}
+	opts := &SecretOptions{SecretsFile: secretsFile, Prompter: p}
+
+	resolved, err := ResolveSecretOptions(testFeatureID, cfg, map[string]any{}, opts)
+	s.NoError(err)
+	s.False(p.called)
+	s.Equal("file-value", resolved[testOptionToken])
+}
+
+func (s *SecretOptionsTestSuite) TestPrompterReturnsEmptyStillErrors() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionToken: {Type: optionTypeSecret},
+		},
+	}
+	p := &mockPrompter{returnVal: ""}
+	opts := &SecretOptions{Prompter: p}
+
+	_, err := ResolveSecretOptions(testFeatureID, cfg, map[string]any{}, opts)
+	s.Error(err)
+	s.True(p.called)
+	s.Contains(err.Error(), "required but no value was provided")
+}
+
+func (s *SecretOptionsTestSuite) TestPrompterErrorPropagated() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionToken: {Type: optionTypeSecret},
+		},
+	}
+	p := &mockPrompter{returnErr: errors.New("terminal closed")}
+	opts := &SecretOptions{Prompter: p}
+
+	_, err := ResolveSecretOptions(testFeatureID, cfg, map[string]any{}, opts)
+	s.Error(err)
+	s.Contains(err.Error(), "terminal closed")
+	s.Contains(err.Error(), "prompt for secret option")
+}
+
+func (s *SecretOptionsTestSuite) TestPrompterNotCalledWhenUserValueExists() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionToken: {Type: optionTypeSecret},
+		},
+	}
+	p := &mockPrompter{returnVal: prompterUnusedVal}
+	opts := &SecretOptions{Prompter: p}
+
+	userOpts := map[string]any{testOptionToken: "user-provided"}
+	resolved, err := ResolveSecretOptions(testFeatureID, cfg, userOpts, opts)
+	s.NoError(err)
+	s.False(p.called)
+	s.Equal("user-provided", resolved[testOptionToken])
+}
+
+func (s *SecretOptionsTestSuite) TestPrompterNotCalledWhenDefaultExists() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionToken: {Type: optionTypeSecret, Default: "default-val"},
+		},
+	}
+	p := &mockPrompter{returnVal: prompterUnusedVal}
+	opts := &SecretOptions{Prompter: p}
+
+	resolved, err := ResolveSecretOptions(testFeatureID, cfg, map[string]any{}, opts)
+	s.NoError(err)
+	s.False(p.called)
+	s.Equal("default-val", resolved[testOptionToken])
+}
+
+func (s *SecretOptionsTestSuite) TestPrompterNotCalledWhenEnvVarSet() {
+	cfg := &config.FeatureConfig{
+		Options: map[string]config.FeatureConfigOption{
+			testOptionToken: {Type: optionTypeSecret},
+		},
+	}
+
+	safeFeatureID := getFeatureSafeID(testFeatureID)
+	safeOptionID := getFeatureSafeID(testOptionToken)
+	envVar := "DEVCONTAINER_FEATURE_SECRET_" + safeFeatureID + "_" + safeOptionID
+	s.T().Setenv(envVar, "env-value")
+
+	p := &mockPrompter{returnVal: prompterUnusedVal}
+	opts := &SecretOptions{Prompter: p}
+
+	resolved, err := ResolveSecretOptions(testFeatureID, cfg, map[string]any{}, opts)
+	s.NoError(err)
+	s.False(p.called)
+	s.Equal("env-value", resolved[testOptionToken])
 }

--- a/pkg/devcontainer/feature/options_secret_test.go
+++ b/pkg/devcontainer/feature/options_secret_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/stretchr/testify/suite"
+	"go.uber.org/zap/zapcore"
 )
 
 type mockPrompter struct {
@@ -376,4 +378,23 @@ func (s *SecretOptionsTestSuite) TestPrompterNotCalledWhenEnvVarSet() {
 	s.NoError(err)
 	s.False(p.called)
 	s.Equal("env-value", resolved[testOptionToken])
+}
+
+func (s *SecretOptionsTestSuite) TestTerminalPrompterNonInteractiveEmitsWarning() {
+	logs := log.InitTestObserved(s.T(), zapcore.WarnLevel)
+
+	prompter := &TerminalSecretPrompter{
+		IsTerminal: func() bool { return false },
+	}
+
+	val, err := prompter.PromptSecret(testFeatureID, testOptionToken)
+	s.NoError(err)
+	s.Empty(val)
+
+	s.Require().Equal(1, logs.Len())
+	entry := logs.All()[0]
+	s.Equal(zapcore.WarnLevel, entry.Level)
+	s.Contains(entry.Message, testFeatureID)
+	s.Contains(entry.Message, testOptionToken)
+	s.Contains(entry.Message, "stdin is not a terminal")
 }

--- a/pkg/devcontainer/feature/secret_prompter.go
+++ b/pkg/devcontainer/feature/secret_prompter.go
@@ -10,10 +10,12 @@ import (
 
 // TerminalSecretPrompter prompts for secrets interactively when stdin is a
 // terminal, and emits a warning in non-interactive mode.
-type TerminalSecretPrompter struct{}
+type TerminalSecretPrompter struct {
+	IsTerminal func() bool
+}
 
 func (p *TerminalSecretPrompter) PromptSecret(featureID, optionName string) (string, error) {
-	if !terminal.IsTerminalIn {
+	if !p.isTerminal() {
 		log.Warnf(
 			"Feature %q: secret option %q has no value "+
 				"and stdin is not a terminal; skipping prompt",
@@ -36,4 +38,11 @@ func (p *TerminalSecretPrompter) PromptSecret(featureID, optionName string) (str
 	}
 
 	return answer, nil
+}
+
+func (p *TerminalSecretPrompter) isTerminal() bool {
+	if p.IsTerminal != nil {
+		return p.IsTerminal()
+	}
+	return terminal.IsTerminalIn
 }

--- a/pkg/devcontainer/feature/secret_prompter.go
+++ b/pkg/devcontainer/feature/secret_prompter.go
@@ -1,0 +1,39 @@
+package feature
+
+import (
+	"fmt"
+
+	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/survey"
+	"github.com/devsy-org/devsy/pkg/terminal"
+)
+
+// TerminalSecretPrompter prompts for secrets interactively when stdin is a
+// terminal, and emits a warning in non-interactive mode.
+type TerminalSecretPrompter struct{}
+
+func (p *TerminalSecretPrompter) PromptSecret(featureID, optionName string) (string, error) {
+	if !terminal.IsTerminalIn {
+		log.Warnf(
+			"Feature %q: secret option %q has no value "+
+				"and stdin is not a terminal; skipping prompt",
+			featureID,
+			optionName,
+		)
+		return "", nil
+	}
+
+	question := fmt.Sprintf(
+		"Enter value for secret option %q in feature %q",
+		optionName, featureID,
+	)
+	answer, err := log.QuestionDefault(&survey.QuestionOptions{
+		Question:   question,
+		IsPassword: true,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	return answer, nil
+}


### PR DESCRIPTION
## Summary
- When a devcontainer feature declares a `type: "secret"` option with no value and no `--feature-secrets-file`, interactively prompt the user with masked input (if stdin is a terminal)
- In non-interactive mode, emit a warning log identifying the feature and option that has no value
- `--feature-secrets-file` still takes full precedence over prompting — no regression
- Added `SecretPrompter` interface with `TerminalSecretPrompter` implementation, wired into both build and compose codepaths
- 8 unit tests covering prompt triggers, secrets file precedence, non-interactive warning, error propagation, and edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Secret feature options can now be provided through interactive terminal prompts when unavailable via configuration files or environment variables.
  * Password-style input for secure secret entry.

* **Tests**
  * Comprehensive test coverage for interactive secret prompting behavior and resolution precedence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/291)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->