### PR TITLE
fix(ci): pin desktop Windows build to windows-2022 for node-gyp compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
             go-os: darwin
             go-arch: universal
             builder-args: --mac
-          - os: windows-latest
+          - os: windows-2022
             go-os: windows
             go-arch: amd64
             builder-args: --win
@@ -145,10 +145,7 @@ jobs:
       - name: configure Windows build tools
         if: runner.os == 'Windows'
         shell: pwsh
-        run: |
-          echo "GYP_MSVS_VERSION=2022" >> $env:GITHUB_ENV
-          $vsPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -property installationPath
-          echo "GYP_MSVS_OVERRIDE_PATH=$vsPath" >> $env:GITHUB_ENV
+        run: echo "GYP_MSVS_VERSION=2022" >> $env:GITHUB_ENV
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary
- Pin desktop Windows build runner from `windows-latest` to `windows-2022` to fix node-gyp/electron-rebuild failure
- `windows-latest` now resolves to `win25-vs2026` with VS 18 which `@electron/node-gyp` doesn't support (only up to VS 17/2022)
- Simplify configure step: remove stale vswhere/GYP_MSVS_OVERRIDE_PATH logic, just set GYP_MSVS_VERSION=2022
- CLI build retains `windows-latest` (Go builds don't use node-gyp)