### PR TITLE
fix(desktop): detect workspace ready during tunnel mode

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -296,19 +296,37 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
       const cmdId = crypto.randomUUID()
       const logPath = logStore.createLogFile(wsId)
       const win = deps.getMainWindow()
+      let signalledDone = false
 
       cli.runStreaming(
         cliArgs,
         (line) => {
           const formatted = formatLogLine(line)
           logStore.appendLog(logPath, formatted)
-          win?.webContents.send("command-progress", {
-            commandId: cmdId,
-            message: formatted,
-            done: false,
-          })
+
+          // Detect the success JSON envelope emitted before the tunnel blocks.
+          // This allows the UI to transition to "ready" even if the process
+          // stays alive to maintain a tunnel.
+          if (!signalledDone && line.includes('"outcome":"success"')) {
+            signalledDone = true
+            win?.webContents.send("command-progress", {
+              commandId: cmdId,
+              message: formatted,
+              done: true,
+            })
+            return
+          }
+
+          if (!signalledDone) {
+            win?.webContents.send("command-progress", {
+              commandId: cmdId,
+              message: formatted,
+              done: false,
+            })
+          }
         },
         (code) => {
+          if (signalledDone) return
           const exitMsg = formatLogLine(
             `Exit code: ${code}`,
             code === 0 ? "INFO" : "ERROR",

--- a/desktop/src/renderer/src/lib/components/workspace/CreateWorkspaceSheet.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/CreateWorkspaceSheet.svelte
@@ -193,7 +193,8 @@ function handleProgress(progress: CommandProgress, wsId: string | undefined) {
   }
   if (progress.done) {
     submitting = false
-    if (stripAnsi(progress.message).includes("Exit code: 0")) {
+    const msg = stripAnsi(progress.message)
+    if (msg.includes("Exit code: 0") || msg.includes('"outcome":"success"')) {
       createdId = wsId ?? null
       toasts.success(`Workspace ${wsId ?? "created"} is ready`)
       requestAnimationFrame(() => {
@@ -445,7 +446,7 @@ async function handleSubmit() {
         </div>
 
         <Sheet.Footer class="px-0 pt-2">
-          <Button type="submit" disabled={submitting || $providers.length === 0} class="w-full">
+          <Button type="submit" disabled={submitting || $providers.length === 0} size="lg">
             {#if submitting}<Spinner />{/if}
             {submitting ? "Creating..." : "Create Workspace"}
           </Button>
@@ -480,7 +481,7 @@ async function handleSubmit() {
 
       {#if createdId}
         <div class="pb-8">
-          <Button class="w-full" bind:ref={openBtnEl} onclick={() => { open = false; goto(`/workspaces/${createdId}`) }}>
+          <Button size="lg" bind:ref={openBtnEl} onclick={() => { open = false; goto(`/workspaces/${createdId}`) }}>
             Open Workspace
           </Button>
         </div>


### PR DESCRIPTION
## Summary

- Fixes the create workspace UI getting stuck on "Creating..." when SSH tunnel mode is enabled. The `devsy up` process stays alive to maintain the tunnel, so the UI now detects the `{"outcome":"success"}` JSON envelope in streamed output to signal readiness without waiting for process exit.
- Shrinks the Create/Open Workspace buttons from full-width blocks to standard `size="lg"` for a more proportional, button-shaped appearance.