### PR TITLE
feat: add workspace rename command with auto-stop and e2e tests

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -220,6 +220,12 @@ jobs:
             install-kind: false
             requires-secret: false
 
+          - label: rename
+            runner: ubuntu-latest
+            free-disk-space: false
+            install-kind: false
+            requires-secret: false
+
           - label: delivery
             runner: ubuntu-latest
             free-disk-space: false

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -1,0 +1,107 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/devsy-org/devsy/cmd/completion"
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/provider"
+	workspace "github.com/devsy-org/devsy/pkg/workspace"
+	"github.com/spf13/cobra"
+)
+
+// RenameCmd holds the rename cmd flags.
+type RenameCmd struct {
+	*flags.GlobalFlags
+}
+
+// NewRenameCmd creates a new command for renaming a workspace.
+func NewRenameCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &RenameCmd{
+		GlobalFlags: globalFlags,
+	}
+
+	return &cobra.Command{
+		Use:   "rename <current-name> <new-name>",
+		Short: "Rename a workspace",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return cmd.Run(cobraCmd.Context(), args)
+		},
+		ValidArgsFunction: func(
+			rootCmd *cobra.Command, args []string, toComplete string,
+		) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return completion.GetWorkspaceSuggestions(
+					rootCmd,
+					cmd.Context,
+					cmd.Provider,
+					args,
+					toComplete,
+					cmd.Owner,
+				)
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
+	}
+}
+
+// Run validates inputs, loads config, and executes the workspace rename.
+func (cmd *RenameCmd) Run(ctx context.Context, args []string) error {
+	oldName, newName := args[0], args[1]
+
+	if oldName == newName {
+		return fmt.Errorf("new name is the same as the current name")
+	}
+
+	if err := validateWorkspaceName(newName); err != nil {
+		return err
+	}
+
+	devsyConfig, err := config.LoadConfig(cmd.Context, cmd.Provider)
+	if err != nil {
+		return err
+	}
+
+	if err := validateWorkspaceExists(devsyConfig, oldName); err != nil {
+		return err
+	}
+
+	if workspace.Exists(ctx, devsyConfig, []string{newName}, "", cmd.Owner) != "" {
+		return fmt.Errorf("workspace %s already exists", newName)
+	}
+
+	return workspace.Rename(ctx, workspace.RenameOptions{
+		DevsyConfig: devsyConfig,
+		OldName:     oldName,
+		NewName:     newName,
+	})
+}
+
+func validateWorkspaceName(newName string) error {
+	if strings.TrimSpace(newName) == "" {
+		return fmt.Errorf("workspace name cannot be empty")
+	}
+	if provider.ProviderNameRegEx.MatchString(newName) {
+		return fmt.Errorf("workspace name can only include lowercase letters, numbers or dashes")
+	}
+	if len(newName) > 48 {
+		return fmt.Errorf("workspace name cannot be longer than 48 characters")
+	}
+	return nil
+}
+
+func validateWorkspaceExists(devsyConfig *config.Config, oldName string) error {
+	wsConfig, err := provider.LoadWorkspaceConfig(devsyConfig.DefaultContext, oldName)
+	if err != nil {
+		return fmt.Errorf("workspace %s not found", oldName)
+	}
+	if wsConfig == nil {
+		return fmt.Errorf("workspace %s not found", oldName)
+	}
+
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,6 +141,7 @@ func BuildRoot() *cobra.Command {
 	rootCmd.AddCommand(NewSetUpCmd(globalFlags))
 	rootCmd.AddCommand(NewRunUserCommandsCmd(globalFlags))
 	rootCmd.AddCommand(NewRunUserCommandsCmdAlias(globalFlags))
+	rootCmd.AddCommand(NewRenameCmd(globalFlags))
 	rootCmd.AddCommand(features.NewFeaturesCmd(globalFlags))
 	rootCmd.AddCommand(templates.NewTemplatesCmd(globalFlags))
 

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/devsy-org/devsy/e2e/tests/outdated"
 	_ "github.com/devsy-org/devsy/e2e/tests/provider"
 	_ "github.com/devsy-org/devsy/e2e/tests/readconfiguration"
+	_ "github.com/devsy-org/devsy/e2e/tests/rename"
 	_ "github.com/devsy-org/devsy/e2e/tests/runusercommands"
 	_ "github.com/devsy-org/devsy/e2e/tests/selfupdate"
 	_ "github.com/devsy-org/devsy/e2e/tests/ssh"

--- a/e2e/framework/command.go
+++ b/e2e/framework/command.go
@@ -287,6 +287,22 @@ func (f *Framework) DevsyProviderRename(
 	return nil
 }
 
+// DevsyRename executes the `devsy rename` command in the test framework.
+func (f *Framework) DevsyRename(
+	ctx context.Context,
+	oldName, newName string,
+	args ...string,
+) error {
+	baseArgs := []string{"rename", oldName, newName}
+	baseArgs = append(baseArgs, args...)
+	err := f.ExecCommand(ctx, false, false, "", baseArgs)
+	if err != nil {
+		return fmt.Errorf("devsy rename failed: %s", err.Error())
+	}
+
+	return nil
+}
+
 // DevsyProviderOptionsJSON executes `devsy provider options --output json` and returns the raw JSON.
 func (f *Framework) DevsyProviderOptionsJSON(
 	ctx context.Context,

--- a/e2e/tests/rename/rename.go
+++ b/e2e/tests/rename/rename.go
@@ -1,0 +1,336 @@
+package rename
+
+import (
+	"context"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+const statusError = "error"
+
+func addDockerProvider(ctx context.Context, f *framework.Framework, name string) error {
+	dockerHost := os.Getenv("DOCKER_HOST")
+	if dockerHost != "" && strings.Contains(dockerHost, "podman") {
+		return f.DevsyProviderAdd(ctx, "docker", "--name", name, "--option=DOCKER_PATH=podman")
+	}
+	return f.DevsyProviderAdd(ctx, "docker", "--name", name)
+}
+
+var _ = ginkgo.Describe(
+	"devsy rename test suite",
+	ginkgo.Label("rename"),
+	ginkgo.Ordered,
+	func() {
+		var initialDir string
+
+		ginkgo.BeforeAll(func() {
+			var err error
+			initialDir, err = os.Getwd()
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should rename a stopped workspace to a new, valid name",
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
+			func(ctx context.Context) {
+				f := framework.NewDefaultFramework(initialDir + "/bin")
+
+				providerName := "rename-provider1"
+				workspaceName := "rename-ws1"
+				renamedWorkspaceName := "renamed-ws1"
+
+				err := f.DevsyProviderDelete(ctx, providerName, "--ignore-not-found")
+				framework.ExpectNoError(err)
+
+				tempDir, err := framework.CopyToTempDir("tests/up/testdata/no-devcontainer")
+				framework.ExpectNoError(err)
+				ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+				err = addDockerProvider(ctx, f, providerName)
+				framework.ExpectNoError(err)
+				err = f.DevsyProviderUse(ctx, providerName)
+				framework.ExpectNoError(err)
+
+				err = f.DevsyUp(ctx, tempDir, "--id", workspaceName)
+				framework.ExpectNoError(err)
+
+				gomega.Eventually(func() string {
+					status, err := f.DevsyStatus(ctx, workspaceName)
+					if err != nil {
+						return statusError
+					}
+					return string(status.State)
+				}).WithTimeout(30 * time.Second).
+					WithPolling(1 * time.Second).
+					Should(gomega.Equal("Running"))
+
+				err = f.DevsyStop(ctx, workspaceName)
+				framework.ExpectNoError(err)
+
+				err = f.DevsyRename(ctx, workspaceName, renamedWorkspaceName)
+				framework.ExpectNoError(err)
+
+				// Old name should not be found
+				_, err = f.FindWorkspace(ctx, workspaceName)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+
+				// New name should exist
+				ws, err := f.FindWorkspace(ctx, renamedWorkspaceName)
+				framework.ExpectNoError(err)
+				gomega.Expect(ws.ID).To(gomega.Equal(renamedWorkspaceName))
+
+				// Can start the renamed workspace
+				err = f.DevsyUp(ctx, renamedWorkspaceName)
+				framework.ExpectNoError(err)
+
+				gomega.Eventually(func() string {
+					status, err := f.DevsyStatus(ctx, renamedWorkspaceName)
+					if err != nil {
+						return statusError
+					}
+					return string(status.State)
+				}).WithTimeout(30 * time.Second).
+					WithPolling(1 * time.Second).
+					Should(gomega.Equal("Running"))
+
+				err = f.DevsyStop(ctx, renamedWorkspaceName)
+				framework.ExpectNoError(err)
+				err = f.DevsyWorkspaceDelete(ctx, renamedWorkspaceName)
+				framework.ExpectNoError(err)
+
+				gomega.Eventually(func() error {
+					_, err := f.FindWorkspace(ctx, renamedWorkspaceName)
+					return err
+				}).WithTimeout(30 * time.Second).
+					WithPolling(1 * time.Second).
+					Should(gomega.HaveOccurred())
+
+				err = f.DevsyProviderDelete(ctx, providerName)
+				framework.ExpectNoError(err)
+			})
+
+		ginkgo.It("should auto-stop a running workspace and rename it",
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
+			func(ctx context.Context) {
+				f := framework.NewDefaultFramework(initialDir + "/bin")
+
+				providerName := "rename-provider2"
+				workspaceName := "rename-ws2"
+				renamedWorkspaceName := "renamed-ws2"
+
+				err := f.DevsyProviderDelete(ctx, providerName, "--ignore-not-found")
+				framework.ExpectNoError(err)
+
+				tempDir, err := framework.CopyToTempDir("tests/up/testdata/no-devcontainer")
+				framework.ExpectNoError(err)
+				ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+				err = addDockerProvider(ctx, f, providerName)
+				framework.ExpectNoError(err)
+				err = f.DevsyProviderUse(ctx, providerName)
+				framework.ExpectNoError(err)
+
+				err = f.DevsyUp(ctx, tempDir, "--id", workspaceName)
+				framework.ExpectNoError(err)
+
+				gomega.Eventually(func() string {
+					status, err := f.DevsyStatus(ctx, workspaceName)
+					if err != nil {
+						return statusError
+					}
+					return string(status.State)
+				}).WithTimeout(30 * time.Second).
+					WithPolling(1 * time.Second).
+					Should(gomega.Equal("Running"))
+
+				// Rename while running — should auto-stop
+				err = f.DevsyRename(ctx, workspaceName, renamedWorkspaceName)
+				framework.ExpectNoError(err)
+
+				_, err = f.FindWorkspace(ctx, workspaceName)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+
+				ws, err := f.FindWorkspace(ctx, renamedWorkspaceName)
+				framework.ExpectNoError(err)
+				gomega.Expect(ws.ID).To(gomega.Equal(renamedWorkspaceName))
+
+				err = f.DevsyWorkspaceDelete(ctx, renamedWorkspaceName)
+				framework.ExpectNoError(err)
+
+				gomega.Eventually(func() error {
+					_, err := f.FindWorkspace(ctx, renamedWorkspaceName)
+					return err
+				}).WithTimeout(30 * time.Second).
+					WithPolling(1 * time.Second).
+					Should(gomega.HaveOccurred())
+
+				err = f.DevsyProviderDelete(ctx, providerName)
+				framework.ExpectNoError(err)
+			})
+
+		ginkgo.It("should fail to rename a workspace to a name that already exists",
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
+			func(ctx context.Context) {
+				f := framework.NewDefaultFramework(initialDir + "/bin")
+
+				providerName := "rename-provider3"
+				workspaceA := "rename-ws3a"
+				workspaceB := "rename-ws3b"
+
+				err := f.DevsyProviderDelete(ctx, providerName, "--ignore-not-found")
+				framework.ExpectNoError(err)
+
+				tempDir, err := framework.CopyToTempDir("tests/up/testdata/no-devcontainer")
+				framework.ExpectNoError(err)
+				ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+				err = addDockerProvider(ctx, f, providerName)
+				framework.ExpectNoError(err)
+				err = f.DevsyProviderUse(ctx, providerName)
+				framework.ExpectNoError(err)
+
+				err = f.DevsyUp(ctx, tempDir, "--id", workspaceA)
+				framework.ExpectNoError(err)
+				err = f.DevsyStop(ctx, workspaceA)
+				framework.ExpectNoError(err)
+
+				err = f.DevsyUp(ctx, tempDir, "--id", workspaceB)
+				framework.ExpectNoError(err)
+				err = f.DevsyStop(ctx, workspaceB)
+				framework.ExpectNoError(err)
+
+				// Attempt rename to existing name
+				err = f.DevsyRename(ctx, workspaceA, workspaceB)
+				framework.ExpectError(err)
+
+				// Both should still exist
+				_, err = f.FindWorkspace(ctx, workspaceA)
+				framework.ExpectNoError(err)
+				_, err = f.FindWorkspace(ctx, workspaceB)
+				framework.ExpectNoError(err)
+
+				err = f.DevsyWorkspaceDelete(ctx, workspaceA)
+				framework.ExpectNoError(err)
+				err = f.DevsyWorkspaceDelete(ctx, workspaceB)
+				framework.ExpectNoError(err)
+
+				err = f.DevsyProviderDelete(ctx, providerName)
+				framework.ExpectNoError(err)
+			})
+
+		ginkgo.It("should fail to rename a non-existent workspace",
+			ginkgo.SpecTimeout(framework.TimeoutShort()),
+			func(ctx context.Context) {
+				f := framework.NewDefaultFramework(initialDir + "/bin")
+
+				err := f.DevsyRename(ctx, "non-existent-ws4", "new-name4")
+				framework.ExpectError(err)
+			})
+
+		ginkgo.It("should fail to rename a workspace to an invalid name",
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
+			func(ctx context.Context) {
+				f := framework.NewDefaultFramework(initialDir + "/bin")
+
+				providerName := "rename-provider5"
+				workspaceName := "rename-ws5"
+
+				err := f.DevsyProviderDelete(ctx, providerName, "--ignore-not-found")
+				framework.ExpectNoError(err)
+
+				tempDir, err := framework.CopyToTempDir("tests/up/testdata/no-devcontainer")
+				framework.ExpectNoError(err)
+				ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+				err = addDockerProvider(ctx, f, providerName)
+				framework.ExpectNoError(err)
+				err = f.DevsyProviderUse(ctx, providerName)
+				framework.ExpectNoError(err)
+
+				err = f.DevsyUp(ctx, tempDir, "--id", workspaceName)
+				framework.ExpectNoError(err)
+				err = f.DevsyStop(ctx, workspaceName)
+				framework.ExpectNoError(err)
+
+				// Invalid characters
+				err = f.DevsyRename(ctx, workspaceName, "invalid/name5")
+				framework.ExpectError(err)
+
+				// Workspace should still exist with original name
+				_, err = f.FindWorkspace(ctx, workspaceName)
+				framework.ExpectNoError(err)
+
+				// Same name
+				err = f.DevsyRename(ctx, workspaceName, workspaceName)
+				framework.ExpectError(err)
+
+				err = f.DevsyWorkspaceDelete(ctx, workspaceName)
+				framework.ExpectNoError(err)
+
+				err = f.DevsyProviderDelete(ctx, providerName)
+				framework.ExpectNoError(err)
+			})
+
+		// Verify that the workspace ID is properly updated in the config after rename.
+		ginkgo.It("should update workspace ID in config after rename",
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
+			func(ctx context.Context) {
+				f := framework.NewDefaultFramework(initialDir + "/bin")
+
+				providerName := "rename-provider6"
+				workspaceName := "rename-ws6"
+				renamedWorkspaceName := "renamed-ws6"
+
+				err := f.DevsyProviderDelete(ctx, providerName, "--ignore-not-found")
+				framework.ExpectNoError(err)
+
+				tempDir, err := framework.CopyToTempDir("tests/up/testdata/no-devcontainer")
+				framework.ExpectNoError(err)
+				ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+				err = addDockerProvider(ctx, f, providerName)
+				framework.ExpectNoError(err)
+				err = f.DevsyProviderUse(ctx, providerName)
+				framework.ExpectNoError(err)
+
+				err = f.DevsyUp(ctx, tempDir, "--id", workspaceName)
+				framework.ExpectNoError(err)
+				err = f.DevsyStop(ctx, workspaceName)
+				framework.ExpectNoError(err)
+
+				// Get workspace UID before rename
+				wsBefore, err := f.FindWorkspace(ctx, workspaceName)
+				framework.ExpectNoError(err)
+				uidBefore := wsBefore.UID
+
+				err = f.DevsyRename(ctx, workspaceName, renamedWorkspaceName)
+				framework.ExpectNoError(err)
+
+				wsAfter, err := f.FindWorkspace(ctx, renamedWorkspaceName)
+				framework.ExpectNoError(err)
+
+				// ID should be updated
+				gomega.Expect(wsAfter.ID).To(gomega.Equal(renamedWorkspaceName))
+				// UID should be preserved
+				gomega.Expect(wsAfter.UID).To(gomega.Equal(uidBefore))
+				// Provider should be preserved
+				gomega.Expect(wsAfter.Provider.Name).To(gomega.Equal(providerName))
+
+				err = f.DevsyWorkspaceDelete(ctx, renamedWorkspaceName)
+				framework.ExpectNoError(err)
+
+				gomega.Eventually(func() error {
+					_, err := f.FindWorkspace(ctx, renamedWorkspaceName)
+					return err
+				}).WithTimeout(30 * time.Second).
+					WithPolling(1 * time.Second).
+					Should(gomega.HaveOccurred())
+
+				err = f.DevsyProviderDelete(ctx, providerName)
+				framework.ExpectNoError(err)
+			})
+	})

--- a/pkg/workspace/rename.go
+++ b/pkg/workspace/rename.go
@@ -1,0 +1,120 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	client2 "github.com/devsy-org/devsy/pkg/client"
+	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/platform"
+	"github.com/devsy-org/devsy/pkg/provider"
+	devssh "github.com/devsy-org/devsy/pkg/ssh"
+)
+
+// RenameOptions holds parameters for renaming a workspace.
+type RenameOptions struct {
+	DevsyConfig *config.Config
+	OldName     string
+	NewName     string
+}
+
+func moveWorkspace(devsyConfig *config.Config, oldName, newName string) error {
+	oldDir, err := provider.GetWorkspaceDir(devsyConfig.DefaultContext, oldName)
+	if err != nil {
+		return fmt.Errorf("get old workspace dir: %w", err)
+	}
+
+	newDir, err := provider.GetWorkspaceDir(devsyConfig.DefaultContext, newName)
+	if err != nil {
+		return fmt.Errorf("get new workspace dir: %w", err)
+	}
+
+	if err := os.Rename(oldDir, newDir); err != nil {
+		return fmt.Errorf("rename workspace dir: %w", err)
+	}
+
+	return nil
+}
+
+// stopWorkspaceIfRunning acquires a lock on the workspace, checks its status,
+// and stops it if it is not already stopped.
+func stopWorkspaceIfRunning(
+	ctx context.Context,
+	devsyConfig *config.Config,
+	wsConfig *provider.Workspace,
+) error {
+	wsClient, err := Get(ctx, GetOptions{
+		DevsyConfig: devsyConfig,
+		Args:        []string{wsConfig.ID},
+		Owner:       platform.AllOwnerFilter,
+	})
+	if err != nil {
+		return fmt.Errorf("get workspace client: %w", err)
+	}
+
+	if err := wsClient.Lock(ctx); err != nil {
+		return fmt.Errorf("lock workspace: %w", err)
+	}
+	defer wsClient.Unlock()
+
+	status, err := wsClient.Status(ctx, client2.StatusOptions{ContainerStatus: true})
+	if err != nil {
+		return fmt.Errorf("get workspace status: %w", err)
+	}
+
+	if status == client2.StatusStopped || status == client2.StatusNotFound {
+		return nil
+	}
+
+	log.Infof("stopping workspace %s before rename", wsConfig.ID)
+	if err := wsClient.Stop(ctx, client2.StopOptions{}); err != nil {
+		return fmt.Errorf("stop workspace before rename: %w", err)
+	}
+
+	return nil
+}
+
+// Rename performs the workspace rename: auto-stops if running, moves the
+// workspace directory, updates the config ID, and removes the old SSH config
+// entry. If any step after the directory move fails, the entire operation is
+// rolled back.
+func Rename(ctx context.Context, opts RenameOptions) error {
+	wsConfig, err := provider.LoadWorkspaceConfig(opts.DevsyConfig.DefaultContext, opts.OldName)
+	if err != nil {
+		return fmt.Errorf("loading workspace config: %w", err)
+	}
+
+	if wsConfig.IsPro() {
+		return fmt.Errorf(
+			"cannot rename pro workspaces; pro workspaces are managed by the platform",
+		)
+	}
+
+	if err := stopWorkspaceIfRunning(ctx, opts.DevsyConfig, wsConfig); err != nil {
+		return err
+	}
+
+	if err := moveWorkspace(opts.DevsyConfig, opts.OldName, opts.NewName); err != nil {
+		return fmt.Errorf("moving workspace: %w", err)
+	}
+
+	wsConfig.ID = opts.NewName
+	wsConfig.Context = opts.DevsyConfig.DefaultContext
+	if err := provider.SaveWorkspaceConfig(wsConfig); err != nil {
+		wsConfig.ID = opts.OldName
+		rollbackErr := moveWorkspace(opts.DevsyConfig, opts.NewName, opts.OldName)
+		return errors.Join(err, rollbackErr)
+	}
+
+	_ = devssh.RemoveFromConfig(
+		opts.OldName,
+		wsConfig.SSHConfigPath,
+		wsConfig.SSHConfigIncludePath,
+	)
+
+	log.Infof("renamed workspace %s to %s", opts.OldName, opts.NewName)
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `devsy rename <current-name> <new-name>` top-level CLI command for renaming workspaces
- Auto-stops running workspaces before rename (matching provider rename behavior)
- Moves workspace directory, updates config ID, cleans up old SSH config entry
- Transactional: rolls back directory move if config update fails
- Validates name format (lowercase alphanumeric + dashes, max 48 chars), name conflicts, Pro workspace guard
- Adds `DevsyRename` e2e framework helper and 6 test scenarios:
  - Rename stopped workspace
  - Auto-stop running workspace and rename
  - Fail on name conflict
  - Fail on non-existent workspace
  - Fail on invalid name / same name
  - Verify workspace ID updated and UID preserved after rename