### PR TITLE
fix(tunnel): eliminate TOCTOU race in port binding

### DIFF
--- a/pkg/tunnel/local_listener.go
+++ b/pkg/tunnel/local_listener.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 
 	"github.com/devsy-org/devsy/pkg/log"
-	"github.com/devsy-org/devsy/pkg/port"
 )
 
 // LocalTunnel manages a local TCP listener that forwards connections
@@ -44,21 +43,15 @@ func NewLocalTunnel(ctx context.Context, opts LocalTunnelOptions) (*LocalTunnel,
 		opts.BasePort = 10800
 	}
 
-	availablePort, err := port.FindAvailablePort(opts.BasePort)
+	listener, listenPort, err := listenAvailablePort(opts.BasePort)
 	if err != nil {
-		return nil, fmt.Errorf("find available port: %w", err)
-	}
-
-	addr := fmt.Sprintf("127.0.0.1:%d", availablePort)
-	listener, err := net.Listen("tcp", addr)
-	if err != nil {
-		return nil, fmt.Errorf("listen on %s: %w", addr, err)
+		return nil, err
 	}
 
 	tunnelCtx, cancel := context.WithCancel(ctx)
 	t := &LocalTunnel{
 		listener: listener,
-		port:     availablePort,
+		port:     listenPort,
 		ctx:      tunnelCtx,
 		cancel:   cancel,
 		dialFunc: opts.DialFunc,
@@ -123,6 +116,22 @@ func (t *LocalTunnel) handleConnection(localConn net.Conn) {
 	defer func() { _ = remoteConn.Close() }()
 
 	bridgeConnections(t.ctx, localConn, remoteConn)
+}
+
+const listenPortRange = 100
+
+func listenAvailablePort(basePort int) (net.Listener, int, error) {
+	for i := range listenPortRange {
+		addr := fmt.Sprintf("127.0.0.1:%d", basePort+i)
+		listener, err := net.Listen("tcp", addr)
+		if err != nil {
+			continue
+		}
+		return listener, basePort + i, nil
+	}
+	return nil, 0, fmt.Errorf(
+		"no available port in range %d-%d", basePort, basePort+listenPortRange-1,
+	)
 }
 
 func bridgeConnections(ctx context.Context, local net.Conn, remote io.ReadWriteCloser) {


### PR DESCRIPTION
## Summary

- Fixes `TestLocalTunnel_ForwardsData` failing on macOS CI with "bind: address already in use" on port 18100
- Replaces the two-step `FindAvailablePort` + `net.Listen` pattern with an atomic `listenAvailablePort` that directly attempts to bind each port in the range
- Eliminates the TOCTOU race window where another process could grab the port between the availability check and the actual bind
- Removes the unused `pkg/port` dependency from the tunnel package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of local tunnel port selection logic. The system now uses a streamlined approach for finding available TCP ports, replacing the previous dependency-based method with an integrated helper function.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->