### PR TITLE
fix: revert IDE probe and fix stale agent binary cache

### DIFF
--- a/cmd/up/configure.go
+++ b/cmd/up/configure.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"os/exec"
-	"time"
 
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
@@ -75,12 +73,6 @@ func (cmd *UpCmd) openIDE(
 		return nil
 	}
 
-	if isNewContainer(wctx) {
-		if err := waitForSSHReady(ctx, client, wctx.user); err != nil {
-			log.Warnf("SSH readiness probe failed: %v", err)
-		}
-	}
-
 	ideConfig := client.WorkspaceConfig().IDE
 	return opener.Open(ctx, ideConfig.Name, ideConfig.Options, opener.Params{
 		GPGAgentForwarding: cmd.GPGAgentForwarding,
@@ -91,71 +83,6 @@ func (cmd *UpCmd) openIDE(
 		User:               wctx.user,
 		Result:             wctx.result,
 	})
-}
-
-const containerNewThreshold = 30 * time.Second
-
-func isNewContainer(wctx *workspaceContext) bool {
-	if wctx.result == nil || wctx.result.ContainerDetails == nil {
-		return false
-	}
-	created, err := time.Parse(time.RFC3339Nano, wctx.result.ContainerDetails.Created)
-	if err != nil {
-		return false
-	}
-	return time.Since(created) < containerNewThreshold
-}
-
-const (
-	sshProbeTimeout  = 10 * time.Second
-	sshProbeInterval = 500 * time.Millisecond
-)
-
-// waitForSSHReady polls until the workspace SSH server accepts connections,
-// using the same transport path that VS Code Remote SSH will use.
-func waitForSSHReady(ctx context.Context, client client2.BaseWorkspaceClient, user string) error {
-	execPath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("resolve executable: %w", err)
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, sshProbeTimeout)
-	defer cancel()
-
-	workspace := client.Workspace()
-	log.Debugf("probing SSH readiness for workspace %s", workspace)
-
-	ticker := time.NewTicker(sshProbeInterval)
-	defer ticker.Stop()
-
-	for {
-		if err := runSSHProbe(ctx, execPath, workspace, user); err == nil {
-			log.Debugf("SSH ready for workspace %s", workspace)
-			return nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("workspace %s SSH not ready within %s", workspace, sshProbeTimeout)
-		case <-ticker.C:
-		}
-	}
-}
-
-func runSSHProbe(ctx context.Context, execPath, workspace, user string) error {
-	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	defer cancel()
-
-	args := []string{"ssh", "--command", "true", workspace}
-	if user != "" {
-		args = []string{"ssh", "--command", "true", "--user", user, workspace}
-	}
-
-	//nolint:gosec // execPath is from os.Executable()
-	cmd := exec.CommandContext(probeCtx, execPath, args...)
-	cmd.Stdout = nil
-	cmd.Stderr = nil
-	return cmd.Run()
 }
 
 type configureSSHParams struct {

--- a/pkg/agent/binary.go
+++ b/pkg/agent/binary.go
@@ -33,13 +33,27 @@ func NewBinaryManager(downloadURL string) (*BinaryManager, error) {
 
 	cache := &BinaryCache{BaseDir: cachePath}
 
+	expectedVersion := versionFromDownloadURL(downloadURL)
+
 	return &BinaryManager{
 		sources: []BinarySource{
 			&InjectSource{},
-			&FileCacheSource{Cache: cache},
-			&HTTPDownloadSource{BaseURL: downloadURL, Cache: cache},
+			&FileCacheSource{Cache: cache, ExpectedVersion: expectedVersion},
+			&HTTPDownloadSource{BaseURL: downloadURL, Cache: cache, Version: expectedVersion},
 		},
 	}, nil
+}
+
+func versionFromDownloadURL(downloadURL string) string {
+	parts := strings.Split(strings.TrimRight(downloadURL, "/"), "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	last := parts[len(parts)-1]
+	if strings.HasPrefix(last, "v") {
+		return last
+	}
+	return ""
 }
 
 func (m *BinaryManager) AcquireBinary(ctx context.Context, arch string) (io.ReadCloser, error) {
@@ -66,8 +80,24 @@ func (c *BinaryCache) Set(arch string, data io.Reader) error {
 	return c.atomicWrite(c.pathFor(arch), data)
 }
 
+func (c *BinaryCache) WriteVersion(arch, ver string) {
+	_ = os.WriteFile(c.versionPathFor(arch), []byte(ver), 0o600) // #nosec G306
+}
+
+func (c *BinaryCache) ReadVersion(arch string) string {
+	data, err := os.ReadFile(c.versionPathFor(arch))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
 func (c *BinaryCache) pathFor(arch string) string {
 	return filepath.Join(c.BaseDir, config.BinaryName+"-"+osLinux+"-"+arch)
+}
+
+func (c *BinaryCache) versionPathFor(arch string) string {
+	return c.pathFor(arch) + ".version"
 }
 
 func (c *BinaryCache) atomicWrite(path string, data io.Reader) error {
@@ -131,10 +161,20 @@ func (s *InjectSource) openCurrentExecutable() (io.ReadCloser, error) {
 }
 
 type FileCacheSource struct {
-	Cache *BinaryCache
+	Cache           *BinaryCache
+	ExpectedVersion string
 }
 
 func (s *FileCacheSource) GetBinary(ctx context.Context, arch string) (io.ReadCloser, error) {
+	if s.ExpectedVersion != "" {
+		cached := s.Cache.ReadVersion(arch)
+		if cached != s.ExpectedVersion {
+			return nil, fmt.Errorf(
+				"cache version %q does not match expected %q",
+				cached, s.ExpectedVersion,
+			)
+		}
+	}
 	return s.Cache.Get(arch)
 }
 
@@ -145,6 +185,7 @@ func (s *FileCacheSource) SourceName() string {
 type HTTPDownloadSource struct {
 	BaseURL string
 	Cache   *BinaryCache
+	Version string
 }
 
 func (s *HTTPDownloadSource) GetBinary(ctx context.Context, arch string) (io.ReadCloser, error) {
@@ -291,6 +332,9 @@ func (s *HTTPDownloadSource) streamAndCache(
 
 	if err := os.Rename(tmpPath, cachePath); err == nil {
 		success = true
+		if s.Version != "" && s.Cache != nil {
+			s.Cache.WriteVersion(arch, s.Version)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reverts the SSH readiness probe from PR #401 which was solving the wrong problem
- Fixes the root cause: `BinaryManager.FileCacheSource` returned stale cached binaries without version validation, preventing agent upgrades from reaching containers

The `FileCacheSource` now checks a `.version` sidecar file against the expected version extracted from the download URL. When the cache is stale, it falls through to `HTTPDownloadSource` for a fresh download.