### PR TITLE
feat(desktop): route to setup flow when provider has required options

### DIFF
--- a/desktop/src/renderer/src/pages/ProviderAddPage.svelte
+++ b/desktop/src/renderer/src/pages/ProviderAddPage.svelte
@@ -6,7 +6,7 @@ import { Input } from "$lib/components/ui/input/index.js"
 import { Label } from "$lib/components/ui/label/index.js"
 import ProviderIcon from "$lib/components/provider/ProviderIcon.svelte"
 import { Spinner } from "$lib/components/ui/spinner/index.js"
-import { providerAdd, providerInit, providerList } from "$lib/ipc/commands.js"
+import { providerAdd, providerInit, providerList, providerOptions } from "$lib/ipc/commands.js"
 import { providers } from "$lib/stores/providers.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
@@ -79,11 +79,24 @@ async function doAdd(name: string, source?: string) {
     return
   }
 
-  // Switch to init phase — show 'Initializing...' on the card
+  // Check if provider has required options that need user input
   initializingPreset = addingPreset
   addingPreset = null
 
   try {
+    const options = await providerOptions(name)
+    const hasRequired = Object.values(options).some(
+      (opt) => opt.required && !opt.value,
+    )
+
+    if (hasRequired) {
+      const updated = await providerList()
+      providers.set(updated)
+      toasts.info(`Configure required options for ${name}`)
+      goto(`/providers?setup=${encodeURIComponent(name)}`)
+      return
+    }
+
     await providerInit(name)
     const updated = await providerList()
     providers.set(updated)
@@ -96,7 +109,7 @@ async function doAdd(name: string, source?: string) {
     toasts.error(
       `Provider added but initialization failed: ${extractErrorMessage(msg)}`,
     )
-    goto("/providers")
+    goto(`/providers?setup=${encodeURIComponent(name)}`)
   } finally {
     submitting = false
     initializingPreset = null


### PR DESCRIPTION
## Summary

- After adding a provider, checks if it has unfilled required options before attempting auto-init
- If required options exist (e.g., SSH's HOST field), redirects to `/providers?setup=<name>` which opens the existing ProviderSheet in setup mode
- Setup sheet handles: required field highlighting, validation, saving options, and initialization via `providerUse()`
- On unexpected init failures, also redirects to setup flow instead of showing a dead-end error toast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved provider configuration validation to ensure all required options are set before initialization
  * Enhanced error handling that guides users back to the provider setup page when initialization fails

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->