### PR TITLE
fix(desktop): show verbose logs during workspace creation

### DIFF
--- a/desktop/src/renderer/src/lib/components/workspace/CreateWorkspaceSheet.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/CreateWorkspaceSheet.svelte
@@ -261,6 +261,7 @@ async function handleSubmit() {
       workspaceId,
       provider: selectedProvider || undefined,
       ide: selectedIde || undefined,
+      debug: true,
     })
 
     commandId = cmdId


### PR DESCRIPTION
## Summary

- Always pass `debug: true` when creating a workspace from the Create Workspace sheet, so the CLI streams verbose progress (image pulls, container setup, SSH config, etc.) instead of only showing the final outcome JSON and exit code.
- Workspace creation is a long-running first-time operation where users need visibility into what's happening — this matches the behavior already present for reset/rebuild/start on the workspace detail page.