### PR TITLE
fix(ci): pin Windows desktop builds to windows-2022 for node-gyp compat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
             go-os: darwin
             go-arch: universal
             builder-args: --mac
-          - os: windows-latest
+          - os: windows-2022
             go-os: windows
             go-arch: amd64
             builder-args: --win


### PR DESCRIPTION
## Summary
- Pin Windows desktop build runner from `windows-latest` to `windows-2022` in `release.yml`
- `windows-latest` now includes VS 18, which node-gyp doesn't recognize, causing `electron-rebuild` / `node-pty` build failures
- `desktop-ci.yml` already uses `windows-2022` — no change needed
- CLI builds intentionally remain on `windows-latest` (no node-gyp dependency)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build platform configuration to enhance release stability and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->