### PR TITLE
fix(ci): correct RC tag regex to match dot-separated format

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       rc_tag:
-        description: "RC tag to promote (e.g., v1.1.0-rc1)"
+        description: "RC tag to promote (e.g., v1.3.0-rc.1)"
         required: true
         type: string
 
@@ -30,7 +30,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RC_TAG: ${{ inputs.rc_tag }}
         run: |
-          if ! echo "$RC_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$'; then
+          if ! echo "$RC_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$'; then
             echo "::error::Invalid RC tag format: $RC_TAG (expected v*.*.*-rc*)"
             exit 1
           fi


### PR DESCRIPTION
## Summary

The `promote-release.yml` workflow validated RC tags with the regex `-rc[0-9]+$`, which expected a format like `v1.3.0-rc4`. However, release-please produces tags in the format `v1.3.0-rc.4` (with a dot between `rc` and the number), causing the validation step to reject all valid RC tags.

This PR fixes the regex to `-rc\.[0-9]+$` to match the actual release-please tag format, and updates the description example from `v1.1.0-rc1` to `v1.3.0-rc.1` to reflect the correct format.