### PR TITLE
fix(tunnel): address lifecycle leaks in SSH tunnel processes

### DIFF
--- a/desktop/src/main/cli.ts
+++ b/desktop/src/main/cli.ts
@@ -4,7 +4,7 @@ import { createInterface } from "node:readline"
 import { promisify } from "node:util"
 
 const execFile = promisify(execFileCb)
-const MAX_CONCURRENT = 10
+const MAX_CONCURRENT = 50
 
 /**
  * On macOS, GUI apps (including Electron) inherit a minimal PATH that excludes
@@ -99,31 +99,43 @@ export class CliRunner {
     }
   }
 
-  runStreaming(
+  private activeChildren = new Set<ChildProcess>()
+
+  async runStreaming(
     args: string[],
     onLine: (line: string, stream: "stdout" | "stderr") => void,
     onExit: (code: number) => void,
-  ): void {
-    this.acquire().then(() => {
-      const child = spawn(this.execPath, [...this.prefixArgs, ...args], {
-        env: this.env,
-      })
-
-      if (child.stdout) {
-        const rl = createInterface({ input: child.stdout })
-        rl.on("line", (line) => onLine(line, "stdout"))
-      }
-
-      if (child.stderr) {
-        const rl = createInterface({ input: child.stderr })
-        rl.on("line", (line) => onLine(line, "stderr"))
-      }
-
-      child.on("close", (code) => {
-        this.release()
-        onExit(code ?? -1)
-      })
+  ): Promise<ChildProcess> {
+    await this.acquire()
+    const child = spawn(this.execPath, [...this.prefixArgs, ...args], {
+      env: this.env,
     })
+
+    this.activeChildren.add(child)
+
+    if (child.stdout) {
+      const rl = createInterface({ input: child.stdout })
+      rl.on("line", (line) => onLine(line, "stdout"))
+    }
+
+    if (child.stderr) {
+      const rl = createInterface({ input: child.stderr })
+      rl.on("line", (line) => onLine(line, "stderr"))
+    }
+
+    child.on("close", (code) => {
+      this.activeChildren.delete(child)
+      this.release()
+      onExit(code ?? -1)
+    })
+
+    return child
+  }
+
+  killAll(): void {
+    for (const child of this.activeChildren) {
+      child.kill("SIGTERM")
+    }
   }
 
   static stripAnsi(str: string): string {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -148,12 +148,15 @@ app.whenReady().then(() => {
     trackEvent("app_close")
     shutdownAnalytics().catch(() => {})
     cli.killAll()
+    for (const proc of tunnelProcesses.values()) {
+      proc.kill("SIGTERM")
+    }
     daemonManager.stop()
     ptyManager.destroyAll()
   })
 
   // Register IPC handlers
-  registerIpcHandlers({
+  const { tunnelProcesses } = registerIpcHandlers({
     cli,
     state,
     logStore,

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -147,6 +147,7 @@ app.whenReady().then(() => {
     ;(app as typeof app & { isQuitting?: boolean }).isQuitting = true
     trackEvent("app_close")
     shutdownAnalytics().catch(() => {})
+    cli.killAll()
     daemonManager.stop()
     ptyManager.destroyAll()
   })

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -46,8 +46,9 @@ function formatLogLine(line: string, level: "INFO" | "ERROR" = "INFO"): string {
   return `${new Date().toISOString()}\t${level}\t${line}`
 }
 
-export function registerIpcHandlers(deps: IpcDependencies): void {
+export function registerIpcHandlers(deps: IpcDependencies): { tunnelProcesses: Map<string, import("node:child_process").ChildProcess> } {
   const { cli, state, logStore } = deps
+  const tunnelProcesses = new Map<string, import("node:child_process").ChildProcess>()
 
   // ── Workspaces ──
   ipcMain.handle("workspace_list", () => state.workspaceList())
@@ -298,17 +299,23 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
       const win = deps.getMainWindow()
       let signalledDone = false
 
-      cli.runStreaming(
+      // Kill any existing tunnel process for this workspace before starting a new one
+      const existing = tunnelProcesses.get(wsId)
+      if (existing) {
+        existing.kill("SIGTERM")
+        tunnelProcesses.delete(wsId)
+      }
+
+      const child = await cli.runStreaming(
         cliArgs,
         (line) => {
           const formatted = formatLogLine(line)
-          logStore.appendLog(logPath, formatted)
 
-          // Detect the success JSON envelope emitted before the tunnel blocks.
-          // This allows the UI to transition to "ready" even if the process
-          // stays alive to maintain a tunnel.
           if (!signalledDone && line.includes('"outcome":"success"')) {
+            logStore.appendLog(logPath, formatted)
             signalledDone = true
+            // Track this as a tunnel process (it stays alive for the tunnel)
+            tunnelProcesses.set(wsId, child)
             win?.webContents.send("command-progress", {
               commandId: cmdId,
               message: formatted,
@@ -318,6 +325,7 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
           }
 
           if (!signalledDone) {
+            logStore.appendLog(logPath, formatted)
             win?.webContents.send("command-progress", {
               commandId: cmdId,
               message: formatted,
@@ -326,6 +334,7 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
           }
         },
         (code) => {
+          tunnelProcesses.delete(wsId)
           if (signalledDone) return
           const exitMsg = formatLogLine(
             `Exit code: ${code}`,
@@ -348,6 +357,12 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
     "workspace_stop",
     async (_event, args: { workspaceId: string; debug?: boolean }) => {
       trackEvent("workspace_stop")
+      // Kill tunnel process for this workspace
+      const tunnelProc = tunnelProcesses.get(args.workspaceId)
+      if (tunnelProc) {
+        tunnelProc.kill("SIGTERM")
+        tunnelProcesses.delete(args.workspaceId)
+      }
       const cmdId = crypto.randomUUID()
       const logPath = logStore.createLogFile(args.workspaceId)
       const win = deps.getMainWindow()
@@ -388,6 +403,12 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
     "workspace_delete",
     async (_event, args: { workspaceId: string; debug?: boolean }) => {
       trackEvent("workspace_delete")
+      // Kill tunnel process for this workspace
+      const tunnelProc = tunnelProcesses.get(args.workspaceId)
+      if (tunnelProc) {
+        tunnelProc.kill("SIGTERM")
+        tunnelProcesses.delete(args.workspaceId)
+      }
       const cmdId = crypto.randomUUID()
       const logPath = logStore.createLogFile(args.workspaceId)
       const win = deps.getMainWindow()
@@ -725,6 +746,8 @@ export function registerIpcHandlers(deps: IpcDependencies): void {
       trackEvent(args.name, sanitizeAnalyticsProperties(args.properties))
     },
   )
+
+  return { tunnelProcesses }
 }
 
 function sanitizeAnalyticsProperties(

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -334,7 +334,9 @@ export function registerIpcHandlers(deps: IpcDependencies): { tunnelProcesses: M
           }
         },
         (code) => {
-          tunnelProcesses.delete(wsId)
+          if (tunnelProcesses.get(wsId) === child) {
+            tunnelProcesses.delete(wsId)
+          }
           if (signalledDone) return
           const exitMsg = formatLogLine(
             `Exit code: ${code}`,

--- a/pkg/tunnel/dial.go
+++ b/pkg/tunnel/dial.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"time"
 
 	"github.com/devsy-org/devsy/pkg/log"
 )
@@ -42,6 +43,7 @@ func (d *WorkspaceDialer) Dial(ctx context.Context) (io.ReadWriteCloser, error) 
 
 	// #nosec G204 -- binary is self-referencing executable
 	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.WaitDelay = 5 * time.Second
 	cmd.Stderr = log.Writer(log.LevelDebug)
 
 	stdin, err := cmd.StdinPipe()

--- a/pkg/tunnel/local_listener.go
+++ b/pkg/tunnel/local_listener.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/devsy-org/devsy/pkg/log"
 )
@@ -13,12 +14,13 @@ import (
 // LocalTunnel manages a local TCP listener that forwards connections
 // to a container SSH server through the Devsy tunnel infrastructure.
 type LocalTunnel struct {
-	listener net.Listener
-	port     int
-	ctx      context.Context
-	cancel   context.CancelFunc
-	wg       sync.WaitGroup
-	dialFunc DialFunc
+	listener            net.Listener
+	port                int
+	ctx                 context.Context
+	cancel              context.CancelFunc
+	wg                  sync.WaitGroup
+	dialFunc            DialFunc
+	healthCheckInterval time.Duration
 }
 
 // DialFunc establishes a connection to the remote SSH server.
@@ -31,6 +33,9 @@ type LocalTunnelOptions struct {
 	BasePort int
 	// DialFunc creates a connection to the remote SSH endpoint
 	DialFunc DialFunc
+	// HealthCheckInterval overrides the default health check interval (for testing).
+	// If zero, defaults to healthCheckInterval (30s).
+	HealthCheckInterval time.Duration
 }
 
 // NewLocalTunnel creates and starts a local TCP listener that forwards
@@ -48,13 +53,19 @@ func NewLocalTunnel(ctx context.Context, opts LocalTunnelOptions) (*LocalTunnel,
 		return nil, err
 	}
 
+	healthInterval := opts.HealthCheckInterval
+	if healthInterval == 0 {
+		healthInterval = healthCheckInterval
+	}
+
 	tunnelCtx, cancel := context.WithCancel(ctx)
 	t := &LocalTunnel{
-		listener: listener,
-		port:     listenPort,
-		ctx:      tunnelCtx,
-		cancel:   cancel,
-		dialFunc: opts.DialFunc,
+		listener:            listener,
+		port:                listenPort,
+		ctx:                 tunnelCtx,
+		cancel:              cancel,
+		dialFunc:            opts.DialFunc,
+		healthCheckInterval: healthInterval,
 	}
 
 	t.wg.Add(1)
@@ -64,6 +75,9 @@ func NewLocalTunnel(ctx context.Context, opts LocalTunnelOptions) (*LocalTunnel,
 		<-tunnelCtx.Done()
 		_ = listener.Close()
 	}()
+
+	t.wg.Add(1)
+	go t.healthCheck()
 
 	return t, nil
 }
@@ -84,6 +98,43 @@ func (t *LocalTunnel) Close() error {
 	err := t.listener.Close()
 	t.wg.Wait()
 	return err
+}
+
+func (t *LocalTunnel) healthCheck() {
+	defer t.wg.Done()
+
+	ticker := time.NewTicker(t.healthCheckInterval)
+	defer ticker.Stop()
+
+	failures := 0
+	for {
+		select {
+		case <-t.ctx.Done():
+			return
+		case <-ticker.C:
+			conn, err := t.dialFunc(t.ctx)
+			if err != nil {
+				failures++
+				log.Debugf(
+					"tunnel health check failed (%d/%d): %v",
+					failures,
+					healthCheckMaxFailures,
+					err,
+				)
+				if failures >= healthCheckMaxFailures {
+					log.Infof(
+						"tunnel health check: %d consecutive failures, shutting down",
+						failures,
+					)
+					t.cancel()
+					return
+				}
+			} else {
+				_ = conn.Close()
+				failures = 0
+			}
+		}
+	}
 }
 
 func (t *LocalTunnel) acceptLoop() {
@@ -118,7 +169,11 @@ func (t *LocalTunnel) handleConnection(localConn net.Conn) {
 	bridgeConnections(t.ctx, localConn, remoteConn)
 }
 
-const listenPortRange = 100
+const (
+	listenPortRange        = 100
+	healthCheckInterval    = 30 * time.Second
+	healthCheckMaxFailures = 3
+)
 
 func listenAvailablePort(basePort int) (net.Listener, int, error) {
 	for i := range listenPortRange {

--- a/pkg/tunnel/local_listener_test.go
+++ b/pkg/tunnel/local_listener_test.go
@@ -189,3 +189,37 @@ func TestLocalTunnel_ContextCancellation(t *testing.T) {
 		t.Error("expected connection to be refused after context cancellation")
 	}
 }
+
+func TestLocalTunnel_HealthCheckShutdown(t *testing.T) {
+	ctx := t.Context()
+
+	tun, err := NewLocalTunnel(ctx, LocalTunnelOptions{
+		BasePort: 18500,
+		DialFunc: func(ctx context.Context) (io.ReadWriteCloser, error) {
+			return nil, fmt.Errorf("workspace gone")
+		},
+		HealthCheckInterval: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTunnel: %v", err)
+	}
+	defer func() { _ = tun.Close() }()
+
+	// The health check should shut down the tunnel after 3 failures
+	// 3 * 50ms = 150ms, give generous timeout
+	deadline := time.After(2 * time.Second)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("tunnel did not shut down after health check failures")
+		case <-ticker.C:
+			_, err := net.DialTimeout("tcp", tun.Addr(), 50*time.Millisecond)
+			if err != nil {
+				return // tunnel shut down - test passes
+			}
+		}
+	}
+}

--- a/pkg/tunnel/local_listener_test.go
+++ b/pkg/tunnel/local_listener_test.go
@@ -216,10 +216,11 @@ func TestLocalTunnel_HealthCheckShutdown(t *testing.T) {
 		case <-deadline:
 			t.Fatal("tunnel did not shut down after health check failures")
 		case <-ticker.C:
-			_, err := net.DialTimeout("tcp", tun.Addr(), 50*time.Millisecond)
+			conn, err := net.DialTimeout("tcp", tun.Addr(), 50*time.Millisecond)
 			if err != nil {
 				return // tunnel shut down - test passes
 			}
+			_ = conn.Close()
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- **Process tracking**: `cli.ts` now returns `ChildProcess` from `runStreaming` and tracks all active children in a `Set`, with a `killAll()` method for app shutdown
- **Tunnel dedup**: `ipc.ts` maintains a `Map<workspaceId, ChildProcess>` — kills existing tunnel before starting a new one, and kills tunnel on workspace stop/delete
- **Disk log cap**: Stops writing to disk logs after the success envelope is detected (prevents unbounded growth from long-lived tunnel output)
- **App quit cleanup**: `index.ts` calls `cli.killAll()` in the `before-quit` handler to SIGTERM all streaming children
- **Semaphore headroom**: Increased `MAX_CONCURRENT` from 10 to 50 to prevent deadlock when many tunnels are active
- **Subprocess safety**: Added `cmd.WaitDelay = 5s` in `dial.go` to prevent goroutine hangs if subprocess doesn't terminate
- **Health check**: `local_listener.go` periodically probes the dial function and self-terminates after 3 consecutive failures (30s interval, configurable for tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic tunnel health monitoring that periodically checks connection status, detects failures, and initiates recovery without user intervention.

* **Performance Improvements**
  * Increased CLI task concurrency limit from 10 to 50 for significantly faster command execution and workspace operations.

* **Reliability**
  * Enhanced process lifecycle management during application shutdown and workspace operations to ensure complete resource cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->