### PR TITLE
fix(ci): upload desktop artifacts via softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: upload desktop artifacts to release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
+          draft: true
+          files: |
+            desktop/release/*.dmg
+            desktop/release/*.zip
+            desktop/release/*.exe
+            desktop/release/*.AppImage
+            desktop/release/*.deb
+            desktop/release/*.rpm
+
       - name: upload update metadata artifact
         uses: actions/upload-artifact@v7
         with:

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -98,6 +98,3 @@ publish:
   - provider: generic
     url: https://dl.devsy.sh/desktop
     useMultipleRangeRequest: false
-  - provider: github
-    owner: devsy-org
-    repo: devsy


### PR DESCRIPTION
## Summary
- Removes the `github` provider from `desktop/electron-builder.yml` — electron-builder's GitHub publish provider was silently skipping all desktop uploads due to a release type mismatch (expects `draft`, but release-please creates `prerelease`)
- Adds `softprops/action-gh-release@v3` step in the `build-desktop` job to upload desktop artifacts (.dmg, .zip, .exe, .AppImage, .deb, .rpm) directly to the GitHub release
- This fixes a bug that has existed since desktop builds were added — no release has ever had desktop artifacts uploaded by electron-builder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated desktop binary release publishing configuration.
  * Enhanced automated release artifact handling for desktop builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->