### PR TITLE
fix(ci): restore softprops release creation and wire rc_notes output correctly

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -65,26 +65,26 @@ jobs:
           echo "Stable tag: $STABLE_TAG at commit: $COMMIT_SHA"
 
       - name: fetch RC release notes
+        id: rc_notes
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RC_TAG: ${{ inputs.rc_tag }}
         run: |
           BODY=$(gh release view "$RC_TAG" --json body -q .body)
-          # Strip -rc.N suffix from the version string in the first line header
           BODY=$(echo "$BODY" | sed "1s/-rc\.[0-9]*//" )
-          echo "$BODY" > /tmp/release-notes.md
+          { echo "body<<EOF"; echo "$BODY"; echo "EOF"; } >> "$GITHUB_OUTPUT"
 
       - name: create stable release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          STABLE_TAG: ${{ steps.version.outputs.stable_tag }}
-          COMMIT_SHA: ${{ steps.version.outputs.commit_sha }}
-        run: |
-          gh release create "$STABLE_TAG" \
-            --target "$COMMIT_SHA" \
-            --title "$STABLE_TAG" \
-            --notes-file /tmp/release-notes.md \
-            --latest
+        uses: softprops/action-gh-release@v3
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          tag_name: ${{ steps.version.outputs.stable_tag }}
+          target_commitish: ${{ steps.version.outputs.commit_sha }}
+          name: ${{ steps.version.outputs.stable_tag }}
+          body: ${{ steps.rc_notes.outputs.body }}
+          draft: false
+          prerelease: false
+          make_latest: true
 
       - name: trigger full rebuild
         env:


### PR DESCRIPTION
## Summary

- Previous fixes attempted `gh release create` with `github.token` and `app-token`, both hitting HTTP 403 — the org policy sets `default_workflow_permissions=read` for all repos, and the app token only has `contents:read`
- `softprops/action-gh-release@v3` with the GitHub App token is the only approach that has worked (runs `26048757691` and `26049369190`)
- Restores `softprops` as the release creation mechanism and adds `id: rc_notes` to the fetch step so its `body` output can be consumed by softprops
- The sed fix (`1s/-rc\.[0-9]*//"`) that rewrites the RC version header is preserved