### PR TITLE
fix(desktop): handle missing autoUpdater on unsigned macOS builds

### DIFF
--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -66,6 +66,11 @@ export async function initAutoUpdater(
   currentChannel = loadChannel()
   const { autoUpdater } = await import("electron-updater")
 
+  if (!autoUpdater || typeof autoUpdater.checkForUpdates !== "function") {
+    console.warn("Auto-updater not available (app is not code-signed)")
+    return
+  }
+
   autoUpdater.autoDownload = true
   autoUpdater.autoInstallOnAppQuit = true
   autoUpdater.allowPrerelease = currentChannel === "beta"
@@ -137,6 +142,13 @@ export async function initAutoUpdater(
 
 export async function checkForUpdates(): Promise<void> {
   const { autoUpdater } = await import("electron-updater")
+  if (!autoUpdater || typeof autoUpdater.checkForUpdates !== "function") {
+    sendUpdateStatus({
+      state: "error",
+      error: "Auto-update is not available (app is not code-signed)",
+    })
+    return
+  }
   await autoUpdater.checkForUpdates()
 }
 
@@ -146,6 +158,13 @@ export async function checkForUpdatesWithChannel(
   const { autoUpdater } = await import("electron-updater")
   currentChannel = channel
   saveChannel(channel)
+  if (!autoUpdater || typeof autoUpdater.checkForUpdates !== "function") {
+    sendUpdateStatus({
+      state: "error",
+      error: "Auto-update is not available (app is not code-signed)",
+    })
+    return
+  }
   autoUpdater.allowPrerelease = channel === "beta"
   autoUpdater.channel = channel === "beta" ? "beta" : "latest"
   await autoUpdater.checkForUpdates()
@@ -153,5 +172,8 @@ export async function checkForUpdatesWithChannel(
 
 export async function installUpdate(): Promise<void> {
   const { autoUpdater } = await import("electron-updater")
+  if (!autoUpdater || typeof autoUpdater.quitAndInstall !== "function") {
+    return
+  }
   autoUpdater.quitAndInstall()
 }


### PR DESCRIPTION
## Summary

- Guards all `electron-updater` autoUpdater access with availability checks
- On unsigned builds (no Apple code signing), the user now sees "Auto-update is not available (app is not code-signed)" instead of a crash
- Prevents the "Cannot read properties of undefined (reading 'checkForUpdates')" error on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced robustness of the auto-update feature with improved availability checks and error handling.
  * Added validation guards to prevent failures when update components are unavailable.
  * Improved error messaging for update-related issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->