### PR TITLE
feat: add beta release channel and split macOS arch builds

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,6 +13,12 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.DEVSY_GITHUB_APP_ID }}
+          private-key: ${{ secrets.DEVSY_GITHUB_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -29,7 +35,7 @@ jobs:
 
       - name: Create release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh release create "$GITHUB_REF_NAME" \
             --generate-notes \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,6 +230,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: download update metadata artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           path: dist/devsy-${{ steps.os.outputs.runner_os }}_*/devsy-${{ steps.os.outputs.runner_os }}-*
 
   build-desktop:
-    name: Build Desktop App on ${{ matrix.os }}
+    name: Build Desktop App (${{ matrix.name }})
     needs: build-cli
     permissions:
       contents: write
@@ -58,15 +58,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - name: linux-x64
+            os: ubuntu-22.04
             go-os: linux
             go-arch: amd64
             builder-args: --linux
-          - os: macos-latest
+          - name: macos-arm64
+            os: macos-latest
             go-os: darwin
-            go-arch: universal
-            builder-args: --mac
-          - os: windows-2022
+            go-arch: arm64
+            builder-args: --mac --arm64
+          - name: macos-x64
+            os: macos-latest
+            go-os: darwin
+            go-arch: amd64
+            builder-args: --mac --x64
+          - name: windows-x64
+            os: windows-2022
             go-os: windows
             go-arch: amd64
             builder-args: --win
@@ -114,15 +122,8 @@ jobs:
         run: |
           TEMP_DIR="${{ runner.temp }}"
           mkdir -p desktop/resources/bin
-
-          if [ "${{ matrix.go-arch }}" = "universal" ]; then
-            # macOS: use both arch binaries for universal build
-            cp "$TEMP_DIR/devsy-bin/devsy-darwin-amd64" desktop/resources/bin/devsy
-            chmod +x desktop/resources/bin/devsy
-          else
-            cp "$TEMP_DIR/devsy-bin/devsy-${{ matrix.go-os }}-${{ matrix.go-arch }}" desktop/resources/bin/devsy
-            chmod +x desktop/resources/bin/devsy
-          fi
+          cp "$TEMP_DIR/devsy-bin/devsy-${{ matrix.go-os }}-${{ matrix.go-arch }}" desktop/resources/bin/devsy
+          chmod +x desktop/resources/bin/devsy
 
           # Also stage binaries for dist/ upload and provider generation
           mkdir -p dist/
@@ -136,7 +137,7 @@ jobs:
           Copy-Item "${{ runner.temp }}/devsy-bin/devsy-windows-amd64.exe" desktop/resources/bin/devsy.exe
 
       - name: generate pro provider
-        if: runner.os == 'Linux'
+        if: matrix.name == 'linux-x64'
         working-directory: ./hack/pro
         env:
           PARTIAL: "true"
@@ -199,13 +200,15 @@ jobs:
       - name: upload update metadata artifact
         uses: actions/upload-artifact@v7
         with:
-          name: update-metadata-${{ matrix.os }}
-          path: desktop/release/latest*.yml
+          name: update-metadata-${{ matrix.name }}
+          path: |
+            desktop/release/latest*.yml
+            desktop/release/beta*.yml
           if-no-files-found: ignore
 
       - name: upload cli assets
         uses: softprops/action-gh-release@v3
-        if: runner.os == 'Linux'
+        if: matrix.name == 'linux-x64'
         with:
           tag_name: ${{ inputs.tag || github.ref_name }}
           draft: true
@@ -213,7 +216,7 @@ jobs:
             ./dist/*
 
       - name: upload desktop linux artifact for flatpak
-        if: runner.os == 'Linux'
+        if: matrix.name == 'linux-x64'
         uses: actions/upload-artifact@v7
         with:
           name: devsy-flatpak
@@ -222,21 +225,36 @@ jobs:
   deploy-update-metadata:
     name: Deploy Electron Update Metadata
     needs: [build-desktop]
-    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
+      - uses: actions/checkout@v6
+
       - name: download update metadata artifacts
         uses: actions/download-artifact@v8
         with:
           pattern: update-metadata-*
           path: metadata/
 
-      - name: arrange files into publish directory
+      - name: fetch existing metadata from live site
         run: |
           mkdir -p publish-dir/desktop
-          find metadata/ -name 'latest*.yml' -exec cp {} publish-dir/desktop/ \;
+          for file in latest-mac.yml latest-linux.yml latest.yml beta-mac.yml beta-linux.yml beta.yml; do
+            curl -sSf "https://dl.devsy.sh/desktop/$file" -o "publish-dir/desktop/$file" 2>/dev/null || true
+          done
+
+      - name: merge macOS metadata from separate arch builds
+        run: |
+          pip install pyyaml
+          python3 hack/merge-mac-metadata.py metadata/ publish-dir/desktop/
+
+      - name: overlay non-mac metadata files
+        run: |
+          find metadata/ -name 'latest-linux.yml' -exec cp {} publish-dir/desktop/ \;
+          find metadata/ -name 'latest.yml' -exec cp {} publish-dir/desktop/ \;
+          find metadata/ -name 'beta-linux.yml' -exec cp {} publish-dir/desktop/ \;
+          find metadata/ -name 'beta.yml' -exec cp {} publish-dir/desktop/ \;
 
       - name: deploy to Netlify (dl.devsy.sh)
         uses: nwtgck/actions-netlify@v3
@@ -294,7 +312,7 @@ jobs:
 
   prerelease:
     name: Publish Prerelease
-    needs: [build-desktop, build-flatpak]
+    needs: [build-desktop, build-flatpak, deploy-update-metadata]
     permissions:
       contents: write
     if: github.event.release.prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,7 @@ jobs:
   deploy-update-metadata:
     name: Deploy Electron Update Metadata
     needs: [build-desktop]
+    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -293,7 +294,7 @@ jobs:
 
   prerelease:
     name: Publish Prerelease
-    needs: [build-desktop, build-flatpak, deploy-update-metadata]
+    needs: [build-desktop, build-flatpak]
     permissions:
       contents: write
     if: github.event.release.prerelease

--- a/README.md
+++ b/README.md
@@ -39,8 +39,13 @@ Take a look at the <a href="https://devsy.sh/docs/getting-started/install">Devsy
 </tr>
 <tr>
 <td><b>macOS</b></td>
-<td>Universal (Apple Silicon + Intel)</td>
-<td><a href="https://github.com/devsy-org/devsy/releases/latest/download/Devsy_mac_universal.dmg"><img src="https://img.shields.io/badge/Download-DMG-blue?style=flat-square&logo=apple" alt="macOS Universal"></a></td>
+<td>Apple Silicon (ARM64)</td>
+<td><a href="https://github.com/devsy-org/devsy/releases/latest/download/Devsy_mac_arm64.dmg"><img src="https://img.shields.io/badge/Download-DMG-blue?style=flat-square&logo=apple" alt="macOS ARM64"></a></td>
+</tr>
+<tr>
+<td><b>macOS</b></td>
+<td>Intel (x64)</td>
+<td><a href="https://github.com/devsy-org/devsy/releases/latest/download/Devsy_mac_x64.dmg"><img src="https://img.shields.io/badge/Download-DMG-blue?style=flat-square&logo=apple" alt="macOS x64"></a></td>
 </tr>
 <tr>
 <td><b>Windows</b></td>

--- a/cmd/self_update.go
+++ b/cmd/self_update.go
@@ -10,6 +10,7 @@ import (
 // SelfUpdateCmd is a struct that defines a command call for "self-update".
 type SelfUpdateCmd struct {
 	Version string
+	Channel string
 	DryRun  bool
 }
 
@@ -22,7 +23,12 @@ func NewSelfUpdateCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			ctx := cobraCmd.Context()
-			if err := selfupdate.Upgrade(ctx, cmd.Version, cmd.DryRun); err != nil {
+			opts := selfupdate.Options{
+				Version:           cmd.Version,
+				DryRun:            cmd.DryRun,
+				IncludePrerelease: cmd.Channel == "beta",
+			}
+			if err := selfupdate.Upgrade(ctx, opts); err != nil {
 				return fmt.Errorf("unable to update: %w", err)
 			}
 			return nil
@@ -32,6 +38,9 @@ func NewSelfUpdateCmd() *cobra.Command {
 	selfUpdateCmd.Flags().
 		StringVar(&cmd.Version, "version", "",
 			"The version to update to. Defaults to the latest stable version available")
+	selfUpdateCmd.Flags().
+		StringVar(&cmd.Channel, "channel", "stable",
+			"Release channel: 'stable' for production releases, 'beta' for pre-release versions")
 	selfUpdateCmd.Flags().
 		BoolVar(&cmd.DryRun, "dry-run", false, "Show which version would be downloaded without actually updating")
 	return selfUpdateCmd

--- a/cmd/self_update.go
+++ b/cmd/self_update.go
@@ -21,6 +21,14 @@ func NewSelfUpdateCmd() *cobra.Command {
 		Use:   "self-update",
 		Short: "Update the Devsy CLI to the newest version",
 		Args:  cobra.NoArgs,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			switch cmd.Channel {
+			case "stable", "beta":
+				return nil
+			default:
+				return fmt.Errorf("invalid channel %q: must be 'stable' or 'beta'", cmd.Channel)
+			}
+		},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			ctx := cobraCmd.Context()
 			opts := selfupdate.Options{

--- a/cmd/self_update.go
+++ b/cmd/self_update.go
@@ -7,6 +7,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	channelStable = "stable"
+	channelBeta   = "beta"
+)
+
 // SelfUpdateCmd is a struct that defines a command call for "self-update".
 type SelfUpdateCmd struct {
 	Version string
@@ -23,10 +28,15 @@ func NewSelfUpdateCmd() *cobra.Command {
 		Args:  cobra.NoArgs,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
 			switch cmd.Channel {
-			case "stable", "beta":
+			case channelStable, channelBeta:
 				return nil
 			default:
-				return fmt.Errorf("invalid channel %q: must be 'stable' or 'beta'", cmd.Channel)
+				return fmt.Errorf(
+					"invalid channel %q: must be %q or %q",
+					cmd.Channel,
+					channelStable,
+					channelBeta,
+				)
 			}
 		},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
@@ -34,7 +44,7 @@ func NewSelfUpdateCmd() *cobra.Command {
 			opts := selfupdate.Options{
 				Version:           cmd.Version,
 				DryRun:            cmd.DryRun,
-				IncludePrerelease: cmd.Channel == "beta",
+				IncludePrerelease: cmd.Channel == channelBeta,
 			}
 			if err := selfupdate.Upgrade(ctx, opts); err != nil {
 				return fmt.Errorf("unable to update: %w", err)
@@ -47,7 +57,7 @@ func NewSelfUpdateCmd() *cobra.Command {
 		StringVar(&cmd.Version, "version", "",
 			"The version to update to. Defaults to the latest stable version available")
 	selfUpdateCmd.Flags().
-		StringVar(&cmd.Channel, "channel", "stable",
+		StringVar(&cmd.Channel, "channel", channelStable,
 			"Release channel: 'stable' for production releases, 'beta' for pre-release versions")
 	selfUpdateCmd.Flags().
 		BoolVar(&cmd.DryRun, "dry-run", false, "Show which version would be downloaded without actually updating")

--- a/cmd/self_update_test.go
+++ b/cmd/self_update_test.go
@@ -41,3 +41,22 @@ func TestNewSelfUpdateCmd_AcceptsNoPositionalArgs(t *testing.T) {
 	err = cmd.Args(cmd, []string{})
 	assert.NoError(t, err, "should accept zero arguments")
 }
+
+func TestNewSelfUpdateCmd_RejectsInvalidChannel(t *testing.T) {
+	cmd := NewSelfUpdateCmd()
+	cmd.SetArgs([]string{"--channel", "nightly"})
+	err := cmd.Execute()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid channel")
+}
+
+func TestNewSelfUpdateCmd_AcceptsValidChannels(t *testing.T) {
+	for _, ch := range []string{"stable", "beta"} {
+		cmd := NewSelfUpdateCmd()
+		require.NoError(t, cmd.Flags().Set("channel", ch))
+		// PreRunE should pass validation
+		preRunE := cmd.PreRunE
+		require.NotNil(t, preRunE)
+		assert.NoError(t, preRunE(cmd, nil))
+	}
+}

--- a/cmd/self_update_test.go
+++ b/cmd/self_update_test.go
@@ -30,7 +30,7 @@ func TestNewSelfUpdateCmd_HasChannelFlag(t *testing.T) {
 	cmd := NewSelfUpdateCmd()
 	f := cmd.Flags().Lookup("channel")
 	require.NotNil(t, f, "--channel flag must exist")
-	assert.Equal(t, "stable", f.DefValue)
+	assert.Equal(t, channelStable, f.DefValue)
 }
 
 func TestNewSelfUpdateCmd_AcceptsNoPositionalArgs(t *testing.T) {
@@ -51,10 +51,9 @@ func TestNewSelfUpdateCmd_RejectsInvalidChannel(t *testing.T) {
 }
 
 func TestNewSelfUpdateCmd_AcceptsValidChannels(t *testing.T) {
-	for _, ch := range []string{"stable", "beta"} {
+	for _, ch := range []string{channelStable, channelBeta} {
 		cmd := NewSelfUpdateCmd()
 		require.NoError(t, cmd.Flags().Set("channel", ch))
-		// PreRunE should pass validation
 		preRunE := cmd.PreRunE
 		require.NotNil(t, preRunE)
 		assert.NoError(t, preRunE(cmd, nil))

--- a/cmd/self_update_test.go
+++ b/cmd/self_update_test.go
@@ -26,6 +26,13 @@ func TestNewSelfUpdateCmd_HasDryRunFlag(t *testing.T) {
 	assert.Equal(t, "false", f.DefValue)
 }
 
+func TestNewSelfUpdateCmd_HasChannelFlag(t *testing.T) {
+	cmd := NewSelfUpdateCmd()
+	f := cmd.Flags().Lookup("channel")
+	require.NotNil(t, f, "--channel flag must exist")
+	assert.Equal(t, "stable", f.DefValue)
+}
+
 func TestNewSelfUpdateCmd_AcceptsNoPositionalArgs(t *testing.T) {
 	cmd := NewSelfUpdateCmd()
 	err := cmd.Args(cmd, []string{"unexpected"})

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -19,15 +19,16 @@ extraResources:
 mac:
   category: public.app-category.developer-tools
   icon: resources/icon.icns
-  x64ArchFiles: "Contents/Resources/bin/devsy"
   artifactName: Devsy_${os}_${arch}.${ext}
   target:
     - target: dmg
       arch:
-        - universal
+        - x64
+        - arm64
     - target: zip
       arch:
-        - universal
+        - x64
+        - arm64
   hardenedRuntime: true
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -670,9 +670,11 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
   ipcMain.handle(
     "set_release_channel",
     async (_event, args: { channel: string }) => {
-      const channel = args.channel as ReleaseChannel
-      setReleaseChannel(channel)
-      await checkForUpdatesWithChannel(channel)
+      if (args.channel !== "stable" && args.channel !== "beta") {
+        throw new Error(`Invalid release channel: ${args.channel}`)
+      }
+      setReleaseChannel(args.channel)
+      await checkForUpdatesWithChannel(args.channel)
     },
   )
 

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -13,8 +13,10 @@ import type { PtyManager } from "./pty.js"
 import type { DaemonState } from "./state.js"
 import {
   type ReleaseChannel,
+  checkForUpdates,
   checkForUpdatesWithChannel,
   getReleaseChannel,
+  installUpdate,
   setReleaseChannel,
 } from "./updater.js"
 import { type ProviderEntry, parseProviderEntries } from "./watcher.js"
@@ -677,6 +679,14 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
       await checkForUpdatesWithChannel(args.channel)
     },
   )
+
+  ipcMain.handle("check_for_updates", async () => {
+    await checkForUpdates()
+  })
+
+  ipcMain.handle("install_update", async () => {
+    installUpdate()
+  })
 
   // ── Analytics ──
   ipcMain.handle(

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -11,6 +11,12 @@ import type { CliRunner } from "./cli.js"
 import type { LogStore } from "./log-store.js"
 import type { PtyManager } from "./pty.js"
 import type { DaemonState } from "./state.js"
+import {
+  type ReleaseChannel,
+  checkForUpdatesWithChannel,
+  getReleaseChannel,
+  setReleaseChannel,
+} from "./updater.js"
 import { type ProviderEntry, parseProviderEntries } from "./watcher.js"
 
 const execFileAsync = promisify(execFile)
@@ -653,6 +659,20 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
       }
 
       return key
+    },
+  )
+
+  // ── Release Channel ──
+  ipcMain.handle("get_release_channel", () => {
+    return getReleaseChannel()
+  })
+
+  ipcMain.handle(
+    "set_release_channel",
+    async (_event, args: { channel: string }) => {
+      const channel = args.channel as ReleaseChannel
+      setReleaseChannel(channel)
+      await checkForUpdatesWithChannel(channel)
     },
   )
 

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -1,13 +1,49 @@
-import { dialog, type BrowserWindow } from "electron"
+import { readFileSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+import { app, dialog, type BrowserWindow } from "electron"
 import { trackEvent } from "./analytics.js"
+
+export type ReleaseChannel = "stable" | "beta"
+
+function settingsPath(): string {
+  return join(app.getPath("userData"), "update-settings.json")
+}
+
+function loadChannel(): ReleaseChannel {
+  try {
+    const data = JSON.parse(readFileSync(settingsPath(), "utf-8"))
+    if (data.channel === "beta") return "beta"
+  } catch {
+    // File doesn't exist or is corrupt
+  }
+  return "stable"
+}
+
+function saveChannel(channel: ReleaseChannel): void {
+  writeFileSync(settingsPath(), JSON.stringify({ channel }))
+}
+
+let currentChannel: ReleaseChannel = "stable"
+
+export function setReleaseChannel(channel: ReleaseChannel): void {
+  currentChannel = channel
+  saveChannel(channel)
+}
+
+export function getReleaseChannel(): ReleaseChannel {
+  return currentChannel
+}
 
 export async function initAutoUpdater(
   getMainWindow: () => BrowserWindow | null,
 ): Promise<void> {
+  currentChannel = loadChannel()
   const { autoUpdater } = await import("electron-updater")
 
   autoUpdater.autoDownload = true
   autoUpdater.autoInstallOnAppQuit = true
+  autoUpdater.allowPrerelease = currentChannel === "beta"
+  autoUpdater.channel = currentChannel === "beta" ? "beta" : "latest"
 
   autoUpdater.on("checking-for-update", () => {
     trackEvent("update_check")
@@ -45,10 +81,20 @@ export async function initAutoUpdater(
     console.error("Auto-update error:", err.message)
   })
 
-  // Check for updates after a short delay to avoid slowing down app launch
   setTimeout(() => {
     autoUpdater.checkForUpdates().catch((err: Error) => {
       console.error("Update check failed:", err.message)
     })
   }, 10_000)
+}
+
+export async function checkForUpdatesWithChannel(
+  channel: ReleaseChannel,
+): Promise<void> {
+  const { autoUpdater } = await import("electron-updater")
+  currentChannel = channel
+  saveChannel(channel)
+  autoUpdater.allowPrerelease = channel === "beta"
+  autoUpdater.channel = channel === "beta" ? "beta" : "latest"
+  await autoUpdater.checkForUpdates()
 }

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -5,6 +5,14 @@ import { trackEvent } from "./analytics.js"
 
 export type ReleaseChannel = "stable" | "beta"
 
+export interface UpdateStatus {
+  state: "checking" | "available" | "not-available" | "downloading" | "downloaded" | "error"
+  version?: string
+  releaseNotes?: string
+  releaseName?: string
+  error?: string
+}
+
 function settingsPath(): string {
   return join(app.getPath("userData"), "update-settings.json")
 }
@@ -24,6 +32,23 @@ function saveChannel(channel: ReleaseChannel): void {
 }
 
 let currentChannel: ReleaseChannel = "stable"
+let getMainWindowFn: (() => BrowserWindow | null) | null = null
+
+function sendUpdateStatus(status: UpdateStatus): void {
+  const win = getMainWindowFn?.()
+  if (win && !win.isDestroyed()) {
+    win.webContents.send("update-status", status)
+  }
+}
+
+function normalizeReleaseNotes(
+  notes: string | { note: string }[] | null | undefined,
+): string | undefined {
+  if (!notes) return undefined
+  if (typeof notes === "string") return notes
+  if (Array.isArray(notes)) return notes.map((n) => n.note).join("\n")
+  return undefined
+}
 
 export function setReleaseChannel(channel: ReleaseChannel): void {
   currentChannel = channel
@@ -37,6 +62,7 @@ export function getReleaseChannel(): ReleaseChannel {
 export async function initAutoUpdater(
   getMainWindow: () => BrowserWindow | null,
 ): Promise<void> {
+  getMainWindowFn = getMainWindow
   currentChannel = loadChannel()
   const { autoUpdater } = await import("electron-updater")
 
@@ -47,14 +73,34 @@ export async function initAutoUpdater(
 
   autoUpdater.on("checking-for-update", () => {
     trackEvent("update_check")
+    sendUpdateStatus({ state: "checking" })
   })
 
   autoUpdater.on("update-available", (info) => {
     trackEvent("update_available", { version: info.version })
+    sendUpdateStatus({
+      state: "available",
+      version: info.version,
+      releaseName: info.releaseName ?? undefined,
+      releaseNotes: normalizeReleaseNotes(info.releaseNotes),
+    })
+  })
+
+  autoUpdater.on("update-not-available", (info) => {
+    sendUpdateStatus({
+      state: "not-available",
+      version: info.version,
+    })
   })
 
   autoUpdater.on("update-downloaded", (info) => {
     trackEvent("update_downloaded", { version: info.version })
+    sendUpdateStatus({
+      state: "downloaded",
+      version: info.version,
+      releaseName: info.releaseName ?? undefined,
+      releaseNotes: normalizeReleaseNotes(info.releaseNotes),
+    })
 
     const win = getMainWindow()
     if (!win) return
@@ -78,6 +124,7 @@ export async function initAutoUpdater(
 
   autoUpdater.on("error", (err) => {
     trackEvent("update_error", { error_type: err.name })
+    sendUpdateStatus({ state: "error", error: err.message })
     console.error("Auto-update error:", err.message)
   })
 
@@ -86,6 +133,11 @@ export async function initAutoUpdater(
       console.error("Update check failed:", err.message)
     })
   }, 10_000)
+}
+
+export async function checkForUpdates(): Promise<void> {
+  const { autoUpdater } = await import("electron-updater")
+  await autoUpdater.checkForUpdates()
 }
 
 export async function checkForUpdatesWithChannel(
@@ -97,4 +149,9 @@ export async function checkForUpdatesWithChannel(
   autoUpdater.allowPrerelease = channel === "beta"
   autoUpdater.channel = channel === "beta" ? "beta" : "latest"
   await autoUpdater.checkForUpdates()
+}
+
+export async function installUpdate(): Promise<void> {
+  const { autoUpdater } = await import("electron-updater")
+  autoUpdater.quitAndInstall()
 }

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -261,6 +261,14 @@ export async function setReleaseChannel(channel: ReleaseChannel): Promise<void> 
   return invoke("set_release_channel", { channel })
 }
 
+export async function checkForUpdates(): Promise<void> {
+  return invoke("check_for_updates")
+}
+
+export async function installUpdate(): Promise<void> {
+  return invoke("install_update")
+}
+
 // Analytics
 export function analyticsTrack(
   name: string,

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -250,6 +250,17 @@ export async function sshKeyGenerate(params: {
   return invoke<SshKeyInfo>("ssh_key_generate", params)
 }
 
+// Release channel
+export type ReleaseChannel = "stable" | "beta"
+
+export async function getReleaseChannel(): Promise<ReleaseChannel> {
+  return invoke<ReleaseChannel>("get_release_channel")
+}
+
+export async function setReleaseChannel(channel: ReleaseChannel): Promise<void> {
+  return invoke("set_release_channel", { channel })
+}
+
 // Analytics
 export function analyticsTrack(
   name: string,

--- a/desktop/src/renderer/src/lib/ipc/events.ts
+++ b/desktop/src/renderer/src/lib/ipc/events.ts
@@ -8,12 +8,21 @@ import type {
 import { listen } from "./bridge.js"
 import type { UnlistenFn } from "./types.js"
 
+export interface UpdateStatus {
+  state: "checking" | "available" | "not-available" | "downloading" | "downloaded" | "error"
+  version?: string
+  releaseNotes?: string
+  releaseName?: string
+  error?: string
+}
+
 export const EVENT_NAMES = {
   WORKSPACES_CHANGED: "workspaces-changed",
   PROVIDERS_CHANGED: "providers-changed",
   MACHINES_CHANGED: "machines-changed",
   CONTEXTS_CHANGED: "contexts-changed",
   COMMAND_PROGRESS: "command-progress",
+  UPDATE_STATUS: "update-status",
 } as const
 
 interface WorkspacesPayload {
@@ -66,6 +75,14 @@ export function onCommandProgress(
   callback: (progress: CommandProgress) => void,
 ): Promise<UnlistenFn> {
   return listen<CommandProgress>(EVENT_NAMES.COMMAND_PROGRESS, (event) => {
+    callback(event.payload)
+  })
+}
+
+export function onUpdateStatus(
+  callback: (status: UpdateStatus) => void,
+): Promise<UnlistenFn> {
+  return listen<UpdateStatus>(EVENT_NAMES.UPDATE_STATUS, (event) => {
     callback(event.payload)
   })
 }

--- a/desktop/src/renderer/src/lib/ipc/mock.ts
+++ b/desktop/src/renderer/src/lib/ipc/mock.ts
@@ -262,6 +262,12 @@ const COMMANDS: Record<string, Handler> = {
   terminal_close: () => undefined,
   terminal_list: () => [],
 
+  // Release channel
+  get_release_channel: () => "stable",
+  set_release_channel: () => undefined,
+  check_for_updates: () => undefined,
+  install_update: () => undefined,
+
   // Analytics
   analytics_track: () => undefined,
 }

--- a/desktop/src/renderer/src/pages/SettingsPage.svelte
+++ b/desktop/src/renderer/src/pages/SettingsPage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { onMount } from "svelte"
-import { Check, ChevronsUpDown } from "@lucide/svelte"
+import { Check } from "@lucide/svelte"
 import { Button } from "$lib/components/ui/button/index.js"
 import { Input } from "$lib/components/ui/input/index.js"
 import { Label } from "$lib/components/ui/label/index.js"
@@ -146,11 +146,13 @@ let upgrading = $state(false)
 let upgradeResult = $state<string | null>(null)
 
 async function handleChannelChange(channel: ReleaseChannel) {
+  const previous = releaseChannel
   releaseChannel = channel
   try {
     await setReleaseChannelIpc(channel)
     toasts.success(`Switched to ${channel} update channel`)
   } catch (err) {
+    releaseChannel = previous
     toasts.error(`Failed to switch channel: ${extractErrorMessage(err)}`)
   }
 }
@@ -336,66 +338,86 @@ function toggleLocal(key: keyof LocalOptions) {
 
         <h2 class="text-lg font-semibold">Updates</h2>
 
-        <div class="flex items-center justify-between">
-          <div>
-            <Label>Automatically Keep Up to Date</Label>
-            <p class="text-xs text-muted-foreground">Download and install new Devsy versions in background</p>
+        <div class="space-y-4">
+          <div class="flex items-center justify-between">
+            <div>
+              <Label>Automatic Updates</Label>
+              <p class="text-xs text-muted-foreground">Download and install updates in the background</p>
+            </div>
+            <Switch checked={$autoUpdate} onCheckedChange={(v) => setAutoUpdate(v)} />
           </div>
-          <Switch checked={$autoUpdate} onCheckedChange={(v) => setAutoUpdate(v)} />
+
+          <div class="space-y-3">
+            <Label>Release Channel</Label>
+            <div class="grid grid-cols-2 gap-3">
+              <button
+                class="rounded-lg border p-3 text-left transition-colors {releaseChannel === 'stable' ? 'border-primary bg-primary/5 ring-1 ring-primary' : 'border-border hover:border-muted-foreground/50'}"
+                onclick={() => handleChannelChange("stable")}
+              >
+                <div class="flex items-center gap-2">
+                  <span class="font-medium text-sm">Stable</span>
+                  {#if releaseChannel === "stable"}
+                    <Check class="h-3.5 w-3.5 text-primary" />
+                  {/if}
+                </div>
+                <p class="mt-1 text-xs text-muted-foreground">Production-ready releases</p>
+              </button>
+              <button
+                class="rounded-lg border p-3 text-left transition-colors {releaseChannel === 'beta' ? 'border-primary bg-primary/5 ring-1 ring-primary' : 'border-border hover:border-muted-foreground/50'}"
+                onclick={() => handleChannelChange("beta")}
+              >
+                <div class="flex items-center gap-2">
+                  <span class="font-medium text-sm">Beta</span>
+                  {#if releaseChannel === "beta"}
+                    <Check class="h-3.5 w-3.5 text-primary" />
+                  {/if}
+                </div>
+                <p class="mt-1 text-xs text-muted-foreground">Early access to new features</p>
+              </button>
+            </div>
+          </div>
         </div>
 
-        <div class="space-y-2">
-          <Label>Release Channel</Label>
-          <p class="text-xs text-muted-foreground">Choose which updates to receive. Beta includes pre-release versions with new features that may be less stable.</p>
-          <div class="flex gap-2">
-            <Button
-              variant={releaseChannel === "stable" ? "default" : "outline"}
-              onclick={() => handleChannelChange("stable")}
-            >
-              Stable
-            </Button>
-            <Button
-              variant={releaseChannel === "beta" ? "default" : "outline"}
-              onclick={() => handleChannelChange("beta")}
-            >
-              Beta
-            </Button>
-          </div>
-        </div>
-
-        <div class="space-y-2">
-          <Label>Current Version</Label>
-          {#if cliVersion}
-            <p class="text-sm">Devsy CLI: <span class="font-mono">{cliVersion}</span></p>
-          {:else}
-            <p class="text-sm text-muted-foreground">Version information not available</p>
-          {/if}
-        </div>
+        <Separator />
 
         <div class="space-y-3">
-          <Label>Switch Version</Label>
-          <p class="text-xs text-muted-foreground">Install a specific Devsy CLI version. Useful for downgrading if a newer version introduced issues.</p>
-          <div class="flex gap-2">
-            <Input
-              value={targetVersion}
-              placeholder="e.g. v0.20.0"
-              oninput={(e) => (targetVersion = e.currentTarget.value)}
-              onkeydown={(e) => { if (e.key === "Enter") handleUpgrade() }}
-              disabled={upgrading}
-              class="max-w-48 font-mono"
-            />
-            <Button
-              onclick={handleUpgrade}
-              disabled={upgrading || !targetVersion}
-              variant="outline"
-            >
-              {upgrading ? "Installing..." : "Install"}
-            </Button>
+          <h2 class="text-lg font-semibold">Version</h2>
+          <div class="flex items-center justify-between rounded-lg border p-3">
+            <div>
+              <p class="text-sm font-medium">Devsy CLI</p>
+              {#if cliVersion}
+                <p class="text-xs font-mono text-muted-foreground">{cliVersion}</p>
+              {:else}
+                <p class="text-xs text-muted-foreground">Not available</p>
+              {/if}
+            </div>
+          </div>
+
+          <div class="space-y-2">
+            <Label>Install Specific Version</Label>
+            <p class="text-xs text-muted-foreground">Downgrade or pin to a specific CLI version</p>
+            <div class="flex gap-2">
+              <Input
+                value={targetVersion}
+                placeholder="e.g. v1.4.0"
+                oninput={(e) => (targetVersion = e.currentTarget.value)}
+                onkeydown={(e) => { if (e.key === "Enter") handleUpgrade() }}
+                disabled={upgrading}
+                class="max-w-48 font-mono"
+              />
+              <Button
+                onclick={handleUpgrade}
+                disabled={upgrading || !targetVersion}
+                variant="outline"
+              >
+                {upgrading ? "Installing..." : "Install"}
+              </Button>
+            </div>
           </div>
           {#if upgradeResult}
             <div class="rounded-md border border-green-600/30 bg-green-600/10 p-3">
               <p class="text-sm text-green-700 dark:text-green-400">
-                Switched to {upgradeResult}. Restart the application to use the new version.
+                Switched to {upgradeResult}. Restart to use the new version.
               </p>
             </div>
           {/if}

--- a/desktop/src/renderer/src/pages/SettingsPage.svelte
+++ b/desktop/src/renderer/src/pages/SettingsPage.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { onMount } from "svelte"
+import { onMount, onDestroy } from "svelte"
 import { Check } from "@lucide/svelte"
 import { Button } from "$lib/components/ui/button/index.js"
 import { Input } from "$lib/components/ui/input/index.js"
@@ -38,8 +38,12 @@ import {
   devsyUpgradeDryRun,
   getReleaseChannel,
   setReleaseChannel as setReleaseChannelIpc,
+  checkForUpdates as checkForUpdatesIpc,
+  installUpdate as installUpdateIpc,
   type ReleaseChannel,
 } from "$lib/ipc/commands.js"
+import { onUpdateStatus, type UpdateStatus } from "$lib/ipc/events.js"
+import type { UnlistenFn } from "$lib/ipc/types.js"
 import { Skeleton } from "$lib/components/ui/skeleton/index.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
@@ -144,6 +148,24 @@ let releaseChannel = $state<ReleaseChannel>("stable")
 let targetVersion = $state("")
 let upgrading = $state(false)
 let upgradeResult = $state<string | null>(null)
+let updateStatus = $state<UpdateStatus | null>(null)
+let unlistenUpdate: UnlistenFn | null = null
+
+async function handleCheckForUpdates() {
+  try {
+    await checkForUpdatesIpc()
+  } catch (err) {
+    toasts.error(`Update check failed: ${extractErrorMessage(err)}`)
+  }
+}
+
+async function handleInstallUpdate() {
+  try {
+    await installUpdateIpc()
+  } catch (err) {
+    toasts.error(`Failed to install update: ${extractErrorMessage(err)}`)
+  }
+}
 
 async function handleChannelChange(channel: ReleaseChannel) {
   const previous = releaseChannel
@@ -210,6 +232,17 @@ onMount(async () => {
   } catch {
     // Ignore — defaults to stable
   }
+  try {
+    unlistenUpdate = await onUpdateStatus((status) => {
+      updateStatus = status
+    })
+  } catch {
+    // Event listener setup failed
+  }
+})
+
+onDestroy(() => {
+  unlistenUpdate?.()
 })
 
 async function loadVersion() {
@@ -384,14 +417,58 @@ function toggleLocal(key: keyof LocalOptions) {
           <h2 class="text-lg font-semibold">Version</h2>
           <div class="flex items-center justify-between rounded-lg border p-3">
             <div>
-              <p class="text-sm font-medium">Devsy CLI</p>
+              <p class="text-sm font-medium">Devsy Desktop</p>
               {#if cliVersion}
                 <p class="text-xs font-mono text-muted-foreground">{cliVersion}</p>
               {:else}
                 <p class="text-xs text-muted-foreground">Not available</p>
               {/if}
             </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onclick={handleCheckForUpdates}
+              disabled={updateStatus?.state === "checking"}
+            >
+              {updateStatus?.state === "checking" ? "Checking..." : "Check for Updates"}
+            </Button>
           </div>
+
+          {#if updateStatus?.state === "not-available"}
+            <div class="rounded-md border border-border bg-muted/50 p-3">
+              <p class="text-sm text-muted-foreground">You're on the latest version.</p>
+            </div>
+          {/if}
+
+          {#if updateStatus?.state === "available" || updateStatus?.state === "downloaded"}
+            <div class="rounded-md border border-primary/30 bg-primary/5 p-3 space-y-2">
+              <div class="flex items-center justify-between">
+                <div>
+                  <p class="text-sm font-medium">
+                    {updateStatus.state === "downloaded" ? "Update ready to install" : "Update available"}
+                  </p>
+                  <p class="text-xs text-muted-foreground">Version {updateStatus.version}</p>
+                </div>
+                {#if updateStatus.state === "downloaded"}
+                  <Button size="sm" onclick={handleInstallUpdate}>Restart & Update</Button>
+                {/if}
+              </div>
+              {#if updateStatus.releaseNotes}
+                <div class="border-t border-border/50 pt-2 mt-2">
+                  <p class="text-xs font-medium text-muted-foreground mb-1">Release Notes</p>
+                  <div class="text-xs text-muted-foreground prose prose-sm dark:prose-invert max-h-40 overflow-y-auto">
+                    {@html updateStatus.releaseNotes}
+                  </div>
+                </div>
+              {/if}
+            </div>
+          {/if}
+
+          {#if updateStatus?.state === "error"}
+            <div class="rounded-md border border-destructive/30 bg-destructive/5 p-3">
+              <p class="text-sm text-destructive">Update check failed: {updateStatus.error}</p>
+            </div>
+          {/if}
 
           <div class="space-y-2">
             <Label>Install Specific Version</Label>

--- a/desktop/src/renderer/src/pages/SettingsPage.svelte
+++ b/desktop/src/renderer/src/pages/SettingsPage.svelte
@@ -36,6 +36,9 @@ import {
   devsyVersion,
   devsyUpgrade,
   devsyUpgradeDryRun,
+  getReleaseChannel,
+  setReleaseChannel as setReleaseChannelIpc,
+  type ReleaseChannel,
 } from "$lib/ipc/commands.js"
 import { Skeleton } from "$lib/components/ui/skeleton/index.js"
 import { toasts } from "$lib/stores/toasts.js"
@@ -137,9 +140,20 @@ let local = $state<LocalOptions>({
 
 // ── Version management ──────────────────────────────────────────────
 
+let releaseChannel = $state<ReleaseChannel>("stable")
 let targetVersion = $state("")
 let upgrading = $state(false)
 let upgradeResult = $state<string | null>(null)
+
+async function handleChannelChange(channel: ReleaseChannel) {
+  releaseChannel = channel
+  try {
+    await setReleaseChannelIpc(channel)
+    toasts.success(`Switched to ${channel} update channel`)
+  } catch (err) {
+    toasts.error(`Failed to switch channel: ${extractErrorMessage(err)}`)
+  }
+}
 
 async function handleUpgrade() {
   if (!targetVersion) return
@@ -189,6 +203,11 @@ onMount(async () => {
   localOptionsStore.set(local)
   loading = false
   await loadVersion()
+  try {
+    releaseChannel = await getReleaseChannel()
+  } catch {
+    // Ignore — defaults to stable
+  }
 })
 
 async function loadVersion() {
@@ -323,6 +342,25 @@ function toggleLocal(key: keyof LocalOptions) {
             <p class="text-xs text-muted-foreground">Download and install new Devsy versions in background</p>
           </div>
           <Switch checked={$autoUpdate} onCheckedChange={(v) => setAutoUpdate(v)} />
+        </div>
+
+        <div class="space-y-2">
+          <Label>Release Channel</Label>
+          <p class="text-xs text-muted-foreground">Choose which updates to receive. Beta includes pre-release versions with new features that may be less stable.</p>
+          <div class="flex gap-2">
+            <Button
+              variant={releaseChannel === "stable" ? "default" : "outline"}
+              onclick={() => handleChannelChange("stable")}
+            >
+              Stable
+            </Button>
+            <Button
+              variant={releaseChannel === "beta" ? "default" : "outline"}
+              onclick={() => handleChannelChange("beta")}
+            >
+              Beta
+            </Button>
+          </div>
         </div>
 
         <div class="space-y-2">

--- a/hack/merge-mac-metadata.py
+++ b/hack/merge-mac-metadata.py
@@ -4,12 +4,10 @@
 When building macOS arm64 and x64 separately, each produces its own
 latest-mac.yml (or beta-mac.yml) with only one architecture's files.
 This script merges them into a single file with entries for both arches.
-
-Usage: python3 merge-mac-metadata.py <metadata-dir> <output-dir>
 """
 
+import argparse
 import glob
-import sys
 from pathlib import Path
 
 import yaml
@@ -43,7 +41,6 @@ def merge_mac_files(metadata_dir: str, output_dir: str) -> None:
 
         base_data["files"] = merged_files
 
-        # Set path to the first file entry (electron-updater uses this as default)
         if merged_files:
             base_data["path"] = merged_files[0]["url"]
             base_data["sha512"] = merged_files[0]["sha512"]
@@ -56,8 +53,21 @@ def merge_mac_files(metadata_dir: str, output_dir: str) -> None:
         print(f"Merged {len(found)} files into {out_file}")
 
 
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Merge macOS electron-updater metadata from separate arch builds"
+    )
+    parser.add_argument(
+        "metadata_dir",
+        help="Directory containing downloaded update-metadata-* artifacts",
+    )
+    parser.add_argument(
+        "output_dir",
+        help="Directory to write merged metadata files into",
+    )
+    args = parser.parse_args()
+    merge_mac_files(args.metadata_dir, args.output_dir)
+
+
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        print(f"Usage: {sys.argv[0]} <metadata-dir> <output-dir>", file=sys.stderr)
-        sys.exit(1)
-    merge_mac_files(sys.argv[1], sys.argv[2])
+    main()

--- a/hack/merge-mac-metadata.py
+++ b/hack/merge-mac-metadata.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Merge macOS electron-updater metadata from separate arch builds.
+
+When building macOS arm64 and x64 separately, each produces its own
+latest-mac.yml (or beta-mac.yml) with only one architecture's files.
+This script merges them into a single file with entries for both arches.
+
+Usage: python3 merge-mac-metadata.py <metadata-dir> <output-dir>
+"""
+
+import glob
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def merge_mac_files(metadata_dir: str, output_dir: str) -> None:
+    metadata_path = Path(metadata_dir)
+    output_path = Path(output_dir)
+
+    for prefix in ("latest-mac", "beta-mac"):
+        pattern = str(metadata_path / "**" / f"{prefix}.yml")
+        found = glob.glob(pattern, recursive=True)
+        if not found:
+            continue
+
+        merged_files = []
+        base_data = None
+
+        for filepath in found:
+            with open(filepath) as f:
+                data = yaml.safe_load(f)
+            if data is None:
+                continue
+            if base_data is None:
+                base_data = data
+            if "files" in data:
+                merged_files.extend(data["files"])
+
+        if base_data is None:
+            continue
+
+        base_data["files"] = merged_files
+
+        # Set path to the first file entry (electron-updater uses this as default)
+        if merged_files:
+            base_data["path"] = merged_files[0]["url"]
+            base_data["sha512"] = merged_files[0]["sha512"]
+            base_data["size"] = merged_files[0].get("size")
+
+        out_file = output_path / f"{prefix}.yml"
+        with open(out_file, "w") as f:
+            yaml.dump(base_data, f, default_flow_style=False, sort_keys=False)
+
+        print(f"Merged {len(found)} files into {out_file}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <metadata-dir> <output-dir>", file=sys.stderr)
+        sys.exit(1)
+    merge_mac_files(sys.argv[1], sys.argv[2])

--- a/pkg/selfupdate/selfupdate.go
+++ b/pkg/selfupdate/selfupdate.go
@@ -12,10 +12,16 @@ import (
 	"github.com/devsy-org/devsy/pkg/version"
 )
 
+type Options struct {
+	Version           string
+	DryRun            bool
+	IncludePrerelease bool
+}
+
 // Upgrade downloads the latest release from github and replaces devsy if a new version is found.
-// If dryRun is true, it only shows what would be downloaded without actually upgrading.
-func Upgrade(ctx context.Context, targetVersion string, dryRun bool) error {
-	release, updater, err := detectRelease(ctx, targetVersion)
+// If DryRun is true, it only shows what would be downloaded without actually upgrading.
+func Upgrade(ctx context.Context, opts Options) error {
+	release, updater, err := detectRelease(ctx, opts)
 	if err != nil {
 		return err
 	}
@@ -31,7 +37,7 @@ func Upgrade(ctx context.Context, targetVersion string, dryRun bool) error {
 		return nil
 	}
 
-	if dryRun {
+	if opts.DryRun {
 		dryRunOutput := fmt.Sprintf(
 			"asset_name=%s\nversion=%s\nos=%s\narch=%s\nurl=%s\nsize=%d\n",
 			release.AssetName,
@@ -61,20 +67,21 @@ func Upgrade(ctx context.Context, targetVersion string, dryRun bool) error {
 	return nil
 }
 
-// detectRelease detects which release to use based on targetVersion.
 func detectRelease(
 	ctx context.Context,
-	targetVersion string,
+	opts Options,
 ) (*selfupdate.Release, *selfupdate.Updater, error) {
-	updater, err := selfupdate.NewUpdater(selfupdate.Config{})
+	updater, err := selfupdate.NewUpdater(selfupdate.Config{
+		Prerelease: opts.IncludePrerelease,
+	})
 	if err != nil {
 		return nil, nil, fmt.Errorf("initialize updater: %w", err)
 	}
 
 	repo := selfupdate.ParseSlug(config.RepoSlug)
 
-	if targetVersion != "" {
-		release, err := detectSpecificVersion(ctx, updater, repo, targetVersion)
+	if opts.Version != "" {
+		release, err := detectSpecificVersion(ctx, updater, repo, opts.Version)
 		return release, updater, err
 	}
 


### PR DESCRIPTION
## Summary

- Split macOS desktop builds from universal into separate arm64 and x64 builds for faster CI and smaller downloads
- Add release channel support (stable/beta) to the desktop app auto-updater with a UI toggle in Settings > Updates
- Add `--channel beta` flag to `devsy self-update` CLI command for opting into pre-release versions
- Deploy electron update metadata for both channels (stable → `latest*.yml`, beta → `beta*.yml`) to Netlify
- Metadata deploy now runs for all releases and preserves the other channel's files via fetch-before-deploy
- Add `hack/merge-mac-metadata.py` to combine macOS metadata from the two separate arch builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release channel selection (Stable/Beta) in desktop app Settings for update preferences.
  * CLI now supports `--channel` flag to specify update channels (defaults to stable).
  * Separated macOS downloads into distinct builds for Apple Silicon and Intel processors.

* **Chores**
  * Updated release automation and build workflows.
  * Refactored update mechanism architecture.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/390?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->