### PR TITLE
fix(ci): use feat: prefix in release PR title for semantic-release

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -40,7 +40,9 @@ jobs:
           gh pr create \
             --base release \
             --head main \
-            --title "release: promote main to stable" \
+            --title "feat(release): promote main to stable" \
             --body "## Commits being promoted
 
-          ${{ steps.commits.outputs.log }}"
+          ${{ steps.commits.outputs.log }}
+
+          > **Merge with rebase** to preserve individual commit messages for semantic-release."


### PR DESCRIPTION
## Summary

- Changes release PR title from `release:` to `feat(release):` so squash merges trigger semantic-release
- Adds note in PR body to prefer rebase merge (preserves individual feat:/fix: commits)
- Also enabled rebase merge on the repo settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release process workflows to refine pull request metadata and merge strategy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/385?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->