### PR TITLE
fix(ci): correct RC tag regex in promote-release workflow

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       rc_tag:
-        description: "RC tag to promote (e.g., v1.1.0-rc1)"
+        description: "RC tag to promote (e.g., v1.3.0-rc.1)"
         required: true
         type: string
 
@@ -30,7 +30,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RC_TAG: ${{ inputs.rc_tag }}
         run: |
-          if ! echo "$RC_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$'; then
+          if ! echo "$RC_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$'; then
             echo "::error::Invalid RC tag format: $RC_TAG (expected v*.*.*-rc*)"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Fix tag validation regex in promote-release.yml to match release-please's dot-separated RC tag format (v1.3.0-rc.4 instead of v1.3.0-rc4)
- Update input description example to show correct format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release candidate tag validation to enforce stricter formatting with dot-separated prerelease numbering (e.g., `v1.3.0-rc.1`).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->