### PR TITLE
fix(ci): add permissions to publish-prerelease job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,6 +278,8 @@ jobs:
   prerelease:
     name: Publish Prerelease
     needs: [build-desktop, build-flatpak, deploy-update-metadata]
+    permissions:
+      contents: write
     if: github.event.release.prerelease
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

- Add `permissions: contents: write` to the `prerelease` job in `.github/workflows/release.yml`
- The `softprops/action-gh-release@v3` action requires `contents: write` to upload release assets; without it the job fails with "Resource not accessible by integration"
- Same fix previously applied to the `build-flatpak` job in PR #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to improve deployment process reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->