### PR TITLE
fix(ci): pass app token via token input for softprops/action-gh-release

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -77,9 +77,8 @@ jobs:
 
       - name: create stable release
         uses: softprops/action-gh-release@v3
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
+          token: ${{ steps.app-token.outputs.token }}
           tag_name: ${{ steps.version.outputs.stable_tag }}
           target_commitish: ${{ steps.version.outputs.commit_sha }}
           name: ${{ steps.version.outputs.stable_tag }}


### PR DESCRIPTION
## Summary

- `softprops/action-gh-release@v3` reads the token from `INPUT_TOKEN` (populated by the `token:` action input) **before** falling back to `GITHUB_TOKEN`
- The workflow was passing the app-token via `env: GITHUB_TOKEN:`, which sets `GITHUB_TOKEN` but not `INPUT_TOKEN`
- So the action used the default `${{ github.token }}` (the low-permissions workflow token) instead of the app-token, causing the 403 "Resource not accessible by integration"
- Fix: pass the app-token via `with: token:` so `INPUT_TOKEN` gets the correct value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration for improved security handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->