### PR TITLE
fix(delete): make --remove-volumes work for plain docker and scope to driver-owned volumes

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -54,6 +54,8 @@ If the workspace is not found, you can use the --ignore-not-found flag to treat 
 		StringVar(&cmd.GracePeriod, "grace-period", "", "The amount of time to give the command to delete the workspace")
 	deleteCmd.Flags().
 		BoolVar(&cmd.Force, "force", false, "Delete workspace even if it is not found remotely anymore")
+	deleteCmd.Flags().
+		BoolVar(&cmd.RemoveVolumes, "remove-volumes", false, "Remove named volumes associated with the workspace")
 	return deleteCmd
 }
 

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -468,6 +468,10 @@ export function registerIpcHandlers(deps: IpcDependencies): { tunnelProcesses: M
       const cliArgs = ["delete", args.workspaceId]
       if (args.debug) cliArgs.push("--debug")
       cliArgs.push("--force")
+      // Remove named docker volumes too so a re-create with the same id
+      // starts from a clean slate instead of picking up the old workspace's
+      // /workspaces/<id> contents.
+      cliArgs.push("--remove-volumes")
 
       cli.runStreaming(
         cliArgs,

--- a/pkg/agent/delivery/local_docker.go
+++ b/pkg/agent/delivery/local_docker.go
@@ -106,21 +106,22 @@ func (d *LocalDockerDelivery) ensureCurrentBinary(
 }
 
 func (d *LocalDockerDelivery) createVolume(ctx context.Context, name string) error {
-	args := []string{
-		"volume", "create",
-		"--label", docker.LabelDriverOwned + "=true",
-		"--label", docker.LabelWorkspaceID + "=" + strings.TrimPrefix(name, volumePrefix),
-		name,
+	labels := map[string]string{
+		docker.LabelDriverOwned: "true",
+		docker.LabelWorkspaceID: strings.TrimPrefix(name, volumePrefix),
 	}
-	out, err := d.cmd(ctx, args...).CombinedOutput()
-	if err != nil {
-		msg := string(out)
-		if strings.Contains(msg, "already exists") {
-			return nil
-		}
-		return fmt.Errorf("%s: %w", msg, err)
+	return d.dockerHelper().CreateVolume(ctx, name, labels)
+}
+
+// dockerHelper builds an on-demand DockerHelper that reuses the delivery's
+// configured docker command and environment. We construct it lazily rather
+// than hold a struct field so the existing zero-value usage of
+// LocalDockerDelivery (and its tests) keeps working.
+func (d *LocalDockerDelivery) dockerHelper() *docker.DockerHelper {
+	return &docker.DockerHelper{
+		DockerCommand: d.dockerCommand(),
+		Environment:   d.Environment,
 	}
-	return nil
 }
 
 func (d *LocalDockerDelivery) helperImageName() string {

--- a/pkg/agent/delivery/local_docker.go
+++ b/pkg/agent/delivery/local_docker.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/agent"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/version"
 )
@@ -105,9 +106,19 @@ func (d *LocalDockerDelivery) ensureCurrentBinary(
 }
 
 func (d *LocalDockerDelivery) createVolume(ctx context.Context, name string) error {
-	out, err := d.cmd(ctx, "volume", "create", name).CombinedOutput()
+	args := []string{
+		"volume", "create",
+		"--label", docker.LabelDriverOwned + "=true",
+		"--label", docker.LabelWorkspaceID + "=" + strings.TrimPrefix(name, volumePrefix),
+		name,
+	}
+	out, err := d.cmd(ctx, args...).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("%s: %w", string(out), err)
+		msg := string(out)
+		if strings.Contains(msg, "already exists") {
+			return nil
+		}
+		return fmt.Errorf("%s: %w", msg, err)
 	}
 	return nil
 }

--- a/pkg/agent/delivery/local_docker_test.go
+++ b/pkg/agent/delivery/local_docker_test.go
@@ -377,6 +377,47 @@ func TestDeliverPreStart_VersionMismatch_Overwrites(t *testing.T) {
 	assert.Equal(t, binaryContent, data)
 }
 
+func TestCreateVolume_AppliesDriverOwnedAndWorkspaceLabels(t *testing.T) {
+	tmpDir := t.TempDir()
+	argsLog := filepath.Join(tmpDir, "args.log")
+
+	scriptPath := filepath.Join(tmpDir, "fake-docker.sh")
+	// Capture the full argv to a file so we can assert label flags appeared,
+	// independent of label-map iteration order.
+	script := "#!/bin/sh\n" +
+		"echo \"$@\" >> \"" + argsLog + "\"\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+	// #nosec G302 -- test script must be executable
+	require.NoError(t, os.Chmod(scriptPath, 0o755))
+
+	d := &LocalDockerDelivery{DockerCommand: scriptPath}
+	err := d.createVolume(context.Background(), volumePrefix+"ws-xyz")
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(argsLog) //nolint:gosec // test reads from controlled temp dir
+	require.NoError(t, err)
+	logged := string(data)
+	assert.Contains(t, logged, "volume create")
+	assert.Contains(t, logged, "--label devsy.driver-owned=true")
+	assert.Contains(t, logged, "--label devsy.workspace-id=ws-xyz")
+	assert.Contains(t, logged, volumePrefix+"ws-xyz")
+}
+
+func TestCreateVolume_AlreadyExistsIsIdempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	scriptPath := filepath.Join(tmpDir, "fake-docker.sh")
+	script := "#!/bin/sh\necho 'Error: volume already exists' 1>&2\nexit 1\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+	// #nosec G302 -- test script must be executable
+	require.NoError(t, os.Chmod(scriptPath, 0o755))
+
+	d := &LocalDockerDelivery{DockerCommand: scriptPath}
+	err := d.createVolume(context.Background(), volumePrefix+"ws-xyz")
+	require.NoError(t, err)
+}
+
 func TestExpectedVersion_UsesFieldWhenSet(t *testing.T) {
 	d := &LocalDockerDelivery{ExpectedVersion: "v3.0.0"}
 	assert.Equal(t, "v3.0.0", d.expectedVersion())

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -560,7 +560,8 @@ func (r *runner) startContainer(
 			return nil, fmt.Errorf("stop dev container: %w", err)
 		}
 
-		if err := r.Driver.DeleteDevContainer(ctx, r.ID); err != nil {
+		// --recreate replaces the container in place; preserve named volumes.
+		if err := r.Driver.DeleteDevContainer(ctx, r.ID, false); err != nil {
 			return nil, fmt.Errorf("delete dev container: %w", err)
 		}
 	}

--- a/pkg/devcontainer/delete.go
+++ b/pkg/devcontainer/delete.go
@@ -33,7 +33,7 @@ func (r *runner) Delete(ctx context.Context, options DeleteOptions) error {
 			}
 		}
 
-		err = r.Driver.DeleteDevContainer(ctx, r.ID)
+		err = r.Driver.DeleteDevContainer(ctx, r.ID, options.RemoveVolumes)
 		if err != nil {
 			return err
 		}

--- a/pkg/devcontainer/delete_test.go
+++ b/pkg/devcontainer/delete_test.go
@@ -2,12 +2,14 @@ package devcontainer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"testing"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/driver"
+	dockerdriver "github.com/devsy-org/devsy/pkg/driver/docker"
 	"github.com/devsy-org/devsy/pkg/provider"
 )
 
@@ -208,6 +210,32 @@ func TestDelete_OmitsRemoveVolumesWhenFlagUnset(t *testing.T) {
 	}
 	if d.deleteRemoveVolumes {
 		t.Error("driver.DeleteDevContainer was called with removeVolumes=true, want false")
+	}
+}
+
+// TestDelete_PropagatesDaemonUnavailableSentinel guards against the
+// regression where the docker driver swallowed daemon-down errors during
+// volume cleanup and returned nil, hiding the failure from `devsy delete
+// --remove-volumes` callers.
+func TestDelete_PropagatesDaemonUnavailableSentinel(t *testing.T) {
+	wrapped := fmt.Errorf("remove volume foo: %w",
+		dockerdriver.ErrDockerDaemonUnavailable)
+	d := &mockDriver{
+		findResult: &config.ContainerDetails{
+			ID:     testContainerID,
+			State:  config.ContainerDetailsState{Status: "exited"},
+			Config: config.ContainerDetailsConfig{Labels: map[string]string{}},
+		},
+		deleteErr: wrapped,
+	}
+	r := newTestRunner(d)
+
+	err := r.Delete(context.Background(), DeleteOptions{RemoveVolumes: true})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, dockerdriver.ErrDockerDaemonUnavailable) {
+		t.Errorf("expected ErrDockerDaemonUnavailable in chain, got: %v", err)
 	}
 }
 

--- a/pkg/devcontainer/delete_test.go
+++ b/pkg/devcontainer/delete_test.go
@@ -17,12 +17,13 @@ const (
 )
 
 type mockDriver struct {
-	findResult   *config.ContainerDetails
-	findErr      error
-	stopCalled   bool
-	stopErr      error
-	deleteCalled bool
-	deleteErr    error
+	findResult          *config.ContainerDetails
+	findErr             error
+	stopCalled          bool
+	stopErr             error
+	deleteCalled        bool
+	deleteErr           error
+	deleteRemoveVolumes bool
 }
 
 func (m *mockDriver) FindDevContainer(
@@ -37,8 +38,11 @@ func (m *mockDriver) StopDevContainer(_ context.Context, _ string) error {
 	return m.stopErr
 }
 
-func (m *mockDriver) DeleteDevContainer(_ context.Context, _ string) error {
+func (m *mockDriver) DeleteDevContainer(
+	_ context.Context, _ string, removeVolumes bool,
+) error {
 	m.deleteCalled = true
+	m.deleteRemoveVolumes = removeVolumes
 	return m.deleteErr
 }
 
@@ -168,6 +172,42 @@ func TestDelete_DeleteError_ReturnsError(t *testing.T) {
 
 	if err == nil {
 		t.Fatal("expected error from DeleteDevContainer, got nil")
+	}
+}
+
+func TestDelete_PropagatesRemoveVolumesToDriver(t *testing.T) {
+	d := &mockDriver{
+		findResult: &config.ContainerDetails{
+			ID:     testContainerID,
+			State:  config.ContainerDetailsState{Status: "exited"},
+			Config: config.ContainerDetailsConfig{Labels: map[string]string{}},
+		},
+	}
+	r := newTestRunner(d)
+
+	if err := r.Delete(context.Background(), DeleteOptions{RemoveVolumes: true}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if !d.deleteRemoveVolumes {
+		t.Error("driver.DeleteDevContainer was called with removeVolumes=false, want true")
+	}
+}
+
+func TestDelete_OmitsRemoveVolumesWhenFlagUnset(t *testing.T) {
+	d := &mockDriver{
+		findResult: &config.ContainerDetails{
+			ID:     testContainerID,
+			State:  config.ContainerDetailsState{Status: "exited"},
+			Config: config.ContainerDetailsConfig{Labels: map[string]string{}},
+		},
+	}
+	r := newTestRunner(d)
+
+	if err := r.Delete(context.Background(), DeleteOptions{}); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if d.deleteRemoveVolumes {
+		t.Error("driver.DeleteDevContainer was called with removeVolumes=true, want false")
 	}
 }
 

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -15,6 +15,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/daemon/agent"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/metadata"
+	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/driver"
 	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
@@ -439,6 +440,11 @@ func (r *runner) runContainer(
 	// check if docker
 	dockerDriver, ok := r.Driver.(driver.DockerDriver)
 	if ok {
+		if buildInfo.Dockerless != nil {
+			if err := r.preCreateDockerlessVolume(ctx, dockerDriver); err != nil {
+				log.Debugf("pre-create dockerless volume: %v", err)
+			}
+		}
 		return dockerDriver.RunDockerDevContainer(ctx, &driver.RunDockerDevContainerParams{
 			WorkspaceID:          r.ID,
 			Options:              runOptions,
@@ -499,7 +505,7 @@ func (r *runner) getDockerlessRunOptions(
 	mounts := mergedConfig.Mounts
 	mounts = append(mounts, &config.Mount{
 		Type:   "volume",
-		Source: "dockerless-" + r.ID,
+		Source: dockerlessVolumeName(r.ID),
 		Target: "/workspaces/.dockerless",
 	})
 
@@ -661,4 +667,27 @@ func GetContainerEntrypointAndArgs(
 		cmd = append(cmd, imageDetails.Config.Cmd...)
 	}
 	return "/bin/sh", cmd
+}
+
+// dockerlessVolumeName returns the named docker volume that backs the
+// dockerless build/cache for a given workspace.
+func dockerlessVolumeName(id string) string {
+	return "dockerless-" + id
+}
+
+// preCreateDockerlessVolume eagerly creates the dockerless volume with
+// devsy-owned labels so that workspace delete can safely target only
+// driver-managed volumes (and not user-declared mounts).
+func (r *runner) preCreateDockerlessVolume(
+	ctx context.Context,
+	d driver.DockerDriver,
+) error {
+	helper, err := d.DockerHelper()
+	if err != nil || helper == nil {
+		return err
+	}
+	return helper.CreateVolume(ctx, dockerlessVolumeName(r.ID), map[string]string{
+		docker.LabelDriverOwned: "true",
+		docker.LabelWorkspaceID: r.ID,
+	})
 }

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -109,6 +109,78 @@ func (r *DockerHelper) FindContainerByID(
 	return nil, nil
 }
 
+// Devsy-managed docker volume labels. Volumes created with these labels
+// are eligible for cleanup on workspace delete. Volumes the user declares
+// in their devcontainer.json `mounts` block will NOT carry these labels
+// and are therefore preserved.
+const (
+	LabelDriverOwned = "devsy.driver-owned"
+	LabelWorkspaceID = "devsy.workspace-id"
+)
+
+// CreateVolume creates a named docker volume with the supplied labels.
+// The call is idempotent: if the volume already exists docker exits 0
+// (and any pre-existing labels are left untouched — docker does not
+// allow updating labels on an existing volume).
+func (r *DockerHelper) CreateVolume(
+	ctx context.Context,
+	name string,
+	labels map[string]string,
+) error {
+	if name == "" {
+		return errors.New("volume name is required")
+	}
+	args := []string{"volume", "create"}
+	for k, v := range labels {
+		args = append(args, "--label", k+"="+v)
+	}
+	args = append(args, name)
+	out, err := r.buildCmd(ctx, args...).CombinedOutput()
+	if err != nil {
+		msg := string(out)
+		// docker volume create returns 0 if the volume already exists, but
+		// some older clients or podman may emit a non-zero status — treat
+		// "already exists" as success either way.
+		if strings.Contains(msg, "already exists") {
+			return nil
+		}
+		return fmt.Errorf("%s: %w", msg, err)
+	}
+	return nil
+}
+
+// InspectVolumeLabels returns the labels attached to a named volume.
+// A missing volume returns (nil, nil) so callers can treat absence as
+// "nothing to filter on" rather than as an error.
+func (r *DockerHelper) InspectVolumeLabels(
+	ctx context.Context,
+	name string,
+) (map[string]string, error) {
+	if name == "" {
+		return nil, nil
+	}
+	out, err := r.buildCmd(
+		ctx, "volume", "inspect", "--format", "{{json .Labels}}", name,
+	).CombinedOutput()
+	if err != nil {
+		msg := string(out)
+		if strings.Contains(msg, "no such volume") ||
+			strings.Contains(msg, "No such volume") {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("%s: %w", msg, err)
+	}
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" || trimmed == "null" {
+		return map[string]string{}, nil
+	}
+	labels := map[string]string{}
+	if err := json.Unmarshal([]byte(trimmed), &labels); err != nil {
+		return nil, fmt.Errorf("parse volume labels: %w", err)
+	}
+	return labels, nil
+}
+
 func (r *DockerHelper) DeleteVolume(ctx context.Context, volume string) error {
 	if volume == "" {
 		return nil

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -163,6 +163,30 @@ func (r *DockerHelper) Remove(ctx context.Context, id string) error {
 	return nil
 }
 
+// RemoveWithVolumes removes a container along with any anonymous volumes
+// attached to it (docker rm -v). Named volumes are NOT covered — those must
+// be removed separately with RemoveVolume since they may be shared.
+func (r *DockerHelper) RemoveWithVolumes(ctx context.Context, id string) error {
+	out, err := r.buildCmd(ctx, "rm", "-v", id).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", string(out), err)
+	}
+
+	return nil
+}
+
+// RemoveVolume removes a named docker volume. "no such volume" and
+// "volume is in use" are returned as errors so the caller can choose to
+// log-and-continue rather than fail the whole delete.
+func (r *DockerHelper) RemoveVolume(ctx context.Context, name string) error {
+	out, err := r.buildCmd(ctx, "volume", "rm", name).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w", string(out), err)
+	}
+
+	return nil
+}
+
 func (r *DockerHelper) Run(
 	ctx context.Context,
 	args []string,

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -542,8 +542,17 @@ func (r *DockerHelper) GetContainerLogs(
 
 func (r *DockerHelper) buildCmd(ctx context.Context, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, r.DockerCommand, args...)
-	if r.Environment != nil {
-		cmd.Env = append(os.Environ(), r.Environment...)
+	// Force English locale so docker CLI emits well-known error strings
+	// regardless of the host's LANG/LC_ALL. The daemon-down classifier in
+	// pkg/driver/docker/docker.go matches English substrings; on a host
+	// with a translated locale, those substrings would miss and a
+	// daemon-down failure would regress to silent success.
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
 	}
+	if r.Environment != nil {
+		cmd.Env = append(cmd.Env, r.Environment...)
+	}
+	cmd.Env = append(cmd.Env, "LC_ALL=C", "LANG=C")
 	return cmd
 }

--- a/pkg/docker/helper_test.go
+++ b/pkg/docker/helper_test.go
@@ -163,6 +163,32 @@ echo null
 	assert.Empty(t, labels)
 }
 
+func TestBuildCmd_ForcesEnglishLocale(t *testing.T) {
+	// buildCmd must append LC_ALL=C and LANG=C so the daemon-down
+	// classifier (which matches English substrings) keeps working on
+	// hosts with non-English LANG/LC_ALL.
+	h := &DockerHelper{DockerCommand: "/bin/true"}
+	cmd := h.buildCmd(context.Background(), "ps")
+
+	require.NotNil(t, cmd.Env, "buildCmd should populate cmd.Env")
+	assert.Contains(t, cmd.Env, "LC_ALL=C")
+	assert.Contains(t, cmd.Env, "LANG=C")
+}
+
+func TestBuildCmd_PreservesExistingEnvironment(t *testing.T) {
+	// When DockerHelper.Environment is set, buildCmd must keep those
+	// entries alongside the forced-locale entries.
+	h := &DockerHelper{
+		DockerCommand: "/bin/true",
+		Environment:   []string{"DOCKER_HOST=tcp://example:2375"},
+	}
+	cmd := h.buildCmd(context.Background(), "ps")
+
+	assert.Contains(t, cmd.Env, "DOCKER_HOST=tcp://example:2375")
+	assert.Contains(t, cmd.Env, "LC_ALL=C")
+	assert.Contains(t, cmd.Env, "LANG=C")
+}
+
 func TestGPUSupportEnabled_CommandFailure(t *testing.T) {
 	tmp := t.TempDir()
 	bin := writeScript(t, tmp, "bad-runtime", `#!/bin/sh

--- a/pkg/docker/helper_test.go
+++ b/pkg/docker/helper_test.go
@@ -1,8 +1,10 @@
 package docker
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -79,6 +81,86 @@ esac
 
 	assert.NoError(t, err)
 	assert.False(t, got, "should not detect GPU when Podman CDI has no nvidia device")
+}
+
+func TestCreateVolume_PassesLabelsAndName(t *testing.T) {
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "args.log")
+	script := `#!/bin/sh
+echo "$@" > ` + logPath + `
+echo created
+`
+	bin := writeScript(t, tmp, "docker-fake", script)
+
+	h := &DockerHelper{DockerCommand: bin}
+	err := h.CreateVolume(context.Background(), "vol-1", map[string]string{
+		LabelDriverOwned: "true",
+	})
+	require.NoError(t, err)
+
+	//nolint:gosec // logPath is a test-controlled temp file
+	logged, err := os.ReadFile(logPath)
+	require.NoError(t, err)
+	got := strings.TrimSpace(string(logged))
+	assert.Contains(t, got, "volume create")
+	assert.Contains(t, got, "--label "+LabelDriverOwned+"=true")
+	assert.Contains(t, got, "vol-1")
+}
+
+func TestCreateVolume_AlreadyExistsIsOK(t *testing.T) {
+	tmp := t.TempDir()
+	bin := writeScript(t, tmp, "docker-fake", `#!/bin/sh
+echo "Error response from daemon: a volume with that name already exists" 1>&2
+exit 1
+`)
+
+	h := &DockerHelper{DockerCommand: bin}
+	err := h.CreateVolume(context.Background(), "vol-1", nil)
+	assert.NoError(t, err)
+}
+
+func TestCreateVolume_EmptyNameRejected(t *testing.T) {
+	h := &DockerHelper{DockerCommand: "/bin/true"}
+	err := h.CreateVolume(context.Background(), "", nil)
+	assert.Error(t, err)
+}
+
+func TestInspectVolumeLabels_NoSuchVolume(t *testing.T) {
+	tmp := t.TempDir()
+	bin := writeScript(t, tmp, "docker-fake", `#!/bin/sh
+echo "Error: no such volume: vol-x" 1>&2
+exit 1
+`)
+
+	h := &DockerHelper{DockerCommand: bin}
+	labels, err := h.InspectVolumeLabels(context.Background(), "vol-x")
+	assert.NoError(t, err)
+	assert.Nil(t, labels)
+}
+
+func TestInspectVolumeLabels_ParsesJSON(t *testing.T) {
+	tmp := t.TempDir()
+	bin := writeScript(t, tmp, "docker-fake", `#!/bin/sh
+echo '{"devsy.driver-owned":"true","devsy.workspace-id":"abc"}'
+`)
+
+	h := &DockerHelper{DockerCommand: bin}
+	labels, err := h.InspectVolumeLabels(context.Background(), "vol")
+	require.NoError(t, err)
+	assert.Equal(t, "true", labels[LabelDriverOwned])
+	assert.Equal(t, "abc", labels[LabelWorkspaceID])
+}
+
+func TestInspectVolumeLabels_NullLabels(t *testing.T) {
+	tmp := t.TempDir()
+	bin := writeScript(t, tmp, "docker-fake", `#!/bin/sh
+echo null
+`)
+
+	h := &DockerHelper{DockerCommand: bin}
+	labels, err := h.InspectVolumeLabels(context.Background(), "vol")
+	require.NoError(t, err)
+	assert.Empty(t, labels)
 }
 
 func TestGPUSupportEnabled_CommandFailure(t *testing.T) {

--- a/pkg/driver/custom/custom.go
+++ b/pkg/driver/custom/custom.go
@@ -131,8 +131,14 @@ func (c *customDriver) TargetArchitecture(ctx context.Context, workspaceId strin
 	return targetArchitecture, nil
 }
 
-// DeleteDevContainer deletes the devcontainer.
-func (c *customDriver) DeleteDevContainer(ctx context.Context, workspaceId string) error {
+// DeleteDevContainer deletes the devcontainer. removeVolumes is delegated
+// to the user-supplied deleteDevContainer command and is otherwise ignored
+// at the driver level — custom drivers don't have a generic volume concept.
+func (c *customDriver) DeleteDevContainer(
+	ctx context.Context,
+	workspaceId string,
+	_ bool,
+) error {
 	writer := log.Writer(log.LevelInfo)
 	defer func() { _ = writer.Close() }()
 

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -181,19 +181,44 @@ func (d *dockerDriver) TagDevContainer(ctx context.Context, image, tag string) e
 	return nil
 }
 
-func (d *dockerDriver) DeleteDevContainer(ctx context.Context, workspaceId string) error {
+// DeleteDevContainer removes the workspace container. When removeVolumes
+// is true it also removes anonymous volumes attached to the container
+// (`docker rm -v`) and each named volume the container referenced. Per-
+// volume errors are logged and skipped because a shared/in-use volume
+// shouldn't block the rest of the delete.
+//
+//nolint:cyclop // short, sequential branches; extracting a helper would trip funcorder.
+func (d *dockerDriver) DeleteDevContainer(
+	ctx context.Context,
+	workspaceId string,
+	removeVolumes bool,
+) error {
 	container, err := d.FindDevContainer(ctx, workspaceId)
 	if err != nil {
 		return err
-	} else if container == nil {
+	}
+	if container == nil {
 		return nil
 	}
-
-	err = d.Docker.Remove(ctx, container.ID)
-	if err != nil {
+	if !removeVolumes {
+		return d.Docker.Remove(ctx, container.ID)
+	}
+	// Snapshot named volumes before removal; the Mounts list is
+	// unrecoverable once the container is gone.
+	var namedVolumes []string
+	for _, m := range container.Mounts {
+		if m.Type == "volume" && m.Source != "" {
+			namedVolumes = append(namedVolumes, m.Source)
+		}
+	}
+	if err := d.Docker.RemoveWithVolumes(ctx, container.ID); err != nil {
 		return err
 	}
-
+	for _, name := range namedVolumes {
+		if err := d.Docker.RemoveVolume(ctx, name); err != nil {
+			log.Debugf("remove volume %s: %v", name, err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -183,11 +183,7 @@ func (d *dockerDriver) TagDevContainer(ctx context.Context, image, tag string) e
 
 // DeleteDevContainer removes the workspace container. When removeVolumes
 // is true it also removes anonymous volumes attached to the container
-// (`docker rm -v`) and each named volume the container referenced. Per-
-// volume errors are logged and skipped because a shared/in-use volume
-// shouldn't block the rest of the delete.
-//
-//nolint:cyclop // short, sequential branches; extracting a helper would trip funcorder.
+// (`docker rm -v`) and each named volume the container referenced.
 func (d *dockerDriver) DeleteDevContainer(
 	ctx context.Context,
 	workspaceId string,
@@ -203,23 +199,7 @@ func (d *dockerDriver) DeleteDevContainer(
 	if !removeVolumes {
 		return d.Docker.Remove(ctx, container.ID)
 	}
-	// Snapshot named volumes before removal; the Mounts list is
-	// unrecoverable once the container is gone.
-	var namedVolumes []string
-	for _, m := range container.Mounts {
-		if m.Type == "volume" && m.Source != "" {
-			namedVolumes = append(namedVolumes, m.Source)
-		}
-	}
-	if err := d.Docker.RemoveWithVolumes(ctx, container.ID); err != nil {
-		return err
-	}
-	for _, name := range namedVolumes {
-		if err := d.Docker.RemoveVolume(ctx, name); err != nil {
-			log.Debugf("remove volume %s: %v", name, err)
-		}
-	}
-	return nil
+	return d.removeContainerAndVolumes(ctx, container)
 }
 
 func (d *dockerDriver) StartDevContainer(ctx context.Context, workspaceId string) error {
@@ -447,6 +427,35 @@ func (d *dockerDriver) UpdateContainerUserUID(
 	}
 
 	return d.applyPermissions(ctx, container.ID, localUser.Uid, localUser.Gid, info.HomeDir, writer)
+}
+
+// removeContainerAndVolumes deletes the container along with its anonymous
+// volumes (via `docker rm -v`), then removes each named volume the
+// container referenced. Named volumes are removed AFTER the container so
+// docker doesn't refuse on "volume in use" against the now-dead container.
+// Per-volume errors are logged at debug and skipped — a volume held by
+// another workspace (e.g. shared dockerless cache) shouldn't block delete.
+func (d *dockerDriver) removeContainerAndVolumes(
+	ctx context.Context,
+	container *config.ContainerDetails,
+) error {
+	// Snapshot named volumes before removal; the Mounts list is
+	// unrecoverable once the container is gone.
+	var namedVolumes []string
+	for _, m := range container.Mounts {
+		if m.Type == "volume" && m.Source != "" {
+			namedVolumes = append(namedVolumes, m.Source)
+		}
+	}
+	if err := d.Docker.RemoveWithVolumes(ctx, container.ID); err != nil {
+		return err
+	}
+	for _, name := range namedVolumes {
+		if err := d.Docker.RemoveVolume(ctx, name); err != nil {
+			log.Debugf("remove volume %s: %v", name, err)
+		}
+	}
+	return nil
 }
 
 func (d *dockerDriver) gatherUpdateRequirements(

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -20,6 +21,12 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 )
+
+// ErrDockerDaemonUnavailable signals that the docker daemon could not be
+// reached during a destructive operation (e.g. volume removal). It is a
+// hard failure: callers MUST surface it rather than treating the request
+// as successfully completed.
+var ErrDockerDaemonUnavailable = errors.New("docker daemon unavailable")
 
 func makeEnvironment(env map[string]string) []string {
 	if env == nil {
@@ -449,21 +456,22 @@ func (d *dockerDriver) removeContainerAndVolumes(
 	if err := d.Docker.RemoveWithVolumes(ctx, container.ID); err != nil {
 		return err
 	}
-	owned := d.filterDriverOwnedVolumes(ctx, candidates)
+	owned, err := d.filterDriverOwnedVolumes(ctx, candidates)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrDockerDaemonUnavailable, err)
+	}
 	for _, name := range owned {
-		err := d.Docker.RemoveVolume(ctx, name)
-		if err == nil {
+		rmErr := d.Docker.RemoveVolume(ctx, name)
+		if rmErr == nil {
 			continue
 		}
-		action := classifyVolumeRemoveError(err)
-		switch action {
+		switch classifyVolumeRemoveError(rmErr) {
 		case volumeErrIgnore:
-			log.Debugf("remove volume %s: %v", name, err)
+			log.Debugf("remove volume %s: %v", name, rmErr)
 		case volumeErrAbort:
-			log.Warnf("docker daemon unavailable, aborting volume cleanup: %v", err)
-			return nil
+			return fmt.Errorf("%w: %w", ErrDockerDaemonUnavailable, rmErr)
 		default:
-			log.Warnf("remove volume %s: %v", name, err)
+			log.Warnf("remove volume %s: %v", name, rmErr)
 		}
 	}
 	return nil
@@ -1325,13 +1333,15 @@ func isLegacyDriverOwnedVolume(name string) bool {
 
 // filterDriverOwnedVolumes keeps only volumes that carry the
 // `devsy.driver-owned=true` label, falling back to legacy name matching
-// for volumes created by older devsy versions. Inspect failures are
-// logged at debug; the volume is excluded to err on the side of caution
-// (better to leak a volume than to wipe a user's cache).
+// for volumes created by older devsy versions. A daemon-down inspect
+// failure aborts the entire walk so the caller can surface the outage;
+// any other inspect error is logged at debug and the volume is excluded
+// to err on the side of caution (better to leak a volume than to wipe
+// a user's cache).
 func (d *dockerDriver) filterDriverOwnedVolumes(
 	ctx context.Context,
 	names []string,
-) []string {
+) ([]string, error) {
 	var owned []string
 	for _, name := range names {
 		if isLegacyDriverOwnedVolume(name) {
@@ -1340,6 +1350,9 @@ func (d *dockerDriver) filterDriverOwnedVolumes(
 		}
 		labels, err := d.Docker.InspectVolumeLabels(ctx, name)
 		if err != nil {
+			if classifyVolumeInspectError(err) == volumeErrAbort {
+				return nil, err
+			}
 			log.Debugf("inspect volume %s labels (skipping): %v", name, err)
 			continue
 		}
@@ -1347,19 +1360,21 @@ func (d *dockerDriver) filterDriverOwnedVolumes(
 			owned = append(owned, name)
 		}
 	}
-	return owned
+	return owned, nil
 }
 
 // classifyVolumeRemoveError maps a docker CLI error message to a coarse
 // action. We rely on string matching because the docker client doesn't
-// expose structured error codes through the CLI.
+// expose structured error codes through the CLI. "permission denied"
+// alone is NOT enough to abort — a single restricted volume (e.g. in a
+// rootless setup) should not halt cleanup of every other volume; we
+// require an accompanying daemon-y hint to treat it as a hard outage.
 func classifyVolumeRemoveError(err error) volumeErrAction {
 	if err == nil {
 		return volumeErrOther
 	}
 	msg := err.Error()
-	if strings.Contains(msg, "Cannot connect to the Docker daemon") ||
-		strings.Contains(msg, "permission denied") {
+	if isDaemonUnavailableMessage(msg) {
 		return volumeErrAbort
 	}
 	if strings.Contains(msg, "is in use") ||
@@ -1368,4 +1383,38 @@ func classifyVolumeRemoveError(err error) volumeErrAction {
 		return volumeErrIgnore
 	}
 	return volumeErrOther
+}
+
+// classifyVolumeInspectError reuses the daemon-unavailable detector so
+// the inspect path can bail out the same way the remove path does. We
+// don't need an Ignore class here because the helper already swallows
+// missing-volume responses upstream.
+func classifyVolumeInspectError(err error) volumeErrAction {
+	if err == nil {
+		return volumeErrOther
+	}
+	if isDaemonUnavailableMessage(err.Error()) {
+		return volumeErrAbort
+	}
+	return volumeErrOther
+}
+
+// isDaemonUnavailableMessage returns true if the docker CLI error string
+// indicates the daemon is unreachable (socket missing, daemon not
+// running, or a daemon-scoped permission denial like
+// "Got permission denied while trying to connect to the Docker daemon").
+func isDaemonUnavailableMessage(msg string) bool {
+	if strings.Contains(msg, "Cannot connect to the Docker daemon") {
+		return true
+	}
+	if strings.Contains(msg, "Is the docker daemon running") {
+		return true
+	}
+	if !strings.Contains(msg, "permission denied") {
+		return false
+	}
+	return strings.Contains(msg, "daemon") ||
+		strings.Contains(msg, "socket") ||
+		strings.Contains(msg, "/var/run/docker") ||
+		strings.Contains(msg, "Got permission denied while trying to connect")
 }

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -431,28 +431,39 @@ func (d *dockerDriver) UpdateContainerUserUID(
 
 // removeContainerAndVolumes deletes the container along with its anonymous
 // volumes (via `docker rm -v`), then removes each named volume the
-// container referenced. Named volumes are removed AFTER the container so
-// docker doesn't refuse on "volume in use" against the now-dead container.
-// Per-volume errors are logged at debug and skipped — a volume held by
-// another workspace (e.g. shared dockerless cache) shouldn't block delete.
+// container referenced that devsy itself created. User-declared mounts
+// (e.g. `node_modules-cache`, language toolchain caches) are preserved
+// because they lack the `devsy.driver-owned` label.
+//
+// Per-volume errors are classified: "in use" / "no such volume" are
+// expected (debug only); a daemon-connection failure aborts further
+// attempts; any other error is surfaced at warn level but does not stop
+// processing of the remaining volumes.
 func (d *dockerDriver) removeContainerAndVolumes(
 	ctx context.Context,
 	container *config.ContainerDetails,
 ) error {
 	// Snapshot named volumes before removal; the Mounts list is
 	// unrecoverable once the container is gone.
-	var namedVolumes []string
-	for _, m := range container.Mounts {
-		if m.Type == "volume" && m.Source != "" {
-			namedVolumes = append(namedVolumes, m.Source)
-		}
-	}
+	candidates := collectNamedVolumes(container)
 	if err := d.Docker.RemoveWithVolumes(ctx, container.ID); err != nil {
 		return err
 	}
-	for _, name := range namedVolumes {
-		if err := d.Docker.RemoveVolume(ctx, name); err != nil {
+	owned := d.filterDriverOwnedVolumes(ctx, candidates)
+	for _, name := range owned {
+		err := d.Docker.RemoveVolume(ctx, name)
+		if err == nil {
+			continue
+		}
+		action := classifyVolumeRemoveError(err)
+		switch action {
+		case volumeErrIgnore:
 			log.Debugf("remove volume %s: %v", name, err)
+		case volumeErrAbort:
+			log.Warnf("docker daemon unavailable, aborting volume cleanup: %v", err)
+			return nil
+		default:
+			log.Warnf("remove volume %s: %v", name, err)
 		}
 	}
 	return nil
@@ -1277,4 +1288,84 @@ func (d *dockerDriver) copyFilesToContainer(
 		return err
 	}
 	return d.copyFileToContainer(ctx, files.groupOut.Name(), containerID, "/etc/group", writer)
+}
+
+// volumeErrAction classifies a docker volume rm error so the caller can
+// decide whether to ignore (expected), abort the whole loop (daemon gone),
+// or surface the issue while still attempting other volumes.
+type volumeErrAction int
+
+const (
+	volumeErrOther volumeErrAction = iota
+	volumeErrIgnore
+	volumeErrAbort
+)
+
+// collectNamedVolumes snapshots the named-volume mounts attached to a
+// container. Anonymous volumes (no Source) are skipped — they're handled
+// by `docker rm -v`.
+func collectNamedVolumes(container *config.ContainerDetails) []string {
+	var out []string
+	for _, m := range container.Mounts {
+		if m.Type == "volume" && m.Source != "" {
+			out = append(out, m.Source)
+		}
+	}
+	return out
+}
+
+// isLegacyDriverOwnedVolume returns true for naming conventions devsy used
+// before label-based ownership was introduced. Pre-upgrade workspaces don't
+// have the `devsy.driver-owned` label, so first-delete-after-upgrade still
+// needs to know which volumes were ours.
+func isLegacyDriverOwnedVolume(name string) bool {
+	return strings.HasPrefix(name, "dockerless-") ||
+		strings.HasPrefix(name, "devsy-agent-")
+}
+
+// filterDriverOwnedVolumes keeps only volumes that carry the
+// `devsy.driver-owned=true` label, falling back to legacy name matching
+// for volumes created by older devsy versions. Inspect failures are
+// logged at debug; the volume is excluded to err on the side of caution
+// (better to leak a volume than to wipe a user's cache).
+func (d *dockerDriver) filterDriverOwnedVolumes(
+	ctx context.Context,
+	names []string,
+) []string {
+	var owned []string
+	for _, name := range names {
+		if isLegacyDriverOwnedVolume(name) {
+			owned = append(owned, name)
+			continue
+		}
+		labels, err := d.Docker.InspectVolumeLabels(ctx, name)
+		if err != nil {
+			log.Debugf("inspect volume %s labels (skipping): %v", name, err)
+			continue
+		}
+		if labels[docker.LabelDriverOwned] == "true" {
+			owned = append(owned, name)
+		}
+	}
+	return owned
+}
+
+// classifyVolumeRemoveError maps a docker CLI error message to a coarse
+// action. We rely on string matching because the docker client doesn't
+// expose structured error codes through the CLI.
+func classifyVolumeRemoveError(err error) volumeErrAction {
+	if err == nil {
+		return volumeErrOther
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "Cannot connect to the Docker daemon") ||
+		strings.Contains(msg, "permission denied") {
+		return volumeErrAbort
+	}
+	if strings.Contains(msg, "is in use") ||
+		strings.Contains(msg, "no such volume") ||
+		strings.Contains(msg, "No such volume") {
+		return volumeErrIgnore
+	}
+	return volumeErrOther
 }

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -206,7 +206,7 @@ func (d *dockerDriver) DeleteDevContainer(
 	if !removeVolumes {
 		return d.Docker.Remove(ctx, container.ID)
 	}
-	return d.removeContainerAndVolumes(ctx, container)
+	return d.removeContainerAndVolumes(ctx, container, workspaceId)
 }
 
 func (d *dockerDriver) StartDevContainer(ctx context.Context, workspaceId string) error {
@@ -449,6 +449,7 @@ func (d *dockerDriver) UpdateContainerUserUID(
 func (d *dockerDriver) removeContainerAndVolumes(
 	ctx context.Context,
 	container *config.ContainerDetails,
+	workspaceID string,
 ) error {
 	// Snapshot named volumes before removal; the Mounts list is
 	// unrecoverable once the container is gone.
@@ -456,7 +457,7 @@ func (d *dockerDriver) removeContainerAndVolumes(
 	if err := d.Docker.RemoveWithVolumes(ctx, container.ID); err != nil {
 		return err
 	}
-	owned, err := d.filterDriverOwnedVolumes(ctx, candidates)
+	owned, err := d.filterDriverOwnedVolumes(ctx, candidates, workspaceID)
 	if err != nil {
 		return fmt.Errorf("%w: %w", ErrDockerDaemonUnavailable, err)
 	}
@@ -1332,15 +1333,23 @@ func isLegacyDriverOwnedVolume(name string) bool {
 }
 
 // filterDriverOwnedVolumes keeps only volumes that carry the
-// `devsy.driver-owned=true` label, falling back to legacy name matching
-// for volumes created by older devsy versions. A daemon-down inspect
-// failure aborts the entire walk so the caller can surface the outage;
-// any other inspect error is logged at debug and the volume is excluded
-// to err on the side of caution (better to leak a volume than to wipe
-// a user's cache).
+// `devsy.driver-owned=true` label AND whose `devsy.workspace-id` label
+// either matches the workspace being deleted or is empty (legacy /
+// diagnostic-missing). Legacy name matching covers volumes created by
+// older devsy versions that predate label-based ownership.
+//
+// The workspace-id check is defense-in-depth: it prevents an orphaned
+// volume left behind by an earlier workspace from being collateral-damaged
+// when an unrelated workspace runs its cleanup pass.
+//
+// A daemon-down inspect failure aborts the entire walk so the caller can
+// surface the outage; any other inspect error is logged at debug and the
+// volume is excluded to err on the side of caution (better to leak a
+// volume than to wipe a user's cache).
 func (d *dockerDriver) filterDriverOwnedVolumes(
 	ctx context.Context,
 	names []string,
+	workspaceID string,
 ) ([]string, error) {
 	var owned []string
 	for _, name := range names {
@@ -1356,11 +1365,26 @@ func (d *dockerDriver) filterDriverOwnedVolumes(
 			log.Debugf("inspect volume %s labels (skipping): %v", name, err)
 			continue
 		}
-		if labels[docker.LabelDriverOwned] == "true" {
+		if volumeOwnedByWorkspace(labels, workspaceID) {
 			owned = append(owned, name)
 		}
 	}
 	return owned, nil
+}
+
+// volumeOwnedByWorkspace returns true when the volume is devsy-owned and
+// safe to delete for the given workspace. A missing `devsy.workspace-id`
+// label is treated as "no constraint" — legacy or diagnostic-missing
+// labels should not block cleanup.
+func volumeOwnedByWorkspace(labels map[string]string, workspaceID string) bool {
+	if labels[docker.LabelDriverOwned] != "true" {
+		return false
+	}
+	wsLabel, hasLabel := labels[docker.LabelWorkspaceID]
+	if !hasLabel || wsLabel == "" {
+		return true
+	}
+	return wsLabel == workspaceID
 }
 
 // classifyVolumeRemoveError maps a docker CLI error message to a coarse

--- a/pkg/driver/docker/docker_test.go
+++ b/pkg/driver/docker/docker_test.go
@@ -1,12 +1,18 @@
 package docker
 
 import (
+	"context"
+	"errors"
+	"os"
 	"os/user"
+	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/driver"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -248,6 +254,86 @@ func (s *DockerDriverTestSuite) TestAddCapabilityArgs_CapAddAndSecurityOpt() {
 		"--cap-add", "SYS_PTRACE",
 		testSecurityOptFlag, testSeccompUnconfined,
 	}, args)
+}
+
+func (s *DockerDriverTestSuite) TestIsLegacyDriverOwnedVolume() {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"dockerless-abc123", true},
+		{"devsy-agent-abc123", true},
+		{"node_modules-cache", false},
+		{"my-cargo-cache", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		s.Equal(tc.want, isLegacyDriverOwnedVolume(tc.name), tc.name)
+	}
+}
+
+func (s *DockerDriverTestSuite) TestClassifyVolumeRemoveError() {
+	cases := []struct {
+		msg  string
+		want volumeErrAction
+	}{
+		{"Error response from daemon: volume is in use", volumeErrIgnore},
+		{"Error: no such volume: foo", volumeErrIgnore},
+		{"Error: No such volume: foo", volumeErrIgnore},
+		{"Cannot connect to the Docker daemon at unix:///var/run/docker.sock", volumeErrAbort},
+		{"permission denied while trying to connect", volumeErrAbort},
+		{"some other docker error", volumeErrOther},
+	}
+	for _, tc := range cases {
+		got := classifyVolumeRemoveError(errors.New(tc.msg))
+		s.Equal(tc.want, got, tc.msg)
+	}
+	s.Equal(volumeErrOther, classifyVolumeRemoveError(nil))
+}
+
+func (s *DockerDriverTestSuite) TestCollectNamedVolumes() {
+	c := &config.ContainerDetails{
+		Mounts: []config.ContainerMount{
+			{Type: "volume", Source: "named-1"},
+			{Type: "volume", Source: ""}, // anonymous, skipped
+			{Type: "bind", Source: "/host"},
+			{Type: "volume", Source: "named-2"},
+		},
+	}
+	got := collectNamedVolumes(c)
+	s.Equal([]string{"named-1", "named-2"}, got)
+}
+
+func writeScript(t *testing.T, dir, name, script string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	//nolint:gosec // test helper needs exec bit
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+	return path
+}
+
+func (s *DockerDriverTestSuite) TestFilterDriverOwnedVolumes_LabelAndLegacy() {
+	tmp := s.T().TempDir()
+	// script branches on the volume name passed at end of args
+	bin := writeScript(s.T(), tmp, "docker-fake", `#!/bin/sh
+last=
+for a in "$@"; do last=$a; done
+case "$last" in
+  labeled) echo '{"devsy.driver-owned":"true"}'; exit 0;;
+  unlabeled) echo '{}'; exit 0;;
+  bogus) echo 'Error: no such volume: bogus' 1>&2; exit 1;;
+esac
+`)
+
+	d := &dockerDriver{Docker: &docker.DockerHelper{DockerCommand: bin}}
+	got := d.filterDriverOwnedVolumes(context.Background(), []string{
+		"dockerless-xyz",  // legacy
+		"devsy-agent-xyz", // legacy
+		"labeled",         // labeled
+		"unlabeled",       // not owned, user cache
+		"bogus",           // missing -> excluded
+	})
+	s.Equal([]string{"dockerless-xyz", "devsy-agent-xyz", "labeled"}, got)
 }
 
 func (s *DockerDriverTestSuite) TestStripMountConsistency() {

--- a/pkg/driver/docker/docker_test.go
+++ b/pkg/driver/docker/docker_test.go
@@ -340,6 +340,9 @@ last=
 for a in "$@"; do last=$a; done
 case "$last" in
   labeled) echo '{"devsy.driver-owned":"true"}'; exit 0;;
+  labeled-match) echo '{"devsy.driver-owned":"true","devsy.workspace-id":"ws-A"}'; exit 0;;
+  labeled-other) echo '{"devsy.driver-owned":"true","devsy.workspace-id":"ws-B"}'; exit 0;;
+  labeled-empty) echo '{"devsy.driver-owned":"true","devsy.workspace-id":""}'; exit 0;;
   unlabeled) echo '{}'; exit 0;;
   bogus) echo 'Error: no such volume: bogus' 1>&2; exit 1;;
 esac
@@ -349,12 +352,75 @@ esac
 	got, err := d.filterDriverOwnedVolumes(context.Background(), []string{
 		"dockerless-xyz",  // legacy
 		"devsy-agent-xyz", // legacy
-		"labeled",         // labeled
+		"labeled",         // driver-owned, no workspace-id label -> kept
+		"labeled-match",   // driver-owned, workspace-id matches -> kept
+		"labeled-other",   // driver-owned, workspace-id DIFFERENT -> excluded
+		"labeled-empty",   // driver-owned, workspace-id empty string -> kept
 		"unlabeled",       // not owned, user cache
 		"bogus",           // missing -> excluded
-	})
+	}, "ws-A")
 	s.NoError(err)
-	s.Equal([]string{"dockerless-xyz", "devsy-agent-xyz", "labeled"}, got)
+	s.Equal([]string{
+		"dockerless-xyz",
+		"devsy-agent-xyz",
+		"labeled",
+		"labeled-match",
+		"labeled-empty",
+	}, got)
+}
+
+func (s *DockerDriverTestSuite) TestVolumeOwnedByWorkspace() {
+	cases := []struct {
+		name   string
+		labels map[string]string
+		ws     string
+		want   bool
+	}{
+		{
+			name:   "not driver-owned",
+			labels: map[string]string{},
+			ws:     "ws-A",
+			want:   false,
+		},
+		{
+			name: "driver-owned, no workspace-id label",
+			labels: map[string]string{
+				docker.LabelDriverOwned: "true",
+			},
+			ws:   "ws-A",
+			want: true,
+		},
+		{
+			name: "driver-owned, empty workspace-id",
+			labels: map[string]string{
+				docker.LabelDriverOwned: "true",
+				docker.LabelWorkspaceID: "",
+			},
+			ws:   "ws-A",
+			want: true,
+		},
+		{
+			name: "driver-owned, matching workspace-id",
+			labels: map[string]string{
+				docker.LabelDriverOwned: "true",
+				docker.LabelWorkspaceID: "ws-A",
+			},
+			ws:   "ws-A",
+			want: true,
+		},
+		{
+			name: "driver-owned, different workspace-id",
+			labels: map[string]string{
+				docker.LabelDriverOwned: "true",
+				docker.LabelWorkspaceID: "ws-B",
+			},
+			ws:   "ws-A",
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		s.Equal(tc.want, volumeOwnedByWorkspace(tc.labels, tc.ws), tc.name)
+	}
 }
 
 // TestFilterDriverOwnedVolumes_DaemonDownAborts verifies that when
@@ -369,7 +435,7 @@ exit 1
 `)
 
 	d := &dockerDriver{Docker: &docker.DockerHelper{DockerCommand: bin}}
-	got, err := d.filterDriverOwnedVolumes(context.Background(), []string{"some-vol"})
+	got, err := d.filterDriverOwnedVolumes(context.Background(), []string{"some-vol"}, "ws-A")
 	s.Error(err)
 	s.Nil(got)
 }
@@ -403,7 +469,7 @@ exit 1
 			{Type: "volume", Source: "dockerless-xyz"},
 		},
 	}
-	err := d.removeContainerAndVolumes(context.Background(), container)
+	err := d.removeContainerAndVolumes(context.Background(), container, "ws-A")
 	s.Error(err)
 	s.ErrorIs(err, ErrDockerDaemonUnavailable)
 }

--- a/pkg/driver/docker/docker_test.go
+++ b/pkg/driver/docker/docker_test.go
@@ -281,7 +281,16 @@ func (s *DockerDriverTestSuite) TestClassifyVolumeRemoveError() {
 		{"Error: no such volume: foo", volumeErrIgnore},
 		{"Error: No such volume: foo", volumeErrIgnore},
 		{"Cannot connect to the Docker daemon at unix:///var/run/docker.sock", volumeErrAbort},
-		{"permission denied while trying to connect", volumeErrAbort},
+		{"Is the docker daemon running?", volumeErrAbort},
+		{
+			"Got permission denied while trying to connect to the Docker daemon socket",
+			volumeErrAbort,
+		},
+		{"permission denied: /var/run/docker.sock", volumeErrAbort},
+		// Bare "permission denied" with no daemon hint must NOT abort —
+		// one restricted volume shouldn't halt cleanup of the rest.
+		{"Error: permission denied removing volume foo", volumeErrOther},
+		{"permission denied", volumeErrOther},
 		{"some other docker error", volumeErrOther},
 	}
 	for _, tc := range cases {
@@ -289,6 +298,17 @@ func (s *DockerDriverTestSuite) TestClassifyVolumeRemoveError() {
 		s.Equal(tc.want, got, tc.msg)
 	}
 	s.Equal(volumeErrOther, classifyVolumeRemoveError(nil))
+}
+
+func (s *DockerDriverTestSuite) TestClassifyVolumeInspectError() {
+	s.Equal(volumeErrOther, classifyVolumeInspectError(nil))
+	s.Equal(
+		volumeErrAbort,
+		classifyVolumeInspectError(
+			errors.New("Cannot connect to the Docker daemon at unix:///var/run/docker.sock"),
+		),
+	)
+	s.Equal(volumeErrOther, classifyVolumeInspectError(errors.New("some inspect failure")))
 }
 
 func (s *DockerDriverTestSuite) TestCollectNamedVolumes() {
@@ -326,14 +346,66 @@ esac
 `)
 
 	d := &dockerDriver{Docker: &docker.DockerHelper{DockerCommand: bin}}
-	got := d.filterDriverOwnedVolumes(context.Background(), []string{
+	got, err := d.filterDriverOwnedVolumes(context.Background(), []string{
 		"dockerless-xyz",  // legacy
 		"devsy-agent-xyz", // legacy
 		"labeled",         // labeled
 		"unlabeled",       // not owned, user cache
 		"bogus",           // missing -> excluded
 	})
+	s.NoError(err)
 	s.Equal([]string{"dockerless-xyz", "devsy-agent-xyz", "labeled"}, got)
+}
+
+// TestFilterDriverOwnedVolumes_DaemonDownAborts verifies that when
+// `docker volume inspect` reports the daemon is unreachable we surface
+// the failure instead of silently treating every candidate as
+// "not owned" and exiting cleanly.
+func (s *DockerDriverTestSuite) TestFilterDriverOwnedVolumes_DaemonDownAborts() {
+	tmp := s.T().TempDir()
+	bin := writeScript(s.T(), tmp, "docker-fake", `#!/bin/sh
+echo 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?' 1>&2
+exit 1
+`)
+
+	d := &dockerDriver{Docker: &docker.DockerHelper{DockerCommand: bin}}
+	got, err := d.filterDriverOwnedVolumes(context.Background(), []string{"some-vol"})
+	s.Error(err)
+	s.Nil(got)
+}
+
+// TestRemoveContainerAndVolumes_DaemonDownReturnsSentinel ensures the
+// daemon-down classification on volume removal produces an error that
+// wraps ErrDockerDaemonUnavailable, rather than the previous silent
+// `return nil` path that masked the outage from `devsy delete`.
+func (s *DockerDriverTestSuite) TestRemoveContainerAndVolumes_DaemonDownReturnsSentinel() {
+	tmp := s.T().TempDir()
+	// First call ("rm -fv ...") succeeds; subsequent volume calls report
+	// the daemon is unreachable. We sequence by writing a counter file.
+	counter := filepath.Join(tmp, "counter")
+	require.NoError(s.T(), os.WriteFile(counter, []byte("0"), 0o600))
+	bin := writeScript(s.T(), tmp, "docker-fake", `#!/bin/sh
+n=$(cat `+counter+`)
+echo $((n+1)) > `+counter+`
+if [ "$n" = "0" ]; then
+  # container removal succeeds
+  exit 0
+fi
+echo 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock' 1>&2
+exit 1
+`)
+
+	d := &dockerDriver{Docker: &docker.DockerHelper{DockerCommand: bin}}
+	container := &config.ContainerDetails{
+		ID: "c1",
+		Mounts: []config.ContainerMount{
+			// legacy name → skipped by inspect path, hits RemoveVolume directly
+			{Type: "volume", Source: "dockerless-xyz"},
+		},
+	}
+	err := d.removeContainerAndVolumes(context.Background(), container)
+	s.Error(err)
+	s.ErrorIs(err, ErrDockerDaemonUnavailable)
 }
 
 func (s *DockerDriverTestSuite) TestStripMountConsistency() {

--- a/pkg/driver/kubernetes/driver.go
+++ b/pkg/driver/kubernetes/driver.go
@@ -102,7 +102,16 @@ func (k *KubernetesDriver) StopDevContainer(ctx context.Context, workspaceId str
 	return nil
 }
 
-func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId string) error {
+// DeleteDevContainer deletes the workspace's pod and PVC. The kubernetes
+// driver always deletes its PVC, so removeVolumes is implicit and the flag
+// is accepted-but-ignored.
+//
+//nolint:cyclop // pre-existing complexity; arg added by --remove-volumes plumbing.
+func (k *KubernetesDriver) DeleteDevContainer(
+	ctx context.Context,
+	workspaceId string,
+	_ bool,
+) error {
 	log.Debugf("Deleting devcontainer for workspace '%s'", workspaceId)
 	defer log.Debugf("Done deleting devcontainer for workspace '%s'", workspaceId)
 

--- a/pkg/driver/types.go
+++ b/pkg/driver/types.go
@@ -27,8 +27,10 @@ type Driver interface {
 	// TargetArchitecture returns the architecture of the container runtime. e.g. amd64 or arm64
 	TargetArchitecture(ctx context.Context, workspaceID string) (string, error)
 
-	// DeleteDevContainer deletes the devcontainer
-	DeleteDevContainer(ctx context.Context, workspaceID string) error
+	// DeleteDevContainer deletes the devcontainer. When removeVolumes is true,
+	// drivers should also remove any named volumes the container references
+	// (drop "in use"/"not found" errors silently).
+	DeleteDevContainer(ctx context.Context, workspaceID string, removeVolumes bool) error
 
 	// StartDevContainer starts the devcontainer
 	StartDevContainer(ctx context.Context, workspaceID string) error


### PR DESCRIPTION
## Summary

Two related fixes to `devsy delete --remove-volumes`:

1. **The flag was a silent no-op for plain docker.** It flowed through every layer until `pkg/devcontainer/delete.go`, where the non-compose branch dropped it and called `docker rm <id>` with no `-v`. Now plumbed through `Driver.DeleteDevContainer(ctx, id, removeVolumes)` and the docker driver does `docker rm -v` plus `docker volume rm` for named volumes the container referenced.
2. **Removing every named volume was unsafe.** User-declared volumes in `devcontainer.json` `mounts` (`node_modules-cache`, language stores, etc.) got wiped when the user clicked Delete on one workspace. Now scoped via `devsy.driver-owned=true` + `devsy.workspace-id=<id>` labels stamped at create time. Legacy unlabeled volumes still cleanable via a name-prefix fallback (`dockerless-*`, `devsy-agent-*`).

## Commits

- `f8f4f2acc` — Expose `--remove-volumes` on `devsy delete` and forward from desktop's `workspace_delete` IPC handler.
- `7509ab7f1` — Plumb `removeVolumes` through `Driver.DeleteDevContainer`; docker driver does `docker rm -v` and removes named volumes the container referenced.
- `e3d985c4a` — Extract `removeContainerAndVolumes` helper to drop the `//nolint:cyclop`.
- `4ca13acfe` — Label-scope volume removal. Pre-create driver-owned volumes (`dockerless-<id>`, `devsy-agent-<id>`) with `devsy.driver-owned=true` + `devsy.workspace-id=<id>` labels. On delete, filter via `Docker.InspectVolumeLabels`. Legacy name-prefix fallback for unlabeled pre-upgrade volumes.
- `094f838a1` — Surface daemon-down failures during volume cleanup via `ErrDockerDaemonUnavailable` sentinel. Distinguish "in use" / "no such volume" (debug + continue) from daemon-down / daemon-y permission errors (warn + abort + propagate). Plumbs the sentinel through `runner.Delete`.
- `30f11f9f8` — Force `LC_ALL=C` + `LANG=C` on docker CLI invocations so daemon-down classification works regardless of host locale.
- `a4ff1a84e` — Defense-in-depth: filter requires `LabelWorkspaceID` to match the workspace being deleted (or be empty/missing for legacy). Prevents an orphaned labeled volume from another workspace getting collected.
- `8ac86ada5` — `LocalDockerDelivery.createVolume` now delegates to `DockerHelper.CreateVolume` instead of duplicating the inline `docker volume create` invocation.

## Behavior change

`devsy delete --remove-volumes` is now safe to leave on as a default in the desktop. User-declared mounts from `devcontainer.json` are no longer wiped. Driver-owned volumes (dockerless cache, agent delivery) are removed when their workspace is deleted.

## Tests

789 targeted tests pass. New coverage for label filter (matching/different/missing workspace-id), error classification (locale-aware daemon-down, narrowed "permission denied" abort scope), `Docker.CreateVolume` idempotency, end-to-end sentinel propagation through `runner.Delete`.