### PR TITLE
fix: don't rewrite container workspace folder on rename

### DIFF
--- a/pkg/workspace/rename.go
+++ b/pkg/workspace/rename.go
@@ -86,19 +86,9 @@ type pathReplacer struct {
 }
 
 func newPathReplacer(
-	containerWorkspaceFolder, localWorkspaceFolder, oldName, newName string,
+	localWorkspaceFolder, oldName, newName string,
 ) *pathReplacer {
 	r := &pathReplacer{}
-
-	if containerWorkspaceFolder != "" {
-		containerParent := strings.TrimSuffix(
-			containerWorkspaceFolder, filepath.Base(containerWorkspaceFolder),
-		)
-		r.pairs = append(r.pairs, [2]string{
-			containerParent + oldName,
-			containerParent + newName,
-		})
-	}
 
 	if localWorkspaceFolder != "" {
 		localParent := strings.TrimSuffix(
@@ -127,17 +117,16 @@ func (r *pathReplacer) applyToMergedConfig(mc *devcontainerconfig.MergedDevConta
 	if mc == nil {
 		return
 	}
-	mc.WorkspaceFolder = r.replace(mc.WorkspaceFolder)
 	if mc.WorkspaceMount != nil {
 		updated := r.replace(*mc.WorkspaceMount)
 		mc.WorkspaceMount = &updated
 	}
 }
 
-// updateWorkspaceResult rewrites workspace_result.json to replace references
-// to the old workspace name with the new one. This ensures that cached paths
-// like ContainerWorkspaceFolder, LocalWorkspaceFolder, and WorkspaceMount
-// stay valid after rename.
+// updateWorkspaceResult rewrites workspace_result.json to replace host-side
+// references to the old workspace name with the new one. Only LocalWorkspaceFolder
+// and WorkspaceMount are updated — ContainerWorkspaceFolder is an in-container
+// path that does not change when the host workspace is renamed.
 func updateWorkspaceResult(devsyConfig *config.Config, oldName, newName string) {
 	context := devsyConfig.DefaultContext
 	result, err := provider.LoadWorkspaceResult(context, newName)
@@ -145,16 +134,14 @@ func updateWorkspaceResult(devsyConfig *config.Config, oldName, newName string) 
 		return
 	}
 
-	var containerWSFolder, localWSFolder string
+	var localWSFolder string
 	if sc := result.SubstitutionContext; sc != nil {
-		containerWSFolder = sc.ContainerWorkspaceFolder
 		localWSFolder = sc.LocalWorkspaceFolder
 	}
 
-	r := newPathReplacer(containerWSFolder, localWSFolder, oldName, newName)
+	r := newPathReplacer(localWSFolder, oldName, newName)
 
 	if sc := result.SubstitutionContext; sc != nil {
-		sc.ContainerWorkspaceFolder = r.replace(sc.ContainerWorkspaceFolder)
 		sc.LocalWorkspaceFolder = r.replace(sc.LocalWorkspaceFolder)
 		sc.WorkspaceMount = r.replace(sc.WorkspaceMount)
 	}

--- a/pkg/workspace/rename_integration_test.go
+++ b/pkg/workspace/rename_integration_test.go
@@ -14,7 +14,9 @@ import (
 )
 
 const (
-	testDefaultContext = "default"
+	testDefaultContext         = "default"
+	testContainerWSFolder      = "/workspaces/ws-old"
+	testContainerWSFolderMount = "type=bind,source=/home/user/ws-old,target=/workspaces/ws-old"
 )
 
 func setupTestPathManager(t *testing.T) {
@@ -242,9 +244,9 @@ func TestUpdateWorkspaceResult_NilMergedConfig(t *testing.T) {
 
 	result := &devcontainerconfig.Result{
 		SubstitutionContext: &devcontainerconfig.SubstitutionContext{
-			ContainerWorkspaceFolder: "/workspaces/ws-old",
+			ContainerWorkspaceFolder: testContainerWSFolder,
 			LocalWorkspaceFolder:     "/home/user/ws-old",
-			WorkspaceMount:           "type=bind,source=/home/user/ws-old,target=/workspaces/ws-old",
+			WorkspaceMount:           testContainerWSFolderMount,
 		},
 		MergedConfig: nil,
 	}
@@ -257,7 +259,7 @@ func TestUpdateWorkspaceResult_NilMergedConfig(t *testing.T) {
 	got := loadWorkspaceResult(t, newName)
 
 	// Container path unchanged
-	assert.Equal(t, "/workspaces/ws-old", got.SubstitutionContext.ContainerWorkspaceFolder)
+	assert.Equal(t, testContainerWSFolder, got.SubstitutionContext.ContainerWorkspaceFolder)
 	// Host-side path updated
 	assert.Equal(t, "/home/user/ws-new", got.SubstitutionContext.LocalWorkspaceFolder)
 	assert.Contains(t, got.SubstitutionContext.WorkspaceMount, "/home/user/ws-new")
@@ -271,13 +273,13 @@ func TestUpdateWorkspaceResult_NilWorkspaceMount(t *testing.T) {
 
 	result := &devcontainerconfig.Result{
 		SubstitutionContext: &devcontainerconfig.SubstitutionContext{
-			ContainerWorkspaceFolder: "/workspaces/ws-old",
+			ContainerWorkspaceFolder: testContainerWSFolder,
 			LocalWorkspaceFolder:     "/home/user/ws-old",
-			WorkspaceMount:           "type=bind,source=/home/user/ws-old,target=/workspaces/ws-old",
+			WorkspaceMount:           testContainerWSFolderMount,
 		},
 		MergedConfig: &devcontainerconfig.MergedDevContainerConfig{},
 	}
-	result.MergedConfig.WorkspaceFolder = "/workspaces/ws-old"
+	result.MergedConfig.WorkspaceFolder = testContainerWSFolder
 	result.MergedConfig.WorkspaceMount = nil
 
 	writeWorkspaceResult(t, newName, result)
@@ -288,7 +290,7 @@ func TestUpdateWorkspaceResult_NilWorkspaceMount(t *testing.T) {
 	got := loadWorkspaceResult(t, newName)
 
 	// Container path unchanged
-	assert.Equal(t, "/workspaces/ws-old", got.MergedConfig.WorkspaceFolder)
+	assert.Equal(t, testContainerWSFolder, got.MergedConfig.WorkspaceFolder)
 	assert.Nil(t, got.MergedConfig.WorkspaceMount)
 }
 

--- a/pkg/workspace/rename_integration_test.go
+++ b/pkg/workspace/rename_integration_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	testDefaultContext   = "default"
-	testContainerWSMount = "/workspaces/ws-old"
+	testDefaultContext = "default"
 )
 
 func setupTestPathManager(t *testing.T) {
@@ -80,17 +79,13 @@ func TestUpdateWorkspaceResult_BasicRename(t *testing.T) {
 
 	got := loadWorkspaceResult(t, newName)
 
-	assert.Equal(
-		t,
-		"/workspaces/my-project-renamed",
-		got.SubstitutionContext.ContainerWorkspaceFolder,
-	)
+	// Container paths should NOT change (they are in-container paths)
+	assert.Equal(t, "/workspaces/my-project", got.SubstitutionContext.ContainerWorkspaceFolder)
+	assert.Equal(t, "/workspaces/my-project", got.MergedConfig.WorkspaceFolder)
+	// Host-side paths should be updated
 	assert.Equal(t, "/home/user/my-project-renamed", got.SubstitutionContext.LocalWorkspaceFolder)
-	assert.Contains(t, got.SubstitutionContext.WorkspaceMount, "/workspaces/my-project-renamed")
 	assert.Contains(t, got.SubstitutionContext.WorkspaceMount, "/home/user/my-project-renamed")
-	assert.Equal(t, "/workspaces/my-project-renamed", got.MergedConfig.WorkspaceFolder)
 	require.NotNil(t, got.MergedConfig.WorkspaceMount)
-	assert.Contains(t, *got.MergedConfig.WorkspaceMount, "/workspaces/my-project-renamed")
 	assert.Contains(t, *got.MergedConfig.WorkspaceMount, "/home/user/my-project-renamed")
 }
 
@@ -120,11 +115,12 @@ func TestUpdateWorkspaceResult_MergedConfigUpdated(t *testing.T) {
 
 	got := loadWorkspaceResult(t, newName)
 
-	assert.Equal(t, "/workspaces/app-v2", got.MergedConfig.WorkspaceFolder)
+	// Container path unchanged
+	assert.Equal(t, "/workspaces/app", got.MergedConfig.WorkspaceFolder)
+	// Host source path updated in mount
 	require.NotNil(t, got.MergedConfig.WorkspaceMount)
-	assert.Equal(
-		t,
-		"type=bind,source=/home/dev/app-v2,target=/workspaces/app-v2",
+	assert.Equal(t,
+		"type=bind,source=/home/dev/app-v2,target=/workspaces/app",
 		*got.MergedConfig.WorkspaceMount,
 	)
 }
@@ -155,18 +151,18 @@ func TestUpdateWorkspaceResult_NonDefaultWorkspaceDir(t *testing.T) {
 
 	got := loadWorkspaceResult(t, newName)
 
-	assert.Equal(t, "/home/coder/project-new", got.SubstitutionContext.ContainerWorkspaceFolder)
+	// Container path unchanged
+	assert.Equal(t, "/home/coder/project", got.SubstitutionContext.ContainerWorkspaceFolder)
+	assert.Equal(t, "/home/coder/project", got.MergedConfig.WorkspaceFolder)
+	// Host-side path updated
 	assert.Equal(t, "/mnt/data/project-new", got.SubstitutionContext.LocalWorkspaceFolder)
-	assert.Equal(
-		t,
-		"type=bind,source=/mnt/data/project-new,target=/home/coder/project-new",
+	assert.Equal(t,
+		"type=bind,source=/mnt/data/project-new,target=/home/coder/project",
 		got.SubstitutionContext.WorkspaceMount,
 	)
-	assert.Equal(t, "/home/coder/project-new", got.MergedConfig.WorkspaceFolder)
 	require.NotNil(t, got.MergedConfig.WorkspaceMount)
-	assert.Equal(
-		t,
-		"type=bind,source=/mnt/data/project-new,target=/home/coder/project-new",
+	assert.Equal(t,
+		"type=bind,source=/mnt/data/project-new,target=/home/coder/project",
 		*got.MergedConfig.WorkspaceMount,
 	)
 }
@@ -197,15 +193,12 @@ func TestUpdateWorkspaceResult_NestedPath(t *testing.T) {
 
 	got := loadWorkspaceResult(t, newName)
 
-	assert.Equal(
-		t,
-		"/workspaces/org/repo-renamed",
-		got.SubstitutionContext.ContainerWorkspaceFolder,
-	)
+	// Container path unchanged
+	assert.Equal(t, "/workspaces/org/repo", got.SubstitutionContext.ContainerWorkspaceFolder)
+	assert.Equal(t, "/workspaces/org/repo", got.MergedConfig.WorkspaceFolder)
+	// Host-side path updated
 	assert.Equal(t, "/home/user/dev/org/repo-renamed", got.SubstitutionContext.LocalWorkspaceFolder)
-	assert.Contains(t, got.SubstitutionContext.WorkspaceMount, "/workspaces/org/repo-renamed")
 	assert.Contains(t, got.SubstitutionContext.WorkspaceMount, "/home/user/dev/org/repo-renamed")
-	assert.Equal(t, "/workspaces/org/repo-renamed", got.MergedConfig.WorkspaceFolder)
 }
 
 func TestUpdateWorkspaceResult_SameNameIdempotent(t *testing.T) {
@@ -249,9 +242,9 @@ func TestUpdateWorkspaceResult_NilMergedConfig(t *testing.T) {
 
 	result := &devcontainerconfig.Result{
 		SubstitutionContext: &devcontainerconfig.SubstitutionContext{
-			ContainerWorkspaceFolder: testContainerWSMount,
+			ContainerWorkspaceFolder: "/workspaces/ws-old",
 			LocalWorkspaceFolder:     "/home/user/ws-old",
-			WorkspaceMount:           "type=bind,source=/home/user/ws-old,target=" + testContainerWSMount,
+			WorkspaceMount:           "type=bind,source=/home/user/ws-old,target=/workspaces/ws-old",
 		},
 		MergedConfig: nil,
 	}
@@ -263,9 +256,11 @@ func TestUpdateWorkspaceResult_NilMergedConfig(t *testing.T) {
 
 	got := loadWorkspaceResult(t, newName)
 
-	assert.Equal(t, "/workspaces/ws-new", got.SubstitutionContext.ContainerWorkspaceFolder)
+	// Container path unchanged
+	assert.Equal(t, "/workspaces/ws-old", got.SubstitutionContext.ContainerWorkspaceFolder)
+	// Host-side path updated
 	assert.Equal(t, "/home/user/ws-new", got.SubstitutionContext.LocalWorkspaceFolder)
-	assert.Contains(t, got.SubstitutionContext.WorkspaceMount, "/workspaces/ws-new")
+	assert.Contains(t, got.SubstitutionContext.WorkspaceMount, "/home/user/ws-new")
 }
 
 func TestUpdateWorkspaceResult_NilWorkspaceMount(t *testing.T) {
@@ -276,13 +271,13 @@ func TestUpdateWorkspaceResult_NilWorkspaceMount(t *testing.T) {
 
 	result := &devcontainerconfig.Result{
 		SubstitutionContext: &devcontainerconfig.SubstitutionContext{
-			ContainerWorkspaceFolder: testContainerWSMount,
+			ContainerWorkspaceFolder: "/workspaces/ws-old",
 			LocalWorkspaceFolder:     "/home/user/ws-old",
-			WorkspaceMount:           "type=bind,source=/home/user/ws-old,target=" + testContainerWSMount,
+			WorkspaceMount:           "type=bind,source=/home/user/ws-old,target=/workspaces/ws-old",
 		},
 		MergedConfig: &devcontainerconfig.MergedDevContainerConfig{},
 	}
-	result.MergedConfig.WorkspaceFolder = testContainerWSMount
+	result.MergedConfig.WorkspaceFolder = "/workspaces/ws-old"
 	result.MergedConfig.WorkspaceMount = nil
 
 	writeWorkspaceResult(t, newName, result)
@@ -292,7 +287,8 @@ func TestUpdateWorkspaceResult_NilWorkspaceMount(t *testing.T) {
 
 	got := loadWorkspaceResult(t, newName)
 
-	assert.Equal(t, "/workspaces/ws-new", got.MergedConfig.WorkspaceFolder)
+	// Container path unchanged
+	assert.Equal(t, "/workspaces/ws-old", got.MergedConfig.WorkspaceFolder)
 	assert.Nil(t, got.MergedConfig.WorkspaceMount)
 }
 
@@ -378,16 +374,12 @@ func TestUpdateWorkspaceResult_RawJSON(t *testing.T) {
 	var got devcontainerconfig.Result
 	require.NoError(t, json.Unmarshal(updatedBytes, &got))
 
-	assert.Equal(t, "/workspaces/new-ws", got.SubstitutionContext.ContainerWorkspaceFolder)
+	// Container path unchanged
+	assert.Equal(t, "/workspaces/old-ws", got.SubstitutionContext.ContainerWorkspaceFolder)
+	assert.Equal(t, "/workspaces/old-ws", got.MergedConfig.WorkspaceFolder)
+	// Host-side path updated
 	assert.Equal(t, "/home/user/new-ws", got.SubstitutionContext.LocalWorkspaceFolder)
-	assert.Equal(t,
-		"type=bind,source=/home/user/new-ws,target=/workspaces/new-ws",
-		got.SubstitutionContext.WorkspaceMount,
-	)
-	assert.Equal(t, "/workspaces/new-ws", got.MergedConfig.WorkspaceFolder)
+	assert.Contains(t, got.SubstitutionContext.WorkspaceMount, "/home/user/new-ws")
 	require.NotNil(t, got.MergedConfig.WorkspaceMount)
-	assert.Equal(t,
-		"type=bind,source=/home/user/new-ws,target=/workspaces/new-ws",
-		*got.MergedConfig.WorkspaceMount,
-	)
+	assert.Contains(t, *got.MergedConfig.WorkspaceMount, "/home/user/new-ws")
 }

--- a/pkg/workspace/rename_test.go
+++ b/pkg/workspace/rename_test.go
@@ -7,20 +7,14 @@ import (
 )
 
 const (
-	testContainerNewWS = "/workspaces/new-ws"
-	testLocalNewWS     = "/home/user/new-ws"
-	testContainerNew   = "/workspaces/new"
-	testContainerOldWS = "/workspaces/old-ws"
-	testLocalOldWS     = "/home/user/old-ws"
-	testContainerApp   = "/workspaces/app"
-	testContainerOld   = "/workspaces/old"
+	testLocalNewWS = "/home/user/new-ws"
+	testLocalOldWS = "/home/user/old-ws"
 )
 
 func TestNewPathReplacer_DefaultWorkspaceDir(t *testing.T) {
-	r := newPathReplacer(testContainerOldWS, testLocalOldWS, "old-ws", "new-ws")
+	r := newPathReplacer(testLocalOldWS, "old-ws", "new-ws")
 
 	expected := [][2]string{
-		{testContainerOldWS, testContainerNewWS},
 		{testLocalOldWS, testLocalNewWS},
 	}
 
@@ -30,10 +24,9 @@ func TestNewPathReplacer_DefaultWorkspaceDir(t *testing.T) {
 }
 
 func TestNewPathReplacer_NonDefaultWorkspaceDir(t *testing.T) {
-	r := newPathReplacer("/home/user/project", "/mnt/data/project", "project", "renamed")
+	r := newPathReplacer("/mnt/data/project", "project", "renamed")
 
 	expected := [][2]string{
-		{"/home/user/project", "/home/user/renamed"},
 		{"/mnt/data/project", "/mnt/data/renamed"},
 	}
 
@@ -43,14 +36,12 @@ func TestNewPathReplacer_NonDefaultWorkspaceDir(t *testing.T) {
 
 func TestNewPathReplacer_NestedWorkspacePath(t *testing.T) {
 	r := newPathReplacer(
-		"/workspace/dev/projects/my-app",
 		"/home/user/workspace/dev/projects/my-app",
 		"my-app",
 		"my-app-v2",
 	)
 
 	expected := [][2]string{
-		{"/workspace/dev/projects/my-app", "/workspace/dev/projects/my-app-v2"},
 		{
 			"/home/user/workspace/dev/projects/my-app",
 			"/home/user/workspace/dev/projects/my-app-v2",
@@ -60,42 +51,20 @@ func TestNewPathReplacer_NestedWorkspacePath(t *testing.T) {
 	assert.Equal(t, expected, r.pairs)
 }
 
-func TestNewPathReplacer_EmptyContainerFolder(t *testing.T) {
-	r := newPathReplacer("", testLocalOldWS, "old-ws", "new-ws")
-
-	expected := [][2]string{
-		{testLocalOldWS, testLocalNewWS},
-	}
-
-	assert.Equal(t, expected, r.pairs)
-}
-
 func TestNewPathReplacer_EmptyLocalFolder(t *testing.T) {
-	r := newPathReplacer(testContainerOldWS, "", "old-ws", "new-ws")
-
-	expected := [][2]string{
-		{testContainerOldWS, testContainerNewWS},
-	}
-
-	assert.Equal(t, expected, r.pairs)
-}
-
-func TestNewPathReplacer_BothEmpty(t *testing.T) {
-	r := newPathReplacer("", "", "old-ws", "new-ws")
+	r := newPathReplacer("", "old-ws", "new-ws")
 
 	assert.Nil(t, r.pairs)
 }
 
 func TestNewPathReplacer_SpecialCharacters(t *testing.T) {
 	r := newPathReplacer(
-		"/workspaces/my-app_v1.0",
 		"/home/user/my-app_v1.0",
 		"my-app_v1.0",
 		"my-app_v2.0",
 	)
 
 	expected := [][2]string{
-		{"/workspaces/my-app_v1.0", "/workspaces/my-app_v2.0"},
 		{"/home/user/my-app_v1.0", "/home/user/my-app_v2.0"},
 	}
 
@@ -105,39 +74,38 @@ func TestNewPathReplacer_SpecialCharacters(t *testing.T) {
 func TestPathReplacer_Replace_BasicReplacement(t *testing.T) {
 	r := &pathReplacer{
 		pairs: [][2]string{
-			{testContainerOldWS, testContainerNewWS},
+			{testLocalOldWS, testLocalNewWS},
 		},
 	}
 
-	output := r.replace("/workspaces/old-ws/src/main.go")
+	output := r.replace("/home/user/old-ws/src/main.go")
 
-	assert.Equal(t, "/workspaces/new-ws/src/main.go", output)
+	assert.Equal(t, "/home/user/new-ws/src/main.go", output)
 	assert.True(t, r.changed)
 }
 
 func TestPathReplacer_Replace_NoMatch(t *testing.T) {
 	r := &pathReplacer{
 		pairs: [][2]string{
-			{testContainerOldWS, testContainerNewWS},
+			{testLocalOldWS, testLocalNewWS},
 		},
 	}
 
-	output := r.replace("/workspaces/other-ws/src/main.go")
+	output := r.replace("/home/user/other-ws/src/main.go")
 
-	assert.Equal(t, "/workspaces/other-ws/src/main.go", output)
+	assert.Equal(t, "/home/user/other-ws/src/main.go", output)
 	assert.False(t, r.changed)
 }
 
 func TestPathReplacer_Replace_MultipleReplacements(t *testing.T) {
 	r := &pathReplacer{
 		pairs: [][2]string{
-			{testContainerOldWS, testContainerNewWS},
 			{testLocalOldWS, testLocalNewWS},
 		},
 	}
 
 	input := "source=/home/user/old-ws,target=/workspaces/old-ws,type=bind"
-	expected := "source=/home/user/new-ws,target=/workspaces/new-ws,type=bind"
+	expected := "source=/home/user/new-ws,target=/workspaces/old-ws,type=bind"
 
 	output := r.replace(input)
 
@@ -148,7 +116,7 @@ func TestPathReplacer_Replace_MultipleReplacements(t *testing.T) {
 func TestPathReplacer_Replace_EmptyString(t *testing.T) {
 	r := &pathReplacer{
 		pairs: [][2]string{
-			{testContainerOldWS, testContainerNewWS},
+			{testLocalOldWS, testLocalNewWS},
 		},
 	}
 
@@ -161,28 +129,12 @@ func TestPathReplacer_Replace_EmptyString(t *testing.T) {
 func TestPathReplacer_Replace_MultipleOccurrences(t *testing.T) {
 	r := &pathReplacer{
 		pairs: [][2]string{
-			{testContainerApp, "/workspaces/app-new"},
+			{"/home/user/app", "/home/user/app-new"},
 		},
 	}
 
-	input := testContainerApp + "/go.mod " + testContainerApp + "/go.sum"
-	expected := "/workspaces/app-new/go.mod /workspaces/app-new/go.sum"
-
-	output := r.replace(input)
-
-	assert.Equal(t, expected, output)
-	assert.True(t, r.changed)
-}
-
-func TestPathReplacer_Replace_PartialMatch(t *testing.T) {
-	r := &pathReplacer{
-		pairs: [][2]string{
-			{testContainerApp, "/workspaces/app-new"},
-		},
-	}
-
-	input := "/workspaces/application/src"
-	expected := "/workspaces/app-newlication/src"
+	input := "/home/user/app/go.mod /home/user/app/go.sum"
+	expected := "/home/user/app-new/go.mod /home/user/app-new/go.sum"
 
 	output := r.replace(input)
 
@@ -195,22 +147,21 @@ func TestPathReplacer_Replace_NoPairs(t *testing.T) {
 		pairs: nil,
 	}
 
-	output := r.replace("/workspaces/old-ws/src/main.go")
+	output := r.replace("/home/user/old-ws/src/main.go")
 
-	assert.Equal(t, "/workspaces/old-ws/src/main.go", output)
+	assert.Equal(t, "/home/user/old-ws/src/main.go", output)
 	assert.False(t, r.changed)
 }
 
 func TestPathReplacer_Replace_WorkspaceMount(t *testing.T) {
 	r := &pathReplacer{
 		pairs: [][2]string{
-			{testContainerOldWS, testContainerNewWS},
 			{testLocalOldWS, testLocalNewWS},
 		},
 	}
 
 	input := "type=bind,source=/home/user/old-ws,target=/workspaces/old-ws"
-	expected := "type=bind,source=/home/user/new-ws,target=/workspaces/new-ws"
+	expected := "type=bind,source=/home/user/new-ws,target=/workspaces/old-ws"
 
 	output := r.replace(input)
 
@@ -221,31 +172,30 @@ func TestPathReplacer_Replace_WorkspaceMount(t *testing.T) {
 func TestPathReplacer_ReplaceMultipleCalls(t *testing.T) {
 	r := &pathReplacer{
 		pairs: [][2]string{
-			{testContainerOld, testContainerNew},
+			{"/home/user/old", "/home/user/new"},
 		},
 	}
 
-	r.replace("/workspaces/other")
+	r.replace("/home/user/other")
 	assert.False(t, r.changed)
 
-	r.replace(testContainerOld)
+	r.replace("/home/user/old")
 	assert.True(t, r.changed)
 
-	r.replace("/workspaces/other")
+	r.replace("/home/user/other")
 	assert.True(t, r.changed, "changed flag should remain true once set")
 }
 
 func TestPathReplacer_ReplacePairOrder(t *testing.T) {
 	r := &pathReplacer{
 		pairs: [][2]string{
-			{testContainerOld, testContainerNew},
 			{"/home/old", "/home/new"},
 			{"/mnt/old", "/mnt/new"},
 		},
 	}
 
-	input := testContainerOld + " /home/old /mnt/old"
-	expected := testContainerNew + " /home/new /mnt/new"
+	input := "/home/old /mnt/old"
+	expected := "/home/new /mnt/new"
 
 	output := r.replace(input)
 
@@ -263,26 +213,26 @@ func TestPathReplacer_ReplaceWithTrailingSlash(t *testing.T) {
 		{
 			name: "no trailing slash in pair or input",
 			pairs: [][2]string{
-				{testContainerOld, testContainerNew},
+				{"/home/user/old", "/home/user/new"},
 			},
-			input:    testContainerOld,
-			expected: testContainerNew,
+			input:    "/home/user/old",
+			expected: "/home/user/new",
 		},
 		{
 			name: "trailing slash in input only",
 			pairs: [][2]string{
-				{testContainerOld, testContainerNew},
+				{"/home/user/old", "/home/user/new"},
 			},
-			input:    testContainerOld + "/",
-			expected: testContainerNew + "/",
+			input:    "/home/user/old/",
+			expected: "/home/user/new/",
 		},
 		{
 			name: "subpath match",
 			pairs: [][2]string{
-				{testContainerOld, testContainerNew},
+				{"/home/user/old", "/home/user/new"},
 			},
-			input:    testContainerOld + "/subdir/file.txt",
-			expected: testContainerNew + "/subdir/file.txt",
+			input:    "/home/user/old/subdir/file.txt",
+			expected: "/home/user/new/subdir/file.txt",
 		},
 	}
 

--- a/pkg/workspace/rename_test.go
+++ b/pkg/workspace/rename_test.go
@@ -9,6 +9,8 @@ import (
 const (
 	testLocalNewWS = "/home/user/new-ws"
 	testLocalOldWS = "/home/user/old-ws"
+	testLocalOld   = "/home/user/old"
+	testLocalNew   = "/home/user/new"
 )
 
 func TestNewPathReplacer_DefaultWorkspaceDir(t *testing.T) {
@@ -172,14 +174,14 @@ func TestPathReplacer_Replace_WorkspaceMount(t *testing.T) {
 func TestPathReplacer_ReplaceMultipleCalls(t *testing.T) {
 	r := &pathReplacer{
 		pairs: [][2]string{
-			{"/home/user/old", "/home/user/new"},
+			{testLocalOld, testLocalNew},
 		},
 	}
 
 	r.replace("/home/user/other")
 	assert.False(t, r.changed)
 
-	r.replace("/home/user/old")
+	r.replace(testLocalOld)
 	assert.True(t, r.changed)
 
 	r.replace("/home/user/other")
@@ -211,28 +213,22 @@ func TestPathReplacer_ReplaceWithTrailingSlash(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "no trailing slash in pair or input",
-			pairs: [][2]string{
-				{"/home/user/old", "/home/user/new"},
-			},
-			input:    "/home/user/old",
-			expected: "/home/user/new",
+			name:     "no trailing slash in pair or input",
+			pairs:    [][2]string{{testLocalOld, testLocalNew}},
+			input:    testLocalOld,
+			expected: testLocalNew,
 		},
 		{
-			name: "trailing slash in input only",
-			pairs: [][2]string{
-				{"/home/user/old", "/home/user/new"},
-			},
-			input:    "/home/user/old/",
-			expected: "/home/user/new/",
+			name:     "trailing slash in input only",
+			pairs:    [][2]string{{testLocalOld, testLocalNew}},
+			input:    testLocalOld + "/",
+			expected: testLocalNew + "/",
 		},
 		{
-			name: "subpath match",
-			pairs: [][2]string{
-				{"/home/user/old", "/home/user/new"},
-			},
-			input:    "/home/user/old/subdir/file.txt",
-			expected: "/home/user/new/subdir/file.txt",
+			name:     "subpath match",
+			pairs:    [][2]string{{testLocalOld, testLocalNew}},
+			input:    testLocalOld + "/subdir/file.txt",
+			expected: testLocalNew + "/subdir/file.txt",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- After renaming a workspace (e.g. `cpp` → `cpp2`), VS Code would show "Workspace does not exist" because the cached `ContainerWorkspaceFolder` was incorrectly rewritten from `/workspaces/cpp` to `/workspaces/cpp2`. The in-container path doesn't change when the host-side workspace is renamed — only host-side paths (`LocalWorkspaceFolder`, `WorkspaceMount`) should be updated.
- Removed the container path rewriting from `updateWorkspaceResult` and `newPathReplacer`, keeping only host-side path updates.