### PR TITLE
chore(log): remove caller file:line from log output

### DIFF
--- a/pkg/log/logger.go
+++ b/pkg/log/logger.go
@@ -31,7 +31,6 @@ func Init(cfg Config) {
 	core := zapcore.NewCore(encoder, zapcore.Lock(os.Stderr), level)
 
 	opts := []zap.Option{
-		zap.AddCaller(),
 		zap.AddStacktrace(zapcore.FatalLevel),
 	}
 	logger := zap.New(core, opts...)


### PR DESCRIPTION
## Summary
- Removes `zap.AddCaller()` so log entries no longer prefix messages with `log/logger.go:105`.
- Affects all formats (text, json, logfmt). No frontend parser reads the `caller` field, so this is backend-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified logging behavior: Stack traces are now included for fatal-level logs, while caller annotations have been removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->