### PR TITLE
fix(ci): use App token in create-release to trigger build workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,6 +13,12 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.DEVSY_GITHUB_APP_ID }}
+          private-key: ${{ secrets.DEVSY_GITHUB_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -29,7 +35,7 @@ jobs:
 
       - name: Create release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh release create "$GITHUB_REF_NAME" \
             --generate-notes \


### PR DESCRIPTION
## Summary

- Uses GitHub App token instead of `github.token` in `create-release.yml`
- This ensures the `release: [published]` event triggers the downstream `release.yml` build workflow (GITHUB_TOKEN events don't trigger other workflows)