### PR TITLE
feat(ci): enable autoMergeRequest in release-please action

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,7 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          autoMergeRequest: true
 
   auto-merge-rc:
     name: Auto-merge RC Release PR


### PR DESCRIPTION
## Summary

- Adds `autoMergeRequest: true` to the `googleapis/release-please-action@v4` step in `.github/workflows/release-please.yml`
- This causes release-please to automatically enable auto-merge on the PRs it creates, so they merge once CI passes
- Config-only change; no application code modified