### PR TITLE
fix(desktop): detect success JSON envelope in workspace start toast

### DIFF
--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -162,7 +162,8 @@ onMount(async () => {
         }
         if (progress.done) {
           operationRunning = false
-          const success = stripAnsi(progress.message).includes("Exit code: 0")
+          const msg = stripAnsi(progress.message)
+          const success = msg.includes("Exit code: 0") || msg.includes('"outcome":"success"')
           if (success) {
             toasts.success(`${operationLabel} ${id} succeeded`)
           } else {


### PR DESCRIPTION
## Summary

- Fix false "Start failed" toast when starting a workspace after disabling SSH tunnel mode
- WorkspaceDetailPage now checks for both `"Exit code: 0"` and `"outcome":"success"` JSON envelope to determine success, matching the logic already in CreateWorkspaceSheet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved success detection for workspace command operations, ensuring more accurate status notifications regardless of the success format used by different commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->