### PR TITLE
fix(desktop): prevent infinite process storm from watcher

### DIFF
--- a/desktop/src/main/cli.ts
+++ b/desktop/src/main/cli.ts
@@ -4,6 +4,7 @@ import { createInterface } from "node:readline"
 import { promisify } from "node:util"
 
 const execFile = promisify(execFileCb)
+const MAX_CONCURRENT = 10
 
 /**
  * On macOS, GUI apps (including Electron) inherit a minimal PATH that excludes
@@ -34,11 +35,10 @@ export class CliRunner {
   private execPath: string
   private prefixArgs: string[]
   private env: NodeJS.ProcessEnv
+  private running = 0
+  private queue: Array<() => void> = []
 
   constructor(private binaryPath: string) {
-    // If the binary is a Node.js script, run it through node directly.
-    // Uses "node" from PATH rather than process.execPath because in Electron
-    // process.execPath is the Electron binary, not Node.js.
     if (/\.[cm]?js$/.test(binaryPath)) {
       this.execPath = "node"
       this.prefixArgs = [binaryPath]
@@ -49,19 +49,42 @@ export class CliRunner {
     this.env = buildEnv()
   }
 
+  private acquire(): Promise<void> {
+    if (this.running < MAX_CONCURRENT) {
+      this.running++
+      return Promise.resolve()
+    }
+    return new Promise((resolve) => {
+      this.queue.push(() => {
+        this.running++
+        resolve()
+      })
+    })
+  }
+
+  private release(): void {
+    this.running--
+    const next = this.queue.shift()
+    if (next) next()
+  }
+
   async run<T>(args: string[]): Promise<T> {
-    const fullArgs = [...this.prefixArgs, ...args, "--output", "json"]
+    await this.acquire()
     try {
+      const fullArgs = [...this.prefixArgs, ...args, "--output", "json"]
       const { stdout } = await execFile(this.execPath, fullArgs, {
         env: this.env,
       })
       return JSON.parse(stdout) as T
     } catch (error: unknown) {
       throw this.wrapError(error)
+    } finally {
+      this.release()
     }
   }
 
   async runRaw(args: string[]): Promise<string> {
+    await this.acquire()
     try {
       const { stdout } = await execFile(
         this.execPath,
@@ -71,6 +94,8 @@ export class CliRunner {
       return stdout
     } catch (error: unknown) {
       throw this.wrapError(error)
+    } finally {
+      this.release()
     }
   }
 
@@ -78,26 +103,27 @@ export class CliRunner {
     args: string[],
     onLine: (line: string, stream: "stdout" | "stderr") => void,
     onExit: (code: number) => void,
-  ): ChildProcess {
-    const child = spawn(this.execPath, [...this.prefixArgs, ...args], {
-      env: this.env,
+  ): void {
+    this.acquire().then(() => {
+      const child = spawn(this.execPath, [...this.prefixArgs, ...args], {
+        env: this.env,
+      })
+
+      if (child.stdout) {
+        const rl = createInterface({ input: child.stdout })
+        rl.on("line", (line) => onLine(line, "stdout"))
+      }
+
+      if (child.stderr) {
+        const rl = createInterface({ input: child.stderr })
+        rl.on("line", (line) => onLine(line, "stderr"))
+      }
+
+      child.on("close", (code) => {
+        this.release()
+        onExit(code ?? -1)
+      })
     })
-
-    if (child.stdout) {
-      const rl = createInterface({ input: child.stdout })
-      rl.on("line", (line) => onLine(line, "stdout"))
-    }
-
-    if (child.stderr) {
-      const rl = createInterface({ input: child.stderr })
-      rl.on("line", (line) => onLine(line, "stderr"))
-    }
-
-    child.on("close", (code) => {
-      onExit(code ?? -1)
-    })
-
-    return child
   }
 
   static stripAnsi(str: string): string {

--- a/desktop/src/main/watcher.ts
+++ b/desktop/src/main/watcher.ts
@@ -51,25 +51,25 @@ export function parseProviderEntries(raw: Record<string, ProviderEntry>) {
 export class Watcher {
   private pollTimer: ReturnType<typeof setInterval> | null = null
   private fsWatcher: ReturnType<typeof watch> | null = null
+  private polling = false
+  private pollQueued = false
 
   constructor(private deps: WatcherDeps) {}
 
   start(): void {
-    // Poll every 3 seconds
-    this.pollTimer = setInterval(() => this.pollOnce(), 3000)
+    this.pollTimer = setInterval(() => this.schedulePoll(), 3000)
 
-    // Watch ~/.devsy/ for filesystem changes
     const devsyDir = join(homedir(), ".devsy")
     if (existsSync(devsyDir)) {
       this.fsWatcher = watch(devsyDir, {
         ignoreInitial: true,
+        ignored: /[\\/]logs[\\/]/,
         awaitWriteFinish: { stabilityThreshold: 500 },
       })
-      this.fsWatcher.on("all", () => this.pollOnce())
+      this.fsWatcher.on("all", () => this.schedulePoll())
     }
 
-    // Initial poll
-    this.pollOnce()
+    this.schedulePoll()
   }
 
   stop(): void {
@@ -83,13 +83,30 @@ export class Watcher {
     }
   }
 
+  private schedulePoll(): void {
+    if (this.polling) {
+      this.pollQueued = true
+      return
+    }
+    this.pollOnce()
+  }
+
   private async pollOnce(): Promise<void> {
-    await Promise.allSettled([
-      this.pollWorkspaces(),
-      this.pollProviders(),
-      this.pollMachines(),
-      this.pollContexts(),
-    ])
+    this.polling = true
+    try {
+      await Promise.allSettled([
+        this.pollWorkspaces(),
+        this.pollProviders(),
+        this.pollMachines(),
+        this.pollContexts(),
+      ])
+    } finally {
+      this.polling = false
+      if (this.pollQueued) {
+        this.pollQueued = false
+        this.schedulePoll()
+      }
+    }
   }
 
   private async pollWorkspaces(): Promise<void> {


### PR DESCRIPTION
## Summary

- The filesystem watcher on `~/.devsy/` triggered unbounded CLI process spawning when debug-mode log writes to `~/.devsy/logs/` caused chokidar events, each spawning 4 CLI poll processes. This caused thousands of devsy processes to accumulate, exhausting memory and CPU.
- Excludes the `logs/` directory from the chokidar watch since log files don't contain workspace state changes.
- Adds a concurrency guard to `pollOnce()` so only one poll cycle runs at a time — additional requests are coalesced into a single follow-up poll.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed polling behavior to prevent concurrent execution, ensuring more reliable and stable file system monitoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->