### PR TITLE
fix(ci): use github.token for stable release creation in promote workflow

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: create stable release
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           STABLE_TAG: ${{ steps.version.outputs.stable_tag }}
           COMMIT_SHA: ${{ steps.version.outputs.commit_sha }}
         run: |


### PR DESCRIPTION
## Summary

- The GitHub App token (`steps.app-token.outputs.token`) returns HTTP 403 when used to create releases via both `gh release create` and `softprops/action-gh-release@v3`
- The workflow already has `permissions: contents: write` at the top level, giving `github.token` the required permission
- Switch the `create stable release` step to use `github.token`, matching the existing `trigger full rebuild` step