### PR TITLE
fix(ci): flatten downloaded CLI artifacts before desktop build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,13 @@ jobs:
           path: ${{ runner.temp }}/devsy-bin/
           merge-multiple: true
 
+      - name: flatten CLI artifacts
+        shell: bash
+        run: |
+          BIN_DIR="${{ runner.temp }}/devsy-bin"
+          find "$BIN_DIR" -mindepth 2 -type f -exec mv {} "$BIN_DIR/" \;
+          find "$BIN_DIR" -mindepth 1 -type d -delete 2>/dev/null || true
+
       - name: setup CLI binary (unix)
         if: runner.os != 'Windows'
         shell: bash


### PR DESCRIPTION
## Summary

- Fixes the v1.2.1-rc release build failure where "Build Desktop App" jobs failed on all 3 platforms because CLI binaries were not found at expected flat paths
- Root cause: goreleaser outputs binaries into nested subdirectories (e.g. `dist/devsy-linux_linux_amd64_v1/devsy-linux-amd64`), and `upload-artifact` preserves this nesting. After download, the desktop build setup steps expect flat paths like `$RUNNER_TEMP/devsy-bin/devsy-linux-amd64` but find nested directories instead
- Adds a flatten step between artifact download and setup that moves all nested files to the top level using `find -mindepth 2 -exec mv`, then removes empty subdirectories