### PR TITLE
fix(log): bridge klog to zap backend via LogrSink

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,9 +21,11 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/telemetry"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 	"golang.org/x/crypto/ssh"
+	"k8s.io/klog/v2"
 )
 
 var globalFlags *flags.GlobalFlags
@@ -42,6 +44,7 @@ func NewRootCmd() *cobra.Command {
 				Debug:     globalFlags.Debug || os.Getenv(config.EnvDebug) == config.BoolTrue,
 				Format:    globalFlags.LogOutput,
 			})
+			klog.SetLogger(logr.New(log.LogrSink()))
 
 			if globalFlags.DevsyHome != "" {
 				_ = os.Setenv(config.EnvHome, globalFlags.DevsyHome)


### PR DESCRIPTION
## Summary

- Wires klog to the shared zap logger immediately after `log.Init()` in `PersistentPreRunE` via `klog.SetLogger(logr.New(log.LogrSink()))`
- Previously, klog calls in `pkg/daemon/platform/local_server.go` and `pkg/platform/remotecommand/` bypassed CLI flag control (`--verbose`, `--quiet`, `--log-output`); they now respect those flags
- `pkg/log/logr.go` already defined `LogrSink()` for this purpose but it was never called; this change completes the wiring
- Agent subprocess (`cmd/agent/agent.go`) does not need the same change — the klog-using packages are only reachable from the main CLI path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved logging infrastructure for enhanced diagnostics and debugging support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/299)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->