### PR TITLE
fix(ci): use origin refs in create-release-pr workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get commit log
         id: commits
         run: |
-          COMMITS=$(git log release..main --oneline)
+          COMMITS=$(git log origin/release..origin/main --oneline)
           {
             echo "log<<EOF"
             echo "$COMMITS"


### PR DESCRIPTION
## Summary

- Fixes `create-release-pr` workflow failure where `git log release..main` couldn't resolve the bare `release` ref
- Uses `origin/release..origin/main` which works with `actions/checkout` fetch-depth: 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process workflow to improve commit log generation accuracy during release preparation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/381?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->