### PR TITLE
fix: wait for container services before opening IDE on first create

### DIFF
--- a/cmd/up/configure.go
+++ b/cmd/up/configure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
@@ -73,6 +74,10 @@ func (cmd *UpCmd) openIDE(
 		return nil
 	}
 
+	if isNewContainer(wctx) {
+		waitForContainerServices(ctx)
+	}
+
 	ideConfig := client.WorkspaceConfig().IDE
 	return opener.Open(ctx, ideConfig.Name, ideConfig.Options, opener.Params{
 		GPGAgentForwarding: cmd.GPGAgentForwarding,
@@ -83,6 +88,28 @@ func (cmd *UpCmd) openIDE(
 		User:               wctx.user,
 		Result:             wctx.result,
 	})
+}
+
+const containerNewThreshold = 30 * time.Second
+
+func isNewContainer(wctx *workspaceContext) bool {
+	if wctx.result == nil || wctx.result.ContainerDetails == nil {
+		return false
+	}
+	created, err := time.Parse(time.RFC3339Nano, wctx.result.ContainerDetails.Created)
+	if err != nil {
+		return false
+	}
+	return time.Since(created) < containerNewThreshold
+}
+
+func waitForContainerServices(ctx context.Context) {
+	const stabilizationDelay = 2 * time.Second
+	log.Debugf("waiting %s for container services to stabilize", stabilizationDelay)
+	select {
+	case <-time.After(stabilizationDelay):
+	case <-ctx.Done():
+	}
 }
 
 type configureSSHParams struct {

--- a/cmd/up/configure.go
+++ b/cmd/up/configure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"time"
 
 	client2 "github.com/devsy-org/devsy/pkg/client"
@@ -75,7 +76,9 @@ func (cmd *UpCmd) openIDE(
 	}
 
 	if isNewContainer(wctx) {
-		waitForContainerServices(ctx)
+		if err := waitForSSHReady(ctx, client, wctx.user); err != nil {
+			log.Warnf("SSH readiness probe failed: %v", err)
+		}
 	}
 
 	ideConfig := client.WorkspaceConfig().IDE
@@ -103,13 +106,56 @@ func isNewContainer(wctx *workspaceContext) bool {
 	return time.Since(created) < containerNewThreshold
 }
 
-func waitForContainerServices(ctx context.Context) {
-	const stabilizationDelay = 2 * time.Second
-	log.Debugf("waiting %s for container services to stabilize", stabilizationDelay)
-	select {
-	case <-time.After(stabilizationDelay):
-	case <-ctx.Done():
+const (
+	sshProbeTimeout  = 10 * time.Second
+	sshProbeInterval = 500 * time.Millisecond
+)
+
+// waitForSSHReady polls until the workspace SSH server accepts connections,
+// using the same transport path that VS Code Remote SSH will use.
+func waitForSSHReady(ctx context.Context, client client2.BaseWorkspaceClient, user string) error {
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve executable: %w", err)
 	}
+
+	ctx, cancel := context.WithTimeout(ctx, sshProbeTimeout)
+	defer cancel()
+
+	workspace := client.Workspace()
+	log.Debugf("probing SSH readiness for workspace %s", workspace)
+
+	ticker := time.NewTicker(sshProbeInterval)
+	defer ticker.Stop()
+
+	for {
+		if err := runSSHProbe(ctx, execPath, workspace, user); err == nil {
+			log.Debugf("SSH ready for workspace %s", workspace)
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("workspace %s SSH not ready within %s", workspace, sshProbeTimeout)
+		case <-ticker.C:
+		}
+	}
+}
+
+func runSSHProbe(ctx context.Context, execPath, workspace, user string) error {
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	args := []string{"ssh", "--command", "true", workspace}
+	if user != "" {
+		args = []string{"ssh", "--command", "true", "--user", user, workspace}
+	}
+
+	//nolint:gosec // execPath is from os.Executable()
+	cmd := exec.CommandContext(probeCtx, execPath, args...)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	return cmd.Run()
 }
 
 type configureSSHParams struct {


### PR DESCRIPTION
## Summary

- Replaces the blind 2-second delay with an SSH readiness probe before opening the IDE on freshly-created containers
- Polls `devsy ssh --command true <workspace>` every 500ms until the SSH transport path succeeds (max 10s timeout)
- Uses the exact same path VS Code Remote SSH will use (`ProxyCommand` → agent → container SSH server)
- Non-fatal on timeout — logs a warning and proceeds, so workspace creation is never blocked
- Only activates for containers created within the last 30 seconds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * IDE now performs SSH readiness verification when working with newly created container workspaces before opening the IDE
  * If the readiness check fails, a warning is logged, but the IDE will still open and continue operating normally

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->