### PR TITLE
fix(ci): pass app token via GITHUB_TOKEN env for softprops release step

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -77,8 +77,9 @@ jobs:
 
       - name: create stable release
         uses: softprops/action-gh-release@v3
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          token: ${{ steps.app-token.outputs.token }}
           tag_name: ${{ steps.version.outputs.stable_tag }}
           target_commitish: ${{ steps.version.outputs.commit_sha }}
           name: ${{ steps.version.outputs.stable_tag }}


### PR DESCRIPTION
## Summary

- The `token:` input on `softprops/action-gh-release@v3` may handle the token differently than the `GITHUB_TOKEN` environment variable
- `release.yml` uses softprops without specifying `token:` and it works for asset uploads using the default `GITHUB_TOKEN`
- This PR switches to passing the app token via the `GITHUB_TOKEN` environment variable (overriding it for just this step), which is the mechanism `release.yml` uses successfully