### PR TITLE
fix(vscode): always disable useExecServer for SSH tunnel mode

### DIFF
--- a/e2e/tests/ide/vscode_settings.go
+++ b/e2e/tests/ide/vscode_settings.go
@@ -63,7 +63,7 @@ var _ = ginkgo.Describe("VS Code Settings JSONC Handling", ginkgo.Label("ide"), 
 	ginkgo.DescribeTable("should parse JSONC settings",
 		func(content string, expectedKeys map[string]any) {
 			writeSettings(content)
-			vscode.EnsureHostSettings(vscode.FlavorStable, false)
+			vscode.EnsureHostSettings(vscode.FlavorStable)
 
 			settings := readParsedSettings()
 			for key, val := range expectedKeys {
@@ -158,7 +158,7 @@ var _ = ginkgo.Describe("VS Code Settings JSONC Handling", ginkgo.Label("ide"), 
     "telemetry.telemetryLevel": "off",
 }`)
 
-		vscode.EnsureHostSettings(vscode.FlavorStable, false)
+		vscode.EnsureHostSettings(vscode.FlavorStable)
 
 		settings := readParsedSettings()
 		// Verify existing settings are preserved
@@ -183,7 +183,7 @@ var _ = ginkgo.Describe("VS Code Settings JSONC Handling", ginkgo.Label("ide"), 
 		err := os.RemoveAll(settingsDir)
 		framework.ExpectNoError(err)
 
-		vscode.EnsureHostSettings(vscode.FlavorStable, false)
+		vscode.EnsureHostSettings(vscode.FlavorStable)
 
 		// Verify the file was created
 		_, err = os.Stat(settingsPath())
@@ -196,7 +196,7 @@ var _ = ginkgo.Describe("VS Code Settings JSONC Handling", ginkgo.Label("ide"), 
 	ginkgo.It("should handle empty settings file", func() {
 		writeSettings(`{}`)
 
-		vscode.EnsureHostSettings(vscode.FlavorStable, false)
+		vscode.EnsureHostSettings(vscode.FlavorStable)
 
 		settings := readParsedSettings()
 		gomega.Expect(settings).To(gomega.HaveKeyWithValue("remote.SSH.useExecServer", false))

--- a/pkg/ide/vscode/open.go
+++ b/pkg/ide/vscode/open.go
@@ -84,7 +84,7 @@ var openConfigs = map[Flavor]openConfig{
 }
 
 func Open(ctx context.Context, params OpenParams) error {
-	EnsureHostSettings(params.Flavor, params.TunnelMode)
+	EnsureHostSettings(params.Flavor)
 
 	cliErr := openViaCLI(ctx, params)
 	if cliErr == nil {

--- a/pkg/ide/vscode/settings.go
+++ b/pkg/ide/vscode/settings.go
@@ -26,19 +26,13 @@ var userSettingsDirNames = map[Flavor]string{
 }
 
 // EnsureHostSettings ensures required VS Code user settings are configured
-// on the host machine. When tunnelMode is false, it disables exec-server mode
-// which is incompatible with ProxyCommand-based SSH connections. When tunnelMode
-// is true, it removes the useExecServer setting since tunnel mode does not
-// require it.
-func EnsureHostSettings(flavor Flavor, tunnelMode bool) {
+// on the host machine. It disables exec-server mode (useExecServer=false)
+// which is required for both ProxyCommand and tunnel-based SSH connections
+// because VS Code needs a remote TCP port to connect to.
+func EnsureHostSettings(flavor Flavor) {
 	settingsPath, err := userSettingsPath(flavor)
 	if err != nil {
 		log.Debugf("cannot determine VS Code settings path: %v", err)
-		return
-	}
-
-	if tunnelMode {
-		removeUserSetting(settingsPath, settingUseExecServer)
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Surfaces the SSH Tunnel Mode option in the desktop context settings UI
- Hides the telemetry toggle from the UI (remains CLI-configurable, enabled by default)
- Fixes VS Code "Failed to parse remote port from server output" error when using tunnel mode by always setting `useExecServer=false` regardless of connection mode

The root cause: `EnsureHostSettings` with `tunnelMode=true` was *removing* the `useExecServer` setting, letting VS Code default to `true`. With exec-server mode active, the remote server uses stdio protocol (no TCP port), but VS Code's local-server mode requires a remote port to forward through its SOCKS proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSH Tunnel Mode toggle has been added to SSH configuration settings, enabling users to control SSH tunneling behavior and manage connection preferences as needed

* **Improvements**
  * Telemetry option has been removed from General settings to streamline and simplify the user configuration interface
  * Remote SSH configuration handling has been updated to ensure consistent and reliable behavior across all supported connection scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->