### PR TITLE
feat(desktop): add local daemon for efficient polling

### DIFF
--- a/cmd/daemon_local.go
+++ b/cmd/daemon_local.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/daemon/local"
+	"github.com/spf13/cobra"
+)
+
+type DaemonLocalCmd struct {
+	*flags.GlobalFlags
+}
+
+func NewDaemonLocalCmd(flags *flags.GlobalFlags) *cobra.Command {
+	cmd := &DaemonLocalCmd{
+		GlobalFlags: flags,
+	}
+	cobraCmd := &cobra.Command{
+		Use:    "daemon-local",
+		Short:  "Run the local daemon for desktop app communication",
+		Hidden: true,
+		RunE: func(cobraCmd *cobra.Command, _ []string) error {
+			return cmd.Run(cobraCmd.Context())
+		},
+	}
+	return cobraCmd
+}
+
+func (cmd *DaemonLocalCmd) Run(ctx context.Context) error {
+	devsyConfig, err := config.LoadConfig(cmd.Context, cmd.Provider)
+	if err != nil {
+		return err
+	}
+
+	ctx, stop := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	d, err := local.New(devsyConfig)
+	if err != nil {
+		return err
+	}
+
+	return d.Run(ctx)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -144,6 +144,7 @@ func BuildRoot() *cobra.Command {
 	rootCmd.AddCommand(NewRenameCmd(globalFlags))
 	rootCmd.AddCommand(features.NewFeaturesCmd(globalFlags))
 	rootCmd.AddCommand(templates.NewTemplatesCmd(globalFlags))
+	rootCmd.AddCommand(NewDaemonLocalCmd(globalFlags))
 
 	inheritCommandFlagsFromEnvironment(rootCmd)
 

--- a/desktop/src/main/daemon-client.ts
+++ b/desktop/src/main/daemon-client.ts
@@ -1,0 +1,66 @@
+import http from "node:http"
+
+const SOCKET_PATH = "/tmp/devsy-local.sock"
+const REQUEST_TIMEOUT = 3000
+
+export class DaemonClient {
+  private socketPath: string
+
+  constructor(socketPath = SOCKET_PATH) {
+    this.socketPath = socketPath
+  }
+
+  async health(): Promise<boolean> {
+    try {
+      await this.get("/health")
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  async listWorkspaces<T>(): Promise<T> {
+    return this.get<T>("/list")
+  }
+
+  async listProviders<T>(): Promise<T> {
+    return this.get<T>("/provider/list")
+  }
+
+  async listMachines<T>(): Promise<T> {
+    return this.get<T>("/machine/list")
+  }
+
+  async listContexts<T>(): Promise<T> {
+    return this.get<T>("/context/list")
+  }
+
+  private get<T>(path: string): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const req = http.get(
+        { socketPath: this.socketPath, path, timeout: REQUEST_TIMEOUT },
+        (res) => {
+          const chunks: Buffer[] = []
+          res.on("data", (chunk: Buffer) => chunks.push(chunk))
+          res.on("end", () => {
+            const body = Buffer.concat(chunks).toString()
+            if (res.statusCode !== 200) {
+              reject(new Error(`daemon ${path}: ${res.statusCode} ${body}`))
+              return
+            }
+            try {
+              resolve(JSON.parse(body) as T)
+            } catch (e) {
+              reject(e)
+            }
+          })
+        },
+      )
+      req.on("error", reject)
+      req.on("timeout", () => {
+        req.destroy()
+        reject(new Error(`daemon ${path}: timeout`))
+      })
+    })
+  }
+}

--- a/desktop/src/main/daemon-client.ts
+++ b/desktop/src/main/daemon-client.ts
@@ -1,12 +1,19 @@
 import http from "node:http"
 
-const SOCKET_PATH = "/tmp/devsy-local.sock"
+const SOCKET_SUFFIX = "devsy-local.sock"
 const REQUEST_TIMEOUT = 3000
+
+function getDefaultSocketPath(): string {
+  if (process.platform === "win32") {
+    return `\\\\.\\pipe\\${SOCKET_SUFFIX}`
+  }
+  return `/tmp/${SOCKET_SUFFIX}`
+}
 
 export class DaemonClient {
   private socketPath: string
 
-  constructor(socketPath = SOCKET_PATH) {
+  constructor(socketPath = getDefaultSocketPath()) {
     this.socketPath = socketPath
   }
 

--- a/desktop/src/main/daemon-manager.ts
+++ b/desktop/src/main/daemon-manager.ts
@@ -1,0 +1,69 @@
+import { spawn } from "node:child_process"
+import { DaemonClient } from "./daemon-client.js"
+
+const HEALTH_INTERVAL = 30_000
+const SPAWN_RETRY_DELAY = 2000
+const MAX_SPAWN_RETRIES = 3
+
+export class DaemonManager {
+  private client: DaemonClient
+  private healthTimer: ReturnType<typeof setInterval> | null = null
+  private running = false
+  private binaryPath: string
+  private prefixArgs: string[]
+
+  constructor(binaryPath: string) {
+    this.client = new DaemonClient()
+    if (/\.[cm]?js$/.test(binaryPath)) {
+      this.binaryPath = "node"
+      this.prefixArgs = [binaryPath]
+    } else {
+      this.binaryPath = binaryPath
+      this.prefixArgs = []
+    }
+  }
+
+  get daemonClient(): DaemonClient {
+    return this.client
+  }
+
+  async start(): Promise<void> {
+    this.running = true
+    await this.ensureRunning()
+    this.healthTimer = setInterval(() => this.ensureRunning(), HEALTH_INTERVAL)
+  }
+
+  stop(): void {
+    this.running = false
+    if (this.healthTimer) {
+      clearInterval(this.healthTimer)
+      this.healthTimer = null
+    }
+  }
+
+  private async ensureRunning(): Promise<void> {
+    if (!this.running) return
+
+    const alive = await this.client.health()
+    if (alive) return
+
+    for (let i = 0; i < MAX_SPAWN_RETRIES; i++) {
+      this.spawnDaemon()
+      await sleep(SPAWN_RETRY_DELAY)
+      if (await this.client.health()) return
+    }
+  }
+
+  private spawnDaemon(): void {
+    const child = spawn(
+      this.binaryPath,
+      [...this.prefixArgs, "daemon-local"],
+      { detached: true, stdio: "ignore" },
+    )
+    child.unref()
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -2,6 +2,7 @@ import { join } from "node:path"
 import { app, BrowserWindow, session } from "electron"
 import { initAnalytics, shutdownAnalytics, trackEvent } from "./analytics.js"
 import { CliRunner } from "./cli.js"
+import { DaemonManager } from "./daemon-manager.js"
 import { registerIpcHandlers } from "./ipc.js"
 import { LogStore } from "./log-store.js"
 import { PtyManager } from "./pty.js"
@@ -138,10 +139,15 @@ app.whenReady().then(() => {
     getMainWindow: () => mainWindow,
   })
 
+  // Start local daemon for efficient polling
+  const daemonManager = new DaemonManager(binaryPath)
+  daemonManager.start()
+
   app.on("before-quit", () => {
     ;(app as typeof app & { isQuitting?: boolean }).isQuitting = true
     trackEvent("app_close")
     shutdownAnalytics().catch(() => {})
+    daemonManager.stop()
     ptyManager.destroyAll()
   })
 
@@ -157,6 +163,7 @@ app.whenReady().then(() => {
   // Start state watcher
   const watcher = new Watcher({
     cli,
+    daemon: daemonManager.daemonClient,
     state,
     getMainWindow: () => mainWindow,
   })

--- a/desktop/src/main/watcher.ts
+++ b/desktop/src/main/watcher.ts
@@ -94,11 +94,28 @@ export class Watcher {
     ])
   }
 
+  private async queryWithFallback<T>(
+    daemonFn: (() => Promise<T>) | undefined,
+    cliFn: () => Promise<T>,
+  ): Promise<T> {
+    if (daemonFn) {
+      try {
+        return await daemonFn()
+      } catch {
+        // Daemon unavailable, fall through to CLI
+      }
+    }
+    return cliFn()
+  }
+
   private async pollWorkspaces(): Promise<void> {
     try {
-      const workspaces = this.deps.daemon
-        ? await this.deps.daemon.listWorkspaces<unknown[]>()
-        : await this.deps.cli.run<unknown[]>(["list", "--skip-pro"])
+      const workspaces = await this.queryWithFallback(
+        this.deps.daemon
+          ? () => this.deps.daemon!.listWorkspaces<unknown[]>()
+          : undefined,
+        () => this.deps.cli.run<unknown[]>(["list", "--skip-pro"]),
+      )
       const changed = this.deps.state.updateWorkspaces(workspaces as any[])
       if (changed) {
         this.send("workspaces-changed", {
@@ -112,12 +129,17 @@ export class Watcher {
 
   private async pollProviders(): Promise<void> {
     try {
-      const raw = this.deps.daemon
-        ? await this.deps.daemon.listProviders<Record<string, ProviderEntry>>()
-        : await this.deps.cli.run<Record<string, ProviderEntry>>([
+      const raw = await this.queryWithFallback(
+        this.deps.daemon
+          ? () =>
+              this.deps.daemon!.listProviders<Record<string, ProviderEntry>>()
+          : undefined,
+        () =>
+          this.deps.cli.run<Record<string, ProviderEntry>>([
             "provider",
             "list",
-          ])
+          ]),
+      )
       const providers = parseProviderEntries(raw)
       const changed = this.deps.state.updateProviders(providers as any[])
       if (changed) {
@@ -132,9 +154,12 @@ export class Watcher {
 
   private async pollMachines(): Promise<void> {
     try {
-      const machines = this.deps.daemon
-        ? await this.deps.daemon.listMachines<unknown[]>()
-        : await this.deps.cli.run<unknown[]>(["machine", "list"])
+      const machines = await this.queryWithFallback(
+        this.deps.daemon
+          ? () => this.deps.daemon!.listMachines<unknown[]>()
+          : undefined,
+        () => this.deps.cli.run<unknown[]>(["machine", "list"]),
+      )
       const changed = this.deps.state.updateMachines(machines as any[])
       if (changed) {
         this.send("machines-changed", {
@@ -148,9 +173,12 @@ export class Watcher {
 
   private async pollContexts(): Promise<void> {
     try {
-      const entries = this.deps.daemon
-        ? await this.deps.daemon.listContexts<ContextEntry[]>()
-        : await this.deps.cli.run<ContextEntry[]>(["context", "list"])
+      const entries = await this.queryWithFallback(
+        this.deps.daemon
+          ? () => this.deps.daemon!.listContexts<ContextEntry[]>()
+          : undefined,
+        () => this.deps.cli.run<ContextEntry[]>(["context", "list"]),
+      )
       const active = entries.find((e) => e.default)?.name ?? ""
       const contexts = entries.map((e) => ({ name: e.name }))
       const changed = this.deps.state.updateContexts(contexts, active)

--- a/desktop/src/main/watcher.ts
+++ b/desktop/src/main/watcher.ts
@@ -4,10 +4,12 @@ import { join } from "node:path"
 import { watch } from "chokidar"
 import type { BrowserWindow } from "electron"
 import type { CliRunner } from "./cli.js"
+import type { DaemonClient } from "./daemon-client.js"
 import type { DaemonState } from "./state.js"
 
 interface WatcherDeps {
   cli: CliRunner
+  daemon?: DaemonClient
   state: DaemonState
   getMainWindow: () => BrowserWindow | null
 }
@@ -94,10 +96,9 @@ export class Watcher {
 
   private async pollWorkspaces(): Promise<void> {
     try {
-      const workspaces = await this.deps.cli.run<unknown[]>([
-        "list",
-        "--skip-pro",
-      ])
+      const workspaces = this.deps.daemon
+        ? await this.deps.daemon.listWorkspaces<unknown[]>()
+        : await this.deps.cli.run<unknown[]>(["list", "--skip-pro"])
       const changed = this.deps.state.updateWorkspaces(workspaces as any[])
       if (changed) {
         this.send("workspaces-changed", {
@@ -111,10 +112,12 @@ export class Watcher {
 
   private async pollProviders(): Promise<void> {
     try {
-      const raw = await this.deps.cli.run<Record<string, ProviderEntry>>([
-        "provider",
-        "list",
-      ])
+      const raw = this.deps.daemon
+        ? await this.deps.daemon.listProviders<Record<string, ProviderEntry>>()
+        : await this.deps.cli.run<Record<string, ProviderEntry>>([
+            "provider",
+            "list",
+          ])
       const providers = parseProviderEntries(raw)
       const changed = this.deps.state.updateProviders(providers as any[])
       if (changed) {
@@ -129,7 +132,9 @@ export class Watcher {
 
   private async pollMachines(): Promise<void> {
     try {
-      const machines = await this.deps.cli.run<unknown[]>(["machine", "list"])
+      const machines = this.deps.daemon
+        ? await this.deps.daemon.listMachines<unknown[]>()
+        : await this.deps.cli.run<unknown[]>(["machine", "list"])
       const changed = this.deps.state.updateMachines(machines as any[])
       if (changed) {
         this.send("machines-changed", {
@@ -143,10 +148,9 @@ export class Watcher {
 
   private async pollContexts(): Promise<void> {
     try {
-      const entries = await this.deps.cli.run<ContextEntry[]>([
-        "context",
-        "list",
-      ])
+      const entries = this.deps.daemon
+        ? await this.deps.daemon.listContexts<ContextEntry[]>()
+        : await this.deps.cli.run<ContextEntry[]>(["context", "list"])
       const active = entries.find((e) => e.default)?.name ?? ""
       const contexts = entries.map((e) => ({ name: e.name }))
       const changed = this.deps.state.updateContexts(contexts, active)

--- a/pkg/daemon/local/daemon.go
+++ b/pkg/daemon/local/daemon.go
@@ -1,0 +1,241 @@
+package local
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
+	providerpkg "github.com/devsy-org/devsy/pkg/provider"
+	"github.com/devsy-org/devsy/pkg/workspace"
+)
+
+const (
+	idleTimeout  = 5 * time.Minute
+	cacheTTL     = 3 * time.Second
+	socketSuffix = "devsy-local.sock"
+)
+
+type Daemon struct {
+	listener net.Listener
+	server   *http.Server
+	config   *config.Config
+
+	mu           sync.RWMutex
+	lastActivity time.Time
+
+	cacheMu      sync.RWMutex
+	workspaces   []*providerpkg.Workspace
+	workspacesAt time.Time
+	providers    map[string]*workspace.ProviderWithOptions
+	providersAt  time.Time
+	machines     []*providerpkg.Machine
+	machinesAt   time.Time
+	contexts     []contextEntry
+	contextsAt   time.Time
+}
+
+type contextEntry struct {
+	Name    string `json:"name"`
+	Default bool   `json:"default,omitempty"`
+}
+
+func GetSocketPath() string {
+	return fmt.Sprintf("/tmp/%s", socketSuffix)
+}
+
+func New(devsyConfig *config.Config) (*Daemon, error) {
+	socketPath := GetSocketPath()
+	ln, err := listen(socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("listen: %w", err)
+	}
+
+	d := &Daemon{
+		listener:     ln,
+		config:       devsyConfig,
+		lastActivity: time.Now(),
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", d.handleHealth)
+	mux.HandleFunc("GET /list", d.handleList)
+	mux.HandleFunc("GET /provider/list", d.handleProviderList)
+	mux.HandleFunc("GET /machine/list", d.handleMachineList)
+	mux.HandleFunc("GET /context/list", d.handleContextList)
+
+	d.server = &http.Server{Handler: mux} //nolint:gosec // local Unix socket, no internet exposure
+	return d, nil
+}
+
+func (d *Daemon) Run(ctx context.Context) error {
+	log.Infof("local daemon listening on %s", GetSocketPath())
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- d.server.Serve(d.listener) }()
+
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case err := <-errCh:
+			return err
+		case <-ctx.Done():
+			return d.shutdown()
+		case <-ticker.C:
+			d.mu.RLock()
+			idle := time.Since(d.lastActivity) > idleTimeout
+			d.mu.RUnlock()
+			if idle {
+				log.Infof("idle timeout reached, shutting down")
+				return d.shutdown()
+			}
+		}
+	}
+}
+
+func (d *Daemon) shutdown() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = os.Remove(GetSocketPath())
+	return d.server.Shutdown(ctx)
+}
+
+func (d *Daemon) touch() {
+	d.mu.Lock()
+	d.lastActivity = time.Now()
+	d.mu.Unlock()
+}
+
+func (d *Daemon) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	d.touch()
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+func (d *Daemon) handleList(w http.ResponseWriter, _ *http.Request) {
+	d.touch()
+
+	d.cacheMu.RLock()
+	if time.Since(d.workspacesAt) < cacheTTL && d.workspaces != nil {
+		data := d.workspaces
+		d.cacheMu.RUnlock()
+		writeJSON(w, data)
+		return
+	}
+	d.cacheMu.RUnlock()
+
+	workspaces, err := workspace.ListLocalWorkspaces(d.config.DefaultContext, true)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	d.cacheMu.Lock()
+	d.workspaces = workspaces
+	d.workspacesAt = time.Now()
+	d.cacheMu.Unlock()
+
+	writeJSON(w, workspaces)
+}
+
+func (d *Daemon) handleProviderList(w http.ResponseWriter, _ *http.Request) {
+	d.touch()
+
+	d.cacheMu.RLock()
+	if time.Since(d.providersAt) < cacheTTL && d.providers != nil {
+		data := d.providers
+		d.cacheMu.RUnlock()
+		writeJSON(w, data)
+		return
+	}
+	d.cacheMu.RUnlock()
+
+	providers, err := workspace.LoadAllProviders(d.config)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	d.cacheMu.Lock()
+	d.providers = providers
+	d.providersAt = time.Now()
+	d.cacheMu.Unlock()
+
+	writeJSON(w, providers)
+}
+
+func (d *Daemon) handleMachineList(w http.ResponseWriter, _ *http.Request) {
+	d.touch()
+
+	d.cacheMu.RLock()
+	if time.Since(d.machinesAt) < cacheTTL && d.machines != nil {
+		data := d.machines
+		d.cacheMu.RUnlock()
+		writeJSON(w, data)
+		return
+	}
+	d.cacheMu.RUnlock()
+
+	machines, err := workspace.ListMachines(d.config)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	d.cacheMu.Lock()
+	d.machines = machines
+	d.machinesAt = time.Now()
+	d.cacheMu.Unlock()
+
+	writeJSON(w, machines)
+}
+
+func (d *Daemon) handleContextList(w http.ResponseWriter, _ *http.Request) {
+	d.touch()
+
+	d.cacheMu.RLock()
+	if time.Since(d.contextsAt) < cacheTTL && d.contexts != nil {
+		data := d.contexts
+		d.cacheMu.RUnlock()
+		writeJSON(w, data)
+		return
+	}
+	d.cacheMu.RUnlock()
+
+	devsyConfig, err := config.LoadConfig("", "")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	entries := make([]contextEntry, 0, len(devsyConfig.Contexts))
+	for name := range devsyConfig.Contexts {
+		entries = append(entries, contextEntry{
+			Name:    name,
+			Default: devsyConfig.DefaultContext == name,
+		})
+	}
+
+	d.cacheMu.Lock()
+	d.contexts = entries
+	d.contextsAt = time.Now()
+	d.config = devsyConfig
+	d.cacheMu.Unlock()
+
+	writeJSON(w, entries)
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/pkg/daemon/local/daemon.go
+++ b/pkg/daemon/local/daemon.go
@@ -46,10 +46,6 @@ type contextEntry struct {
 	Default bool   `json:"default,omitempty"`
 }
 
-func GetSocketPath() string {
-	return fmt.Sprintf("/tmp/%s", socketSuffix)
-}
-
 func New(devsyConfig *config.Config) (*Daemon, error) {
 	socketPath := GetSocketPath()
 	ln, err := listen(socketPath)

--- a/pkg/daemon/local/socket.go
+++ b/pkg/daemon/local/socket.go
@@ -1,0 +1,34 @@
+package local
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func Dial() (net.Conn, error) {
+	return net.DialTimeout("unix", GetSocketPath(), 2*time.Second)
+}
+
+func listen(addr string) (net.Listener, error) {
+	conn, err := net.Dial("unix", addr)
+	if err == nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("%s: address already in use", addr)
+	}
+	_ = os.Remove(addr)
+
+	sockDir := filepath.Dir(addr)
+	if _, err := os.Stat(sockDir); errors.Is(err, os.ErrNotExist) {
+		_ = os.MkdirAll(sockDir, 0o755) //nolint:gosec // socket dir in /tmp
+	}
+	pipe, err := net.Listen("unix", addr)
+	if err != nil {
+		return nil, err
+	}
+	_ = os.Chmod(addr, 0o666) //nolint:gosec // allow any local user to connect
+	return pipe, err
+}

--- a/pkg/daemon/local/socket_unix.go
+++ b/pkg/daemon/local/socket_unix.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package local
 
 import (
@@ -8,6 +10,10 @@ import (
 	"path/filepath"
 	"time"
 )
+
+func GetSocketPath() string {
+	return fmt.Sprintf("/tmp/%s", socketSuffix)
+}
 
 func Dial() (net.Conn, error) {
 	return net.DialTimeout("unix", GetSocketPath(), 2*time.Second)

--- a/pkg/daemon/local/socket_windows.go
+++ b/pkg/daemon/local/socket_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package local
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/Microsoft/go-winio"
+)
+
+func GetSocketPath() string {
+	return fmt.Sprintf("\\\\.\\pipe\\%s", socketSuffix)
+}
+
+func Dial() (net.Conn, error) {
+	timeout := 2 * time.Second
+	return winio.DialPipe(GetSocketPath(), &timeout)
+}
+
+func listen(addr string) (net.Listener, error) {
+	return winio.ListenPipe(addr, nil)
+}


### PR DESCRIPTION
## Summary

- Adds a persistent local daemon (`devsy daemon-local`) that serves workspace, provider, machine, and context data over a Unix domain socket (`/tmp/devsy-local.sock`)
- The daemon uses an in-memory cache with 3-second TTL to reduce filesystem/network reads, and auto-shuts down after 5 minutes of inactivity
- The desktop app spawns and monitors the daemon via `DaemonManager`, using it for all polling operations with automatic fallback to direct CLI execution if the daemon is unavailable
- Eliminates the per-poll CLI process spawning overhead (previously 4 processes every 3 seconds) by routing all read queries through the single long-lived daemon process