### PR TITLE
fix(ci): rewrite RC version header to stable in promote workflow

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -69,8 +69,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RC_TAG: ${{ inputs.rc_tag }}
+          STABLE_TAG: ${{ steps.version.outputs.stable_tag }}
         run: |
           BODY=$(gh release view "$RC_TAG" --json body -q .body)
+          STABLE_VERSION="${STABLE_TAG#v}"
+          BODY=$(echo "$BODY" | sed "1s/^.*-rc\.[0-9]* /$STABLE_VERSION /")
           { echo "body<<EOF"; echo "$BODY"; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
       - name: create stable release


### PR DESCRIPTION
## Summary

- Adds a **fetch RC release notes** step that reads the RC body and rewrites the first-line version header from (e.g.) `1.3.0-rc.10 (2026-05-18)` to `1.3.0 (2026-05-18)` using `sed`
- Switches `create stable release` from `--generate-notes --notes-start-tag` to `--notes-file /tmp/release-notes.md` so the corrected body is used
- Removes `--draft` and adds `--latest` so the release publishes directly as the latest stable release without a separate publish step

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release promotion process to ensure stable releases are properly marked as the latest version with consistent release notes derived from release candidates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->