### PR TITLE
feat: add workspace folder override for IDE open

### DIFF
--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -38,6 +38,7 @@ type UpCmd struct {
 	SSHConfigPath      string
 	SecretsFile        string
 	FeatureSecretsFile string
+	WorkspaceFolder    string
 
 	DotfilesSource        string
 	DotfilesScript        string
@@ -217,6 +218,10 @@ func (cmd *UpCmd) executeDevsyUp(
 			client.WorkspaceConfig().Source.GitSubPath,
 		)
 		workdir = result.SubstitutionContext.ContainerWorkspaceFolder
+	}
+	if cmd.WorkspaceFolder != "" {
+		result.SubstitutionContext.ContainerWorkspaceFolder = cmd.WorkspaceFolder
+		workdir = cmd.WorkspaceFolder
 	}
 
 	return &workspaceContext{result: result, user: user, workdir: workdir}, nil

--- a/cmd/up/up_flags.go
+++ b/cmd/up/up_flags.go
@@ -137,6 +137,9 @@ func (cmd *UpCmd) registerIDEFlags(upCmd *cobra.Command) {
 	upCmd.Flags().
 		BoolVar(&cmd.OpenIDE, "open-ide", true,
 			"If this is false and an IDE is configured, Devsy will only install the IDE server backend, but not open it")
+	upCmd.Flags().
+		StringVar(&cmd.WorkspaceFolder, "workspace-folder", "",
+			"Override the folder path opened in the IDE (absolute path inside the container)")
 }
 
 func (cmd *UpCmd) registerGitFlags(upCmd *cobra.Command) {

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -281,6 +281,7 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
         provider?: string
         ide?: string
         debug?: boolean
+        workspaceFolder?: string
       },
     ) => {
       trackEvent("workspace_create", { provider: args.provider })
@@ -289,6 +290,7 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
       if (args.provider) cliArgs.push("--provider", args.provider)
       if (args.ide) cliArgs.push("--ide", args.ide)
       if (args.debug) cliArgs.push("--debug")
+      if (args.workspaceFolder) cliArgs.push("--workspace-folder", args.workspaceFolder)
 
       const wsId = args.workspaceId ?? args.source
       const cmdId = crypto.randomUUID()

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -22,6 +22,7 @@ export async function workspaceUp(params: {
   provider?: string
   ide?: string
   debug?: boolean
+  workspaceFolder?: string
 }): Promise<string> {
   return invoke<string>("workspace_up", params)
 }

--- a/desktop/src/renderer/src/lib/stores/settings.ts
+++ b/desktop/src/renderer/src/lib/stores/settings.ts
@@ -351,3 +351,40 @@ export function initSettings() {
 
   return unsubscribe
 }
+
+// ── Per-workspace folder override ──────────────────────────────────
+
+const WORKSPACE_FOLDERS_KEY = "devsy-workspace-folders"
+
+export function getWorkspaceFolder(workspaceId: string): string {
+  if (!browser) return ""
+  try {
+    const stored = localStorage.getItem(WORKSPACE_FOLDERS_KEY)
+    if (stored) {
+      const map = JSON.parse(stored) as Record<string, string>
+      return map[workspaceId] ?? ""
+    }
+  } catch {
+    // ignore
+  }
+  return ""
+}
+
+export function setWorkspaceFolder(
+  workspaceId: string,
+  folder: string,
+): void {
+  if (!browser) return
+  try {
+    const stored = localStorage.getItem(WORKSPACE_FOLDERS_KEY)
+    const map: Record<string, string> = stored ? JSON.parse(stored) : {}
+    if (folder) {
+      map[workspaceId] = folder
+    } else {
+      delete map[workspaceId]
+    }
+    localStorage.setItem(WORKSPACE_FOLDERS_KEY, JSON.stringify(map))
+  } catch {
+    // ignore
+  }
+}

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -46,7 +46,7 @@ import {
   workspaceLogDelete,
 } from "$lib/ipc/commands.js"
 import { onCommandProgress } from "$lib/ipc/events.js"
-import { loadLocalOptions } from "$lib/stores/settings.js"
+import { loadLocalOptions, getWorkspaceFolder, setWorkspaceFolder } from "$lib/stores/settings.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
 import type { LogEntry } from "$lib/types/index.js"
@@ -127,6 +127,9 @@ let selectedIde = $state<string | null>(null)
 let renaming = $state(false)
 let renameValue = $state("")
 let renameSaving = $state(false)
+let editingFolder = $state(false)
+let folderValue = $state("")
+let customFolder = $state("")
 let currentIde = $derived(selectedIde ?? workspace?.ide?.name ?? "none")
 let filteredIdes = $derived(
   IDE_OPTIONS.filter((i) =>
@@ -180,6 +183,7 @@ onMount(async () => {
   }
 
   loadLogs()
+  customFolder = getWorkspaceFolder(id)
 
   // Auto-trigger IDE open when navigated with ?action=open-ide
   const qs = new URLSearchParams($querystring ?? "")
@@ -312,9 +316,10 @@ async function handleStart() {
 
 async function handleOpenIde() {
   const ide = currentIde !== "none" ? currentIde : undefined
+  const folder = customFolder || undefined
   startStreamingOp("Open IDE")
   try {
-    commandId = await workspaceUp({ source: id, ide, debug: isDebug() })
+    commandId = await workspaceUp({ source: id, ide, debug: isDebug(), workspaceFolder: folder })
   } catch (err) {
     operationRunning = false
     toasts.error(`Failed to open IDE: ${extractErrorMessage(err)}`)
@@ -549,6 +554,30 @@ async function handleRename() {
                 </Command.Root>
               </Popover.Content>
             </Popover.Root>
+          </div>
+
+          <div class="text-muted-foreground">Workspace Folder</div>
+          <div>
+            {#if editingFolder}
+              <form class="flex items-center gap-2" onsubmit={(e) => { e.preventDefault(); setWorkspaceFolder(id, folderValue.trim()); customFolder = folderValue.trim(); editingFolder = false; toasts.success("Workspace folder updated") }}>
+                <Input
+                  value={folderValue}
+                  oninput={(e) => (folderValue = e.currentTarget.value)}
+                  placeholder="/workspaces/my-project"
+                  class="h-7 w-56 text-xs font-mono"
+                />
+                <Button variant="outline" size="sm" type="submit" class="h-7 text-xs">Save</Button>
+                <Button variant="ghost" size="sm" type="button" class="h-7 text-xs" onclick={() => (editingFolder = false)}>Cancel</Button>
+              </form>
+            {:else}
+              <span class="inline-flex items-center gap-2">
+                <span class="font-mono text-xs">{customFolder || "Default"}</span>
+                <Button variant="ghost" size="icon-sm" onclick={() => { folderValue = customFolder; editingFolder = true }} disabled={operationRunning}>
+                  <Pencil class="h-3 w-3" />
+                  <span class="sr-only">Edit workspace folder</span>
+                </Button>
+              </span>
+            {/if}
           </div>
 
           <div class="text-muted-foreground">Source</div>


### PR DESCRIPTION
## Summary

- Adds a `--workspace-folder` flag to `devsy up` that overrides the container folder path opened in the IDE, allowing users to open a subfolder or alternate path instead of the default workspace root.
- Exposes this as an editable "Workspace Folder" field on the workspace detail page in the desktop app, persisted per-workspace in localStorage.
- The override is passed through the IPC bridge to the CLI on every `devsy up` invocation when set.