### PR TITLE
fix(ci): add prerelease versioning to release-please config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   release:
-    types: [prereleased, published]
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   release:
-    types: [prereleased]
+    types: [prereleased, published]
   workflow_dispatch:
     inputs:
       tag:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
       "release-type": "go",
       "prerelease-type": "rc",
       "prerelease": true,
+      "versioning": "prerelease",
       "bump-minor-pre-major": true,
       "component": "devsy",
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Summary

- Add `\"versioning\": \"prerelease\"` to `release-please-config.json` — without this key, release-please uses default versioning and produces stable versions instead of RC versions despite `\"prerelease\": true` being set
- Add `published` to `release.yml` trigger types (`[prereleased, published]`) so stable releases promoted from RC also trigger artifact builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to trigger on both pre-release and published events
  * Enhanced release configuration with prerelease versioning settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/305?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->