### PR TITLE
feat(git): support includeIf conditional config directives

### DIFF
--- a/cmd/agent/container/credentials_server.go
+++ b/cmd/agent/container/credentials_server.go
@@ -165,7 +165,7 @@ func configureGitUserLocally(
 	client tunnel.TunnelClient,
 ) error {
 	// get local credentials
-	localGitUser, err := gitcredentials.GetUser(userName)
+	localGitUser, err := gitcredentials.GetUser(userName, "")
 	if err != nil {
 		return err
 	} else if localGitUser.Name != "" && localGitUser.Email != "" {

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -228,7 +228,11 @@ func (t *tunnelServer) DockerCredentials(
 }
 
 func (t *tunnelServer) GitUser(ctx context.Context, empty *tunnel.Empty) (*tunnel.Message, error) {
-	gitUser, err := gitcredentials.GetUser("")
+	workingDir := ""
+	if t.workspace != nil {
+		workingDir = t.workspace.Source.LocalFolder
+	}
+	gitUser, err := gitcredentials.GetUser("", workingDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -522,7 +522,7 @@ func setupPlatformGitCredentials(
 	// setup platform git user
 	if platformOptions.UserCredentials.GitUser != "" &&
 		platformOptions.UserCredentials.GitEmail != "" {
-		gitUser, err := gitcredentials.GetUser(userName)
+		gitUser, err := gitcredentials.GetUser(userName, "")
 		if err == nil && gitUser.Name == "" && gitUser.Email == "" {
 			log.Info("Setup workspace git user and email")
 			err := gitcredentials.SetUser(userName, &gitcredentials.GitUser{

--- a/pkg/gitcredentials/gitcredentials.go
+++ b/pkg/gitcredentials/gitcredentials.go
@@ -185,7 +185,7 @@ func SetUser(userName string, user *GitUser) error {
 	return nil
 }
 
-func GetUser(userName string) (*GitUser, error) {
+func GetUser(userName string, workingDir string) (*GitUser, error) {
 	gitUser := &GitUser{}
 
 	scopeArgs := []string{"config"}
@@ -195,15 +195,23 @@ func GetUser(userName string) (*GitUser, error) {
 			return gitUser, fmt.Errorf("get git global dir for %s: %w", userName, err)
 		}
 		scopeArgs = append(scopeArgs, "--file", p)
-	} else {
+	} else if workingDir == "" {
 		scopeArgs = append(scopeArgs, "--global")
 	}
 
+	nameCmd := exec.Command("git", append(scopeArgs, "user.name")...)   // #nosec G204
+	emailCmd := exec.Command("git", append(scopeArgs, "user.email")...) // #nosec G204
+
+	if workingDir != "" {
+		nameCmd.Dir = workingDir
+		emailCmd.Dir = workingDir
+	}
+
 	// we ignore the error here, because if email is empty we don't care
-	name, _ := exec.Command("git", append(scopeArgs[:], "user.name")...).Output()
+	name, _ := nameCmd.Output()
 	gitUser.Name = strings.TrimSpace(string(name))
 
-	email, _ := exec.Command("git", append(scopeArgs[:], "user.email")...).Output()
+	email, _ := emailCmd.Output()
 	gitUser.Email = strings.TrimSpace(string(email))
 
 	return gitUser, nil

--- a/pkg/gitcredentials/gitcredentials_test.go
+++ b/pkg/gitcredentials/gitcredentials_test.go
@@ -1,0 +1,92 @@
+package gitcredentials
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUser_WorkingDirResolvesIncludeIf(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	projectDir := t.TempDir()
+	//nolint:gosec // test-only, args are constants
+	require.NoError(t, exec.Command("git", "init", projectDir).Run())
+
+	projectConfigPath := filepath.Join(tmpHome, "project.gitconfig")
+	require.NoError(t, os.WriteFile(projectConfigPath, []byte(`[user]
+	name = Project User
+	email = project@example.com
+`), 0o600))
+
+	globalConfigPath := filepath.Join(tmpHome, ".gitconfig")
+	require.NoError(t, os.WriteFile(globalConfigPath, fmt.Appendf(nil, `[user]
+	name = Global User
+	email = global@example.com
+[includeIf "gitdir:%s/"]
+	path = %s
+`, projectDir, projectConfigPath), 0o600))
+
+	user, err := GetUser("", projectDir)
+	require.NoError(t, err)
+	assert.Equal(t, "Project User", user.Name)
+	assert.Equal(t, "project@example.com", user.Email)
+}
+
+func TestGetUser_EmptyWorkingDirUsesGlobal(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	globalConfigPath := filepath.Join(tmpHome, ".gitconfig")
+	require.NoError(t, os.WriteFile(globalConfigPath, []byte(`[user]
+	name = Global User
+	email = global@example.com
+`), 0o600))
+
+	user, err := GetUser("", "")
+	require.NoError(t, err)
+	assert.Equal(t, "Global User", user.Name)
+	assert.Equal(t, "global@example.com", user.Email)
+}
+
+func TestGetUser_WorkingDirWithNoMatchingIncludeIfUsesGlobal(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	otherDir := t.TempDir()
+
+	projectConfigPath := filepath.Join(tmpHome, "project.gitconfig")
+	require.NoError(t, os.WriteFile(projectConfigPath, []byte(`[user]
+	name = Project User
+	email = project@example.com
+`), 0o600))
+
+	globalConfigPath := filepath.Join(tmpHome, ".gitconfig")
+	require.NoError(t, os.WriteFile(globalConfigPath, fmt.Appendf(nil, `[user]
+	name = Global User
+	email = global@example.com
+[includeIf "gitdir:%s/"]
+	path = %s
+`, otherDir, projectConfigPath), 0o600))
+
+	projectDir := t.TempDir()
+	//nolint:gosec // test-only, args are constants
+	require.NoError(t, exec.Command("git", "init", projectDir).Run())
+
+	user, err := GetUser("", projectDir)
+	require.NoError(t, err)
+	assert.Equal(t, "Global User", user.Name)
+	assert.Equal(t, "global@example.com", user.Email)
+}

--- a/pkg/gitsshsigning/utils.go
+++ b/pkg/gitsshsigning/utils.go
@@ -11,15 +11,13 @@ const (
 	GPGFormatSSH             = "ssh"
 )
 
-// ExtractGitConfiguration is used for extracting values from users local .gitconfig
-// that are needed to setup devsy-ssh-signature helper inside the workspace.
-func ExtractGitConfiguration() (string, string, error) {
-	format, err := readGitConfigValue(GPGFormatConfigKey)
+func ExtractGitConfiguration(workingDir string) (string, string, error) {
+	format, err := readGitConfigValue(GPGFormatConfigKey, workingDir)
 	if err != nil {
 		return "", "", err
 	}
 
-	signingKey, err := readGitConfigValue(UsersSigningKeyConfigKey)
+	signingKey, err := readGitConfigValue(UsersSigningKeyConfigKey, workingDir)
 	if err != nil {
 		return "", "", err
 	}
@@ -27,8 +25,11 @@ func ExtractGitConfiguration() (string, string, error) {
 	return format, signingKey, nil
 }
 
-func readGitConfigValue(key string) (string, error) {
+func readGitConfigValue(key string, workingDir string) (string, error) {
 	cmd := exec.Command("git", "config", "--get", key)
+	if workingDir != "" {
+		cmd.Dir = workingDir
+	}
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/pkg/gitsshsigning/utils_test.go
+++ b/pkg/gitsshsigning/utils_test.go
@@ -1,0 +1,63 @@
+package gitsshsigning
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractGitConfiguration_WorkingDirResolvesIncludeIf(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	projectDir := t.TempDir()
+	//nolint:gosec // test-only, args are constants
+	require.NoError(t, exec.Command("git", "init", projectDir).Run())
+
+	projectConfigPath := filepath.Join(tmpHome, "project.gitconfig")
+	require.NoError(t, os.WriteFile(projectConfigPath, []byte(`[gpg]
+	format = ssh
+[user]
+	signingkey = /path/to/signing.pub
+`), 0o600))
+
+	globalConfigPath := filepath.Join(tmpHome, ".gitconfig")
+	require.NoError(t, os.WriteFile(globalConfigPath, fmt.Appendf(nil, `[includeIf "gitdir:%s/"]
+	path = %s
+`, projectDir, projectConfigPath), 0o600))
+
+	format, signingKey, err := ExtractGitConfiguration(projectDir)
+	require.NoError(t, err)
+	assert.Equal(t, GPGFormatSSH, format)
+	assert.Equal(t, "/path/to/signing.pub", signingKey)
+}
+
+func TestExtractGitConfiguration_WorkingDirWithGlobalSigningConfig(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+
+	projectDir := t.TempDir()
+	//nolint:gosec // test-only, args are constants
+	require.NoError(t, exec.Command("git", "init", projectDir).Run())
+
+	globalConfigPath := filepath.Join(tmpHome, ".gitconfig")
+	require.NoError(t, os.WriteFile(globalConfigPath, []byte(`[gpg]
+	format = ssh
+[user]
+	signingkey = /global/key.pub
+`), 0o600))
+
+	format, signingKey, err := ExtractGitConfiguration(projectDir)
+	require.NoError(t, err)
+	assert.Equal(t, GPGFormatSSH, format)
+	assert.Equal(t, "/global/key.pub", signingKey)
+}

--- a/pkg/tunnel/services.go
+++ b/pkg/tunnel/services.go
@@ -109,10 +109,10 @@ func runTunnelServer(ctx context.Context, cancel context.CancelFunc, p tunnelSer
 // When explicitKey is set (from --git-ssh-signing-key flag), it takes
 // precedence over the host's .gitconfig. This ensures signing works
 // even when user.signingkey is not in the host git configuration.
-func addGitSSHSigningKey(command string, explicitKey string) string {
+func addGitSSHSigningKey(command string, explicitKey string, workingDir string) string {
 	userSigningKey := explicitKey
 	if userSigningKey == "" {
-		format, extracted, err := gitsshsigning.ExtractGitConfiguration()
+		format, extracted, err := gitsshsigning.ExtractGitConfiguration(workingDir)
 		if err != nil {
 			log.Debugf("failed to extract git configuration: %v", err)
 			return command
@@ -138,7 +138,11 @@ func buildCredentialsCommand(opts RunServicesOptions) string {
 		command += " --configure-git-helper"
 	}
 	if opts.ConfigureGitSSHSignatureHelper {
-		command = addGitSSHSigningKey(command, opts.GitSSHSigningKey)
+		workingDir := ""
+		if opts.Workspace != nil {
+			workingDir = opts.Workspace.Source.LocalFolder
+		}
+		command = addGitSSHSigningKey(command, opts.GitSSHSigningKey, workingDir)
 	}
 	if opts.ConfigureDockerCredentials {
 		command += " --configure-docker-helper"

--- a/pkg/tunnel/services_test.go
+++ b/pkg/tunnel/services_test.go
@@ -11,7 +11,7 @@ const testBaseCommand = "devsy agent container credentials-server --user root"
 
 func TestAddGitSSHSigningKey_ExplicitKey(t *testing.T) {
 	command := testBaseCommand
-	result := addGitSSHSigningKey(command, "/path/to/key.pub")
+	result := addGitSSHSigningKey(command, "/path/to/key.pub", "")
 
 	encoded := base64.StdEncoding.EncodeToString([]byte("/path/to/key.pub"))
 	assert.Equal(t, command+" --git-user-signing-key "+encoded, result)
@@ -22,7 +22,7 @@ func TestAddGitSSHSigningKey_ExplicitKeyTakesPrecedence(t *testing.T) {
 	// of what ExtractGitConfiguration might return from host .gitconfig.
 	command := testBaseCommand
 	explicitKey := "/explicit/key.pub"
-	result := addGitSSHSigningKey(command, explicitKey)
+	result := addGitSSHSigningKey(command, explicitKey, "")
 
 	encoded := base64.StdEncoding.EncodeToString([]byte(explicitKey))
 	assert.Equal(t, command+" --git-user-signing-key "+encoded, result)
@@ -35,7 +35,7 @@ func TestAddGitSSHSigningKey_EmptyExplicitKey_FallsBackToHostConfig(t *testing.T
 	t.Setenv("HOME", tmpHome)
 	t.Setenv("XDG_CONFIG_HOME", tmpHome)
 
-	result := addGitSSHSigningKey(command, "")
+	result := addGitSSHSigningKey(command, "", "")
 
 	assert.Equal(t, command, result)
 	assert.NotContains(t, result, "--git-user-signing-key")


### PR DESCRIPTION
## Summary

- Thread a `workingDir` parameter through `GetUser()`, `ExtractGitConfiguration()`, and `addGitSSHSigningKey()` so git config commands run in the workspace directory where `includeIf "gitdir:..."` directives are evaluated correctly
- When `workingDir` is non-empty, the `--global` flag is omitted and `cmd.Dir` is set instead, letting git resolve the full config chain including conditional includes; when empty, previous `--global` behavior is preserved
- Add unit tests covering includeIf resolution, global fallback, and non-matching includeIf patterns for both `GetUser` and `ExtractGitConfiguration`

### Spec alignment

The [devcontainer specification](https://containers.dev/implementors/spec/) does not prescribe how git configuration should be resolved or forwarded — this is left to implementors. VS Code's reference implementation copies the host `.gitconfig` file into the container, which means `includeIf` directives are preserved in the file but won't match inside the container (different paths).

Devsy's approach is different and arguably more correct: it resolves git config values **on the host** — where `includeIf "gitdir:..."` patterns can match the actual workspace path — then forwards the resolved values (`user.name`, `user.email`, `user.signingkey`, `gpg.format`) into the container. This ensures users with multiple git identities (e.g., personal vs. work repos) get the correct identity applied without any container-side path gymnastics.

**No deviations from spec**: since the spec is silent on this topic, this implementation is fully compatible. The approach is strictly better than file-copying because it correctly evaluates conditional includes in their intended context.

Closes devpod#750