### PR TITLE
fix(ci): skip electron update metadata deploy for pre-releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,6 +13,12 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.DEVSY_GITHUB_APP_ID }}
+          private-key: ${{ secrets.DEVSY_GITHUB_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -29,7 +35,7 @@ jobs:
 
       - name: Create release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh release create "$GITHUB_REF_NAME" \
             --generate-notes \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,7 @@ jobs:
   deploy-update-metadata:
     name: Deploy Electron Update Metadata
     needs: [build-desktop]
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -293,7 +294,7 @@ jobs:
 
   prerelease:
     name: Publish Prerelease
-    needs: [build-desktop, build-flatpak, deploy-update-metadata]
+    needs: [build-desktop, build-flatpak]
     permissions:
       contents: write
     if: github.event.release.prerelease


### PR DESCRIPTION
## Summary

- Skip the `deploy-update-metadata` job for pre-releases since electron-builder doesn't generate `latest*.yml` auto-update manifests for pre-release versions
- Remove `deploy-update-metadata` from the `prerelease` job's `needs` so the pre-release publish step isn't blocked by a skipped job