### PR TITLE
fix: use actual container mount path after workspace rename

### DIFF
--- a/pkg/devcontainer/config/container_details.go
+++ b/pkg/devcontainer/config/container_details.go
@@ -18,6 +18,15 @@ type ContainerDetails struct {
 	Created string                 `json:"Created,omitempty"`
 	State   ContainerDetailsState  `json:"State"`
 	Config  ContainerDetailsConfig `json:"Config"`
+	Mounts  []ContainerMount       `json:"Mounts,omitempty"`
+}
+
+// ContainerMount represents a mount point on a container as returned by
+// docker/podman inspect.
+type ContainerMount struct {
+	Type        string `json:"Type,omitempty"`
+	Source      string `json:"Source,omitempty"`
+	Destination string `json:"Destination,omitempty"`
 }
 
 type ContainerDetailsConfig struct {

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -90,6 +90,14 @@ func (r *runner) runSingleContainer(
 	if options.Recreate && parsedConfig.Config.ContainerID != "" {
 		return nil, fmt.Errorf("cannot recreate container not created by Devsy")
 	} else if !options.Recreate && containerDetails != nil {
+		if actual := workspaceMountDestination(containerDetails); actual != "" &&
+			actual != substitutionContext.ContainerWorkspaceFolder {
+			log.Infof(
+				"container workspace mount is %s, updating from computed %s",
+				actual, substitutionContext.ContainerWorkspaceFolder,
+			)
+			substitutionContext.ContainerWorkspaceFolder = actual
+		}
 		resolved, err = r.resolveExistingContainer(ctx, containerDetails, params)
 	} else {
 		resolved, err = r.resolveNewContainer(ctx, params)
@@ -353,6 +361,18 @@ func (r *runner) findRunningContainerOrFail(
 		return nil, fmt.Errorf("dev container %s not found after %s", r.ID, operation)
 	}
 	return details, nil
+}
+
+// workspaceMountDestination returns the container-side destination of the
+// workspace bind mount, or "" if none is found. This is used to prefer the
+// actual container mount path over the recomputed one after a rename.
+func workspaceMountDestination(containerDetails *config.ContainerDetails) string {
+	for _, mount := range containerDetails.Mounts {
+		if mount.Type == "bind" && strings.HasPrefix(mount.Destination, "/workspaces/") {
+			return mount.Destination
+		}
+	}
+	return ""
 }
 
 func (r *runner) buildRunOptionsForDelivery(

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -363,12 +363,17 @@ func (r *runner) findRunningContainerOrFail(
 	return details, nil
 }
 
+const (
+	mountTypeBind    = "bind"
+	workspacesPrefix = "/workspaces/"
+)
+
 // workspaceMountDestination returns the container-side destination of the
 // workspace bind mount, or "" if none is found. This is used to prefer the
 // actual container mount path over the recomputed one after a rename.
 func workspaceMountDestination(containerDetails *config.ContainerDetails) string {
 	for _, mount := range containerDetails.Mounts {
-		if mount.Type == "bind" && strings.HasPrefix(mount.Destination, "/workspaces/") {
+		if mount.Type == mountTypeBind && strings.HasPrefix(mount.Destination, workspacesPrefix) {
 			return mount.Destination
 		}
 	}

--- a/pkg/devcontainer/single_test.go
+++ b/pkg/devcontainer/single_test.go
@@ -1,0 +1,67 @@
+package devcontainer
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+)
+
+func TestWorkspaceMountDestination(t *testing.T) {
+	tests := []struct {
+		name   string
+		mounts []config.ContainerMount
+		want   string
+	}{
+		{
+			name:   "no mounts",
+			mounts: nil,
+			want:   "",
+		},
+		{
+			name: "bind mount under /workspaces/",
+			mounts: []config.ContainerMount{
+				{Type: "bind", Source: "/home/user/project", Destination: "/workspaces/my-app"},
+			},
+			want: "/workspaces/my-app",
+		},
+		{
+			name: "volume mount under /workspaces/ is ignored",
+			mounts: []config.ContainerMount{
+				{Type: "volume", Source: "myvol", Destination: "/workspaces/other"},
+			},
+			want: "",
+		},
+		{
+			name: "bind mount outside /workspaces/ is ignored",
+			mounts: []config.ContainerMount{
+				{Type: "bind", Source: "/host/path", Destination: "/app"},
+			},
+			want: "",
+		},
+		{
+			name: "multiple mounts returns first workspace bind",
+			mounts: []config.ContainerMount{
+				{Type: "volume", Source: "cache", Destination: "/cache"},
+				{Type: "bind", Source: "/home/user/ws", Destination: "/workspaces/old-name"},
+				{Type: "bind", Source: "/tmp/extra", Destination: "/extra"},
+			},
+			want: "/workspaces/old-name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			details := &config.ContainerDetails{
+				ID:     testContainerID,
+				State:  config.ContainerDetailsState{Status: testStatusRunning},
+				Config: config.ContainerDetailsConfig{Labels: map[string]string{}},
+				Mounts: tt.mounts,
+			}
+
+			got := workspaceMountDestination(details)
+			if got != tt.want {
+				t.Errorf("workspaceMountDestination() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/devcontainer/single_test.go
+++ b/pkg/devcontainer/single_test.go
@@ -6,7 +6,9 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 )
 
-func TestWorkspaceMountDestination(t *testing.T) {
+const mountTypeVolume = "volume"
+
+func TestWorkspaceMountDestination(t *testing.T) { //nolint:funlen // table-driven test
 	tests := []struct {
 		name   string
 		mounts []config.ContainerMount
@@ -20,30 +22,54 @@ func TestWorkspaceMountDestination(t *testing.T) {
 		{
 			name: "bind mount under /workspaces/",
 			mounts: []config.ContainerMount{
-				{Type: "bind", Source: "/home/user/project", Destination: "/workspaces/my-app"},
+				{
+					Type:        mountTypeBind,
+					Source:      "/home/user/project",
+					Destination: "/workspaces/my-app",
+				},
 			},
 			want: "/workspaces/my-app",
 		},
 		{
 			name: "volume mount under /workspaces/ is ignored",
 			mounts: []config.ContainerMount{
-				{Type: "volume", Source: "myvol", Destination: "/workspaces/other"},
+				{
+					Type:        mountTypeVolume,
+					Source:      "myvol",
+					Destination: "/workspaces/other",
+				},
 			},
 			want: "",
 		},
 		{
 			name: "bind mount outside /workspaces/ is ignored",
 			mounts: []config.ContainerMount{
-				{Type: "bind", Source: "/host/path", Destination: "/app"},
+				{
+					Type:        mountTypeBind,
+					Source:      "/host/path",
+					Destination: "/opt/data",
+				},
 			},
 			want: "",
 		},
 		{
 			name: "multiple mounts returns first workspace bind",
 			mounts: []config.ContainerMount{
-				{Type: "volume", Source: "cache", Destination: "/cache"},
-				{Type: "bind", Source: "/home/user/ws", Destination: "/workspaces/old-name"},
-				{Type: "bind", Source: "/tmp/extra", Destination: "/extra"},
+				{
+					Type:        mountTypeVolume,
+					Source:      "cache",
+					Destination: "/cache",
+				},
+				{
+					Type:        mountTypeBind,
+					Source:      "/home/user/ws",
+					Destination: "/workspaces/old-name",
+				},
+				{
+					Type:        mountTypeBind,
+					Source:      "/tmp/extra",
+					Destination: "/extra",
+				},
 			},
 			want: "/workspaces/old-name",
 		},


### PR DESCRIPTION
## Summary

- After a workspace rename, VS Code opens `/workspaces/<new-name>` which doesn't exist inside the container — the actual workspace is still at `/workspaces/<old-name>`
- The old container (found by stable UID label) retains its original bind mounts, but `getWorkspace()` recomputes `ContainerWorkspaceFolder` from the new workspace ID
- Fix: when reusing an existing container, read its actual workspace bind mount destination from Docker inspect and prefer it over the recomputed value
- Non-destructive: container is reused as-is, no data loss from installed packages/tools/extensions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced workspace mount detection and auto-adjustment. Containers now track mount points for workspace folders. When existing bind mounts are detected at startup, the system automatically adjusts workspace folder paths to match, improving compatibility with containers that have pre-configured workspace mounts and reducing manual configuration steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->