### PR TITLE
fix(desktop): update workspace store immediately after rename

### DIFF
--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -378,6 +378,9 @@ async function handleRename() {
   renameSaving = true
   try {
     await workspaceRename(id, trimmed)
+    workspaces.update((current) =>
+      current.map((w) => (w.id === id ? { ...w, id: trimmed } : w)),
+    )
     toasts.success(`Renamed workspace to ${trimmed}`)
     renaming = false
     goto(`/workspaces/${trimmed}`)


### PR DESCRIPTION
## Summary

- After renaming a workspace, the page navigates to the new URL (`/workspaces/new-name`) but the workspaces store still holds the old ID until the watcher polls (up to 3s later). This causes the page to show "Workspace not found" and hides all action buttons (Start, Open IDE, etc.).
- Fix: optimistically update the workspace ID in the Svelte store immediately after the rename IPC call succeeds, before navigating. The watcher will eventually confirm the same state from the backend.