### PR TITLE
feat(ci): add path-based filtering to skip e2e on non-Go changes

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -10,11 +10,12 @@ jobs:
   changes:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       go: ${{ steps.filter.outputs.go }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -601,7 +602,8 @@ jobs:
       - name: Check required jobs
         run: |
           # Fail if any required job failed (not skipped)
-          if [[ "${{ needs.precommit.result }}" == "failure" ]] || \
+          if [[ "${{ needs.changes.result }}" == "failure" ]] || \
+             [[ "${{ needs.precommit.result }}" == "failure" ]] || \
              [[ "${{ needs.lint.result }}" == "failure" ]] || \
              [[ "${{ needs.build-cli.result }}" == "failure" ]] || \
              [[ "${{ needs.integration-tests-unprivileged.result }}" == "failure" ]] || \

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -7,6 +7,26 @@ on:
   pull_request:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      go: ${{ steps.filter.outputs.go }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            go:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.goreleaser.yml'
+              - 'e2e/**'
+              - '.github/workflows/pr-ci.yml'
+
   precommit:
     name: Pre-commit
     runs-on: ubuntu-latest
@@ -49,7 +69,8 @@ jobs:
 
   build-cli:
     name: Build CLI Binary on ${{ matrix.runner }}
-    needs: [precommit, lint]
+    needs: [changes, precommit, lint]
+    if: needs.changes.outputs.go == 'true'
     strategy:
       matrix:
         include:
@@ -89,7 +110,8 @@ jobs:
 
   integration-tests-unprivileged:
     name: Test ${{ matrix.label }} on ${{ matrix.runner }}
-    needs: [build-cli]
+    needs: [changes, build-cli]
+    if: needs.changes.outputs.go == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -155,7 +177,8 @@ jobs:
 
   integration-tests:
     name: Test ${{ matrix.label }}${{ matrix.install-podman && format(' ({0})', matrix.install-podman) || '' }} on ${{ matrix.runner }}
-    needs: [can-read-secret, build-cli]
+    needs: [changes, can-read-secret, build-cli]
+    if: needs.changes.outputs.go == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -562,3 +585,28 @@ jobs:
       - name: verify docker is installed
         if: matrix.label == 'docker-install' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')
         run: docker --version && docker ps
+
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - changes
+      - precommit
+      - lint
+      - build-cli
+      - integration-tests-unprivileged
+      - integration-tests
+    steps:
+      - name: Check required jobs
+        run: |
+          # Fail if any required job failed (not skipped)
+          if [[ "${{ needs.precommit.result }}" == "failure" ]] || \
+             [[ "${{ needs.lint.result }}" == "failure" ]] || \
+             [[ "${{ needs.build-cli.result }}" == "failure" ]] || \
+             [[ "${{ needs.integration-tests-unprivileged.result }}" == "failure" ]] || \
+             [[ "${{ needs.integration-tests.result }}" == "failure" ]]; then
+            echo "One or more required jobs failed"
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped"


### PR DESCRIPTION
## Summary
- Add dorny/paths-filter@v3 to detect Go source changes in pr-ci.yml
- Gate build-cli and integration test jobs behind path filter output
- Add ci-success gate job that always reports (pass on skip, fail on failure)

This allows non-Go PRs (docs, CI config, desktop) to merge without running the full 35+ e2e test suite, saving significant CI time and cost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI pipeline to skip unnecessary jobs when Go-related files aren't modified
  * Added CI status aggregation job for improved workflow transparency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->