### PR TITLE
fix(provider): persist options without running init

### DIFF
--- a/cmd/provider/set_options.go
+++ b/cmd/provider/set_options.go
@@ -17,7 +17,8 @@ import (
 type SetOptionsCmd struct {
 	*flags.GlobalFlags
 
-	Dry bool
+	Dry      bool
+	SkipInit bool
 
 	Reconfigure   bool
 	SingleMachine bool
@@ -55,6 +56,8 @@ func NewSetOptionsCmd(f *flags.GlobalFlags) *cobra.Command {
 		StringArrayVarP(&cmd.Options, "option", "o", []string{}, "Provider option in the form KEY=VALUE")
 	setOptionsCmd.Flags().
 		BoolVar(&cmd.Dry, "dry", false, "Dry will not persist the options to file and instead return the new filled options")
+	setOptionsCmd.Flags().
+		BoolVar(&cmd.SkipInit, "skip-init", false, "If true will skip running the provider init command")
 	return setOptionsCmd
 }
 
@@ -86,7 +89,7 @@ func (cmd *SetOptionsCmd) Run(ctx context.Context, args []string) error {
 		UserOptions:    cmd.Options,
 		Reconfigure:    cmd.Reconfigure,
 		SkipRequired:   cmd.Dry,
-		SkipInit:       cmd.Dry,
+		SkipInit:       cmd.Dry || cmd.SkipInit,
 		SkipSubOptions: false,
 		SingleMachine:  &cmd.SingleMachine,
 	})

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -126,7 +126,7 @@ export function registerIpcHandlers(deps: IpcDependencies): { tunnelProcesses: M
   ipcMain.handle(
     "provider_set_options",
     async (_event, args: { name: string; options: string[] }) => {
-      const cliArgs = ["provider", "set-options", args.name]
+      const cliArgs = ["provider", "set-options", args.name, "--skip-init"]
       for (const opt of args.options) {
         cliArgs.push("-o", opt)
       }

--- a/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
@@ -91,11 +91,9 @@ async function loadOptions() {
     const raw = await providerOptions(provider.name)
     options = raw as unknown as Record<string, ProviderOption>
 
-    const currentOpts = provider.options ?? {}
     for (const [key, opt] of Object.entries(options)) {
-      const currentVal = currentOpts[key]
-      if (currentVal?.value != null) {
-        optionValues[key] = String(currentVal.value)
+      if (opt.value != null) {
+        optionValues[key] = String(opt.value)
       } else if (opt.default != null) {
         optionValues[key] = String(opt.default)
       } else {
@@ -202,6 +200,8 @@ async function handleSaveOptions() {
       if (val !== "") values[key] = val
     }
     await providerSetOptions(provider.name, values)
+    const updated = await providerList()
+    providers.set(updated)
     initialValues = { ...optionValues }
     if (setup) {
       await providerUse(provider.name)


### PR DESCRIPTION
## Summary

- Add `--skip-init` flag to `provider set-options` CLI command so options can be saved without triggering provider init
- Desktop IPC handler passes `--skip-init` when saving options — init is handled separately by the setup flow
- Refresh providers store after saving so re-opening the sheet shows the correct values

Fixes the issue where saving SSH provider options would fail with "ssh: connect to host ... Undefined error: 0" and silently discard the values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--skip-init` flag to the provider set-options command, allowing configuration updates without provider re-initialization.

* **Bug Fixes**
  * Provider list now automatically refreshes after saving provider options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/417?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->