### PR TITLE
fix(ci): deploy electron update metadata to dl.devsy.sh via Netlify

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,8 @@ jobs:
     name: Deploy Electron Update Metadata
     needs: [build-desktop]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: download update metadata artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,6 +219,31 @@ jobs:
           name: devsy-flatpak
           path: desktop/release/*.deb
 
+  deploy-update-metadata:
+    name: Deploy Electron Update Metadata
+    needs: [build-desktop]
+    runs-on: ubuntu-latest
+    steps:
+      - name: download update metadata artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: update-metadata-*
+          path: metadata/
+
+      - name: arrange files into publish directory
+        run: |
+          mkdir -p publish-dir/desktop
+          find metadata/ -name 'latest*.yml' -exec cp {} publish-dir/desktop/ \;
+
+      - name: deploy to Netlify (dl.devsy.sh)
+        uses: nwtgck/actions-netlify@v3
+        with:
+          publish-dir: ./publish-dir
+          production-deploy: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_DL_SITE_ID }}
+
   build-flatpak:
     name: Build Flatpak
     runs-on: ubuntu-latest
@@ -266,7 +291,7 @@ jobs:
 
   prerelease:
     name: Publish Prerelease
-    needs: [build-desktop, build-flatpak]
+    needs: [build-desktop, build-flatpak, deploy-update-metadata]
     permissions:
       contents: write
     if: github.event.release.prerelease


### PR DESCRIPTION
## Summary

- Adds a new `deploy-update-metadata` job to `release.yml` that downloads the three electron updater metadata artifacts (`update-metadata-ubuntu-22.04`, `update-metadata-macos-latest`, `update-metadata-windows-2022`) and deploys them to the dedicated dl.devsy.sh Netlify site
- Files are arranged into `publish-dir/desktop/` so they are served at `https://dl.devsy.sh/desktop/latest*.yml`, matching the `generic` provider URL configured in `desktop/electron-builder.yml`
- Uses `NETLIFY_DL_SITE_ID` secret (separate from the main site's `NETLIFY_SITE_ID`) to avoid touching devsy.sh
- `prerelease` job now depends on `deploy-update-metadata` to ensure metadata is live before the release is published
- Job has `permissions: contents: read` (least-privilege)

**Required secret:** `NETLIFY_DL_SITE_ID` must be added to repo secrets pointing to the dl.devsy.sh Netlify site.