### PR TITLE
fix(ssh): keep agent socket path under macOS sun_path limit

### DIFF
--- a/cmd/helper/ssh_server.go
+++ b/cmd/helper/ssh_server.go
@@ -97,7 +97,8 @@ func (cmd *SSHServerCmd) Run(_ *cobra.Command, _ []string) error {
 		}
 	}
 
-	// Sweep auth-agent-conn-* directories left behind by predecessors that
+	// Sweep stale per-connection agent socket directories left behind by
+	// predecessors that
 	// were killed by docker exec / proxy-chain teardown before any internal
 	// SSH cleanup could run. Liveness is decided via a per-directory flock
 	// the owning process holds for its lifetime; the kernel releases the

--- a/e2e/tests/ssh/agent_forward.go
+++ b/e2e/tests/ssh/agent_forward.go
@@ -311,7 +311,7 @@ var _ = ginkgo.Describe(
 				exitCmd.Env = append(os.Environ(), "SSH_AUTH_SOCK="+authSock)
 				_ = exitCmd.Run()
 
-				// On a fresh devsy ssh connection, assert no auth-agent-conn-*
+				// On a fresh devsy ssh connection, assert no devsy-ssh-agent-*
 				// directories remain. With lazy allocation, none are ever
 				// created; with the cleanup goroutine, any leftover is removed.
 				gomega.Eventually(func() string {
@@ -320,13 +320,13 @@ var _ = ginkgo.Describe(
 					out, _ := f.DevsySSH(
 						pollCtx,
 						tempDir,
-						"sh -c 'ls -d \"$XDG_RUNTIME_DIR\"/auth-agent-conn-* 2>/dev/null | wc -l'",
+						"sh -c 'ls -d \"$XDG_RUNTIME_DIR\"/devsy-ssh-agent-* 2>/dev/null | wc -l'",
 					)
 					return strings.TrimSpace(out)
 				}).WithTimeout(30*time.Second).WithPolling(500*time.Millisecond).
 					Should(
 						gomega.Equal("0"),
-						"no auth-agent-conn-* dir must remain after a no-forward connection closes",
+						"no devsy-ssh-agent-* dir must remain after a no-forward connection closes",
 					)
 			},
 		)

--- a/pkg/ssh/server/agent.go
+++ b/pkg/ssh/server/agent.go
@@ -12,7 +12,21 @@ import (
 	"github.com/devsy-org/ssh"
 )
 
-const agentSocketDirPrefix = "auth-agent-conn-"
+const (
+	agentSocketDirPrefix = "devsy-ssh-agent-"
+
+	// maxAgentSocketPath is the most restrictive Unix-domain socket path
+	// length across supported platforms (macOS/BSD: sun_path[104];
+	// Linux: sun_path[108]). bind(2) returns EINVAL when exceeded, which
+	// surfaces as "invalid argument" — a confusing error far from the cause.
+	// We check eagerly and fail with a clear message instead.
+	maxAgentSocketPath = 104
+
+	// agentListenFile mirrors the socket filename ssh.NewAgentListener
+	// creates inside the directory we pass it. Kept in sync so we can
+	// pre-validate the final socket path length.
+	agentListenFile = "listener.sock"
+)
 
 func setupAgentListener(reuseSock string) (net.Listener, string, error) {
 	runtimeDir, err := config.DefaultPathManager().RuntimeDir()
@@ -32,6 +46,9 @@ func setupAgentListener(reuseSock string) (net.Listener, string, error) {
 	dir := ""
 	if reuseSock != "" {
 		dir = filepath.Join(runtimeDir, fmt.Sprintf("auth-agent-%s", reuseSock))
+		if err := checkAgentSocketPathLen(dir); err != nil {
+			return nil, "", err
+		}
 		// #nosec G301 -- TODO Consider using a more secure permission setting and ownership if needed.
 		err = os.MkdirAll(dir, 0o755)
 		if err != nil {
@@ -64,6 +81,9 @@ func setupConnectionAgentListener(connID string) (net.Listener, string, error) {
 	}
 
 	dir := filepath.Join(runtimeDir, fmt.Sprintf("%s%s", agentSocketDirPrefix, connID))
+	if err := checkAgentSocketPathLen(dir); err != nil {
+		return nil, "", err
+	}
 	// #nosec G301
 	err = os.MkdirAll(dir, 0o755)
 	if err != nil {
@@ -92,8 +112,8 @@ func setupConnectionAgentListener(connID string) (net.Listener, string, error) {
 	return l, socketDir, nil
 }
 
-// SweepStaleAgentSockets walks the runtime directory and removes any
-// auth-agent-conn-* directory whose owning process is no longer alive.
+// SweepStaleAgentSockets removes per-connection agent socket directories
+// whose owning process is no longer alive.
 // Liveness is detected via a per-directory flock: the owning process holds
 // an exclusive flock on the lockfile for its lifetime, so any other process
 // that can successfully take the flock knows the original owner is gone.
@@ -126,6 +146,29 @@ func SweepStaleAgentSockets() {
 		}
 		log.Debugf("swept stale agent socket dir: %s", dirPath)
 	}
+}
+
+// checkAgentSocketPathLen verifies the eventual unix socket path fits within
+// the OS sun_path limit. bind(2) returns the unhelpful EINVAL when it does
+// not, so we validate up front and emit a clear, actionable error that
+// names the offending path and the limit.
+func checkAgentSocketPathLen(dir string) error {
+	sockPath := filepath.Join(dir, agentListenFile)
+	if len(sockPath) > maxAgentSocketPath {
+		log.Warnf(
+			"agent socket path exceeds max (%d > %d): %s",
+			len(sockPath),
+			maxAgentSocketPath,
+			sockPath,
+		)
+		return fmt.Errorf(
+			"agent socket path exceeds max (%d > %d): %s",
+			len(sockPath),
+			maxAgentSocketPath,
+			sockPath,
+		)
+	}
+	return nil
 }
 
 // cleanupAgentSocketDir removes the per-connection agent socket directory.

--- a/pkg/ssh/server/ssh.go
+++ b/pkg/ssh/server/ssh.go
@@ -231,14 +231,17 @@ func cleanupAgentOnConnClosing(ctx ssh.Context, _ *gossh.ServerConn) {
 // newConnID returns a short hex identifier unique to the connection.
 // Uses crypto/rand; on the unlikely event of a rand.Read failure falls
 // back to a sha256-of-time derivation so the connection still gets an ID.
+// 4 random bytes (8 hex chars) keeps the resulting unix socket path under
+// the macOS 104-byte sun_path limit while leaving ~4B values of headroom
+// against accidental same-host collisions.
 func newConnID(remote string) string {
-	var b [8]byte
+	var b [4]byte
 	_, err := rand.Read(b[:])
 	if err == nil {
 		return hex.EncodeToString(b[:])
 	}
 	sum := sha256.Sum256([]byte(remote + strconv.FormatInt(time.Now().UnixNano(), 10)))
-	return fmt.Sprintf("%x", sum)[:16]
+	return fmt.Sprintf("%x", sum)[:8]
 }
 
 // ensureConnAgentState lazily allocates the per-connection agent listener


### PR DESCRIPTION
## Summary

SSH agent forwarding broke on macOS for fresh workspaces because the per-connection agent socket path landed at **105 chars** — one over the 104-byte `sun_path` limit on macOS/BSD. `bind(2)` returned the unhelpful `EINVAL` (\"invalid argument\") and the tunnel setup failed:

```
ssh agent forwarding setup failed (connID=…): new agent listener:
listen unix /var/folders/<...>/T/devsy-502/auth-agent-conn-0e5824509493988e/listener.sock:
bind: invalid argument
```

Regression introduced by #434 (per-connection agent-forwarding socket) — the test commit `20ef2a9ed` already shortened the connID for tests but the production `newConnID` still returned 16 hex chars.

## Changes

- **Shorter dir prefix**: `auth-agent-conn-` → `devsy-ssh-agent-` (still self-documenting; net path savings vs. old prefix is balanced by also shortening connID below).
- **Shorter connID**: 16 hex (8 random bytes) → 8 hex (4 bytes). 2³² is plenty for per-host directory uniqueness, and the existing flock-based janitor catches any collision with a dead predecessor.
- **Eager path-length check** (`checkAgentSocketPathLen`): validates the eventual socket path against `maxAgentSocketPath = 104` before `mkdir` / `bind`, logs a `Warnf`, and returns a clear error (`agent socket path exceeds max (N > 104): <path>`). Wired into both `setupConnectionAgentListener` and the reuse-sock branch of `setupAgentListener`.
- **Test + doc updates**: e2e sweep test now greps for the new prefix; stale prefix references in godoc / inline comments updated.

Worst-case macOS path is now **97 chars** (7 chars headroom even with a 3-digit uid; ~100 with a 6-digit uid).

## Path comparison

| | Before | After |
|---|---|---|
| Example | `/var/folders/<...>/T/devsy-502/auth-agent-conn-0e5824509493988e/listener.sock` | `/var/folders/<...>/T/devsy-502/devsy-ssh-agent-0e582450/listener.sock` |
| Length | 105 | 97 |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented proactive validation of SSH agent socket paths to detect length constraints early, with clear error messages replacing cryptic bind failures.
  * Enhanced cleanup mechanisms for temporary SSH agent socket directories left behind by previous connections, improving reliability of SSH agent forwarding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->