### PR TITLE
fix(ci): revert CI skip condition on release-please PRs

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   precommit:
-    if: "github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'autorelease: pending')"
     name: Pre-commit
     runs-on: ubuntu-latest
     steps:
@@ -17,7 +16,6 @@ jobs:
       - uses: j178/prek-action@v2
 
   lint:
-    if: "github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'autorelease: pending')"
     name: Lint
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +33,6 @@ jobs:
           only-new-issues: true
 
   can-read-secret:
-    if: "github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'autorelease: pending')"
     name: Can Read Secret
     runs-on: ubuntu-latest
     outputs:
@@ -51,7 +48,6 @@ jobs:
           fi
 
   build-cli:
-    if: "github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'autorelease: pending')"
     name: Build CLI Binary on ${{ matrix.runner }}
     needs: [precommit, lint]
     strategy:
@@ -92,7 +88,6 @@ jobs:
           path: dist/devsy-${{ steps.os.outputs.runner_os }}_*/devsy-${{ steps.os.outputs.runner_os }}-*
 
   integration-tests-unprivileged:
-    if: "github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'autorelease: pending')"
     name: Test ${{ matrix.label }} on ${{ matrix.runner }}
     needs: [build-cli]
     strategy:
@@ -159,7 +154,6 @@ jobs:
           go test -v -ginkgo.v -timeout 1500s --ginkgo.label-filter="${{ matrix.label }}"
 
   integration-tests:
-    if: "github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'autorelease: pending')"
     name: Test ${{ matrix.label }}${{ matrix.install-podman && format(' ({0})', matrix.install-podman) || '' }} on ${{ matrix.runner }}
     needs: [can-read-secret, build-cli]
     strategy:


### PR DESCRIPTION
## Summary

- Reverts DEVSY-104 (PR #318) which added `if:` conditions to all 6 jobs in `pr-ci.yml` to skip CI on `autorelease: pending` PRs
- GitHub branch protection treats SKIPPED required checks as NOT satisfied, which blocked PR #315 (release-please v1.3.0-rc.1) from auto-merging
- Removes the 6 job-level `if:` conditions from: precommit, lint, can-read-secret, build-cli, integration-tests-unprivileged, integration-tests