### PR TITLE
chore(ci): add custom domain operation to netlify-ops workflow

### DIFF
--- a/.github/workflows/netlify-ops.yml
+++ b/.github/workflows/netlify-ops.yml
@@ -10,6 +10,7 @@ on:
         options:
           - restore-devsy-sh
           - find-dl-site
+          - add-dl-custom-domain
 
 jobs:
   restore-devsy-sh:
@@ -94,3 +95,44 @@ jobs:
           echo "NETLIFY_DL_SITE_ID = $DL_SITE_ID"
           echo "========================================"
           echo "Run: gh secret set NETLIFY_DL_SITE_ID --org devsy-org --visibility all --body \"$DL_SITE_ID\""
+
+  add-dl-custom-domain:
+    name: Add dl.devsy.sh Custom Domain to dl-devsy-sh Site
+    if: inputs.operation == 'add-dl-custom-domain'
+    runs-on: ubuntu-latest
+    env:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      DL_SITE_ID: a6c8ca4e-62c1-4c75-95ba-1abcd2af540f
+    steps:
+      - name: Add custom domain and report DNS instructions
+        run: |
+          echo "Adding dl.devsy.sh as custom domain to site $DL_SITE_ID..."
+          RESPONSE=$(curl -s -w "\n%{http_code}" -X PUT \
+            -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{"custom_domain": "dl.devsy.sh"}' \
+            "https://api.netlify.com/api/v1/sites/$DL_SITE_ID")
+
+          HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+          BODY=$(echo "$RESPONSE" | sed '$d')
+
+          if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
+            echo "ERROR: Custom domain update failed (HTTP $HTTP_CODE)"
+            echo "$BODY"
+            exit 1
+          fi
+
+          echo "Custom domain set (HTTP $HTTP_CODE)"
+          NETLIFY_SUBDOMAIN=$(echo "$BODY" | jq -r '.subdomain // .name')
+          echo ""
+          echo "========================================"
+          echo "CUSTOM DOMAIN CONFIGURED: dl.devsy.sh"
+          echo "========================================"
+          echo ""
+          echo "CEO DNS action required — add this DNS record:"
+          echo "  Type:  CNAME"
+          echo "  Name:  dl"
+          echo "  Value: ${NETLIFY_SUBDOMAIN}.netlify.app"
+          echo ""
+          echo "Full site info:"
+          echo "$BODY" | jq '{id, name, custom_domain, subdomain, url, ssl_url}'

--- a/.github/workflows/netlify-ops.yml
+++ b/.github/workflows/netlify-ops.yml
@@ -26,12 +26,12 @@ jobs:
           DEPLOYS=$(curl -s -H "Authorization: Bearer $NETLIFY_AUTH_TOKEN" \
             "https://api.netlify.com/api/v1/sites/$NETLIFY_SITE_ID/deploys?per_page=100")
 
-          DEPLOY_ID=$(echo "$DEPLOYS" | jq -r '[.[] | select(.state == "ready")] | .[0].id')
-          DEPLOY_INFO=$(echo "$DEPLOYS" | jq -r '[.[] | select(.state == "ready")] | .[0] | {id, created_at, deploy_source, title}')
+          DEPLOY_ID=$(echo "$DEPLOYS" | jq -r '[.[] | select(.state == "ready" and .deploy_source != "cli")] | .[0].id')
+          DEPLOY_INFO=$(echo "$DEPLOYS" | jq -r '[.[] | select(.state == "ready" and .deploy_source != "cli")] | .[0] | {id, created_at, deploy_source, title}')
 
           if [ "$DEPLOY_ID" = "null" ] || [ -z "$DEPLOY_ID" ]; then
-            echo "ERROR: No ready deploy found in last 100. States seen:"
-            echo "$DEPLOYS" | jq '[.[] | .state] | group_by(.) | map({state: .[0], count: length})'
+            echo "ERROR: No non-CLI ready deploy found in last 100. All deploys:"
+            echo "$DEPLOYS" | jq '.[] | {id, state, deploy_source, created_at}' | head -80
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

Adds `add-dl-custom-domain` operation to `netlify-ops.yml` that configures `dl.devsy.sh` as the custom domain on the `dl-devsy-sh` Netlify site via the Netlify API, and outputs the CNAME DNS record the CEO needs to add.