### PR TITLE
feat(cmd): consolidate IDE launch flags into --ide-launch=auto|headless|skip

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -261,6 +261,10 @@ func (cmd *BuildCmd) build(
 		}
 	}
 	user := devcconfig.GetRemoteUser(result)
-	_ = devcconfig.WriteResultJSON(os.Stdout, containerID, user, workdir, nil)
+	_ = devcconfig.WriteResultJSON(os.Stdout, devcconfig.ResultEnvelope{
+		ContainerID:           containerID,
+		RemoteUser:            user,
+		RemoteWorkspaceFolder: workdir,
+	})
 	return nil
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -196,7 +196,11 @@ func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	if emitJSON {
-		_ = devcconfig.WriteResultJSON(os.Stderr, containerDetails.ID, user, workdir, nil)
+		_ = devcconfig.WriteResultJSON(os.Stderr, devcconfig.ResultEnvelope{
+			ContainerID:           containerDetails.ID,
+			RemoteUser:            user,
+			RemoteWorkspaceFolder: workdir,
+		})
 	}
 	return nil
 }
@@ -255,7 +259,10 @@ func (cmd *ExecCmd) runWithContainerID(ctx context.Context, args []string) error
 	}
 
 	if emitJSON {
-		_ = devcconfig.WriteResultJSON(os.Stderr, containerDetails.ID, "", workdir, nil)
+		_ = devcconfig.WriteResultJSON(os.Stderr, devcconfig.ResultEnvelope{
+			ContainerID:           containerDetails.ID,
+			RemoteWorkspaceFolder: workdir,
+		})
 	}
 	return nil
 }

--- a/cmd/runusercommands.go
+++ b/cmd/runusercommands.go
@@ -161,7 +161,11 @@ func (cmd *RunUserCommandsCmd) Run(ctx context.Context) error {
 
 	user := devcconfig.GetRemoteUser(result)
 	log.Infof("lifecycle commands completed for container %s", params.containerID)
-	_ = devcconfig.WriteResultJSON(os.Stderr, params.containerID, user, params.workdir, nil)
+	_ = devcconfig.WriteResultJSON(os.Stderr, devcconfig.ResultEnvelope{
+		ContainerID:           params.containerID,
+		RemoteUser:            user,
+		RemoteWorkspaceFolder: params.workdir,
+	})
 	return nil
 }
 
@@ -226,7 +230,11 @@ func (cmd *RunUserCommandsCmd) runWithContainerID(ctx context.Context) error {
 
 	user := devcconfig.GetRemoteUser(result)
 	log.Infof("lifecycle commands completed for container %s", params.containerID)
-	_ = devcconfig.WriteResultJSON(os.Stderr, params.containerID, user, params.workdir, nil)
+	_ = devcconfig.WriteResultJSON(os.Stderr, devcconfig.ResultEnvelope{
+		ContainerID:           params.containerID,
+		RemoteUser:            user,
+		RemoteWorkspaceFolder: params.workdir,
+	})
 	return nil
 }
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -124,7 +124,11 @@ func (cmd *SetUpCmd) Run(ctx context.Context) error {
 	user := devcconfig.GetRemoteUser(result)
 	log.Infof("set-up completed for container %s", containerDetails.ID)
 	if emitJSON {
-		_ = devcconfig.WriteResultJSON(os.Stderr, containerDetails.ID, user, workdir, nil)
+		_ = devcconfig.WriteResultJSON(os.Stderr, devcconfig.ResultEnvelope{
+			ContainerID:           containerDetails.ID,
+			RemoteUser:            user,
+			RemoteWorkspaceFolder: workdir,
+		})
 	}
 	return nil
 }

--- a/cmd/up/configure.go
+++ b/cmd/up/configure.go
@@ -62,15 +62,16 @@ func (cmd *UpCmd) configureWorkspace(
 	return nil
 }
 
-// openIDE opens the configured IDE.
+// openIDE opens the configured IDE and returns the IDE URL (empty for desktop
+// IDEs whose URLs are OS-handler URIs, or when launch is skipped).
 func (cmd *UpCmd) openIDE(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	client client2.BaseWorkspaceClient,
 	wctx *workspaceContext,
-) error {
-	if !cmd.OpenIDE {
-		return nil
+) (string, error) {
+	if cmd.IDELaunch == opener.LaunchSkip {
+		return "", nil
 	}
 
 	ideConfig := client.WorkspaceConfig().IDE
@@ -83,6 +84,7 @@ func (cmd *UpCmd) openIDE(
 		User:               wctx.user,
 		Result:             wctx.result,
 		TunnelMode:         wctx.tunnelPort > 0,
+		Launch:             cmd.IDELaunch,
 	})
 }
 

--- a/cmd/up/up.go
+++ b/cmd/up/up.go
@@ -34,7 +34,7 @@ type UpCmd struct {
 	ConfigureSSH       bool
 	GPGAgentForwarding bool
 	SSHTunnelMode      bool
-	OpenIDE            bool
+	IDELaunch          opener.IDELaunchMode
 	Reconfigure        bool
 
 	SSHConfigPath      string
@@ -116,7 +116,8 @@ func (cmd *UpCmd) Run( //nolint:cyclop
 		log.Warnf("Failed to reconfigure SSH with tunnel port: %v", err)
 	}
 
-	if err := cmd.openIDE(ctx, devsyConfig, client, wctx); err != nil {
+	ideURL, err := cmd.openIDE(ctx, devsyConfig, client, wctx)
+	if err != nil {
 		if emitJSON {
 			_ = config2.WriteErrorJSON(os.Stdout, err.Error())
 		}
@@ -132,7 +133,13 @@ func (cmd *UpCmd) Run( //nolint:cyclop
 			}
 			warnings = wctx.result.HostWarnings
 		}
-		_ = config2.WriteResultJSON(os.Stdout, containerID, wctx.user, wctx.workdir, warnings)
+		_ = config2.WriteResultJSON(os.Stdout, config2.ResultEnvelope{
+			ContainerID:           containerID,
+			RemoteUser:            wctx.user,
+			RemoteWorkspaceFolder: wctx.workdir,
+			URL:                   ideURL,
+			Warnings:              warnings,
+		})
 	}
 
 	if wctx.tunnelPort > 0 {

--- a/cmd/up/up_flags.go
+++ b/cmd/up/up_flags.go
@@ -1,6 +1,9 @@
 package up
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/devsy-org/devsy/pkg/ide/opener"
+	"github.com/spf13/cobra"
+)
 
 func (cmd *UpCmd) registerFlags(upCmd *cobra.Command) {
 	cmd.registerSSHFlags(upCmd)
@@ -137,9 +140,12 @@ func (cmd *UpCmd) registerIDEFlags(upCmd *cobra.Command) {
 		StringVar(&cmd.IDE, "ide", "", "The IDE to open the workspace in. If empty will use vscode locally or in browser")
 	upCmd.Flags().
 		StringArrayVar(&cmd.IDEOptions, "ide-option", []string{}, "IDE option in the form KEY=VALUE")
-	upCmd.Flags().
-		BoolVar(&cmd.OpenIDE, "open-ide", true,
-			"If this is false and an IDE is configured, Devsy will only install the IDE server backend, but not open it")
+	cmd.IDELaunch = opener.LaunchAuto
+	upCmd.Flags().Var(
+		&cmd.IDELaunch,
+		"ide-launch",
+		"How to launch the IDE: auto opens it (default), headless skips the host browser/app, skip does not launch.",
+	)
 	upCmd.Flags().
 		StringVar(&cmd.WorkspaceFolder, "workspace-folder", "",
 			"Override the folder path opened in the IDE (absolute path inside the container)")

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -329,6 +329,7 @@ export function registerIpcHandlers(deps: IpcDependencies): { tunnelProcesses: M
         workspaceId?: string
         provider?: string
         ide?: string
+        ideLaunch?: "auto" | "headless" | "skip"
         debug?: boolean
         workspaceFolder?: string
       },
@@ -338,6 +339,7 @@ export function registerIpcHandlers(deps: IpcDependencies): { tunnelProcesses: M
       if (args.workspaceId) cliArgs.push("--id", args.workspaceId)
       if (args.provider) cliArgs.push("--provider", args.provider)
       if (args.ide) cliArgs.push("--ide", args.ide)
+      if (args.ideLaunch) cliArgs.push("--ide-launch", args.ideLaunch)
       if (args.debug) cliArgs.push("--debug")
       if (args.workspaceFolder) cliArgs.push("--workspace-folder", args.workspaceFolder)
 

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -293,6 +293,7 @@ async function handleLaunch() {
       workspaceId,
       provider: selectedProvider || undefined,
       ide: selectedIde && selectedIde !== "none" ? selectedIde : undefined,
+      ideLaunch: "auto",
       workspaceFolder: workspaceFolder.trim() || undefined,
       debug: true,
     })

--- a/desktop/src/renderer/src/lib/ipc/commands.test.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.test.ts
@@ -45,6 +45,20 @@ describe("IPC commands", () => {
       expect(result).toBe("cmd-123")
     })
 
+    it("workspaceUp forwards ideLaunch", async () => {
+      mockInvoke.mockResolvedValue("cmd-789")
+      await workspaceUp({
+        source: "github.com/org/repo",
+        ide: "openvscode",
+        ideLaunch: "headless",
+      })
+      expect(mockInvoke).toHaveBeenCalledWith("workspace_up", {
+        source: "github.com/org/repo",
+        ide: "openvscode",
+        ideLaunch: "headless",
+      })
+    })
+
     it("workspaceUp works with minimal parameters", async () => {
       mockInvoke.mockResolvedValue("cmd-456")
       await workspaceUp({ source: "my-repo" })

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -21,6 +21,7 @@ export async function workspaceUp(params: {
   workspaceId?: string
   provider?: string
   ide?: string
+  ideLaunch?: "auto" | "headless" | "skip"
   debug?: boolean
   workspaceFolder?: string
 }): Promise<string> {

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -319,7 +319,13 @@ async function handleOpenIde() {
   const folder = customFolder || undefined
   startStreamingOp("Open IDE")
   try {
-    commandId = await workspaceUp({ source: id, ide, debug: isDebug(), workspaceFolder: folder })
+    commandId = await workspaceUp({
+      source: id,
+      ide,
+      ideLaunch: "auto",
+      debug: isDebug(),
+      workspaceFolder: folder,
+    })
   } catch (err) {
     operationRunning = false
     toasts.error(`Failed to open IDE: ${extractErrorMessage(err)}`)

--- a/e2e/tests/ide/browser_returns.go
+++ b/e2e/tests/ide/browser_returns.go
@@ -38,13 +38,13 @@ func setupBrowserIDE(ctx context.Context, initialDir string) (*framework.Framewo
 	return f, tempDir
 }
 
-// upBrowserIDE runs `devsy up --ide=openvscode --ide-option OPEN=false` against
+// upBrowserIDE runs `devsy up --ide=openvscode --ide-launch=headless` against
 // tempDir, optionally with extra args (e.g. "--recreate"). It returns the
 // resolved workspace's tunnel state, which is asserted non-nil.
 func upBrowserIDE(
 	ctx context.Context, f *framework.Framework, tempDir string, extraArgs ...string,
 ) *opener.TunnelState {
-	args := []string{"--ide=openvscode", "--ide-option", "OPEN=false"}
+	args := []string{"--ide=openvscode", "--ide-launch=headless"}
 	args = append(args, extraArgs...)
 	args = append(args, tempDir)
 	err := f.DevsyUpWithIDE(ctx, args...)
@@ -82,10 +82,10 @@ var _ = ginkgo.Describe(
 			func(ctx context.Context) {
 				f, tempDir := setupBrowserIDE(ctx, initialDir)
 
-				// Run up with a browser IDE. --ide-option OPEN=false suppresses the
+				// Run up with a browser IDE. --ide-launch=headless suppresses the
 				// host browser launch (no display available in CI) but still runs
 				// openIDE → startDetachedBrowserTunnel → writes tunnel.json.
-				// --open-ide=false would skip openIDE entirely, which is not what
+				// --ide-launch=skip would skip openIDE entirely, which is not what
 				// the test exercises. With the old blocking behavior this would
 				// still hang past SpecTimeout; with the new behavior the CLI
 				// returns.

--- a/e2e/tests/ide/ide.go
+++ b/e2e/tests/ide/ide.go
@@ -34,17 +34,17 @@ var _ = ginkgo.Describe("devsy ide test suite", ginkgo.Label("ide"), ginkgo.Orde
 				framework.ExpectNoError(err)
 			})
 
-			err = f.DevsyUpWithIDE(ctx, tempDir, "--open-ide=false", "--ide=vscode")
+			err = f.DevsyUpWithIDE(ctx, tempDir, "--ide-launch=skip", "--ide=vscode")
 			framework.ExpectNoError(err)
 
-			err = f.DevsyUpWithIDE(ctx, tempDir, "--open-ide=false", "--ide=openvscode")
+			err = f.DevsyUpWithIDE(ctx, tempDir, "--ide-launch=skip", "--ide=openvscode")
 			framework.ExpectNoError(err)
 
-			err = f.DevsyUpWithIDE(ctx, tempDir, "--open-ide=false", "--ide=jupyternotebook")
+			err = f.DevsyUpWithIDE(ctx, tempDir, "--ide-launch=skip", "--ide=jupyternotebook")
 			framework.ExpectNoError(err)
 
 			// TODO: Fix broken IDE
-			// err = f.DevsyUpWithIDE(ctx, tempDir, "--open-ide=false", "--ide=fleet")
+			// err = f.DevsyUpWithIDE(ctx, tempDir, "--ide-launch=skip", "--ide=fleet")
 			// framework.ExpectNoError(err)
 
 			// check if ssh works

--- a/e2e/tests/up/up_behaviors.go
+++ b/e2e/tests/up/up_behaviors.go
@@ -170,14 +170,14 @@ var _ = ginkgo.Describe("up command behaviors", ginkgo.Label("up-behaviors"), fu
 			)
 			framework.ExpectNoError(err)
 
-			// --ide-option OPEN=false keeps the openIDE pipeline active (so the
+			// --ide-launch=headless keeps the openIDE pipeline active (so the
 			// success envelope ordering is exercised) but skips the host browser
 			// launch (no display available in CI).
 			stdout, _, err := dtc.f.DevsyUpStreamsRaw(
 				ctx,
 				tempDir,
 				"--ide=openvscode",
-				"--ide-option", "OPEN=false",
+				"--ide-launch=headless",
 				"--result-format", "json",
 			)
 			framework.ExpectNoError(err)

--- a/pkg/devcontainer/config/envelope.go
+++ b/pkg/devcontainer/config/envelope.go
@@ -11,6 +11,7 @@ type ResultEnvelope struct {
 	ContainerID           string   `json:"containerId"`
 	RemoteUser            string   `json:"remoteUser"`
 	RemoteWorkspaceFolder string   `json:"remoteWorkspaceFolder"`
+	URL                   string   `json:"url,omitempty"`
 	Warnings              []string `json:"warnings,omitempty"`
 }
 
@@ -19,15 +20,11 @@ type ErrorEnvelope struct {
 	Message string `json:"message"`
 }
 
-//nolint:revive
-func WriteResultJSON(w io.Writer, containerID, user, workdir string, warnings []string) error {
-	env := ResultEnvelope{
-		Outcome:               "success",
-		ContainerID:           containerID,
-		RemoteUser:            user,
-		RemoteWorkspaceFolder: workdir,
-		Warnings:              warnings,
-	}
+// WriteResultJSON serializes env as a success envelope to w. The caller
+// supplies the envelope fields; this function stamps Outcome="success" and
+// appends a trailing newline.
+func WriteResultJSON(w io.Writer, env ResultEnvelope) error {
+	env.Outcome = "success"
 	data, err := json.Marshal(env)
 	if err != nil {
 		return err

--- a/pkg/devcontainer/config/envelope_test.go
+++ b/pkg/devcontainer/config/envelope_test.go
@@ -13,6 +13,7 @@ func TestWriteResultJSON(t *testing.T) {
 		containerID string
 		user        string
 		workdir     string
+		url         string
 		warnings    []string
 	}{
 		{
@@ -53,12 +54,34 @@ func TestWriteResultJSON(t *testing.T) {
 				"memory: required 256gb (274877906944 bytes), available 17179869184 bytes",
 			},
 		},
+		{
+			name:        "with url",
+			containerID: "abc123",
+			user:        "vscode",
+			workdir:     "/workspaces/project",
+			url:         "http://localhost:8080/?folder=/workspaces/project",
+			warnings:    nil,
+		},
+		{
+			name:        "empty url omitted",
+			containerID: "abc123",
+			user:        "vscode",
+			workdir:     "/workspaces/project",
+			url:         "",
+			warnings:    nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			err := WriteResultJSON(&buf, tt.containerID, tt.user, tt.workdir, tt.warnings)
+			err := WriteResultJSON(&buf, ResultEnvelope{
+				ContainerID:           tt.containerID,
+				RemoteUser:            tt.user,
+				RemoteWorkspaceFolder: tt.workdir,
+				URL:                   tt.url,
+				Warnings:              tt.warnings,
+			})
 			if err != nil {
 				t.Fatalf("WriteResultJSON returned error: %v", err)
 			}
@@ -85,6 +108,15 @@ func TestWriteResultJSON(t *testing.T) {
 			if envelope.RemoteWorkspaceFolder != tt.workdir {
 				t.Errorf("remoteWorkspaceFolder = %q, want %q",
 					envelope.RemoteWorkspaceFolder, tt.workdir)
+			}
+			if envelope.URL != tt.url {
+				t.Errorf("url = %q, want %q", envelope.URL, tt.url)
+			}
+			if tt.url == "" && bytes.Contains(output, []byte(`"url"`)) {
+				t.Error("url field must be omitted when empty")
+			}
+			if tt.url != "" && !bytes.Contains(output, []byte(`"url"`)) {
+				t.Error("url field must be present when set")
 			}
 			if len(tt.warnings) == 0 {
 				if envelope.Warnings != nil {

--- a/pkg/ide/jupyter/jupyter.go
+++ b/pkg/ide/jupyter/jupyter.go
@@ -12,7 +12,6 @@ import (
 )
 
 const (
-	OpenOption        = "OPEN"
 	BindAddressOption = "BIND_ADDRESS"
 )
 
@@ -21,15 +20,6 @@ var Options = ide.Options{
 		Name:        BindAddressOption,
 		Description: "The address to bind the server to locally, e.g. 0.0.0.0:12345",
 		Default:     "",
-	},
-	OpenOption: {
-		Name:        OpenOption,
-		Description: "If Devsy should automatically open the browser",
-		Default:     "true",
-		Enum: []string{
-			"true",
-			"false",
-		},
 	},
 }
 

--- a/pkg/ide/opener/ide_launch_mode.go
+++ b/pkg/ide/opener/ide_launch_mode.go
@@ -1,0 +1,51 @@
+package opener
+
+import "fmt"
+
+// IDELaunchMode controls how the openIDE phase runs.
+//
+//   - LaunchAuto: full launch — start tunnel (for browser IDEs) and open
+//     the host browser/app.
+//   - LaunchHeadless: do not open the host browser/app. For browser IDEs
+//     (openvscode, jupyter, rstudio) the detached tunnel still spawns. For
+//     Fleet the workspace-side URL is logged so the user can open it
+//     manually. For other desktop IDEs (VSCode flavors, JetBrains, Zed) the
+//     openIDE phase only does the host launch, so headless is functionally
+//     equivalent to skip — backend install (where one exists) happens
+//     during workspace setup, not here.
+//   - LaunchSkip: short-circuit the openIDE phase entirely.
+type IDELaunchMode string
+
+const (
+	LaunchAuto     IDELaunchMode = "auto"
+	LaunchHeadless IDELaunchMode = "headless"
+	LaunchSkip     IDELaunchMode = "skip"
+)
+
+// String implements pflag.Value.
+func (m *IDELaunchMode) String() string {
+	if m == nil || *m == "" {
+		return string(LaunchAuto)
+	}
+	return string(*m)
+}
+
+// Set implements pflag.Value. Strict (case-sensitive) parse to match
+// the kubectl/docker convention; returns a descriptive error on bad input.
+func (m *IDELaunchMode) Set(v string) error {
+	switch IDELaunchMode(v) {
+	case LaunchAuto, LaunchHeadless, LaunchSkip:
+		*m = IDELaunchMode(v)
+		return nil
+	default:
+		return fmt.Errorf(
+			"invalid --ide-launch value %q (must be one of %s, %s, %s)",
+			v, LaunchAuto, LaunchHeadless, LaunchSkip,
+		)
+	}
+}
+
+// Type implements pflag.Value.
+func (m *IDELaunchMode) Type() string {
+	return "auto|headless|skip"
+}

--- a/pkg/ide/opener/ide_launch_mode_test.go
+++ b/pkg/ide/opener/ide_launch_mode_test.go
@@ -1,0 +1,69 @@
+package opener
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIDELaunchMode_Set_Valid(t *testing.T) {
+	tests := []struct {
+		input string
+		want  IDELaunchMode
+	}{
+		{"auto", LaunchAuto},
+		{"headless", LaunchHeadless},
+		{"skip", LaunchSkip},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			var m IDELaunchMode
+			if err := m.Set(tt.input); err != nil {
+				t.Fatalf("Set(%q) returned error: %v", tt.input, err)
+			}
+			if m != tt.want {
+				t.Errorf("after Set(%q), m = %q, want %q", tt.input, m, tt.want)
+			}
+			if got := m.String(); got != tt.input {
+				t.Errorf("String() = %q, want %q", got, tt.input)
+			}
+		})
+	}
+}
+
+func TestIDELaunchMode_Set_Invalid(t *testing.T) {
+	tests := []string{
+		"HEADLESS", // case-strict
+		"",
+		"yes",
+		"true",
+		"none",
+		"Auto",
+		"Skip",
+	}
+	for _, in := range tests {
+		t.Run(in, func(t *testing.T) {
+			var m IDELaunchMode
+			err := m.Set(in)
+			if err == nil {
+				t.Fatalf("Set(%q) returned nil error; want error", in)
+			}
+			if !strings.Contains(err.Error(), "must be one of") {
+				t.Errorf("error %q does not contain %q", err.Error(), "must be one of")
+			}
+		})
+	}
+}
+
+func TestIDELaunchMode_Type(t *testing.T) {
+	var m IDELaunchMode
+	if got := m.Type(); got != "auto|headless|skip" {
+		t.Errorf("Type() = %q, want %q", got, "auto|headless|skip")
+	}
+}
+
+func TestIDELaunchMode_String_ZeroValue(t *testing.T) {
+	var m IDELaunchMode
+	if got := m.String(); got != "auto" {
+		t.Errorf("zero-value String() = %q, want %q", got, "auto")
+	}
+}

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -37,6 +37,7 @@ type IDEParams struct {
 	User               string
 	Result             *config2.Result
 	TunnelMode         bool
+	Launch             IDELaunchMode
 }
 
 // IsBrowserIDE reports whether the given IDE name uses a browser-based
@@ -48,13 +49,14 @@ func IsBrowserIDE(ideName string) bool {
 	return ok
 }
 
-// Open dispatches to the correct IDE opener based on ideName.
+// Open dispatches to the correct IDE opener based on ideName. It returns the
+// IDE URL (when meaningful — see per-IDE openers) along with any error.
 func Open(
 	ctx context.Context,
 	ideName string,
 	ideOptions map[string]config.OptionValue,
 	params IDEParams,
-) error {
+) (string, error) {
 	if fn, ok := browserIDEOpener(ideName); ok {
 		return fn(ctx, ideOptions, params)
 	}
@@ -65,7 +67,7 @@ func Open(
 // browserIDEOpener returns a handler for browser-based IDEs if ideName matches.
 func browserIDEOpener(
 	ideName string,
-) (func(context.Context, map[string]config.OptionValue, IDEParams) error, bool) {
+) (func(context.Context, map[string]config.OptionValue, IDEParams) (string, error), bool) {
 	switch ideName {
 	case string(config.IDEOpenVSCode):
 		return openVSCodeBrowser, true
@@ -83,31 +85,43 @@ func openDesktopIDE(
 	ideName string,
 	ideOptions map[string]config.OptionValue,
 	params IDEParams,
-) error {
+) (string, error) {
+	// Fleet is special: its opener retrieves a workspace-side URL even in
+	// headless mode (just doesn't pop a host browser). Route to startFleet
+	// before the headless short-circuit so the URL still gets logged.
+	if ideName == string(config.IDEFleet) {
+		return startFleet(ctx, params)
+	}
+
+	// For other desktop IDEs (VSCode flavors, JetBrains, Zed), headless and
+	// skip are equivalent at the opener layer: backend install (if any)
+	// happens during workspace setup; the opener phase only does the host
+	// launch, which headless suppresses.
+	if params.Launch == LaunchHeadless {
+		return "", nil
+	}
+
 	switch ideName {
 	case string(config.IDEVSCode), string(config.IDEVSCodeInsiders), string(config.IDECursor),
 		string(config.IDECodium), string(config.IDEPositron), string(config.IDEWindsurf),
 		string(config.IDEAntigravity), string(config.IDEBob):
-		return openVSCodeFlavor(ctx, ideName, ideOptions, params)
+		return "", openVSCodeFlavor(ctx, ideName, ideOptions, params)
 
 	case string(config.IDERustRover), string(config.IDEGoland), string(config.IDEPyCharm),
 		string(config.IDEPhpStorm), string(config.IDEIntellij), string(config.IDECLion),
 		string(config.IDERider), string(config.IDERubyMine), string(config.IDEWebStorm),
 		string(config.IDEDataSpell):
-		return openJetBrains(ideName, ideOptions, params)
-
-	case string(config.IDEFleet):
-		return startFleet(ctx, params.Client)
+		return "", openJetBrains(ideName, ideOptions, params)
 
 	case string(config.IDEZed):
-		return zed.Open(
+		return "", zed.Open(
 			ctx, ideOptions, params.User,
 			params.Result.SubstitutionContext.ContainerWorkspaceFolder,
 			params.Client.Workspace(),
 		)
 
 	default:
-		return nil
+		return "", nil
 	}
 }
 
@@ -264,10 +278,10 @@ func openJupyterBrowser(
 	ctx context.Context,
 	ideOptions map[string]config.OptionValue,
 	params IDEParams,
-) error {
+) (string, error) {
 	if params.GPGAgentForwarding {
 		if err := gpg.ForwardAgent(params.Client); err != nil {
-			return err
+			return "", err
 		}
 	}
 
@@ -276,15 +290,15 @@ func openJupyterBrowser(
 		jupyter.DefaultServerPort,
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	targetURL := fmt.Sprintf("http://localhost:%d/lab", jupyterPort)
-	openBrowser := jupyter.Options.GetValue(ideOptions, jupyter.OpenOption) == config.BoolTrue
+	openBrowser := params.Launch == LaunchAuto
 
 	pkglog.Infof("Starting jupyter notebook in browser mode at %s", targetURL)
 	extraPorts := []string{fmt.Sprintf("%s:%d", addr, jupyter.DefaultServerPort)}
-	return startDetachedBrowserTunnel(ctx, params, tunnel.BrowserTunnelParams{
+	if err := startDetachedBrowserTunnel(ctx, params, tunnel.BrowserTunnelParams{
 		DevsyConfig:      params.DevsyConfig,
 		Client:           params.Client,
 		User:             params.User,
@@ -293,17 +307,20 @@ func openJupyterBrowser(
 		AuthSockID:       params.SSHAuthSockID,
 		GitSSHSigningKey: params.GitSSHSigningKey,
 		DaemonStartFunc:  makeDaemonStartFunc(params, false, extraPorts),
-	}, browserIDEInvocation{Label: "jupyter", OpenBrowser: openBrowser})
+	}, browserIDEInvocation{Label: "jupyter", OpenBrowser: openBrowser}); err != nil {
+		return "", err
+	}
+	return targetURL, nil
 }
 
 func openRStudioBrowser(
 	ctx context.Context,
 	ideOptions map[string]config.OptionValue,
 	params IDEParams,
-) error {
+) (string, error) {
 	if params.GPGAgentForwarding {
 		if err := gpg.ForwardAgent(params.Client); err != nil {
-			return err
+			return "", err
 		}
 	}
 
@@ -312,15 +329,15 @@ func openRStudioBrowser(
 		rstudio.DefaultServerPort,
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	targetURL := fmt.Sprintf("http://localhost:%d", rsPort)
-	openBrowser := rstudio.Options.GetValue(ideOptions, rstudio.OpenOption) == config.BoolTrue
+	openBrowser := params.Launch == LaunchAuto
 
 	pkglog.Infof("Starting RStudio server in browser mode at %s", targetURL)
 	extraPorts := []string{fmt.Sprintf("%s:%d", addr, rstudio.DefaultServerPort)}
-	return startDetachedBrowserTunnel(ctx, params, tunnel.BrowserTunnelParams{
+	if err := startDetachedBrowserTunnel(ctx, params, tunnel.BrowserTunnelParams{
 		DevsyConfig:      params.DevsyConfig,
 		Client:           params.Client,
 		User:             params.User,
@@ -329,17 +346,20 @@ func openRStudioBrowser(
 		AuthSockID:       params.SSHAuthSockID,
 		GitSSHSigningKey: params.GitSSHSigningKey,
 		DaemonStartFunc:  makeDaemonStartFunc(params, false, extraPorts),
-	}, browserIDEInvocation{Label: "rstudio", OpenBrowser: openBrowser})
+	}, browserIDEInvocation{Label: "rstudio", OpenBrowser: openBrowser}); err != nil {
+		return "", err
+	}
+	return targetURL, nil
 }
 
 func openVSCodeBrowser(
 	ctx context.Context,
 	ideOptions map[string]config.OptionValue,
 	params IDEParams,
-) error {
+) (string, error) {
 	if params.GPGAgentForwarding {
 		if err := gpg.ForwardAgent(params.Client); err != nil {
-			return err
+			return "", err
 		}
 	}
 
@@ -349,11 +369,11 @@ func openVSCodeBrowser(
 		openvscode.DefaultVSCodePort,
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	targetURL := fmt.Sprintf("http://localhost:%d/?folder=%s", vscodePort, folder)
-	openBrowser := openvscode.Options.GetValue(ideOptions, openvscode.OpenOption) == config.BoolTrue
+	openBrowser := params.Launch == LaunchAuto
 
 	pkglog.Infof("Starting vscode in browser mode at %s", targetURL)
 	forwardPorts := openvscode.Options.GetValue(
@@ -361,7 +381,7 @@ func openVSCodeBrowser(
 		openvscode.ForwardPortsOption,
 	) == config.BoolTrue
 	extraPorts := []string{fmt.Sprintf("%s:%d", addr, openvscode.DefaultVSCodePort)}
-	return startDetachedBrowserTunnel(ctx, params, tunnel.BrowserTunnelParams{
+	if err := startDetachedBrowserTunnel(ctx, params, tunnel.BrowserTunnelParams{
 		DevsyConfig:      params.DevsyConfig,
 		Client:           params.Client,
 		User:             params.User,
@@ -371,35 +391,47 @@ func openVSCodeBrowser(
 		AuthSockID:       params.SSHAuthSockID,
 		GitSSHSigningKey: params.GitSSHSigningKey,
 		DaemonStartFunc:  makeDaemonStartFunc(params, forwardPorts, extraPorts),
-	}, browserIDEInvocation{Label: LabelVSCodeBrowser, OpenBrowser: openBrowser})
+	}, browserIDEInvocation{Label: LabelVSCodeBrowser, OpenBrowser: openBrowser}); err != nil {
+		return "", err
+	}
+	return targetURL, nil
 }
 
-func startFleet(ctx context.Context, client client2.BaseWorkspaceClient) error {
+func startFleet(ctx context.Context, params IDEParams) (string, error) {
 	stdout := &bytes.Buffer{}
 	sshCmd, err := tunnel.CreateSSHCommand(
 		ctx,
-		client,
+		params.Client,
 		[]string{"--command", "cat " + fleet.FleetURLFileName},
 	)
 	if err != nil {
-		return err
+		return "", err
 	}
 	sshCmd.Stdout = stdout
 	err = sshCmd.Run()
 	if err != nil {
-		return command.WrapCommandError(stdout.Bytes(), err)
+		return "", command.WrapCommandError(stdout.Bytes(), err)
 	}
 
 	url := strings.TrimSpace(stdout.String())
 	if len(url) == 0 {
-		return fmt.Errorf("seems like fleet is not running within the container")
+		return "", fmt.Errorf("seems like fleet is not running within the container")
 	}
 
+	if params.Launch == LaunchHeadless {
+		// Headless: surface the URL so the caller can grab it. Skip the
+		// public-URL warning since the caller explicitly opted out of the
+		// interactive flow.
+		pkglog.Infof("Fleet is available at %s", url)
+		return url, nil
+	}
 	pkglog.Warnf(
 		"Fleet is exposed at a publicly reachable URL, please make sure to not disclose this URL " +
 			"to anyone as they will be able to reach your workspace from that",
 	)
 	pkglog.Infof("Starting Fleet at %s ...", url)
-
-	return open2.Run(url)
+	if err := open2.Run(url); err != nil {
+		return "", err
+	}
+	return url, nil
 }

--- a/pkg/ide/opener/opener_test.go
+++ b/pkg/ide/opener/opener_test.go
@@ -1,8 +1,66 @@
 package opener
 
 import (
+	"context"
 	"testing"
+
+	"github.com/devsy-org/devsy/pkg/config"
 )
+
+// TestIDEParams_Launch_OpenBrowser asserts the mapping that browser IDE openers
+// use to decide whether to spawn the host browser: openBrowser is true iff
+// Launch is LaunchAuto. LaunchHeadless and LaunchSkip both yield false.
+func TestIDEParams_Launch_OpenBrowser(t *testing.T) {
+	tests := []struct {
+		name string
+		mode IDELaunchMode
+		want bool
+	}{
+		{"auto opens", LaunchAuto, true},
+		{"headless does not open", LaunchHeadless, false},
+		{"skip does not open", LaunchSkip, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := IDEParams{Launch: tt.mode}
+			got := params.Launch == LaunchAuto
+			if got != tt.want {
+				t.Errorf("Launch=%q: openBrowser=%v, want %v", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestOpenDesktopIDE_HeadlessShortCircuits verifies that LaunchHeadless makes
+// openDesktopIDE return nil without dispatching to any per-IDE handler for
+// non-Fleet desktop IDEs. Each chosen IDE name matches an explicit switch
+// case in openDesktopIDE — if the headless guard were ever removed, dispatch
+// would deref nil params.Client / params.Result and panic, failing the test.
+// Fleet is excluded because it intentionally runs even under headless (to
+// retrieve the workspace-side URL).
+func TestOpenDesktopIDE_HeadlessShortCircuits(t *testing.T) {
+	desktopIDEs := []string{
+		string(config.IDEVSCode),
+		string(config.IDEIntellij),
+		string(config.IDEZed),
+	}
+	for _, ide := range desktopIDEs {
+		t.Run(ide, func(t *testing.T) {
+			url, err := openDesktopIDE(
+				context.Background(),
+				ide,
+				nil,
+				IDEParams{Launch: LaunchHeadless},
+			)
+			if err != nil {
+				t.Errorf("expected nil for headless desktop IDE, got %v", err)
+			}
+			if url != "" {
+				t.Errorf("expected empty URL for headless desktop IDE, got %q", url)
+			}
+		})
+	}
+}
 
 func TestParseAddressAndPort_Empty(t *testing.T) {
 	addr, p, err := ParseAddressAndPort("", 10000)

--- a/pkg/ide/openvscode/openvscode.go
+++ b/pkg/ide/openvscode/openvscode.go
@@ -26,7 +26,6 @@ const (
 
 const (
 	ForwardPortsOption  = "FORWARD_PORTS"
-	OpenOption          = "OPEN"
 	BindAddressOption   = "BIND_ADDRESS"
 	VersionOption       = "VERSION"
 	DownloadAmd64Option = "DOWNLOAD_AMD64"
@@ -52,15 +51,6 @@ var Options = ide.Options{
 		Name:        VersionOption,
 		Description: "The version for the open vscode binary",
 		Default:     "v1.84.2",
-	},
-	OpenOption: {
-		Name:        OpenOption,
-		Description: "If Devsy should automatically open the browser",
-		Default:     "true",
-		Enum: []string{
-			"true",
-			"false",
-		},
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,

--- a/pkg/ide/rstudio/rstudio.go
+++ b/pkg/ide/rstudio/rstudio.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	OpenOption        = "OPEN"
 	BindAddressOption = "BIND_ADDRESS"
 )
 
@@ -33,15 +32,6 @@ var Options = ide.Options{
 		Name:        BindAddressOption,
 		Description: "The address to bind the server to locally, e.g. 0.0.0.0:12345",
 		Default:     "",
-	},
-	OpenOption: {
-		Name:        OpenOption,
-		Description: "If Devsy should automatically open the browser",
-		Default:     "true",
-		Enum: []string{
-			"true",
-			"false",
-		},
 	},
 }
 
@@ -382,7 +372,7 @@ func setupPreferences(workspaceFolder, userName string) error {
 		return err
 	}
 
-	prefsPath := filepath.Join(prefsDir, "rstudio-prefs.json")
+	prefsPath := filepath.Join(prefsDir, preferencesFile)
 	err = os.WriteFile(prefsPath, outPrefs, os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("save preferences: %w", err)


### PR DESCRIPTION
## Summary

Replaces two overlapping flags with a single tri-state knob (hard cutover, no back-compat).

**Before**: `--open-ide=true|false` (coarse on/off, all IDEs) + `--ide-option OPEN=true|false` (invisible per-IDE option for browser IDEs only). Three mutually-exclusive user intents were spread across two flags with asymmetric semantics — browser IDEs needed both flags to express all 3 states, desktop IDEs had no "headless" mode at all, and the per-IDE `OPEN` option was hidden from `--help`.

**After**: `--ide-launch=auto|headless|skip` (default `auto`).

- `auto` — full launch (start tunnel for browser IDEs, open the host browser/app).
- `headless` — do not open the host browser/app. Browser IDEs still start their tunnel; Fleet still logs its URL; other desktop IDEs (VSCode, JetBrains, Zed) no-op (functionally equivalent to `skip`).
- `skip` — short-circuit the IDE-launch phase entirely.

## Deleted

- `--open-ide` flag (and `cmd.OpenIDE` field).
- `OpenOption` constants and `Options` map entries in `pkg/ide/openvscode`, `pkg/ide/jupyter`, `pkg/ide/rstudio`.

## Other changes

- `ResultEnvelope` gains a `URL` field (`omitempty`). `opener.Open` now returns `(url, err)`; browser IDEs surface their `http://localhost:PORT/...` URL, Fleet surfaces its fetched URL, other desktop IDEs return `""`. JSON consumers (e.g. desktop wizard) can now capture the connection URL without log scraping.
- `WriteResultJSON` signature simplified to `(w, ResultEnvelope)` so callers build the envelope literal — keeps the function under revive's argument-limit and removes a `//nolint`.
- E2E tests migrated: `--open-ide=false` → `--ide-launch=skip`; `--ide-option OPEN=false` → `--ide-launch=headless`.
- Desktop frontend (TS): `workspaceUp` IPC gains an `ideLaunch?: "auto" | "headless" | "skip"` field; existing call sites (workspace wizard, "Open IDE" button) pass `"auto"`.

## Breaking changes

This is a hard cutover — no aliases or deprecation warnings. Any caller using `--open-ide=false` or `--ide-option OPEN=false` will see "unknown flag" errors on upgrade. Migrate to `--ide-launch=skip` or `--ide-launch=headless` respectively.

## Tests

- `pkg/ide/opener/ide_launch_mode_test.go` — pflag.Value parsing (case-strict, invalid values, default).
- `pkg/ide/opener/opener_test.go` — `LaunchAuto`/`LaunchHeadless`/`LaunchSkip` → `openBrowser` mapping; desktop IDE headless short-circuit.
- `pkg/devcontainer/config/envelope_test.go` — URL field set/empty/omitempty.
- E2E coverage retained via the existing `ide` and `up-behaviors` matrix labels.