### PR TITLE
fix: handle JSONC comments in VS Code settings parsing

### DIFF
--- a/e2e/tests/ide/vscode_settings.go
+++ b/e2e/tests/ide/vscode_settings.go
@@ -1,0 +1,202 @@
+package ide
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/devsy-org/devsy/pkg/ide/vscode"
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+)
+
+var _ = ginkgo.Describe("VS Code Settings JSONC Handling", ginkgo.Label("ide"), func() {
+	var (
+		tmpHome     string
+		origHome    string
+		settingsDir string
+	)
+
+	ginkgo.BeforeEach(func() {
+		var err error
+		origHome = os.Getenv("HOME")
+
+		tmpHome, err = os.MkdirTemp("", "vscode-settings-test-*")
+		framework.ExpectNoError(err)
+
+		// On Linux, VS Code settings live at ~/.config/Code/User/settings.json
+		settingsDir = filepath.Join(tmpHome, ".config", "Code", "User")
+		err = os.MkdirAll(settingsDir, 0o750)
+		framework.ExpectNoError(err)
+
+		err = os.Setenv("HOME", tmpHome)
+		framework.ExpectNoError(err)
+	})
+
+	ginkgo.AfterEach(func() {
+		err := os.Setenv("HOME", origHome)
+		framework.ExpectNoError(err)
+		_ = os.RemoveAll(tmpHome)
+	})
+
+	settingsPath := func() string {
+		return filepath.Join(settingsDir, "settings.json")
+	}
+
+	writeSettings := func(content string) {
+		err := os.WriteFile(settingsPath(), []byte(content), 0o600)
+		framework.ExpectNoError(err)
+	}
+
+	readParsedSettings := func() map[string]any {
+		data, err := os.ReadFile(settingsPath())
+		framework.ExpectNoError(err)
+		var settings map[string]any
+		err = json.Unmarshal(data, &settings)
+		framework.ExpectNoError(err)
+		return settings
+	}
+
+	ginkgo.DescribeTable("should parse JSONC settings",
+		func(content string, expectedKeys map[string]any) {
+			writeSettings(content)
+			vscode.EnsureHostSettings(vscode.FlavorStable)
+
+			settings := readParsedSettings()
+			for key, val := range expectedKeys {
+				gomega.Expect(settings).To(gomega.HaveKeyWithValue(key, val))
+			}
+			gomega.Expect(settings).To(gomega.HaveKeyWithValue("remote.SSH.useExecServer", false))
+		},
+		ginkgo.Entry("with line comments", `{
+    // This is a line comment
+    "editor.fontSize": 14,
+    // Another comment
+    "editor.tabSize": 4
+}`, map[string]any{
+			"editor.fontSize": float64(14),
+			"editor.tabSize":  float64(4),
+		}),
+		ginkgo.Entry("with block comments", `{
+    /* Block comment explaining font size */
+    "editor.fontSize": 16,
+    /*
+     * Multi-line block comment
+     * with multiple lines
+     */
+    "editor.wordWrap": "on"
+}`, map[string]any{
+			"editor.fontSize": float64(16),
+			"editor.wordWrap": "on",
+		}),
+		ginkgo.Entry("with trailing commas", `{
+    "editor.fontSize": 14,
+    "editor.tabSize": 4,
+    "editor.wordWrap": "on",
+}`, map[string]any{
+			"editor.fontSize": float64(14),
+			"editor.tabSize":  float64(4),
+			"editor.wordWrap": "on",
+		}),
+		ginkgo.Entry("preserving existing settings during merge", `{
+    // User's custom font settings
+    "editor.fontSize": 18,
+    "editor.fontFamily": "Fira Code",
+    /* Terminal settings */
+    "terminal.integrated.fontSize": 13,
+    "workbench.colorTheme": "One Dark Pro",
+}`, map[string]any{
+			"editor.fontSize":              float64(18),
+			"editor.fontFamily":            "Fira Code",
+			"terminal.integrated.fontSize": float64(13),
+			"workbench.colorTheme":         "One Dark Pro",
+		}),
+	)
+
+	ginkgo.It("should handle real-world VS Code settings with mixed JSONC", func() {
+		writeSettings(`{
+    // ========================
+    // Editor Settings
+    // ========================
+    "editor.fontSize": 14,
+    "editor.tabSize": 4,
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.rulers": [80, 120],
+    "editor.minimap.enabled": false,
+
+    /*
+     * Terminal configuration
+     * Updated: 2024-01-15
+     */
+    "terminal.integrated.fontSize": 13,
+    "terminal.integrated.defaultProfile.linux": "zsh",
+
+    // Git settings
+    "git.autofetch": true,
+    "git.confirmSync": false,
+
+    /* File associations */
+    "files.associations": {
+        "*.jsonc": "jsonc",
+        "*.env.*": "dotenv",
+    },
+
+    // Extension-specific settings
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.formatOnSave": true,
+    },
+
+    // Remote SSH (user may have this set to true)
+    "remote.SSH.useExecServer": true,
+
+    // Telemetry
+    "telemetry.telemetryLevel": "off",
+}`)
+
+		vscode.EnsureHostSettings(vscode.FlavorStable)
+
+		settings := readParsedSettings()
+		// Verify existing settings are preserved
+		gomega.Expect(settings).To(gomega.HaveKeyWithValue("editor.fontSize", float64(14)))
+		gomega.Expect(settings).To(gomega.HaveKeyWithValue("editor.formatOnSave", true))
+		gomega.Expect(settings).To(gomega.HaveKeyWithValue("editor.minimap.enabled", false))
+		gomega.Expect(settings).
+			To(gomega.HaveKeyWithValue("terminal.integrated.fontSize", float64(13)))
+		gomega.Expect(settings).To(gomega.HaveKeyWithValue("git.autofetch", true))
+		gomega.Expect(settings).To(gomega.HaveKeyWithValue("telemetry.telemetryLevel", "off"))
+
+		// Verify nested objects are preserved
+		gomega.Expect(settings).To(gomega.HaveKey("files.associations"))
+		gomega.Expect(settings).To(gomega.HaveKey("[python]"))
+
+		// Verify the critical setting was overridden from true to false
+		gomega.Expect(settings).To(gomega.HaveKeyWithValue("remote.SSH.useExecServer", false))
+	})
+
+	ginkgo.It("should create settings file when none exists", func() {
+		// Remove the settings directory entirely to test creation from scratch
+		err := os.RemoveAll(settingsDir)
+		framework.ExpectNoError(err)
+
+		vscode.EnsureHostSettings(vscode.FlavorStable)
+
+		// Verify the file was created
+		_, err = os.Stat(settingsPath())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		settings := readParsedSettings()
+		gomega.Expect(settings).To(gomega.HaveKeyWithValue("remote.SSH.useExecServer", false))
+	})
+
+	ginkgo.It("should handle empty settings file", func() {
+		writeSettings(`{}`)
+
+		vscode.EnsureHostSettings(vscode.FlavorStable)
+
+		settings := readParsedSettings()
+		gomega.Expect(settings).To(gomega.HaveKeyWithValue("remote.SSH.useExecServer", false))
+	})
+})

--- a/e2e/tests/ide/vscode_settings.go
+++ b/e2e/tests/ide/vscode_settings.go
@@ -11,6 +11,8 @@ import (
 	"github.com/onsi/gomega"
 )
 
+const settingEditorFontSize = "editor.fontSize"
+
 var _ = ginkgo.Describe("VS Code Settings JSONC Handling", ginkgo.Label("ide"), func() {
 	var (
 		tmpHome     string
@@ -75,8 +77,8 @@ var _ = ginkgo.Describe("VS Code Settings JSONC Handling", ginkgo.Label("ide"), 
     // Another comment
     "editor.tabSize": 4
 }`, map[string]any{
-			"editor.fontSize": float64(14),
-			"editor.tabSize":  float64(4),
+			settingEditorFontSize: float64(14),
+			"editor.tabSize":      float64(4),
 		}),
 		ginkgo.Entry("with block comments", `{
     /* Block comment explaining font size */
@@ -87,17 +89,17 @@ var _ = ginkgo.Describe("VS Code Settings JSONC Handling", ginkgo.Label("ide"), 
      */
     "editor.wordWrap": "on"
 }`, map[string]any{
-			"editor.fontSize": float64(16),
-			"editor.wordWrap": "on",
+			settingEditorFontSize: float64(16),
+			"editor.wordWrap":     "on",
 		}),
 		ginkgo.Entry("with trailing commas", `{
     "editor.fontSize": 14,
     "editor.tabSize": 4,
     "editor.wordWrap": "on",
 }`, map[string]any{
-			"editor.fontSize": float64(14),
-			"editor.tabSize":  float64(4),
-			"editor.wordWrap": "on",
+			settingEditorFontSize: float64(14),
+			"editor.tabSize":      float64(4),
+			"editor.wordWrap":     "on",
 		}),
 		ginkgo.Entry("preserving existing settings during merge", `{
     // User's custom font settings
@@ -107,7 +109,7 @@ var _ = ginkgo.Describe("VS Code Settings JSONC Handling", ginkgo.Label("ide"), 
     "terminal.integrated.fontSize": 13,
     "workbench.colorTheme": "One Dark Pro",
 }`, map[string]any{
-			"editor.fontSize":              float64(18),
+			settingEditorFontSize:          float64(18),
 			"editor.fontFamily":            "Fira Code",
 			"terminal.integrated.fontSize": float64(13),
 			"workbench.colorTheme":         "One Dark Pro",
@@ -160,7 +162,7 @@ var _ = ginkgo.Describe("VS Code Settings JSONC Handling", ginkgo.Label("ide"), 
 
 		settings := readParsedSettings()
 		// Verify existing settings are preserved
-		gomega.Expect(settings).To(gomega.HaveKeyWithValue("editor.fontSize", float64(14)))
+		gomega.Expect(settings).To(gomega.HaveKeyWithValue(settingEditorFontSize, float64(14)))
 		gomega.Expect(settings).To(gomega.HaveKeyWithValue("editor.formatOnSave", true))
 		gomega.Expect(settings).To(gomega.HaveKeyWithValue("editor.minimap.enabled", false))
 		gomega.Expect(settings).

--- a/pkg/ide/vscode/settings.go
+++ b/pkg/ide/vscode/settings.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/util"
+	"github.com/tailscale/hujson"
 )
 
 const settingUseExecServer = "remote.SSH.useExecServer"
@@ -74,7 +75,11 @@ func readSettingsFile(path string) (map[string]any, error) {
 	existing := make(map[string]any)
 	data, err := os.ReadFile(path) // #nosec G304 -- path is constructed internally
 	if err == nil {
-		if err := json.Unmarshal(data, &existing); err != nil {
+		normalized, err := hujson.Standardize(data)
+		if err != nil {
+			return nil, fmt.Errorf("normalize settings: %w", err)
+		}
+		if err := json.Unmarshal(normalized, &existing); err != nil {
 			return nil, fmt.Errorf("parse settings: %w", err)
 		}
 	} else if !os.IsNotExist(err) {

--- a/pkg/ide/vscode/settings_test.go
+++ b/pkg/ide/vscode/settings_test.go
@@ -98,10 +98,147 @@ func (s *SettingsSuite) TestMergeUserSettings_OverridesWrongValue() {
 	s.Equal(false, settings[settingUseExecServer])
 }
 
+func (s *SettingsSuite) TestMergeUserSettings_HandlesLineComments() {
+	path := filepath.Join(s.tmpDir, "settings.json")
+	s.writeRaw(path, `{
+    // Editor configuration
+    "editor.fontSize": 14,
+    // Theme setting
+    "workbench.colorTheme": "Monokai"
+}`)
+
+	err := mergeUserSettings(path, map[string]any{
+		settingUseExecServer: false,
+	})
+	s.Require().NoError(err)
+
+	data, err := os.ReadFile(path) // #nosec G304 -- test fixture
+	s.Require().NoError(err)
+
+	var settings map[string]any
+	s.Require().NoError(json.Unmarshal(data, &settings))
+	s.Equal(float64(14), settings["editor.fontSize"])
+	s.Equal("Monokai", settings["workbench.colorTheme"])
+	s.Equal(false, settings[settingUseExecServer])
+}
+
+func (s *SettingsSuite) TestMergeUserSettings_HandlesBlockComments() {
+	path := filepath.Join(s.tmpDir, "settings.json")
+	s.writeRaw(path, `{
+    /* Main editor settings */
+    "editor.fontSize": 16,
+    /*
+     * Multi-line block comment
+     * describing the theme
+     */
+    "workbench.colorTheme": "Solarized Dark"
+}`)
+
+	err := mergeUserSettings(path, map[string]any{
+		settingUseExecServer: false,
+	})
+	s.Require().NoError(err)
+
+	data, err := os.ReadFile(path) // #nosec G304 -- test fixture
+	s.Require().NoError(err)
+
+	var settings map[string]any
+	s.Require().NoError(json.Unmarshal(data, &settings))
+	s.Equal(float64(16), settings["editor.fontSize"])
+	s.Equal("Solarized Dark", settings["workbench.colorTheme"])
+	s.Equal(false, settings[settingUseExecServer])
+}
+
+func (s *SettingsSuite) TestMergeUserSettings_HandlesTrailingCommas() {
+	path := filepath.Join(s.tmpDir, "settings.json")
+	s.writeRaw(path, `{
+    "editor.fontSize": 12,
+    "workbench.colorTheme": "Nord",
+    "editor.tabSize": 4,
+}`)
+
+	err := mergeUserSettings(path, map[string]any{
+		settingUseExecServer: false,
+	})
+	s.Require().NoError(err)
+
+	data, err := os.ReadFile(path) // #nosec G304 -- test fixture
+	s.Require().NoError(err)
+
+	var settings map[string]any
+	s.Require().NoError(json.Unmarshal(data, &settings))
+	s.Equal(float64(12), settings["editor.fontSize"])
+	s.Equal("Nord", settings["workbench.colorTheme"])
+	s.Equal(float64(4), settings["editor.tabSize"])
+	s.Equal(false, settings[settingUseExecServer])
+}
+
+func (s *SettingsSuite) TestMergeUserSettings_HandlesMixedJSONC() {
+	path := filepath.Join(s.tmpDir, "settings.json")
+	s.writeRaw(path, `{
+    // Line comment at the top
+    "editor.fontSize": 14,
+    /* Block comment */
+    "workbench.colorTheme": "One Dark Pro",
+    "editor.wordWrap": "on", // inline comment
+    /*
+     * Another block comment
+     */
+    "files.autoSave": "afterDelay",
+}`)
+
+	err := mergeUserSettings(path, map[string]any{
+		settingUseExecServer: false,
+	})
+	s.Require().NoError(err)
+
+	data, err := os.ReadFile(path) // #nosec G304 -- test fixture
+	s.Require().NoError(err)
+
+	var settings map[string]any
+	s.Require().NoError(json.Unmarshal(data, &settings))
+	s.Equal(float64(14), settings["editor.fontSize"])
+	s.Equal("One Dark Pro", settings["workbench.colorTheme"])
+	s.Equal("on", settings["editor.wordWrap"])
+	s.Equal("afterDelay", settings["files.autoSave"])
+	s.Equal(false, settings[settingUseExecServer])
+}
+
+func (s *SettingsSuite) TestMergeUserSettings_HandlesCommentsAroundTargetSetting() {
+	path := filepath.Join(s.tmpDir, "settings.json")
+	s.writeRaw(path, `{
+    "editor.fontSize": 14,
+    // This setting controls SSH exec server mode
+    "remote.SSH.useExecServer": true,
+    /* Keep this disabled for proxy compatibility */
+    "workbench.colorTheme": "Monokai"
+}`)
+
+	err := mergeUserSettings(path, map[string]any{
+		settingUseExecServer: false,
+	})
+	s.Require().NoError(err)
+
+	data, err := os.ReadFile(path) // #nosec G304 -- test fixture
+	s.Require().NoError(err)
+
+	var settings map[string]any
+	s.Require().NoError(json.Unmarshal(data, &settings))
+	s.Equal(float64(14), settings["editor.fontSize"])
+	s.Equal("Monokai", settings["workbench.colorTheme"])
+	s.Equal(false, settings[settingUseExecServer])
+}
+
 func (s *SettingsSuite) writeJSON(path string, v any) {
 	s.T().Helper()
 	s.Require().NoError(os.MkdirAll(filepath.Dir(path), 0o750))
 	data, err := json.Marshal(v)
 	s.Require().NoError(err)
 	s.Require().NoError(os.WriteFile(path, data, 0o600))
+}
+
+func (s *SettingsSuite) writeRaw(path string, content string) {
+	s.T().Helper()
+	s.Require().NoError(os.MkdirAll(filepath.Dir(path), 0o750))
+	s.Require().NoError(os.WriteFile(path, []byte(content), 0o600))
 }


### PR DESCRIPTION
## Summary

- Fixes "invalid character '/' looking for beginning of object key string" error when VS Code settings.json contains JSONC comments or trailing commas
- Uses `hujson.Standardize` to strip JSONC extensions before `json.Unmarshal`, matching the existing pattern in `pkg/devcontainer/config/parse.go`
- Adds 5 unit tests covering line comments, block comments, trailing commas, mixed JSONC, and comments around the target setting
- Adds e2e integration test with 7 test cases exercising `EnsureHostSettings` with realistic JSONC settings files