### PR TITLE
fix(ci): explicitly request contents:write permission for app token

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           app-id: ${{ secrets.DEVSY_GITHUB_APP_ID }}
           private-key: ${{ secrets.DEVSY_GITHUB_APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary

- The devsy-app installation has `contents: write` at the org level, but the generated token may not be getting the write scope
- Adding `permission-contents: write` to `actions/create-github-app-token@v3` explicitly requests that the installation token be scoped with contents write access
- This may resolve the `HTTP 403: Resource not accessible by integration` error on the `create stable release` step