### PR TITLE
fix: disable VS Code exec-server mode incompatible with ProxyCommand SSH

### DIFF
--- a/pkg/ide/vscode/open.go
+++ b/pkg/ide/vscode/open.go
@@ -83,6 +83,8 @@ var openConfigs = map[Flavor]openConfig{
 }
 
 func Open(ctx context.Context, params OpenParams) error {
+	EnsureHostSettings(params.Flavor)
+
 	cliErr := openViaCLI(ctx, params)
 	if cliErr == nil {
 		log.Infof("opened %s via CLI", params.Flavor.DisplayName())

--- a/pkg/ide/vscode/settings.go
+++ b/pkg/ide/vscode/settings.go
@@ -1,0 +1,114 @@
+package vscode
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/util"
+)
+
+const settingUseExecServer = "remote.SSH.useExecServer"
+
+var userSettingsDirNames = map[Flavor]string{
+	FlavorStable:      "Code",
+	FlavorInsiders:    "Code - Insiders",
+	FlavorCursor:      "Cursor",
+	FlavorPositron:    "Positron",
+	FlavorCodium:      "VSCodium",
+	FlavorWindsurf:    "Windsurf",
+	FlavorAntigravity: "Antigravity",
+	FlavorBob:         "Bob",
+}
+
+// EnsureHostSettings ensures required VS Code user settings are configured
+// on the host machine. This is needed to disable exec-server mode which is
+// incompatible with ProxyCommand-based SSH connections.
+func EnsureHostSettings(flavor Flavor) {
+	settingsPath, err := userSettingsPath(flavor)
+	if err != nil {
+		log.Debugf("cannot determine VS Code settings path: %v", err)
+		return
+	}
+
+	required := map[string]any{
+		settingUseExecServer: false,
+	}
+
+	if err := mergeUserSettings(settingsPath, required); err != nil {
+		log.Debugf("failed to update VS Code host settings: %v", err)
+	}
+}
+
+func userSettingsPath(flavor Flavor) (string, error) {
+	dirName, ok := userSettingsDirNames[flavor]
+	if !ok {
+		dirName = userSettingsDirNames[FlavorStable]
+	}
+
+	homeDir, err := util.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	var base string
+	switch runtime.GOOS {
+	case "darwin":
+		base = filepath.Join(homeDir, "Library", "Application Support")
+	case "windows":
+		base = os.Getenv("APPDATA")
+		if base == "" {
+			base = filepath.Join(homeDir, "AppData", "Roaming")
+		}
+	default:
+		base = filepath.Join(homeDir, ".config")
+	}
+
+	return filepath.Join(base, dirName, "User", "settings.json"), nil
+}
+
+func readSettingsFile(path string) (map[string]any, error) {
+	existing := make(map[string]any)
+	data, err := os.ReadFile(path) // #nosec G304 -- path is constructed internally
+	if err == nil {
+		if err := json.Unmarshal(data, &existing); err != nil {
+			return nil, fmt.Errorf("parse settings: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, err
+	}
+	return existing, nil
+}
+
+func mergeUserSettings(path string, required map[string]any) error {
+	existing, err := readSettingsFile(path)
+	if err != nil {
+		return err
+	}
+
+	changed := false
+	for key, val := range required {
+		if existing[key] != val {
+			existing[key] = val
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return err
+	}
+
+	out, err := json.MarshalIndent(existing, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, out, 0o600)
+}

--- a/pkg/ide/vscode/settings_test.go
+++ b/pkg/ide/vscode/settings_test.go
@@ -1,0 +1,107 @@
+package vscode
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type SettingsSuite struct {
+	suite.Suite
+	tmpDir string
+}
+
+func TestSettingsSuite(t *testing.T) {
+	suite.Run(t, new(SettingsSuite))
+}
+
+func (s *SettingsSuite) SetupTest() {
+	s.tmpDir = s.T().TempDir()
+}
+
+func (s *SettingsSuite) TestMergeUserSettings_CreatesNewFile() {
+	path := filepath.Join(s.tmpDir, "User", "settings.json")
+	err := mergeUserSettings(path, map[string]any{
+		settingUseExecServer: false,
+	})
+	s.Require().NoError(err)
+
+	data, err := os.ReadFile(path) // #nosec G304 -- test fixture
+	s.Require().NoError(err)
+
+	var settings map[string]any
+	s.Require().NoError(json.Unmarshal(data, &settings))
+	s.Equal(false, settings[settingUseExecServer])
+}
+
+func (s *SettingsSuite) TestMergeUserSettings_PreservesExistingSettings() {
+	path := filepath.Join(s.tmpDir, "settings.json")
+	existing := map[string]any{
+		"editor.fontSize":      float64(14),
+		"workbench.colorTheme": "One Dark Pro",
+	}
+	s.writeJSON(path, existing)
+
+	err := mergeUserSettings(path, map[string]any{
+		settingUseExecServer: false,
+	})
+	s.Require().NoError(err)
+
+	data, err := os.ReadFile(path) // #nosec G304 -- test fixture
+	s.Require().NoError(err)
+
+	var settings map[string]any
+	s.Require().NoError(json.Unmarshal(data, &settings))
+	s.Equal(float64(14), settings["editor.fontSize"])
+	s.Equal("One Dark Pro", settings["workbench.colorTheme"])
+	s.Equal(false, settings[settingUseExecServer])
+}
+
+func (s *SettingsSuite) TestMergeUserSettings_DoesNotRewriteIfAlreadySet() {
+	path := filepath.Join(s.tmpDir, "settings.json")
+	existing := map[string]any{
+		settingUseExecServer: false,
+	}
+	s.writeJSON(path, existing)
+
+	info1, _ := os.Stat(path)
+
+	err := mergeUserSettings(path, map[string]any{
+		settingUseExecServer: false,
+	})
+	s.Require().NoError(err)
+
+	info2, _ := os.Stat(path)
+	s.Equal(info1.ModTime(), info2.ModTime())
+}
+
+func (s *SettingsSuite) TestMergeUserSettings_OverridesWrongValue() {
+	path := filepath.Join(s.tmpDir, "settings.json")
+	existing := map[string]any{
+		settingUseExecServer: true,
+	}
+	s.writeJSON(path, existing)
+
+	err := mergeUserSettings(path, map[string]any{
+		settingUseExecServer: false,
+	})
+	s.Require().NoError(err)
+
+	data, err := os.ReadFile(path) // #nosec G304 -- test fixture
+	s.Require().NoError(err)
+
+	var settings map[string]any
+	s.Require().NoError(json.Unmarshal(data, &settings))
+	s.Equal(false, settings[settingUseExecServer])
+}
+
+func (s *SettingsSuite) writeJSON(path string, v any) {
+	s.T().Helper()
+	s.Require().NoError(os.MkdirAll(filepath.Dir(path), 0o750))
+	data, err := json.Marshal(v)
+	s.Require().NoError(err)
+	s.Require().NoError(os.WriteFile(path, data, 0o600))
+}


### PR DESCRIPTION
## Summary

- VS Code Remote SSH uses an A/B experiment to enable `useExecServer=true` for a growing subset of users. When enabled, it breaks ProxyCommand-based SSH tunnels (like Devsy's `devsy ssh --stdio`) by attempting stdio communication over the same channel the proxy uses.
- This is NOT caused by a Devsy change — users get moved into the experiment bucket when VS Code or the Remote SSH extension auto-updates.
- Automatically sets `remote.SSH.useExecServer=false` in the host VS Code user settings before opening a remote connection.
- Supports all VS Code flavors (Stable, Insiders, Cursor, Positron, Codium, Windsurf, Antigravity, Bob) across macOS, Linux, and Windows.
- Preserves all existing user settings; only writes when the value needs changing.

## How `useExecServer` works

**`useExecServer=true` (broken with ProxyCommand):**
VS Code opens the SSH channel and uses stdio directly to communicate with the remote server process — no TCP port is bound. The server reports `listeningOn====` (empty). This works fine for direct SSH connections, but with ProxyCommand-based tunnels (like `devsy ssh --stdio`), both the proxy and the exec server are competing for the same stdio channel, causing the connection to fail with "Failed to parse remote port from server output."

**`useExecServer=false` (working with ProxyCommand):**
VS Code tells the remote server to bind a TCP port on localhost, then tunnels traffic through a SOCKS proxy (`-D` flag) over the SSH connection. The server reports `listeningOn==PORT==` with an actual port number. VS Code then forwards local connections through the SOCKS tunnel to that remote port. This path is fully compatible with ProxyCommand-based SSH because the proxy only handles the SSH transport layer — it doesn't interfere with how VS Code communicates with its server.

## Verified working

Tested with VS Code 1.121.0 + Remote-SSH 0.122.0 on macOS arm64 connecting through Devsy's ProxyCommand tunnel:

```
[15:55:37.611] remote.SSH.useExecServer = false
...
[15:55:37.714] Spawning local server with {... "sshArgs":["-v","-T","-D","62851","-o","ConnectTimeout=60","node-js.devsy"]}
...
[15:56:00.679] listeningOn==44863==
...
[15:56:00.680] Remote server is listening on port 44863
[15:56:00.686] Starting forwarding server. local port 62879 -> socksPort 62851 -> remotePort 44863
[15:56:00.687] Tunneled port 44863 to local port 62879
[15:56:00.687] Resolved "ssh-remote+node-js.devsy" to "port 62879"
```

## Context & References

The VS Code Remote SSH extension has been gradually rolling out `useExecServer=true` via server-side A/B experiments since mid-2024. The same extension version (e.g., 0.122.0) can have the setting enabled or disabled depending on the user's experiment bucket — there is no version boundary where it flips for everyone. Users get moved into the enabled bucket without warning when VS Code or the extension auto-updates.

There is no VS Code CLI flag to override this setting inline — it can only be controlled via the user's `settings.json` file.

**Upstream issues documenting the breakage:**

- [microsoft/vscode-remote-release#10331](https://github.com/microsoft/vscode-remote-release/issues/10331) — "Can't establish connection error on 0.114.x when using ProxyCommand via gateway server." Confirms ProxyCommand-based SSH configs break when `useExecServer` is enabled.
- [microsoft/vscode-remote-release#10939](https://github.com/microsoft/vscode-remote-release/issues/10939) — "Can't connect to Remote SSH server using Exec server." Logs show `Failed to parse remote port from server output`. Reporter notes: "use Exec Server was enabled (probably automatically as I read that this will be made the default for everyone)."
- [microsoft/vscode-remote-release#11119](https://github.com/microsoft/vscode-remote-release/issues/11119) — "Remote SSH Exec Server ignores Local Server Download setting." Workaround: "Disable Remote - SSH extension setting 'Use Exec Server'."

**Downstream impact on other tools:**

- [coder/coder#12708](https://github.com/coder/coder/issues/12708) — "Issue with running workspace after recent update." Logs show `Exec server for ssh-remote+coder-vscode--...failed: Error` and `Could not establish a connection`. Same root cause.
- [coder/vscode-coder#955](https://github.com/coder/vscode-coder/issues/955) — Coder's diagnostic bundle proposal recognizes `useExecServer` as a setting that "directly changes the failure path" during triage.

**Why writing to user settings is the only option:**

VS Code does not support `--setting key=value` CLI flags, environment variables, or SSH config directives to control this behavior. The only mechanisms are `settings.json`, `--user-data-dir` (which isolates the entire VS Code instance), or `--profile` (which requires pre-creating a named profile). Writing to user settings is the least invasive approach that doesn't disrupt the user's extensions, themes, or other configuration.