### PR TITLE
refactor(desktop): extract isCommandSuccess helper with null guard

### DIFF
--- a/desktop/src/renderer/src/lib/components/workspace/CreateWorkspaceSheet.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/CreateWorkspaceSheet.svelte
@@ -19,7 +19,7 @@ import { providers } from "$lib/stores/providers.js"
 import { workspaces } from "$lib/stores/workspaces.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
-import { stripAnsi } from "$lib/utils/log-parser.js"
+import { isCommandSuccess, stripAnsi } from "$lib/utils/log-parser.js"
 import type { UnlistenFn } from "$lib/ipc/types.js"
 
 let {
@@ -193,8 +193,7 @@ function handleProgress(progress: CommandProgress, wsId: string | undefined) {
   }
   if (progress.done) {
     submitting = false
-    const msg = stripAnsi(progress.message)
-    if (msg.includes("Exit code: 0") || msg.includes('"outcome":"success"')) {
+    if (isCommandSuccess(progress.message)) {
       createdId = wsId ?? null
       toasts.success(`Workspace ${wsId ?? "created"} is ready`)
       requestAnimationFrame(() => {

--- a/desktop/src/renderer/src/lib/utils/log-parser.ts
+++ b/desktop/src/renderer/src/lib/utils/log-parser.ts
@@ -7,6 +7,20 @@ export function stripAnsi(str: string): string {
   return str.replace(ANSI_RE, "").replace(BRACKET_RE, "")
 }
 
+export function isCommandSuccess(message: string | undefined | null): boolean {
+  if (!message) return false
+  const { message: body } = parseLogLine(message)
+  if (body.startsWith("{")) {
+    try {
+      const envelope = JSON.parse(body)
+      if (envelope.outcome === "success") return true
+    } catch {
+      // not valid JSON, fall through
+    }
+  }
+  return body === "Exit code: 0"
+}
+
 export interface ParsedLogLine {
   time: string
   level: "info" | "warn" | "fatal" | "debug" | "error" | ""

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -52,7 +52,7 @@ import { extractErrorMessage } from "$lib/utils/error.js"
 import type { LogEntry } from "$lib/types/index.js"
 import type { UnlistenFn } from "$lib/ipc/types.js"
 import { formatTimestamp } from "$lib/utils/time.js"
-import { stripAnsi } from "$lib/utils/log-parser.js"
+import { isCommandSuccess, stripAnsi } from "$lib/utils/log-parser.js"
 import { Skeleton } from "$lib/components/ui/skeleton/index.js"
 
 let { params = {} }: { params?: Record<string, string> } = $props()
@@ -162,8 +162,7 @@ onMount(async () => {
         }
         if (progress.done) {
           operationRunning = false
-          const msg = stripAnsi(progress.message)
-          const success = msg.includes("Exit code: 0") || msg.includes('"outcome":"success"')
+          const success = isCommandSuccess(progress.message)
           if (success) {
             toasts.success(`${operationLabel} ${id} succeeded`)
           } else {


### PR DESCRIPTION
## Summary

- Address PR #412 review feedback: add null guard before `stripAnsi` and extract shared helper
- New `isCommandSuccess()` in `log-parser.ts` handles null/undefined messages and centralizes success detection
- Both `WorkspaceDetailPage` and `CreateWorkspaceSheet` now use the shared helper