### PR TITLE
fix(desktop): restore copy logs button in workspace wizard

### DIFF
--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -26,7 +26,7 @@ import { providers } from "$lib/stores/providers.js"
 import { workspaces } from "$lib/stores/workspaces.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
-import { isCommandSuccess } from "$lib/utils/log-parser.js"
+import { isCommandSuccess, stripAnsi } from "$lib/utils/log-parser.js"
 import type { UnlistenFn } from "$lib/ipc/types.js"
 
 type Step = "provider" | "source" | "ide" | "review" | "launch"
@@ -679,9 +679,28 @@ function selectTemplate(t: { name: string; source: string }) {
           {/if}
 
           {#if outputLines.length > 0}
-            <div class="max-h-80 overflow-auto rounded-md border">
-              <LogTable lines={outputLines} />
-              <div bind:this={outputEl}></div>
+            <div class="space-y-2">
+              <div class="flex items-center justify-between">
+                <h3 class="text-xs font-medium text-muted-foreground uppercase tracking-wider">Output</h3>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onclick={async () => {
+                    try {
+                      await navigator.clipboard.writeText(outputLines.map(stripAnsi).join("\n"))
+                      toasts.success("Copied to clipboard")
+                    } catch {
+                      toasts.error("Failed to copy")
+                    }
+                  }}
+                >
+                  Copy
+                </Button>
+              </div>
+              <div class="max-h-80 overflow-auto rounded-md border">
+                <LogTable lines={outputLines} />
+                <div bind:this={outputEl}></div>
+              </div>
             </div>
           {:else if launchRunning}
             <div class="flex items-center justify-center py-8">


### PR DESCRIPTION
## Summary
- Bring back the Copy button above the streamed creation output on the wizard's launch step (dropped in #432 when `CreateWorkspaceSheet` was replaced by `WorkspaceWizard`).
- Copies log lines with ANSI codes stripped via the existing `stripAnsi` helper and surfaces the same success/error toasts as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Copy" button in the workspace wizard output section, allowing users to copy logs to clipboard with success/failure notifications for confirmation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->