### PR TITLE
fix(ci): deploy beta update metadata on prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,7 +225,6 @@ jobs:
   deploy-update-metadata:
     name: Deploy Electron Update Metadata
     needs: [build-desktop]
-    if: ${{ !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -252,10 +251,17 @@ jobs:
           pip install pyyaml
           python3 hack/merge-mac-metadata.py metadata/ publish-dir/desktop/
 
-      - name: overlay non-mac metadata files
+      - name: overlay non-mac metadata files (stable release)
+        if: ${{ !github.event.release.prerelease }}
         run: |
           find metadata/ -name 'latest-linux.yml' -exec cp {} publish-dir/desktop/ \;
           find metadata/ -name 'latest.yml' -exec cp {} publish-dir/desktop/ \;
+          find metadata/ -name 'beta-linux.yml' -exec cp {} publish-dir/desktop/ \;
+          find metadata/ -name 'beta.yml' -exec cp {} publish-dir/desktop/ \;
+
+      - name: overlay non-mac metadata files (prerelease)
+        if: ${{ github.event.release.prerelease }}
+        run: |
           find metadata/ -name 'beta-linux.yml' -exec cp {} publish-dir/desktop/ \;
           find metadata/ -name 'beta.yml' -exec cp {} publish-dir/desktop/ \;
 
@@ -315,7 +321,7 @@ jobs:
 
   prerelease:
     name: Publish Prerelease
-    needs: [build-desktop, build-flatpak]
+    needs: [build-desktop, build-flatpak, deploy-update-metadata]
     permissions:
       contents: write
     if: github.event.release.prerelease


### PR DESCRIPTION
## Summary

- Removes the `!github.event.release.prerelease` gate from `deploy-update-metadata` so it runs for all releases
- Splits the overlay step: stable releases deploy both `latest*.yml` and `beta*.yml`; prereleases only deploy `beta*.yml`
- Adds `deploy-update-metadata` as a dependency of the `prerelease` job so metadata is live before the release is published

This fixes the beta auto-update channel — previously, beta channel users never received prereleases via auto-update because no metadata was deployed to `dl.devsy.sh` during prerelease workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow automation to improve metadata deployment for stable and prerelease versions.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal build and release infrastructure improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->