### PR TITLE
feat(desktop): add workspace rename UI with inline editing

### DIFF
--- a/desktop/e2e/fixtures/mock-devsy.cjs
+++ b/desktop/e2e/fixtures/mock-devsy.cjs
@@ -392,6 +392,20 @@ switch (cmd) {
     break
   }
 
+  case "rename": {
+    const oldId = sub
+    const newId = extra
+    if (oldId && newId) {
+      const idx = state.workspaces.findIndex((w) => w.id === oldId)
+      if (idx !== -1) {
+        state.workspaces[idx].id = newId
+        saveState(state)
+      }
+    }
+    out("")
+    break
+  }
+
   case "upgrade":
     out("Already up to date.")
     process.exit(0)

--- a/desktop/e2e/integration.e2e.ts
+++ b/desktop/e2e/integration.e2e.ts
@@ -300,6 +300,28 @@ test.describe
       await expect(headerArea).toContainText("Stopped", { timeout: 10000 })
     })
 
+    test("can rename a workspace", async () => {
+      // We're on the node-js detail page after stopping it
+
+      // Click the rename (pencil) button
+      await page.locator('[data-slot="workspace-rename-btn"]').click()
+
+      // Fill the rename input with new name
+      const renameInput = page.locator('[data-slot="workspace-rename-input"]')
+      await renameInput.waitFor({ timeout: 5000 })
+      await renameInput.fill("node-js-renamed")
+
+      // Click Save
+      await page.locator('[data-slot="workspace-rename-save"]').click()
+
+      // Wait for rename to complete and navigation to new URL
+      await page.waitForTimeout(4000)
+
+      // Verify the new name appears in the header
+      const headerArea = page.locator("h1", { hasText: "node-js-renamed" })
+      await expect(headerArea).toBeVisible({ timeout: 10000 })
+    })
+
     test("should delete workspace from detail page", async () => {
       // Open the More actions dropdown, then click Delete
       await page.getByRole("button", { name: "More actions" }).click()
@@ -313,10 +335,11 @@ test.describe
       // Navigates to /workspaces on success — wait for table
       await page.locator("table").waitFor({ timeout: 15000 })
 
-      // Verify node-js is gone
-      await expect(page.locator("table")).not.toContainText("node-js", {
-        timeout: 10000,
-      })
+      // Verify renamed workspace is gone
+      await expect(page.locator("table")).not.toContainText(
+        "node-js-renamed",
+        { timeout: 10000 },
+      )
     })
   })
 

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -58,6 +58,17 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
     },
   )
 
+  ipcMain.handle(
+    "workspace_rename",
+    async (
+      _event,
+      args: { workspaceId: string; newWorkspaceId: string },
+    ) => {
+      trackEvent("workspace_rename", { workspaceId: args.workspaceId })
+      await cli.runRaw(["rename", args.workspaceId, args.newWorkspaceId])
+    },
+  )
+
   // ── Providers ──
   ipcMain.handle("provider_list", async () => {
     const raw = await cli.run<Record<string, ProviderEntry>>([

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -58,6 +58,13 @@ export async function workspaceStatus(workspaceId: string): Promise<string> {
   return invoke<string>("workspace_status", { workspaceId })
 }
 
+export async function workspaceRename(
+  workspaceId: string,
+  newWorkspaceId: string,
+): Promise<void> {
+  return invoke("workspace_rename", { workspaceId, newWorkspaceId })
+}
+
 // Provider commands
 export async function providerList(): Promise<Provider[]> {
   return invoke<Provider[]>("provider_list")

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -7,6 +7,7 @@ import {
   ClipboardCopy,
   Ellipsis,
   Monitor,
+  Pencil,
   Play,
   RefreshCw,
   RotateCcw,
@@ -17,6 +18,7 @@ import {
 import * as Tooltip from "$lib/components/ui/tooltip/index.js"
 import { Spinner } from "$lib/components/ui/spinner/index.js"
 import { Button } from "$lib/components/ui/button/index.js"
+import { Input } from "$lib/components/ui/input/index.js"
 import * as ButtonGroup from "$lib/components/ui/button-group/index.js"
 import { badgeVariants } from "$lib/components/ui/badge/index.js"
 import * as Command from "$lib/components/ui/command/index.js"
@@ -38,6 +40,7 @@ import {
   workspaceRebuild,
   workspaceReset,
   workspaceDelete,
+  workspaceRename,
   workspaceLogsList,
   workspaceLogRead,
   workspaceLogDelete,
@@ -121,6 +124,9 @@ let connecting = $state(false)
 let ideComboOpen = $state(false)
 let ideSearch = $state("")
 let selectedIde = $state<string | null>(null)
+let renaming = $state(false)
+let renameValue = $state("")
+let renameSaving = $state(false)
 let currentIde = $derived(selectedIde ?? workspace?.ide?.name ?? "none")
 let filteredIdes = $derived(
   IDE_OPTIONS.filter((i) =>
@@ -357,6 +363,30 @@ async function handleDelete() {
     toasts.error(`Failed to delete: ${extractErrorMessage(err)}`)
   }
 }
+
+function startRename() {
+  renameValue = id
+  renaming = true
+}
+
+async function handleRename() {
+  const trimmed = renameValue.trim()
+  if (!trimmed || trimmed === id) {
+    renaming = false
+    return
+  }
+  renameSaving = true
+  try {
+    await workspaceRename(id, trimmed)
+    toasts.success(`Renamed workspace to ${trimmed}`)
+    renaming = false
+    goto(`/workspaces/${trimmed}`)
+  } catch (err) {
+    toasts.error(`Failed to rename: ${extractErrorMessage(err)}`)
+  } finally {
+    renameSaving = false
+  }
+}
 </script>
 
 <div class="flex min-h-0 flex-1 flex-col gap-6">
@@ -364,7 +394,29 @@ async function handleDelete() {
     <Button variant="ghost" size="sm" onclick={() => goto("/workspaces")}>
       &larr; Back
     </Button>
-    <h1 class="text-2xl font-bold">{id}</h1>
+    {#if renaming}
+      <form class="flex items-center gap-2" onsubmit={(e) => { e.preventDefault(); handleRename() }}>
+        <Input
+          data-slot="workspace-rename-input"
+          value={renameValue}
+          oninput={(e) => (renameValue = e.currentTarget.value)}
+          class="h-8 w-56 text-lg font-bold"
+          disabled={renameSaving}
+        />
+        <Button data-slot="workspace-rename-save" variant="outline" size="sm" type="submit" disabled={renameSaving || !renameValue.trim()}>
+          {renameSaving ? "Saving..." : "Save"}
+        </Button>
+        <Button data-slot="workspace-rename-cancel" variant="ghost" size="sm" type="button" onclick={() => (renaming = false)} disabled={renameSaving}>
+          Cancel
+        </Button>
+      </form>
+    {:else}
+      <h1 class="text-2xl font-bold">{id}</h1>
+      <Button data-slot="workspace-rename-btn" variant="ghost" size="icon-sm" onclick={startRename}>
+        <Pencil class="h-4 w-4" />
+        <span class="sr-only">Rename</span>
+      </Button>
+    {/if}
     {#if workspace?.provider?.name}
       <span class={badgeVariants({ variant: "secondary" })}>{workspace.provider.name}</span>
     {/if}

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -412,7 +412,7 @@ async function handleRename() {
       </form>
     {:else}
       <h1 class="text-2xl font-bold">{id}</h1>
-      <Button data-slot="workspace-rename-btn" variant="ghost" size="icon-sm" onclick={startRename}>
+      <Button data-slot="workspace-rename-btn" variant="ghost" size="icon-sm" onclick={startRename} disabled={operationRunning}>
         <Pencil class="h-4 w-4" />
         <span class="sr-only">Rename</span>
       </Button>


### PR DESCRIPTION
## Summary
- Add `workspace_rename` IPC handler with telemetry tracking in the main process
- Add `workspaceRename` command export for the renderer
- Add inline editable workspace name in WorkspaceDetailPage header (pencil icon, Input/Save/Cancel form, toast feedback, URL navigation on rename)
- Add mock CLI `rename` command for e2e testing
- Add e2e test covering the full workspace rename flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workspace rename functionality. Users can now rename workspaces directly from the workspace detail page using a dedicated rename button, input field, and confirmation actions. The feature includes proper validation and error handling.

* **Tests**
  * Added end-to-end tests to verify workspace rename operations work correctly and subsequent workspace operations function as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->