### PR TITLE
fix(config): use ~/.devsy on macOS to avoid spaces in paths

### DIFF
--- a/pkg/config/pathmanager_darwin.go
+++ b/pkg/config/pathmanager_darwin.go
@@ -25,7 +25,7 @@ func (d *darwinPathManager) ConfigDir() (string, error) {
 		return "", fmt.Errorf("config dir: %w", err)
 	}
 
-	return ensureDir(filepath.Join(home, "Library", "Application Support", RepoName))
+	return ensureDir(filepath.Join(home, "."+RepoName))
 }
 
 func (d *darwinPathManager) DataDir() (string, error) {
@@ -34,7 +34,7 @@ func (d *darwinPathManager) DataDir() (string, error) {
 		return "", fmt.Errorf("data dir: %w", err)
 	}
 
-	return ensureDir(filepath.Join(home, "Library", "Application Support", RepoName))
+	return ensureDir(filepath.Join(home, "."+RepoName))
 }
 
 func (d *darwinPathManager) CacheDir() (string, error) {
@@ -43,7 +43,7 @@ func (d *darwinPathManager) CacheDir() (string, error) {
 		return "", fmt.Errorf("cache dir: %w", err)
 	}
 
-	return ensureDir(filepath.Join(home, "Library", "Caches", RepoName))
+	return ensureDir(filepath.Join(home, ".cache", RepoName))
 }
 
 func (d *darwinPathManager) StateDir() (string, error) {
@@ -52,7 +52,7 @@ func (d *darwinPathManager) StateDir() (string, error) {
 		return "", fmt.Errorf("state dir: %w", err)
 	}
 
-	return ensureDir(filepath.Join(home, "Library", "Application Support", RepoName, "state"))
+	return ensureDir(filepath.Join(home, "."+RepoName, "state"))
 }
 
 func (d *darwinPathManager) RuntimeDir() (string, error) {

--- a/pkg/config/pathmanager_linux.go
+++ b/pkg/config/pathmanager_linux.go
@@ -20,36 +20,24 @@ func newPlatformPathManager() PathManager {
 }
 
 func (l *linuxPathManager) ConfigDir() (string, error) {
-	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
-		return ensureDir(filepath.Join(dir, RepoName))
-	}
-
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("config dir: %w", err)
 	}
 
-	return ensureDir(filepath.Join(home, ".config", RepoName))
+	return ensureDir(filepath.Join(home, "."+RepoName))
 }
 
 func (l *linuxPathManager) DataDir() (string, error) {
-	if dir := os.Getenv("XDG_DATA_HOME"); dir != "" {
-		return ensureDir(filepath.Join(dir, RepoName))
-	}
-
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("data dir: %w", err)
 	}
 
-	return ensureDir(filepath.Join(home, ".local", "share", RepoName))
+	return ensureDir(filepath.Join(home, "."+RepoName))
 }
 
 func (l *linuxPathManager) CacheDir() (string, error) {
-	if dir := os.Getenv("XDG_CACHE_HOME"); dir != "" {
-		return ensureDir(filepath.Join(dir, RepoName))
-	}
-
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cache dir: %w", err)
@@ -59,22 +47,14 @@ func (l *linuxPathManager) CacheDir() (string, error) {
 }
 
 func (l *linuxPathManager) StateDir() (string, error) {
-	if dir := os.Getenv("XDG_STATE_HOME"); dir != "" {
-		return ensureDir(filepath.Join(dir, RepoName))
-	}
-
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("state dir: %w", err)
 	}
 
-	return ensureDir(filepath.Join(home, ".local", "state", RepoName))
+	return ensureDir(filepath.Join(home, "."+RepoName, "state"))
 }
 
 func (l *linuxPathManager) RuntimeDir() (string, error) {
-	if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
-		return ensureDir(filepath.Join(dir, RepoName))
-	}
-
 	return ensureDir(filepath.Join(os.TempDir(), fmt.Sprintf("%s-%d", RepoName, os.Getuid())))
 }

--- a/pkg/config/pathmanager_linux_test.go
+++ b/pkg/config/pathmanager_linux_test.go
@@ -27,16 +27,11 @@ func skipIfNotLinux(t *testing.T) {
 	}
 }
 
-func TestLinuxXDGDefaults(t *testing.T) {
+func TestLinuxDefaults(t *testing.T) {
 	skipIfNotLinux(t)
 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", "")
-	t.Setenv("XDG_DATA_HOME", "")
-	t.Setenv("XDG_CACHE_HOME", "")
-	t.Setenv("XDG_STATE_HOME", "")
-	t.Setenv("XDG_RUNTIME_DIR", "")
 
 	pm := newTestLinuxPM()
 	uid := os.Getuid()
@@ -50,53 +45,11 @@ func TestLinuxXDGDefaults(t *testing.T) {
 		fn   func() (string, error)
 		want string
 	}{
-		{"ConfigDir", pm.ConfigDir, filepath.Join(home, ".config", RepoName)},
-		{"DataDir", pm.DataDir, filepath.Join(home, ".local", "share", RepoName)},
+		{"ConfigDir", pm.ConfigDir, filepath.Join(home, "."+RepoName)},
+		{"DataDir", pm.DataDir, filepath.Join(home, "."+RepoName)},
 		{"CacheDir", pm.CacheDir, filepath.Join(home, ".cache", RepoName)},
-		{"StateDir", pm.StateDir, filepath.Join(home, ".local", "state", RepoName)},
+		{"StateDir", pm.StateDir, filepath.Join(home, "."+RepoName, "state")},
 		{"RuntimeDir", pm.RuntimeDir, wantRuntime},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.fn()
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got != tt.want {
-				t.Errorf("got %q, want %q", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestLinuxXDGEnvOverrides(t *testing.T) {
-	skipIfNotLinux(t)
-
-	customConfig := t.TempDir()
-	customData := t.TempDir()
-	customCache := t.TempDir()
-	customState := t.TempDir()
-	customRuntime := t.TempDir()
-
-	t.Setenv("XDG_CONFIG_HOME", customConfig)
-	t.Setenv("XDG_DATA_HOME", customData)
-	t.Setenv("XDG_CACHE_HOME", customCache)
-	t.Setenv("XDG_STATE_HOME", customState)
-	t.Setenv("XDG_RUNTIME_DIR", customRuntime)
-
-	pm := newTestLinuxPM()
-
-	tests := []struct {
-		name string
-		fn   func() (string, error)
-		want string
-	}{
-		{"ConfigDir", pm.ConfigDir, filepath.Join(customConfig, RepoName)},
-		{"DataDir", pm.DataDir, filepath.Join(customData, RepoName)},
-		{"CacheDir", pm.CacheDir, filepath.Join(customCache, RepoName)},
-		{"StateDir", pm.StateDir, filepath.Join(customState, RepoName)},
-		{"RuntimeDir", pm.RuntimeDir, filepath.Join(customRuntime, RepoName)},
 	}
 
 	for _, tt := range tests {
@@ -117,7 +70,6 @@ func TestConfigFilePathDefault(t *testing.T) {
 
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv(EnvConfig, "")
 
 	pm := newTestLinuxPM()
@@ -127,7 +79,7 @@ func TestConfigFilePathDefault(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	want := filepath.Join(home, ".config", RepoName, ConfigFile)
+	want := filepath.Join(home, "."+RepoName, ConfigFile)
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -151,12 +103,12 @@ func TestConfigFilePathDEVSYCONFIGOverride(t *testing.T) {
 func TestContextDataSubPaths(t *testing.T) {
 	skipIfNotLinux(t)
 
-	dataDir := t.TempDir()
-	t.Setenv("XDG_DATA_HOME", dataDir)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
 	pm := newTestLinuxPM()
 	ctx := "myctx"
-	base := filepath.Join(dataDir, RepoName, "contexts", ctx)
+	base := filepath.Join(home, "."+RepoName, "contexts", ctx)
 
 	tests := []struct {
 		name string
@@ -207,12 +159,12 @@ func TestContextDataSubPaths(t *testing.T) {
 func TestProviderAndProInstanceSubPaths(t *testing.T) {
 	skipIfNotLinux(t)
 
-	dataDir := t.TempDir()
-	t.Setenv("XDG_DATA_HOME", dataDir)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
 	pm := newTestLinuxPM()
 	ctx := "myctx"
-	base := filepath.Join(dataDir, RepoName, "contexts", ctx)
+	base := filepath.Join(home, "."+RepoName, "contexts", ctx)
 
 	tests := []struct {
 		name string
@@ -267,11 +219,11 @@ func TestProviderAndProInstanceSubPaths(t *testing.T) {
 func TestCacheSubPaths(t *testing.T) {
 	skipIfNotLinux(t)
 
-	cacheDir := t.TempDir()
-	t.Setenv("XDG_CACHE_HOME", cacheDir)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
 	pm := newTestLinuxPM()
-	base := filepath.Join(cacheDir, RepoName)
+	base := filepath.Join(home, ".cache", RepoName)
 
 	tests := []struct {
 		name string
@@ -305,11 +257,9 @@ func TestCacheSubPaths(t *testing.T) {
 func TestRuntimeSubPaths(t *testing.T) {
 	skipIfNotLinux(t)
 
-	runtimeDir := t.TempDir()
-	t.Setenv("XDG_RUNTIME_DIR", runtimeDir)
-
 	pm := newTestLinuxPM()
-	base := filepath.Join(runtimeDir, RepoName)
+	uid := os.Getuid()
+	base := filepath.Join(os.TempDir(), fmt.Sprintf("%s-%d", RepoName, uid))
 
 	tests := []struct {
 		name string
@@ -356,8 +306,8 @@ func TestRuntimeSubPaths(t *testing.T) {
 func TestStateSubPaths(t *testing.T) {
 	skipIfNotLinux(t)
 
-	stateDir := t.TempDir()
-	t.Setenv("XDG_STATE_HOME", stateDir)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 
 	pm := newTestLinuxPM()
 
@@ -366,7 +316,7 @@ func TestStateSubPaths(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	want := filepath.Join(stateDir, RepoName, "logs")
+	want := filepath.Join(home, "."+RepoName, "state", "logs")
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

- Change macOS data/config paths from `~/Library/Application Support/devsy` to `~/.devsy`
- Fixes provider init scripts that use `$PROVIDER_FOLDER` without quotes in shell commands, which caused word-splitting on the space in "Application Support"
- Error was: `stat /Users/.../Library/Application: no such file or directory` followed by `init: exit status 127`
- Cache moves to `~/.cache/devsy` (also space-free)
- Consistent with how many CLI tools behave on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * On macOS, configuration, cache, and state files are now stored in hidden directories within the user's home folder (e.g., `~/.<RepoName>`) instead of the ~/Library directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->