### PR TITLE
feat(ssh): add local TCP tunnel mode for VS Code useExecServer compatibility

### DIFF
--- a/cmd/up/configure.go
+++ b/cmd/up/configure.go
@@ -101,6 +101,13 @@ func (cmd *UpCmd) reconfigureSSHWithTunnel(
 	}
 
 	sshConfigIncludePath := devsyConfig.ContextOption(config.ContextOptionSSHConfigIncludePath)
+	if sshConfigIncludePath != "" {
+		includePath, err := devssh.ResolveSSHConfigPath(sshConfigIncludePath)
+		if err != nil {
+			return err
+		}
+		sshConfigIncludePath = includePath
+	}
 
 	return devssh.ConfigureSSHConfig(devssh.SSHConfigParams{
 		SSHConfigPath:        path,

--- a/cmd/up/configure.go
+++ b/cmd/up/configure.go
@@ -82,6 +82,33 @@ func (cmd *UpCmd) openIDE(
 		Client:             client,
 		User:               wctx.user,
 		Result:             wctx.result,
+		TunnelMode:         wctx.tunnelPort > 0,
+	})
+}
+
+// reconfigureSSHWithTunnel re-writes the SSH config with the tunnel port
+// after the tunnel has been successfully started. This replaces the initial
+// ProxyCommand-based config with a direct TCP connection to the local tunnel.
+func (cmd *UpCmd) reconfigureSSHWithTunnel(
+	client client2.BaseWorkspaceClient,
+	wctx *workspaceContext,
+) error {
+	if !cmd.ConfigureSSH || wctx.tunnelPort == 0 {
+		return nil
+	}
+	// Re-write SSH config with tunnel port
+	path, err := devssh.ResolveSSHConfigPath(cmd.SSHConfigPath)
+	if err != nil {
+		return err
+	}
+	return devssh.ConfigureSSHConfig(devssh.SSHConfigParams{
+		SSHConfigPath: path,
+		Context:       client.Context(),
+		Workspace:     client.Workspace(),
+		User:          wctx.user,
+		Workdir:       wctx.workdir,
+		TunnelPort:    wctx.tunnelPort,
+		Provider:      client.Provider(),
 	})
 }
 

--- a/cmd/up/tunnel.go
+++ b/cmd/up/tunnel.go
@@ -1,0 +1,47 @@
+package up
+
+import (
+	"context"
+	"fmt"
+
+	client2 "github.com/devsy-org/devsy/pkg/client"
+	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/tunnel"
+)
+
+// startTunnel creates a local TCP tunnel that forwards connections to the
+// container SSH server. The returned cleanup function must be called when
+// the tunnel is no longer needed (typically via defer).
+func (cmd *UpCmd) startTunnel(
+	ctx context.Context,
+	_ *config.Config,
+	client client2.BaseWorkspaceClient,
+	wctx *workspaceContext,
+) (int, func(), error) {
+	log.Info("Starting SSH tunnel for workspace")
+
+	dialer := &tunnel.WorkspaceDialer{
+		Context:   client.Context(),
+		User:      wctx.user,
+		Workspace: client.Workspace(),
+		Workdir:   wctx.workdir,
+		GPGAgent:  cmd.GPGAgentForwarding,
+	}
+
+	localTunnel, err := tunnel.NewLocalTunnel(ctx, tunnel.LocalTunnelOptions{
+		BasePort: 10800,
+		DialFunc: dialer.Dial,
+	})
+	if err != nil {
+		return 0, nil, fmt.Errorf("create local tunnel: %w", err)
+	}
+
+	log.Infof("SSH tunnel listening on port %d", localTunnel.Port())
+
+	cleanup := func() {
+		_ = localTunnel.Close()
+	}
+
+	return localTunnel.Port(), cleanup, nil
+}

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -32,6 +32,7 @@ type UpCmd struct {
 
 	ConfigureSSH       bool
 	GPGAgentForwarding bool
+	SSHTunnelMode      bool
 	OpenIDE            bool
 	Reconfigure        bool
 
@@ -92,6 +93,24 @@ func (cmd *UpCmd) Run( //nolint:cyclop
 		return err
 	}
 
+	// Start TCP tunnel if enabled
+	useTunnel := cmd.SSHTunnelMode ||
+		devsyConfig.ContextOption(config.ContextOptionSSHTunnelMode) == config.BoolTrue
+	if useTunnel {
+		tunnelPort, tunnelCleanup, err := cmd.startTunnel(ctx, devsyConfig, client, wctx)
+		if err != nil {
+			log.Warnf("Failed to start SSH tunnel, falling back to ProxyCommand: %v", err)
+		} else {
+			defer tunnelCleanup()
+			wctx.tunnelPort = tunnelPort
+		}
+	}
+
+	// Re-write SSH config with tunnel port if tunnel started successfully
+	if err := cmd.reconfigureSSHWithTunnel(client, wctx); err != nil {
+		log.Warnf("Failed to reconfigure SSH with tunnel port: %v", err)
+	}
+
 	if err := cmd.openIDE(ctx, devsyConfig, client, wctx); err != nil {
 		if emitJSON {
 			_ = config2.WriteErrorJSON(os.Stdout, err.Error())
@@ -144,9 +163,10 @@ func (cmd *UpCmd) execute(cobraCmd *cobra.Command, args []string) error {
 
 // workspaceContext holds the result of workspace preparation.
 type workspaceContext struct {
-	result  *config2.Result
-	user    string
-	workdir string
+	result     *config2.Result
+	user       string
+	workdir    string
+	tunnelPort int
 }
 
 // resolveDotfilesOptions populates DotfilesRepo and DotfilesScript

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -129,6 +129,11 @@ func (cmd *UpCmd) Run( //nolint:cyclop
 		}
 		_ = config2.WriteResultJSON(os.Stdout, containerID, wctx.user, wctx.workdir, warnings)
 	}
+
+	if wctx.tunnelPort > 0 {
+		log.Infof("SSH tunnel active on port %d, waiting for shutdown signal...", wctx.tunnelPort)
+		<-ctx.Done()
+	}
 	return nil
 }
 

--- a/cmd/up/up_flags.go
+++ b/cmd/up/up_flags.go
@@ -23,6 +23,9 @@ func (cmd *UpCmd) registerSSHFlags(upCmd *cobra.Command) {
 	upCmd.Flags().
 		StringVar(&cmd.SSHConfigPath, "ssh-config", "",
 			"The path to the ssh config to modify, if empty will use ~/.ssh/config")
+	upCmd.Flags().
+		BoolVar(&cmd.SSHTunnelMode, "ssh-tunnel-mode", false,
+			"If true will use a local TCP tunnel instead of ProxyCommand for SSH connections")
 }
 
 func (cmd *UpCmd) registerDotfilesFlags(upCmd *cobra.Command) {

--- a/e2e/tests/ssh/ssh_tunnel_mode_test.go
+++ b/e2e/tests/ssh/ssh_tunnel_mode_test.go
@@ -1,0 +1,257 @@
+package ssh
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe(
+	"devsy ssh tunnel mode",
+	ginkgo.Label("ssh", "tunnel-mode"),
+	ginkgo.Ordered,
+	func() {
+		var initialDir string
+
+		ginkgo.BeforeEach(func() {
+			var err error
+			initialDir, err = os.Getwd()
+			framework.ExpectNoError(err)
+		})
+
+		ginkgo.It("should start workspace with --ssh-tunnel-mode and SSH into it",
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
+			func(ctx context.Context) {
+				if runtime.GOOS == osWindows {
+					ginkgo.Skip("skipping on windows")
+				}
+
+				tempDir, err := framework.CopyToTempDir("tests/ssh/testdata/local-test")
+				framework.ExpectNoError(err)
+
+				f := framework.NewDefaultFramework(initialDir + "/bin")
+				_ = f.DevsyProviderAdd(ctx, "docker")
+				err = f.DevsyProviderUse(ctx, "docker")
+				framework.ExpectNoError(err)
+
+				ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
+					_ = f.DevsyWorkspaceDelete(cleanupCtx, tempDir)
+					framework.CleanupTempDir(initialDir, tempDir)
+				})
+
+				devsyUpCtx, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
+				defer cancel()
+				err = f.DevsyUp(devsyUpCtx, tempDir, "--ssh-tunnel-mode")
+				framework.ExpectNoError(err)
+
+				devsySSHCtx, cancelSSH := context.WithDeadline(ctx, time.Now().Add(20*time.Second))
+				defer cancelSSH()
+				err = f.DevsySSHEchoTestString(devsySSHCtx, tempDir)
+				framework.ExpectNoError(err)
+			},
+		)
+
+		ginkgo.It("should write SSH config with Hostname and Port instead of ProxyCommand",
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
+			func(ctx context.Context) {
+				if runtime.GOOS == osWindows {
+					ginkgo.Skip("skipping on windows")
+				}
+
+				tempDir, err := framework.CopyToTempDir("tests/ssh/testdata/local-test")
+				framework.ExpectNoError(err)
+
+				sshConfigDir := ginkgo.GinkgoT().TempDir()
+				sshConfigPath := filepath.Join(sshConfigDir, "config")
+
+				f := framework.NewDefaultFramework(initialDir + "/bin")
+				_ = f.DevsyProviderAdd(ctx, "docker")
+				err = f.DevsyProviderUse(ctx, "docker")
+				framework.ExpectNoError(err)
+
+				ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
+					_ = f.DevsyWorkspaceDelete(cleanupCtx, tempDir)
+					framework.CleanupTempDir(initialDir, tempDir)
+				})
+
+				devsyUpCtx, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
+				defer cancel()
+				err = f.DevsyUp(
+					devsyUpCtx,
+					tempDir,
+					"--ssh-tunnel-mode",
+					"--ssh-config",
+					sshConfigPath,
+				)
+				framework.ExpectNoError(err)
+
+				configBytes, err := os.ReadFile(filepath.Clean(sshConfigPath))
+				framework.ExpectNoError(err)
+				config := string(configBytes)
+
+				gomega.Expect(config).To(
+					gomega.ContainSubstring("Hostname 127.0.0.1"),
+					"SSH config should use localhost hostname in tunnel mode",
+				)
+				gomega.Expect(config).To(
+					gomega.MatchRegexp(`Port \d+`),
+					"SSH config should contain a Port entry in tunnel mode",
+				)
+				gomega.Expect(config).NotTo(
+					gomega.ContainSubstring("ProxyCommand"),
+					"SSH config should not contain ProxyCommand in tunnel mode",
+				)
+			},
+		)
+
+		ginkgo.It("should establish a working local TCP tunnel listener",
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
+			func(ctx context.Context) {
+				if runtime.GOOS == osWindows {
+					ginkgo.Skip("skipping on windows")
+				}
+
+				tempDir, err := framework.CopyToTempDir("tests/ssh/testdata/local-test")
+				framework.ExpectNoError(err)
+
+				sshConfigDir := ginkgo.GinkgoT().TempDir()
+				sshConfigPath := filepath.Join(sshConfigDir, "config")
+
+				f := framework.NewDefaultFramework(initialDir + "/bin")
+				_ = f.DevsyProviderAdd(ctx, "docker")
+				err = f.DevsyProviderUse(ctx, "docker")
+				framework.ExpectNoError(err)
+
+				ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
+					_ = f.DevsyWorkspaceDelete(cleanupCtx, tempDir)
+					framework.CleanupTempDir(initialDir, tempDir)
+				})
+
+				devsyUpCtx, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
+				defer cancel()
+				err = f.DevsyUp(
+					devsyUpCtx,
+					tempDir,
+					"--ssh-tunnel-mode",
+					"--ssh-config",
+					sshConfigPath,
+				)
+				framework.ExpectNoError(err)
+
+				configBytes, err := os.ReadFile(filepath.Clean(sshConfigPath))
+				framework.ExpectNoError(err)
+				config := string(configBytes)
+
+				var port string
+				for line := range strings.SplitSeq(config, "\n") {
+					trimmed := strings.TrimSpace(line)
+					if p, ok := strings.CutPrefix(trimmed, "Port "); ok {
+						port = p
+						break
+					}
+				}
+				gomega.Expect(port).NotTo(gomega.BeEmpty(), "should find Port in SSH config")
+
+				addr := net.JoinHostPort("127.0.0.1", port)
+				conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+					"should be able to connect to local tunnel port",
+				)
+				_ = conn.Close()
+			},
+		)
+
+		ginkgo.It("should handle multiple sequential SSH commands via tunnel",
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
+			func(ctx context.Context) {
+				if runtime.GOOS == osWindows {
+					ginkgo.Skip("skipping on windows")
+				}
+
+				tempDir, err := framework.CopyToTempDir("tests/ssh/testdata/local-test")
+				framework.ExpectNoError(err)
+
+				f := framework.NewDefaultFramework(initialDir + "/bin")
+				_ = f.DevsyProviderAdd(ctx, "docker")
+				err = f.DevsyProviderUse(ctx, "docker")
+				framework.ExpectNoError(err)
+
+				ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
+					_ = f.DevsyWorkspaceDelete(cleanupCtx, tempDir)
+					framework.CleanupTempDir(initialDir, tempDir)
+				})
+
+				devsyUpCtx, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
+				defer cancel()
+				err = f.DevsyUp(devsyUpCtx, tempDir, "--ssh-tunnel-mode")
+				framework.ExpectNoError(err)
+
+				for i := range 3 {
+					sshCtx, cancelSSH := context.WithDeadline(ctx, time.Now().Add(20*time.Second))
+					out, err := f.DevsySSH(
+						sshCtx,
+						tempDir,
+						"echo iteration-"+strings.Repeat("x", i),
+					)
+					cancelSSH()
+					framework.ExpectNoError(err)
+					gomega.Expect(out).To(
+						gomega.ContainSubstring("iteration-"),
+						"sequential SSH command should succeed",
+					)
+				}
+			},
+		)
+
+		ginkgo.It("should fall back to ProxyCommand when tunnel mode is not enabled",
+			ginkgo.SpecTimeout(framework.TimeoutModerate()),
+			func(ctx context.Context) {
+				if runtime.GOOS == osWindows {
+					ginkgo.Skip("skipping on windows")
+				}
+
+				tempDir, err := framework.CopyToTempDir("tests/ssh/testdata/local-test")
+				framework.ExpectNoError(err)
+
+				sshConfigDir := ginkgo.GinkgoT().TempDir()
+				sshConfigPath := filepath.Join(sshConfigDir, "config")
+
+				f := framework.NewDefaultFramework(initialDir + "/bin")
+				_ = f.DevsyProviderAdd(ctx, "docker")
+				err = f.DevsyProviderUse(ctx, "docker")
+				framework.ExpectNoError(err)
+
+				ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
+					_ = f.DevsyWorkspaceDelete(cleanupCtx, tempDir)
+					framework.CleanupTempDir(initialDir, tempDir)
+				})
+
+				devsyUpCtx, cancel := context.WithDeadline(ctx, time.Now().Add(5*time.Minute))
+				defer cancel()
+				err = f.DevsyUp(devsyUpCtx, tempDir, "--ssh-config", sshConfigPath)
+				framework.ExpectNoError(err)
+
+				configBytes, err := os.ReadFile(filepath.Clean(sshConfigPath))
+				framework.ExpectNoError(err)
+				config := string(configBytes)
+
+				gomega.Expect(config).To(
+					gomega.ContainSubstring("ProxyCommand"),
+					"SSH config should use ProxyCommand when tunnel mode is disabled",
+				)
+				gomega.Expect(config).NotTo(
+					gomega.ContainSubstring("Hostname 127.0.0.1"),
+					"SSH config should not have localhost hostname without tunnel mode",
+				)
+			},
+		)
+	},
+)

--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -23,6 +23,7 @@ const (
 	ContextOptionAgentInjectTimeout         = "AGENT_INJECT_TIMEOUT"
 	ContextOptionRegistryCache              = "REGISTRY_CACHE"
 	ContextOptionSSHStrictHostKeyChecking   = "SSH_STRICT_HOST_KEY_CHECKING"
+	ContextOptionSSHTunnelMode              = "SSH_TUNNEL_MODE"
 )
 
 var ContextOptions = []ContextOption{
@@ -107,6 +108,12 @@ var ContextOptions = []ContextOption{
 	{
 		Name:        ContextOptionSSHStrictHostKeyChecking,
 		Description: "Enables strict ssh host key checking for all operations",
+		Default:     "false",
+		Enum:        []string{"true", "false"},
+	},
+	{
+		Name:        ContextOptionSSHTunnelMode,
+		Description: "Use a local TCP tunnel instead of ProxyCommand for SSH connections",
 		Default:     "false",
 		Enum:        []string{"true", "false"},
 	},

--- a/pkg/config/context_tunnel_test.go
+++ b/pkg/config/context_tunnel_test.go
@@ -1,0 +1,77 @@
+package config
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestContextOptionSSHTunnelMode_Exists(t *testing.T) {
+	found := false
+	for _, opt := range ContextOptions {
+		if opt.Name == ContextOptionSSHTunnelMode {
+			found = true
+			if opt.Default != BoolFalse {
+				t.Errorf("expected default %q, got %q", BoolFalse, opt.Default)
+			}
+			if len(opt.Enum) != 2 || opt.Enum[0] != BoolTrue || opt.Enum[1] != BoolFalse {
+				t.Errorf("expected enum [true, false], got %v", opt.Enum)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Fatal("ContextOptionSSHTunnelMode not found in ContextOptions")
+	}
+}
+
+func TestMergeContextOptions_SSHTunnelMode_SetFromEnv(t *testing.T) {
+	cfg := &ContextConfig{
+		Options: map[string]OptionValue{},
+	}
+	environ := []string{
+		fmt.Sprintf("%s=%s", ContextOptionSSHTunnelMode, BoolTrue),
+	}
+
+	MergeContextOptions(cfg, environ)
+
+	val, ok := cfg.Options[ContextOptionSSHTunnelMode]
+	if !ok {
+		t.Fatal("SSH_TUNNEL_MODE not merged from environment")
+	}
+	if val.Value != BoolTrue {
+		t.Errorf("expected value %q, got %q", BoolTrue, val.Value)
+	}
+	if !val.UserProvided {
+		t.Error("expected UserProvided to be true")
+	}
+}
+
+func TestMergeContextOptions_SSHTunnelMode_NotOverridden(t *testing.T) {
+	cfg := &ContextConfig{
+		Options: map[string]OptionValue{
+			ContextOptionSSHTunnelMode: {Value: BoolFalse, UserProvided: true},
+		},
+	}
+	environ := []string{
+		fmt.Sprintf("%s=%s", ContextOptionSSHTunnelMode, BoolTrue),
+	}
+
+	MergeContextOptions(cfg, environ)
+
+	val := cfg.Options[ContextOptionSSHTunnelMode]
+	if val.Value != BoolFalse {
+		t.Errorf("expected existing value %q to be preserved, got %q", BoolFalse, val.Value)
+	}
+}
+
+func TestMergeContextOptions_SSHTunnelMode_AbsentFromEnv(t *testing.T) {
+	cfg := &ContextConfig{
+		Options: map[string]OptionValue{},
+	}
+
+	MergeContextOptions(cfg, []string{})
+
+	if _, ok := cfg.Options[ContextOptionSSHTunnelMode]; ok {
+		t.Error("SSH_TUNNEL_MODE should not be set when absent from environment")
+	}
+}

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -36,6 +36,7 @@ type Params struct {
 	Client             client2.BaseWorkspaceClient
 	User               string
 	Result             *config2.Result
+	TunnelMode         bool
 }
 
 // Open dispatches to the correct IDE opener based on ideName.
@@ -155,10 +156,11 @@ func openVSCodeFlavor(
 	params Params,
 ) error {
 	return vscode.Open(ctx, vscode.OpenParams{
-		Workspace: params.Client.Workspace(),
-		Folder:    params.Result.SubstitutionContext.ContainerWorkspaceFolder,
-		NewWindow: vscode.Options.GetValue(ideOptions, vscode.OpenNewWindow) == config.BoolTrue,
-		Flavor:    vsCodeFlavorMap[ideName],
+		Workspace:  params.Client.Workspace(),
+		Folder:     params.Result.SubstitutionContext.ContainerWorkspaceFolder,
+		NewWindow:  vscode.Options.GetValue(ideOptions, vscode.OpenNewWindow) == config.BoolTrue,
+		Flavor:     vsCodeFlavorMap[ideName],
+		TunnelMode: params.TunnelMode,
 	})
 }
 

--- a/pkg/ide/vscode/open.go
+++ b/pkg/ide/vscode/open.go
@@ -18,10 +18,11 @@ import (
 const containersExtension = "ms-vscode-remote.remote-containers"
 
 type OpenParams struct {
-	Workspace string
-	Folder    string
-	NewWindow bool
-	Flavor    Flavor
+	Workspace  string
+	Folder     string
+	NewWindow  bool
+	Flavor     Flavor
+	TunnelMode bool
 }
 
 type openConfig struct {
@@ -83,7 +84,7 @@ var openConfigs = map[Flavor]openConfig{
 }
 
 func Open(ctx context.Context, params OpenParams) error {
-	EnsureHostSettings(params.Flavor)
+	EnsureHostSettings(params.Flavor, params.TunnelMode)
 
 	cliErr := openViaCLI(ctx, params)
 	if cliErr == nil {

--- a/pkg/ide/vscode/settings.go
+++ b/pkg/ide/vscode/settings.go
@@ -25,12 +25,19 @@ var userSettingsDirNames = map[Flavor]string{
 }
 
 // EnsureHostSettings ensures required VS Code user settings are configured
-// on the host machine. This is needed to disable exec-server mode which is
-// incompatible with ProxyCommand-based SSH connections.
-func EnsureHostSettings(flavor Flavor) {
+// on the host machine. When tunnelMode is false, it disables exec-server mode
+// which is incompatible with ProxyCommand-based SSH connections. When tunnelMode
+// is true, it removes the useExecServer setting since tunnel mode does not
+// require it.
+func EnsureHostSettings(flavor Flavor, tunnelMode bool) {
 	settingsPath, err := userSettingsPath(flavor)
 	if err != nil {
 		log.Debugf("cannot determine VS Code settings path: %v", err)
+		return
+	}
+
+	if tunnelMode {
+		removeUserSetting(settingsPath, settingUseExecServer)
 		return
 	}
 
@@ -40,6 +47,32 @@ func EnsureHostSettings(flavor Flavor) {
 
 	if err := mergeUserSettings(settingsPath, required); err != nil {
 		log.Debugf("failed to update VS Code host settings: %v", err)
+	}
+}
+
+// removeUserSetting removes a single key from the VS Code user settings file.
+// It is a no-op if the file does not exist or the key is not present.
+func removeUserSetting(path string, key string) {
+	existing, err := readSettingsFile(path)
+	if err != nil {
+		log.Debugf("cannot read settings file for removal: %v", err)
+		return
+	}
+
+	if _, ok := existing[key]; !ok {
+		return
+	}
+
+	delete(existing, key)
+
+	out, err := json.MarshalIndent(existing, "", "    ")
+	if err != nil {
+		log.Debugf("cannot marshal settings after removal: %v", err)
+		return
+	}
+
+	if err := os.WriteFile(path, out, 0o600); err != nil {
+		log.Debugf("cannot write settings after removal: %v", err)
 	}
 }
 

--- a/pkg/ide/vscode/settings_test.go
+++ b/pkg/ide/vscode/settings_test.go
@@ -98,6 +98,39 @@ func (s *SettingsSuite) TestMergeUserSettings_OverridesWrongValue() {
 	s.Equal(false, settings[settingUseExecServer])
 }
 
+func (s *SettingsSuite) TestRemoveUserSetting_RemovesKey() {
+	path := filepath.Join(s.tmpDir, "settings.json")
+	initial := map[string]any{
+		settingUseExecServer: false,
+		"editor.fontSize":    float64(14),
+	}
+	s.writeJSON(path, initial)
+
+	removeUserSetting(path, settingUseExecServer)
+
+	settings, err := readSettingsFile(path)
+	s.Require().NoError(err)
+	s.NotContains(settings, settingUseExecServer, "useExecServer should have been removed")
+	s.Equal(float64(14), settings["editor.fontSize"], "other settings should be preserved")
+}
+
+func (s *SettingsSuite) TestRemoveUserSetting_NoFile() {
+	// Should not panic when file doesn't exist
+	removeUserSetting(filepath.Join(s.tmpDir, "nonexistent", "settings.json"), "some.key")
+}
+
+func (s *SettingsSuite) TestRemoveUserSetting_KeyNotPresent() {
+	path := filepath.Join(s.tmpDir, "settings.json")
+	initial := map[string]any{"editor.fontSize": float64(14)}
+	s.writeJSON(path, initial)
+
+	removeUserSetting(path, "nonexistent.key")
+
+	settings, err := readSettingsFile(path)
+	s.Require().NoError(err)
+	s.Len(settings, 1, "file should be unchanged")
+}
+
 func (s *SettingsSuite) writeJSON(path string, v any) {
 	s.T().Helper()
 	s.Require().NoError(os.MkdirAll(filepath.Dir(path), 0o750))

--- a/pkg/ssh/config.go
+++ b/pkg/ssh/config.go
@@ -35,6 +35,7 @@ type SSHConfigParams struct {
 	GPGAgent             bool
 	DevsyHome            string
 	Provider             string
+	TunnelPort           int // If > 0, use TCP tunnel mode instead of ProxyCommand
 }
 
 func ConfigureSSHConfig(params SSHConfigParams) error {
@@ -47,16 +48,17 @@ func ConfigureSSHConfig(params SSHConfigParams) error {
 	}
 
 	newFile, err := addHost(addHostParams{
-		path:      targetPath,
-		host:      params.Workspace + config.SSHHostSuffix,
-		user:      params.User,
-		context:   params.Context,
-		workspace: params.Workspace,
-		workdir:   params.Workdir,
-		command:   params.Command,
-		gpgagent:  params.GPGAgent,
-		devsyHome: params.DevsyHome,
-		provider:  params.Provider,
+		path:       targetPath,
+		host:       params.Workspace + config.SSHHostSuffix,
+		user:       params.User,
+		context:    params.Context,
+		workspace:  params.Workspace,
+		workdir:    params.Workdir,
+		command:    params.Command,
+		gpgagent:   params.GPGAgent,
+		devsyHome:  params.DevsyHome,
+		provider:   params.Provider,
+		tunnelPort: params.TunnelPort,
 	})
 	if err != nil {
 		return fmt.Errorf("parse ssh config: %w", err)
@@ -72,16 +74,17 @@ type DevsySSHEntry struct {
 }
 
 type addHostParams struct {
-	path      string
-	host      string
-	user      string
-	context   string
-	workspace string
-	workdir   string
-	command   string
-	gpgagent  bool
-	devsyHome string
-	provider  string
+	path       string
+	host       string
+	user       string
+	context    string
+	workspace  string
+	workdir    string
+	command    string
+	gpgagent   bool
+	devsyHome  string
+	provider   string
+	tunnelPort int
 }
 
 func addHost(params addHostParams) (string, error) {
@@ -187,6 +190,14 @@ func (b *sshConfigBuilder) addProxyCommand(proxyCmd string) *sshConfigBuilder {
 	return b
 }
 
+func (b *sshConfigBuilder) addTunnelConnection(port int) *sshConfigBuilder {
+	b.lines = append(b.lines,
+		"  Hostname 127.0.0.1",
+		fmt.Sprintf("  Port %d", port),
+	)
+	return b
+}
+
 func (b *sshConfigBuilder) addUser(user, host string) *sshConfigBuilder {
 	b.lines = append(b.lines, "  User "+user, MarkerEndPrefix+host)
 	return b
@@ -214,6 +225,15 @@ func buildSSHConfigLines(params addHostParams, proxyCmd string) []string {
 	return newSSHConfigBuilder(params.host).
 		addSSHOptions(params.provider).
 		addProxyCommand(proxyCmd).
+		addUser(params.user, params.host).
+		build()
+}
+
+// buildTunnelConfigLines creates the SSH config entry lines for TCP tunnel mode.
+func buildTunnelConfigLines(params addHostParams) []string {
+	return newSSHConfigBuilder(params.host).
+		addSSHOptions(params.provider).
+		addTunnelConnection(params.tunnelPort).
 		addUser(params.user, params.host).
 		build()
 }
@@ -267,8 +287,13 @@ func mergeSSHConfig(lines, newLines []string, position int) string {
 }
 
 func addHostSection(config, execPath string, params addHostParams) (string, error) {
-	proxyCmd := buildProxyCommand(execPath, params)
-	newLines := buildSSHConfigLines(params, proxyCmd)
+	var newLines []string
+	if params.tunnelPort > 0 {
+		newLines = buildTunnelConfigLines(params)
+	} else {
+		proxyCmd := buildProxyCommand(execPath, params)
+		newLines = buildSSHConfigLines(params, proxyCmd)
+	}
 
 	position, lines, err := findInsertPosition(config)
 	if err != nil {

--- a/pkg/ssh/config_tunnel_test.go
+++ b/pkg/ssh/config_tunnel_test.go
@@ -1,0 +1,191 @@
+package ssh
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	testUser          = "testuser"
+	testUserRoot      = "root"
+	testContext       = "default"
+	testProvider      = "docker"
+	testHost          = "my-workspace.devsy"
+	testWorkspace     = "my-workspace"
+	testWorkspaceShrt = "test"
+	testDevsyBin      = "/usr/local/bin/devsy"
+	testExecPath      = "/path/to/exec"
+	testHostSimple    = "test.devsy"
+	testHostBasic     = "testhost"
+	testContextAlt    = "testcontext"
+	testWorkspaceAlt  = "testworkspace"
+	testTunnelPort    = 10800
+	testTunnelPortStr = "Port 10800"
+	testHostnameLocal = "Hostname 127.0.0.1"
+	testProxyCommand  = "ProxyCommand"
+)
+
+type SSHConfigTunnelTestSuite struct {
+	suite.Suite
+}
+
+func TestSSHConfigTunnelSuite(t *testing.T) {
+	suite.Run(t, new(SSHConfigTunnelTestSuite))
+}
+
+func (s *SSHConfigTunnelTestSuite) TestAddHostSection_TunnelMode_Basic() {
+	params := addHostParams{
+		host:       testHost,
+		user:       testUser,
+		context:    testContext,
+		workspace:  testWorkspace,
+		tunnelPort: testTunnelPort,
+		provider:   testProvider,
+	}
+
+	result, err := addHostSection("", testDevsyBin, params)
+	assert.NoError(s.T(), err)
+
+	assert.Contains(s.T(), result, testHostnameLocal)
+	assert.Contains(s.T(), result, testTunnelPortStr)
+	assert.NotContains(s.T(), result, testProxyCommand)
+	assert.Contains(s.T(), result, "ForwardAgent yes")
+	assert.Contains(s.T(), result, "LogLevel error")
+	assert.Contains(s.T(), result, "StrictHostKeyChecking no")
+	assert.Contains(s.T(), result, "UserKnownHostsFile /dev/null")
+	assert.Contains(s.T(), result, "HostKeyAlgorithms rsa-sha2-256,rsa-sha2-512,ssh-rsa")
+	assert.Contains(s.T(), result, MarkerStartPrefix+testHost)
+	assert.Contains(s.T(), result, MarkerEndPrefix+testHost)
+	assert.Contains(s.T(), result, "User "+testUser)
+}
+
+func (s *SSHConfigTunnelTestSuite) TestAddHostSection_TunnelMode_DifferentPort() {
+	params := addHostParams{
+		host:       testHostSimple,
+		user:       testUserRoot,
+		context:    testContext,
+		workspace:  testWorkspaceShrt,
+		tunnelPort: 12345,
+		provider:   testProvider,
+	}
+
+	result, err := addHostSection("", testDevsyBin, params)
+	assert.NoError(s.T(), err)
+
+	assert.Contains(s.T(), result, testHostnameLocal)
+	assert.Contains(s.T(), result, "Port 12345")
+	assert.NotContains(s.T(), result, testProxyCommand)
+	assert.Contains(s.T(), result, "User "+testUserRoot)
+}
+
+func (s *SSHConfigTunnelTestSuite) TestAddHostSection_TunnelMode_AWSProvider() {
+	params := addHostParams{
+		host:       testHostSimple,
+		user:       testUser,
+		context:    testContext,
+		workspace:  testWorkspaceShrt,
+		tunnelPort: testTunnelPort,
+		provider:   "aws",
+	}
+
+	result, err := addHostSection("", testDevsyBin, params)
+	assert.NoError(s.T(), err)
+
+	assert.Contains(s.T(), result, "ConnectTimeout 60")
+	assert.Contains(s.T(), result, testHostnameLocal)
+	assert.Contains(s.T(), result, testTunnelPortStr)
+	assert.NotContains(s.T(), result, testProxyCommand)
+}
+
+func (s *SSHConfigTunnelTestSuite) TestAddHostSection_ProxyCommandMode_NoTunnel() {
+	params := addHostParams{
+		host:      testHostSimple,
+		user:      testUserRoot,
+		context:   testContext,
+		workspace: testWorkspaceShrt,
+		provider:  testProvider,
+	}
+
+	result, err := addHostSection("", testExecPath, params)
+	assert.NoError(s.T(), err)
+
+	assert.Contains(s.T(), result, testProxyCommand)
+	assert.NotContains(s.T(), result, testHostnameLocal)
+	assert.NotContains(s.T(), result, "Port ")
+}
+
+func (s *SSHConfigTunnelTestSuite) TestAddHostSection_TunnelMode_ExistingConfig() {
+	existingConfig := `Host existinghost
+  User existinguser`
+
+	params := addHostParams{
+		host:       testHostSimple,
+		user:       testUser,
+		context:    testContext,
+		workspace:  testWorkspaceShrt,
+		tunnelPort: testTunnelPort,
+		provider:   testProvider,
+	}
+
+	result, err := addHostSection(existingConfig, testDevsyBin, params)
+	assert.NoError(s.T(), err)
+
+	assert.Contains(s.T(), result, testHostnameLocal)
+	assert.Contains(s.T(), result, testTunnelPortStr)
+	assert.NotContains(s.T(), result, testProxyCommand)
+	assert.Contains(s.T(), result, existingConfig)
+}
+
+func (s *SSHConfigTunnelTestSuite) TestAddHostSection_TunnelMode_FullExpectedOutput() {
+	params := addHostParams{
+		host:       testHostBasic,
+		user:       testUser,
+		context:    testContextAlt,
+		workspace:  testWorkspaceAlt,
+		tunnelPort: testTunnelPort,
+		provider:   "",
+	}
+
+	result, err := addHostSection("", testExecPath, params)
+	assert.NoError(s.T(), err)
+
+	expected := `# Devsy Start testhost
+Host testhost
+  ForwardAgent yes
+  LogLevel error
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  HostKeyAlgorithms rsa-sha2-256,rsa-sha2-512,ssh-rsa
+  Hostname 127.0.0.1
+  Port 10800
+  User testuser
+# Devsy End testhost`
+
+	assert.Equal(s.T(), expected, result)
+}
+
+func (s *SSHConfigTunnelTestSuite) TestBuildTunnelConfigLines() {
+	params := addHostParams{
+		host:       testHost,
+		user:       testUser,
+		context:    testContext,
+		workspace:  testWorkspace,
+		tunnelPort: testTunnelPort,
+		provider:   testProvider,
+	}
+
+	lines := buildTunnelConfigLines(params)
+	config := strings.Join(lines, "\n")
+
+	assert.Contains(s.T(), config, testHostnameLocal)
+	assert.Contains(s.T(), config, testTunnelPortStr)
+	assert.NotContains(s.T(), config, testProxyCommand)
+	assert.Contains(s.T(), config, "ForwardAgent yes")
+	assert.Contains(s.T(), config, "StrictHostKeyChecking no")
+	assert.Contains(s.T(), config, MarkerStartPrefix+testHost)
+	assert.Contains(s.T(), config, MarkerEndPrefix+testHost)
+	assert.Contains(s.T(), config, "User "+testUser)
+}

--- a/pkg/tunnel/dial.go
+++ b/pkg/tunnel/dial.go
@@ -1,0 +1,120 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+
+	"github.com/devsy-org/devsy/pkg/log"
+)
+
+const (
+	sshSubcommand = "ssh"
+	sshStdioFlag  = "--stdio"
+)
+
+type WorkspaceDialer struct {
+	// DevsyBinary is the path to the devsy binary. If empty, os.Executable() is used.
+	DevsyBinary string
+	// Context is the Devsy context name
+	Context string
+	// User is the workspace user
+	User string
+	// Workspace is the workspace name/ID
+	Workspace string
+	// Workdir is the optional working directory
+	Workdir string
+	// GPGAgent enables GPG agent forwarding
+	GPGAgent bool
+}
+
+// Dial creates a new connection to the workspace by spawning devsy ssh --stdio.
+// Each call creates an independent connection, allowing multiple simultaneous
+// SSH sessions (e.g. VS Code opening several connections).
+func (d *WorkspaceDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) {
+	binary, args, err := d.buildCommand()
+	if err != nil {
+		return nil, err
+	}
+
+	// #nosec G204 -- binary is self-referencing executable
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Stderr = log.Writer(log.LevelDebug)
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdin pipe: %w", err)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start devsy ssh: %w", err)
+	}
+
+	return &processConn{
+		cmd:    cmd,
+		stdin:  stdin,
+		stdout: stdout,
+	}, nil
+}
+
+func (d *WorkspaceDialer) buildCommand() (string, []string, error) {
+	binary := d.DevsyBinary
+	if binary == "" {
+		var err error
+		binary, err = os.Executable()
+		if err != nil {
+			return "", nil, fmt.Errorf("resolve devsy binary: %w", err)
+		}
+	}
+
+	args := []string{sshSubcommand, sshStdioFlag}
+	if d.Context != "" {
+		args = append(args, "--context", d.Context)
+	}
+	if d.User != "" {
+		args = append(args, "--user", d.User)
+	}
+	if d.Workdir != "" {
+		args = append(args, "--workdir", d.Workdir)
+	}
+	if d.GPGAgent {
+		args = append(args, "--gpg-agent-forwarding")
+	}
+	args = append(args, d.Workspace)
+
+	return binary, args, nil
+}
+
+// processConn wraps a subprocess stdin/stdout as an io.ReadWriteCloser.
+type processConn struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	once   sync.Once
+}
+
+func (c *processConn) Read(p []byte) (int, error) {
+	return c.stdout.Read(p)
+}
+
+func (c *processConn) Write(p []byte) (int, error) {
+	return c.stdin.Write(p)
+}
+
+func (c *processConn) Close() error {
+	var closeErr error
+	c.once.Do(func() {
+		_ = c.stdin.Close()
+		_ = c.stdout.Close()
+		closeErr = c.cmd.Wait()
+	})
+	return closeErr
+}

--- a/pkg/tunnel/local_listener.go
+++ b/pkg/tunnel/local_listener.go
@@ -1,0 +1,165 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+
+	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/port"
+)
+
+// LocalTunnel manages a local TCP listener that forwards connections
+// to a container SSH server through the Devsy tunnel infrastructure.
+type LocalTunnel struct {
+	listener net.Listener
+	port     int
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	dialFunc DialFunc
+}
+
+// DialFunc establishes a connection to the remote SSH server.
+// Each call returns a new bidirectional stream to the container SSH port.
+type DialFunc func(ctx context.Context) (io.ReadWriteCloser, error)
+
+// LocalTunnelOptions configures a local TCP tunnel.
+type LocalTunnelOptions struct {
+	// BasePort is the starting port to search from (default: 10800)
+	BasePort int
+	// DialFunc creates a connection to the remote SSH endpoint
+	DialFunc DialFunc
+}
+
+// NewLocalTunnel creates and starts a local TCP listener that forwards
+// connections to the container SSH server.
+func NewLocalTunnel(ctx context.Context, opts LocalTunnelOptions) (*LocalTunnel, error) {
+	if opts.BasePort == 0 {
+		opts.BasePort = 10800
+	}
+
+	availablePort, err := port.FindAvailablePort(opts.BasePort)
+	if err != nil {
+		return nil, fmt.Errorf("find available port: %w", err)
+	}
+
+	addr := fmt.Sprintf("127.0.0.1:%d", availablePort)
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("listen on %s: %w", addr, err)
+	}
+
+	tunnelCtx, cancel := context.WithCancel(ctx)
+	t := &LocalTunnel{
+		listener: listener,
+		port:     availablePort,
+		ctx:      tunnelCtx,
+		cancel:   cancel,
+		dialFunc: opts.DialFunc,
+	}
+
+	t.wg.Add(1)
+	go t.acceptLoop()
+
+	go func() {
+		<-tunnelCtx.Done()
+		_ = listener.Close()
+	}()
+
+	return t, nil
+}
+
+// Port returns the local port the tunnel is listening on.
+func (t *LocalTunnel) Port() int {
+	return t.port
+}
+
+// Addr returns the full listener address (e.g., "127.0.0.1:10800").
+func (t *LocalTunnel) Addr() string {
+	return t.listener.Addr().String()
+}
+
+// Close shuts down the tunnel listener and waits for active connections to finish.
+func (t *LocalTunnel) Close() error {
+	t.cancel()
+	err := t.listener.Close()
+	t.wg.Wait()
+	return err
+}
+
+func (t *LocalTunnel) acceptLoop() {
+	defer t.wg.Done()
+
+	for {
+		conn, err := t.listener.Accept()
+		if err != nil {
+			if t.ctx.Err() != nil {
+				return
+			}
+			log.Debugf("tunnel accept error: %v", err)
+			return
+		}
+
+		t.wg.Add(1)
+		go t.handleConnection(conn)
+	}
+}
+
+func (t *LocalTunnel) handleConnection(localConn net.Conn) {
+	defer t.wg.Done()
+	defer func() { _ = localConn.Close() }()
+
+	remoteConn, err := t.dialFunc(t.ctx)
+	if err != nil {
+		log.Debugf("tunnel dial error: %v", err)
+		return
+	}
+	defer func() { _ = remoteConn.Close() }()
+
+	bridgeConnections(t.ctx, localConn, remoteConn)
+}
+
+func bridgeConnections(ctx context.Context, local net.Conn, remote io.ReadWriteCloser) {
+	done := make(chan struct{})
+	defer close(done)
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = local.Close()
+			_ = remote.Close()
+		case <-done:
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// local -> remote: when local's read side hits EOF, close remote's write side
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(remote, local)
+		// Signal the remote that no more data is coming
+		if tc, ok := remote.(*net.TCPConn); ok {
+			_ = tc.CloseWrite()
+		} else {
+			// For non-TCP remote connections, close entirely to signal EOF
+			_ = remote.Close()
+		}
+	}()
+
+	// remote -> local: when remote's read side hits EOF, close local's write side
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(local, remote)
+		// Signal the local client that no more data is coming
+		if tc, ok := local.(*net.TCPConn); ok {
+			_ = tc.CloseWrite()
+		}
+	}()
+
+	wg.Wait()
+}

--- a/pkg/tunnel/local_listener_test.go
+++ b/pkg/tunnel/local_listener_test.go
@@ -1,0 +1,191 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newEchoServer(t *testing.T) net.Listener {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("echo listener: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				data, _ := io.ReadAll(c)
+				_, _ = c.Write(data)
+			}(conn)
+		}
+	}()
+
+	return listener
+}
+
+func echoDialFunc(addr string) DialFunc {
+	return func(ctx context.Context) (io.ReadWriteCloser, error) {
+		return net.Dial("tcp", addr)
+	}
+}
+
+func sendAndReceive(t *testing.T, addr string, msg []byte) []byte {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial tunnel: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	if _, err := conn.Write(msg); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := conn.(*net.TCPConn).CloseWrite(); err != nil {
+		t.Fatalf("close write: %v", err)
+	}
+
+	if err := conn.SetReadDeadline(time.Now().Add(5 * time.Second)); err != nil {
+		t.Fatalf("set deadline: %v", err)
+	}
+
+	buf, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	return buf
+}
+
+func TestLocalTunnel_ListensOnPort(t *testing.T) {
+	ctx := t.Context()
+
+	tun, err := NewLocalTunnel(ctx, LocalTunnelOptions{
+		BasePort: 18000,
+		DialFunc: func(ctx context.Context) (io.ReadWriteCloser, error) {
+			return nil, io.EOF
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTunnel: %v", err)
+	}
+	defer func() { _ = tun.Close() }()
+
+	if tun.Port() < 18000 {
+		t.Errorf("expected port >= 18000, got %d", tun.Port())
+	}
+
+	conn, err := net.DialTimeout("tcp", tun.Addr(), time.Second)
+	if err != nil {
+		t.Fatalf("dial tunnel: %v", err)
+	}
+	_ = conn.Close()
+}
+
+func TestLocalTunnel_ForwardsData(t *testing.T) {
+	ctx := t.Context()
+	echoServer := newEchoServer(t)
+
+	tun, err := NewLocalTunnel(ctx, LocalTunnelOptions{
+		BasePort: 18100,
+		DialFunc: echoDialFunc(echoServer.Addr().String()),
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTunnel: %v", err)
+	}
+	defer func() { _ = tun.Close() }()
+
+	msg := []byte("hello tunnel")
+	buf := sendAndReceive(t, tun.Addr(), msg)
+
+	if string(buf) != "hello tunnel" {
+		t.Errorf("expected %q, got %q", "hello tunnel", string(buf))
+	}
+}
+
+func TestLocalTunnel_MultipleConcurrentConnections(t *testing.T) {
+	ctx := t.Context()
+	echoServer := newEchoServer(t)
+
+	tun, err := NewLocalTunnel(ctx, LocalTunnelOptions{
+		BasePort: 18200,
+		DialFunc: echoDialFunc(echoServer.Addr().String()),
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTunnel: %v", err)
+	}
+	defer func() { _ = tun.Close() }()
+
+	var wg sync.WaitGroup
+	for i := range 5 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			msg := fmt.Appendf(nil, "msg-%d", id)
+			buf := sendAndReceive(t, tun.Addr(), msg)
+			if string(buf) != string(msg) {
+				t.Errorf("conn %d: expected %q, got %q", id, msg, buf)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestLocalTunnel_CloseStopsAccepting(t *testing.T) {
+	ctx := t.Context()
+
+	tun, err := NewLocalTunnel(ctx, LocalTunnelOptions{
+		BasePort: 18300,
+		DialFunc: func(ctx context.Context) (io.ReadWriteCloser, error) {
+			return nil, io.EOF
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTunnel: %v", err)
+	}
+
+	addr := tun.Addr()
+	_ = tun.Close()
+
+	time.Sleep(50 * time.Millisecond)
+	_, err = net.DialTimeout("tcp", addr, 500*time.Millisecond)
+	if err == nil {
+		t.Error("expected connection to be refused after Close()")
+	}
+}
+
+func TestLocalTunnel_ContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	tun, err := NewLocalTunnel(ctx, LocalTunnelOptions{
+		BasePort: 18400,
+		DialFunc: func(ctx context.Context) (io.ReadWriteCloser, error) {
+			return nil, io.EOF
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTunnel: %v", err)
+	}
+	defer func() { _ = tun.Close() }()
+
+	addr := tun.Addr()
+	cancel()
+
+	time.Sleep(100 * time.Millisecond)
+	_, err = net.DialTimeout("tcp", addr, 500*time.Millisecond)
+	if err == nil {
+		t.Error("expected connection to be refused after context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `SSH_TUNNEL_MODE` context option and `--ssh-tunnel-mode` CLI flag that enables a local TCP tunnel instead of ProxyCommand for SSH connections
- When enabled, a local TCP listener on `127.0.0.1:<port>` bridges connections to the workspace via `devsy ssh --stdio`, allowing VS Code's `useExecServer=true` to work natively
- SSH config entries in tunnel mode use `Hostname 127.0.0.1` + `Port` instead of `ProxyCommand`, and VS Code settings are adjusted accordingly (useExecServer override removed)
- Feature is off by default and can be enabled per-context or per-invocation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSH tunnel mode to route SSH via a local TCP tunnel instead of ProxyCommand
  * New CLI flag and config option to enable tunnel-based SSH connections
  * VS Code host settings now respect tunnel mode (adjusts remote SSH behavior)

* **Tests**
  * Added unit and end-to-end tests covering tunnel dialing, local tunnel listener, SSH config generation, and VS Code settings behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->