### PR TITLE
fix(ci): add --no-build to netlify deploy in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         run: |
           npm install -g netlify-cli
-          netlify deploy --prod \
+          netlify deploy --prod --no-build \
             --dir=public \
             --site="$NETLIFY_SITE_ID"
 


### PR DESCRIPTION
## Summary

- Add `--no-build` flag to `netlify deploy` in the release workflow to prevent Netlify CLI from running site build commands before deploying.
- The deploy step uploads pre-built static files — no build step is needed. Without `--no-build`, the latest netlify-cli reads the site's build configuration and attempts `yarn build`, which fails because no build script exists in this context.
- Follow-up to PR #321 which fixed the `--config` removal but missed this flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal deployment workflow configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->