### PR TITLE
fix(ci): fix Netlify deploy and Flatpak upload in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,8 @@ jobs:
     name: Build Flatpak
     runs-on: ubuntu-latest
     needs: [build-desktop]
+    permissions:
+      contents: write
     container:
       image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-48
       options: --privileged
@@ -263,14 +265,14 @@ jobs:
           path: sites/dl-devsy-sh/public/desktop
 
       - name: deploy metadata
+        working-directory: sites/dl-devsy-sh
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         run: |
           npm install -g netlify-cli
           netlify deploy --prod \
-            --config=sites/dl-devsy-sh/netlify.toml \
-            --dir=sites/dl-devsy-sh/public \
+            --dir=public \
             --site="$NETLIFY_SITE_ID"
 
   prerelease:


### PR DESCRIPTION
## Summary

- Fix "Deploy Update Metadata to Netlify" failure: latest netlify-cli removed `--config` flag. Added `working-directory: sites/dl-devsy-sh` so `netlify.toml` is auto-discovered, changed `--dir` to relative `public`.
- Fix "Build Flatpak" failure: added `permissions: contents: write` to `build-flatpak` job so `softprops/action-gh-release@v3` can upload assets to the GitHub release.

Both failures caused "Publish Prerelease" to be skipped in release run 26009097494 (tag v1.3.0-rc.1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance deployment reliability and process optimization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->