### PR TITLE
fix(ci): resolve 3 desktop build failures in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,12 +131,17 @@ jobs:
       - name: generate pro provider
         if: runner.os == 'Linux'
         working-directory: ./hack/pro
-        run: go run ./main.go ${{ inputs.tag || github.ref_name }} ../../desktop/resources/bin > ../../dist/provider.yaml
+        env:
+          PARTIAL: "true"
+        run: go run ./main.go ${{ inputs.tag || github.ref_name }} ../../dist > ../../dist/provider.yaml
 
       - name: configure Windows build tools
         if: runner.os == 'Windows'
         shell: pwsh
-        run: echo "GYP_MSVS_VERSION=2022" >> $env:GITHUB_ENV
+        run: |
+          echo "GYP_MSVS_VERSION=2022" >> $env:GITHUB_ENV
+          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
+          echo "GYP_MSVS_OVERRIDE_PATH=$vsPath" >> $env:GITHUB_ENV
 
       - uses: actions/setup-python@v6
         with:
@@ -160,6 +165,10 @@ jobs:
       - name: install xvfb
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: build desktop app
+        working-directory: desktop
+        run: npx electron-vite build
 
       - name: package and publish with electron-builder
         working-directory: desktop


### PR DESCRIPTION
## Summary

Fixes 3 pre-existing desktop build failures in the release workflow that were causing all desktop app builds (ubuntu, macOS, windows) to fail:

- **Ubuntu**: `generate pro provider` step panicked because it looked for arch-suffixed binaries in `desktop/resources/bin/` (which only has the renamed `devsy` binary). Changed base_path to `dist/` where arch-suffixed binaries are staged, and added `PARTIAL=true` as safety net for missing platform checksums.
- **macOS/all**: `electron-builder` failed because `dist/main/index.js` didn't exist. Added missing `electron-vite build` step before electron-builder packaging.
- **Windows**: `electron-rebuild` during `npm ci` failed with node-gyp stdout maxBuffer overflow during VS enumeration. Added `vswhere.exe` to pin `GYP_MSVS_OVERRIDE_PATH` directly, avoiding the enumeration.

All 5 recent release runs showed identical failures. CLI binary builds were unaffected — only desktop builds failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved desktop application build pipeline with enhanced provider generation and Windows build-tool configuration for more reliable release builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->