### PR TITLE
fix(desktop): restore sidebar logo size

### DIFF
--- a/desktop/src/renderer/src/lib/components/layout/Sidebar.svelte
+++ b/desktop/src/renderer/src/lib/components/layout/Sidebar.svelte
@@ -107,7 +107,9 @@ function isActive(href: string): boolean {
     <Sidebar.Menu>
       <Sidebar.MenuItem>
         <Sidebar.MenuButton size="lg" class="pointer-events-none">
-          <AppLogo class="size-8 rounded-lg" />
+          <div class="flex aspect-square size-8 items-center justify-center overflow-hidden rounded-lg">
+            <AppLogo class="size-full" />
+          </div>
           <div class="grid flex-1 text-left text-sm leading-tight">
             <span class="truncate font-semibold">Devsy</span>
             <span class="truncate text-xs text-muted-foreground">Desktop</span>


### PR DESCRIPTION
## Summary
- After #429, the new `AppLogo` SVG was being shrunk to 16px because the sidebar `MenuButton` variant includes `[&>svg]:size-4`, which targets direct child `<svg>` elements. The previous `Box` icon was wrapped in a `<div>`, shielding it from that rule.
- Wrap `AppLogo` in a `size-8` div so the badge fills the full 32px slot again, restoring the pre-#429 footprint. The branding SVG itself is unchanged.