### PR TITLE
fix(ci): use make_latest legacy to avoid admin permission in promote workflow

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -84,7 +84,7 @@ jobs:
           body: ${{ steps.rc_notes.outputs.body }}
           draft: false
           prerelease: false
-          make_latest: true
+          make_latest: "legacy"
 
       - name: trigger full rebuild
         env:


### PR DESCRIPTION
## Summary

- The `devsy-app` GitHub App installation has `contents: write` and `metadata: read` but not `administration: write`
- The `make_latest: true` parameter on `softprops/action-gh-release@v3` calls the GitHub Releases API with `make_latest=true`, which requires elevated permissions the app token doesn't have → HTTP 403 "Resource not accessible by integration"
- Switching to `make_latest: "legacy"` uses the automatic latest-release behavior (whichever non-prerelease release was published most recently becomes latest), which only requires `contents: write`
- This is the minimal fix that restores the behavior from the working runs at 17:15 and 17:27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to adjust how stable releases are marked as the latest version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->