### PR TITLE
fix(ci): remove permission-contents scope restriction from app token

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           app-id: ${{ secrets.DEVSY_GITHUB_APP_ID }}
           private-key: ${{ secrets.DEVSY_GITHUB_APP_PRIVATE_KEY }}
-          permission-contents: write
 
       - uses: actions/checkout@v6
         with:
@@ -77,16 +76,15 @@ jobs:
 
       - name: create stable release
         uses: softprops/action-gh-release@v3
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
+          token: ${{ steps.app-token.outputs.token }}
           tag_name: ${{ steps.version.outputs.stable_tag }}
           target_commitish: ${{ steps.version.outputs.commit_sha }}
           name: ${{ steps.version.outputs.stable_tag }}
           body: ${{ steps.rc_notes.outputs.body }}
           draft: false
           prerelease: false
-          make_latest: "legacy"
+          make_latest: true
 
       - name: trigger full rebuild
         env:


### PR DESCRIPTION
## Summary

- Per the `actions/create-github-app-token@v3` docs: *"By default, the token inherits all of the installation's permissions."* When any `permission-*` input is specified, **the token is restricted to only those permissions** — all others are dropped.
- PR #355 added `permission-contents: write`, which inadvertently stripped all other permissions from the token (e.g. `metadata: read` needed for API calls), causing `softprops/action-gh-release` to receive a narrowly-scoped token that couldn't create releases.
- This PR removes `permission-contents: write` so the token inherits all installation permissions (contents: write, metadata: read, pull_requests: write) — exactly matching the working configuration from runs 26048757691 and 26049369190.
- Also restores `token:` input on softprops (not env override) and `make_latest: true`, matching the proven working state.
- The only functional change vs the original working commit is the sed rewrite line in `fetch RC release notes`.