### PR TITLE
test(e2e): migrate down tests from MCR to hosted test registry

### DIFF
--- a/e2e/tests/down/down.go
+++ b/e2e/tests/down/down.go
@@ -29,18 +29,20 @@ var _ = ginkgo.Describe("testing down command", ginkgo.Label("down"), func() {
 		f, err := framework.SetupDockerProvider(initialDir+"/bin", "docker")
 		framework.ExpectNoError(err)
 
-		name := "vscode-remote-try-python"
+		tempDir, err := framework.CopyToTempDir("tests/down/testdata/docker")
+		framework.ExpectNoError(err)
+		ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
 
-		err = f.DevsyUp(ctx, "https://github.com/microsoft/vscode-remote-try-python.git")
+		err = f.DevsyUp(ctx, tempDir)
 		framework.ExpectNoError(err)
 
 		// Verify workspace is running
-		status, err := f.DevsyStatus(ctx, name)
+		status, err := f.DevsyStatus(ctx, tempDir)
 		framework.ExpectNoError(err)
 		gomega.Expect(strings.ToUpper(status.State)).To(gomega.Equal("RUNNING"))
 
 		// Get workspace UID for container lookup
-		workspace, err := f.FindWorkspace(ctx, name)
+		workspace, err := f.FindWorkspace(ctx, tempDir)
 		framework.ExpectNoError(err)
 
 		containerIDs, err := dockerHelper.FindContainer(ctx, []string{
@@ -50,7 +52,7 @@ var _ = ginkgo.Describe("testing down command", ginkgo.Label("down"), func() {
 		gomega.Expect(containerIDs).NotTo(gomega.BeEmpty(), "container should exist before down")
 
 		// Run devsy down
-		err = f.DevsyDown(ctx, name)
+		err = f.DevsyDown(ctx, tempDir)
 		framework.ExpectNoError(err)
 
 		// Verify container is gone
@@ -61,7 +63,7 @@ var _ = ginkgo.Describe("testing down command", ginkgo.Label("down"), func() {
 		gomega.Expect(containerIDs).To(gomega.BeEmpty(), "container should be deleted after down")
 
 		// Verify workspace no longer appears in list
-		_, err = f.FindWorkspace(ctx, name)
+		_, err = f.FindWorkspace(ctx, tempDir)
 		gomega.Expect(err).To(gomega.HaveOccurred(), "workspace should not be in list after down")
 	}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 
@@ -69,27 +71,29 @@ var _ = ginkgo.Describe("testing down command", ginkgo.Label("down"), func() {
 		f, err := framework.SetupDockerProvider(initialDir+"/bin", "docker")
 		framework.ExpectNoError(err)
 
-		name := "vscode-remote-try-python"
-		ginkgo.DeferCleanup(f.DevsyWorkspaceDelete, name)
+		tempDir, err := framework.CopyToTempDir("tests/down/testdata/docker")
+		framework.ExpectNoError(err)
+		ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+		ginkgo.DeferCleanup(f.DevsyWorkspaceDelete, tempDir)
 
-		err = f.DevsyUp(ctx, "https://github.com/microsoft/vscode-remote-try-python.git")
+		err = f.DevsyUp(ctx, tempDir)
 		framework.ExpectNoError(err)
 
 		// Verify workspace is running
-		status, err := f.DevsyStatus(ctx, name)
+		status, err := f.DevsyStatus(ctx, tempDir)
 		framework.ExpectNoError(err)
 		gomega.Expect(strings.ToUpper(status.State)).To(gomega.Equal("RUNNING"))
 
 		// Get workspace UID for container lookup
-		workspace, err := f.FindWorkspace(ctx, name)
+		workspace, err := f.FindWorkspace(ctx, tempDir)
 		framework.ExpectNoError(err)
 
 		// Run devsy stop
-		err = f.DevsyStop(ctx, name)
+		err = f.DevsyStop(ctx, tempDir)
 		framework.ExpectNoError(err)
 
 		// Verify workspace still exists in list (just stopped, not deleted)
-		_, err = f.FindWorkspace(ctx, name)
+		_, err = f.FindWorkspace(ctx, tempDir)
 		framework.ExpectNoError(err)
 
 		// Verify container still exists (stopped but not removed)

--- a/e2e/tests/down/testdata/docker/.devcontainer.json
+++ b/e2e/tests/down/testdata/docker/.devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu"
+}


### PR DESCRIPTION
## Summary

- Replace GitHub clone of `microsoft/vscode-remote-try-python` (which pulls images from `mcr.microsoft.com` at runtime) with a local `e2e/tests/down/testdata/docker/` directory using `ghcr.io/devsy-org/test-images/base:ubuntu`
- Eliminates transient MCR 403 errors that cause flaky CI failures (e.g., PR #292)
- Aligns the down test suite with the pattern used by all other e2e test suites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end tests for the `down` and `stop` commands with improved test isolation and workspace state verification, ensuring more reliable validation of command behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/293)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->