### PR TITLE
fix(ide): helper owns browser-open, port-forward, KubeConfig log noise

### DIFF
--- a/cmd/helper/browser_tunnel.go
+++ b/cmd/helper/browser_tunnel.go
@@ -31,6 +31,11 @@ type BrowserTunnelCmd struct {
 	User             string
 	GitSSHSigningKey string
 	InheritListeners []string
+	// OpenBrowser tells the helper to probe TargetURL and open the host
+	// browser once the listener accepts. The parent CLI exits in
+	// milliseconds after spawning the helper, so the auto-open must be
+	// owned by this long-lived process.
+	OpenBrowser bool
 }
 
 // NewBrowserTunnelCmd creates a new browser-tunnel helper command.
@@ -58,6 +63,12 @@ func NewBrowserTunnelCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		"inherit-listener",
 		nil,
 		"Inherited listener fd, format host:port=fd (repeatable, unix only)",
+	)
+	c.Flags().BoolVar(
+		&cmd.OpenBrowser,
+		"open-browser",
+		false,
+		"Open a host browser pointing at --target-url once the local listener is reachable",
 	)
 	return c
 }
@@ -166,6 +177,14 @@ func (cmd *BrowserTunnelCmd) Run(ctx context.Context) error {
 		return fmt.Errorf("parse inherited listeners: %w", err)
 	}
 
+	// Launch the probe-then-open goroutine before the blocking
+	// StartBrowserTunnel call so the TCP probe runs concurrently with
+	// SSH dial + listener bind. The probe observes ctx so it unwinds
+	// when the helper receives a signal.
+	if cmd.OpenBrowser && cmd.TargetURL != "" {
+		go opener.OpenBrowserWhenReachable(ctx, cmd.TargetURL)
+	}
+
 	return tunnel.StartBrowserTunnel(ctx, tunnel.BrowserTunnelParams{
 		DevsyConfig:      devsyConfig,
 		Client:           client,
@@ -176,6 +195,11 @@ func (cmd *BrowserTunnelCmd) Run(ctx context.Context) error {
 		AuthSockID:       cmd.AuthSockID,
 		GitSSHSigningKey: cmd.GitSSHSigningKey,
 		ExtraListeners:   extraListeners,
+		// Helper lifecycle is owned by opener.KillBrowserTunnel and
+		// devsy stop/delete; the EXIT_AFTER_TIMEOUT idle shutdown
+		// would otherwise close the port-forward shortly after the
+		// browser tab goes quiet.
+		DisableIdleTimeout: true,
 	})
 }
 

--- a/cmd/helper/browser_tunnel_test.go
+++ b/cmd/helper/browser_tunnel_test.go
@@ -3,7 +3,42 @@ package helper
 import (
 	"strings"
 	"testing"
+
+	"github.com/devsy-org/devsy/cmd/flags"
 )
+
+// TestNewBrowserTunnelCmd_OpenBrowserFlag locks down the flag plumbing for
+// --open-browser. Without this wiring the helper has no way to know it
+// should launch a host browser, since the parent CLI no longer owns that.
+func TestNewBrowserTunnelCmd_OpenBrowserFlag(t *testing.T) {
+	gf := &flags.GlobalFlags{}
+	c := NewBrowserTunnelCmd(gf)
+	if err := c.ParseFlags([]string{
+		"--workspace", "ws",
+		"--target-url", "http://localhost:1234",
+		"--open-browser",
+	}); err != nil {
+		t.Fatalf("ParseFlags: %v", err)
+	}
+	openFlag := c.Flags().Lookup("open-browser")
+	if openFlag == nil {
+		t.Fatal("--open-browser flag not registered")
+	}
+	if openFlag.Value.String() != "true" {
+		t.Errorf("--open-browser = %q, want true", openFlag.Value.String())
+	}
+
+	// Default (flag absent) is false.
+	gf2 := &flags.GlobalFlags{}
+	c2 := NewBrowserTunnelCmd(gf2)
+	if err := c2.ParseFlags([]string{"--workspace", "ws"}); err != nil {
+		t.Fatalf("ParseFlags (default): %v", err)
+	}
+	if c2.Flags().Lookup("open-browser").Value.String() != "false" {
+		t.Errorf("--open-browser default = %q, want false",
+			c2.Flags().Lookup("open-browser").Value.String())
+	}
+}
 
 func TestParseInheritedListenerEntry_Errors(t *testing.T) {
 	tests := []struct {

--- a/e2e/tests/ide/browser_returns.go
+++ b/e2e/tests/ide/browser_returns.go
@@ -3,8 +3,13 @@
 package ide
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"net"
+	"net/url"
 	"os"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -187,6 +192,105 @@ var _ = ginkgo.Describe(
 
 				err := f.DevsyStop(ctx, tempDir)
 				framework.ExpectNoError(err)
+			},
+		)
+
+		ginkgo.It(
+			"browser-tunnel port-forward survives past the old 5s idle timeout",
+			ginkgo.SpecTimeout(framework.TimeoutLong()),
+			func(ctx context.Context) {
+				f, tempDir := setupBrowserIDE(ctx, initialDir)
+				state := upBrowserIDE(ctx, f, tempDir)
+
+				// Parse host:port from state.TargetURL (e.g.
+				// http://localhost:10800/?folder=...).
+				u, err := url.Parse(state.TargetURL)
+				framework.ExpectNoError(err)
+				addr := u.Host
+
+				// First wait for the listener to actually bind. Use Eventually
+				// so a slow cold-start (which the 30s probe budget is sized
+				// for) doesn't race the assertion.
+				gomega.Eventually(func() error {
+					c, dialErr := net.DialTimeout("tcp", addr, 1*time.Second)
+					if dialErr == nil {
+						_ = c.Close()
+					}
+					return dialErr
+				}).WithTimeout(30*time.Second).WithPolling(500*time.Millisecond).
+					Should(gomega.Succeed(), "helper port-forward at %s never came up", addr)
+
+				// Now sleep past the OLD 5s idle window with NO connections.
+				time.Sleep(8 * time.Second)
+
+				// And the listener must still accept.
+				conn, err := net.DialTimeout("tcp", addr, 3*time.Second)
+				gomega.Expect(err).NotTo(gomega.HaveOccurred(),
+					"expected helper port-forward at %s to still accept after 8s idle", addr)
+				if conn != nil {
+					_ = conn.Close()
+				}
+
+				framework.ExpectNoError(f.DevsyStop(ctx, tempDir))
+			},
+		)
+
+		ginkgo.It(
+			"passes --open-browser to the helper when --ide-launch=auto",
+			ginkgo.SpecTimeout(framework.TimeoutLong()),
+			func(ctx context.Context) {
+				if runtime.GOOS != "linux" {
+					ginkgo.Skip("/proc/<pid>/cmdline inspection requires Linux")
+				}
+				f, tempDir := setupBrowserIDE(ctx, initialDir)
+
+				err := f.DevsyUpWithIDE(ctx,
+					"--ide=openvscode", "--ide-launch=auto", tempDir,
+				)
+				framework.ExpectNoError(err)
+
+				ws, err := f.FindWorkspace(ctx, tempDir)
+				framework.ExpectNoError(err)
+				gomega.Expect(ws).NotTo(gomega.BeNil())
+				state, err := opener.ReadTunnelState(ws.Context, ws.ID)
+				framework.ExpectNoError(err)
+				gomega.Expect(state).NotTo(gomega.BeNil(),
+					"expected tunnel.json to exist for browser IDE")
+				gomega.Expect(state.PID).To(gomega.BeNumerically(">", 0))
+
+				// Read the helper's argv from /proc.
+				cmdlineBytes, err := os.ReadFile(
+					fmt.Sprintf("/proc/%d/cmdline", state.PID),
+				)
+				framework.ExpectNoError(err)
+				cmdlineBytes = bytes.TrimRight(cmdlineBytes, "\x00")
+				args2 := strings.Split(string(cmdlineBytes), "\x00")
+
+				gomega.Expect(args2).To(gomega.ContainElement("--open-browser"),
+					"expected helper to be launched with --open-browser, got args: %v", args2)
+
+				framework.ExpectNoError(f.DevsyStop(ctx, tempDir))
+			},
+		)
+
+		ginkgo.It(
+			"does not log 'setup KubeConfig' on a workspace without kubeconfig forwarding",
+			ginkgo.SpecTimeout(framework.TimeoutLong()),
+			func(ctx context.Context) {
+				f, tempDir := setupBrowserIDE(ctx, initialDir)
+				stdout, stderr, err := f.DevsyUpStreamsRaw(ctx, tempDir,
+					"--ide=openvscode", "--ide-launch=headless", "--debug")
+				framework.ExpectNoError(err)
+				combined := stdout + stderr
+
+				// The line "setup KubeConfig" used to fire unconditionally.
+				// After the fix it only fires when the host actually has a
+				// config to forward, which is not configured for the default
+				// test workspace.
+				gomega.Expect(combined).NotTo(gomega.ContainSubstring("setup KubeConfig"),
+					"should not log 'setup KubeConfig' when host has no kubeconfig to forward")
+
+				framework.ExpectNoError(f.DevsyStop(ctx, tempDir))
 			},
 		)
 	},

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -382,16 +382,19 @@ func setupKubeConfig(
 	if shouldSkipKubeConfig(tunnelClient) {
 		return nil
 	}
-	log.Info("setup KubeConfig")
 
 	kubeConfigRes, err := tunnelClient.KubeConfig(ctx, &tunnel.Message{})
 	if err != nil {
 		return err
 	}
-	if kubeConfigRes.Message == "" { // no kubeconfig returned, skip
+	if kubeConfigRes.Message == "" {
+		// Empty payload means the host had nothing to forward; trace at
+		// debug so a missing ~/.kube/config is diagnosable on demand.
+		log.Debug("kubeconfig RPC returned empty payload; skipping kubeconfig setup")
 		return nil
 	}
 
+	log.Info("setup KubeConfig")
 	if err := writeKubeConfig(setupInfo, kubeConfigRes.Message); err != nil {
 		return err
 	}

--- a/pkg/devcontainer/setup/setup_test.go
+++ b/pkg/devcontainer/setup/setup_test.go
@@ -1,0 +1,76 @@
+package setup
+
+import (
+	"context"
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/agent/tunnel"
+	"github.com/devsy-org/devsy/pkg/log"
+	"go.uber.org/zap/zapcore"
+	"google.golang.org/grpc"
+)
+
+// fakeTunnelClient is a minimal stub of tunnel.TunnelClient. Only KubeConfig
+// is exercised here; the other methods return zero values and are unused by
+// setupKubeConfig.
+type fakeTunnelClient struct {
+	tunnel.TunnelClient // embed for the unused methods (nil panics if called)
+	kubeConfigPayload   string
+}
+
+// Compile-time guard: a typo in the KubeConfig signature would silently
+// fail to override the embedded interface method otherwise.
+var _ tunnel.TunnelClient = (*fakeTunnelClient)(nil)
+
+func (f *fakeTunnelClient) KubeConfig(
+	_ context.Context, _ *tunnel.Message, _ ...grpc.CallOption,
+) (*tunnel.Message, error) {
+	return &tunnel.Message{Message: f.kubeConfigPayload}, nil
+}
+
+// TestSetupKubeConfig_EmptyPayloadSuppressesInfoLog verifies that an empty
+// KubeConfig RPC reply does NOT emit the "setup KubeConfig" Info line. The
+// e2e substring-absence check is brittle to log renames; this is the
+// direct guard for the demotion to Debug.
+func TestSetupKubeConfig_EmptyPayloadSuppressesInfoLog(t *testing.T) {
+	logs := log.InitTestObserved(t, zapcore.DebugLevel)
+
+	client := &fakeTunnelClient{kubeConfigPayload: ""}
+	if err := setupKubeConfig(context.Background(), nil, client); err != nil {
+		t.Fatalf("setupKubeConfig: %v", err)
+	}
+
+	for _, entry := range logs.All() {
+		if entry.Level >= zapcore.InfoLevel {
+			// "setup KubeConfig" specifically must not appear at Info+.
+			if entry.Message == "setup KubeConfig" {
+				t.Errorf("expected no 'setup KubeConfig' log; got: %+v", entry)
+			}
+		}
+	}
+	if got := logs.FilterMessageSnippet("setup KubeConfig").Len(); got != 0 {
+		t.Errorf("expected zero 'setup KubeConfig' entries, got %d", got)
+	}
+}
+
+// TestSetupKubeConfig_NonEmptyPayloadEmitsInfoLog asserts the Info-level
+// "setup KubeConfig" line still fires when the host returns a non-empty
+// kubeconfig payload. writeKubeConfig may fail in the test environment, but
+// the log is emitted BEFORE that call so we still expect to see it.
+func TestSetupKubeConfig_NonEmptyPayloadEmitsInfoLog(t *testing.T) {
+	logs := log.InitTestObserved(t, zapcore.DebugLevel)
+
+	client := &fakeTunnelClient{
+		kubeConfigPayload: "apiVersion: v1\nclusters: []",
+	}
+	// Error is expected because writeKubeConfig will fail without a valid
+	// remote user / home dir in the test env; we only care about the log.
+	_ = setupKubeConfig(context.Background(), nil, client)
+
+	if got := logs.FilterMessage("setup KubeConfig").Len(); got == 0 {
+		t.Errorf(
+			"expected at least one 'setup KubeConfig' log entry on non-empty payload, got 0 (all=%v)",
+			logs.All(),
+		)
+	}
+}

--- a/pkg/ide/opener/browser_tunnel.go
+++ b/pkg/ide/opener/browser_tunnel.go
@@ -22,9 +22,12 @@ import (
 )
 
 // browserProbeBudget bounds how long openBrowserWhenReachable will wait for
-// the target URL's port to accept TCP connections before giving up.
+// the target URL's port to accept TCP connections before giving up. The
+// cold-start path (agent injection + SSH session + listener bind) can take
+// tens of seconds; the reuse path skips the probe entirely, so this only
+// costs latency on the first launch.
 const (
-	browserProbeBudget   = 5 * time.Second
+	browserProbeBudget   = 30 * time.Second
 	browserProbeInterval = 200 * time.Millisecond
 	browserProbeDial     = 300 * time.Millisecond
 )
@@ -205,7 +208,13 @@ func startDetachedBrowserTunnel(
 		return reusedURL, nil
 	}
 
-	pid, logLocation, err := spawnTunnelHelper(contextName, workspaceID, tunnelParams, label)
+	pid, logLocation, err := spawnTunnelHelper(spawnHelperOpts{
+		ContextName:  contextName,
+		WorkspaceID:  workspaceID,
+		TunnelParams: tunnelParams,
+		Label:        label,
+		OpenBrowser:  openBrowser,
+	})
 	if err != nil {
 		return "", err
 	}
@@ -216,11 +225,24 @@ func startDetachedBrowserTunnel(
 		label, pid, logLocation, workspaceID,
 	)
 
-	if openBrowser {
-		go openBrowserAsync(ctx, tunnelParams.TargetURL)
-	}
+	// The browser auto-open is owned by the helper (via --open-browser),
+	// not by this process: the parent CLI exits in milliseconds and would
+	// reap any goroutine started here before the probe could run.
 
 	return tunnelParams.TargetURL, nil
+}
+
+// spawnHelperOpts groups the inputs spawnTunnelHelper needs. OpenBrowser
+// sits here rather than on tunnel.BrowserTunnelParams because the
+// runtime-loaded helper owns the browser-launch end-to-end; threading it
+// through the shared params struct would imply other callers can request
+// auto-open too, which they cannot.
+type spawnHelperOpts struct {
+	ContextName  string
+	WorkspaceID  string
+	TunnelParams tunnel.BrowserTunnelParams
+	Label        string
+	OpenBrowser  bool
 }
 
 // spawnTunnelHelper locates the current executable, builds the helper
@@ -228,17 +250,18 @@ func startDetachedBrowserTunnel(
 // detached helper process, and records its PID in the tunnel state file.
 // It returns the spawned helper PID and the log location that should be
 // reported to the user.
-func spawnTunnelHelper(
-	contextName, workspaceID string,
-	tunnelParams tunnel.BrowserTunnelParams,
-	label string,
-) (int, string, error) {
+func spawnTunnelHelper(opts spawnHelperOpts) (int, string, error) {
+	contextName := opts.ContextName
+	workspaceID := opts.WorkspaceID
+	tunnelParams := opts.TunnelParams
+	label := opts.Label
+
 	execPath, err := os.Executable()
 	if err != nil {
 		return 0, "", fmt.Errorf("locate executable: %w", err)
 	}
 
-	args := buildHelperArgs(contextName, workspaceID, tunnelParams)
+	args := buildHelperArgs(contextName, workspaceID, tunnelParams, opts.OpenBrowser)
 
 	// Pre-bind the host listeners in the parent so the chosen ports are
 	// truly reserved before the helper forks. On Windows this is a no-op.
@@ -347,6 +370,7 @@ func attachHelperStdio(cmd *exec.Cmd, logFile, devNull *os.File) {
 func buildHelperArgs(
 	contextName, workspaceID string,
 	tunnelParams tunnel.BrowserTunnelParams,
+	openBrowser bool,
 ) []string {
 	args := []string{
 		"helper", "browser-tunnel",
@@ -362,6 +386,9 @@ func buildHelperArgs(
 	}
 	for _, p := range tunnelParams.ExtraPorts {
 		args = append(args, "--extra-ports", p)
+	}
+	if openBrowser {
+		args = append(args, "--open-browser")
 	}
 	if pkglog.DebugEnabled() {
 		args = append(args, "--debug")
@@ -490,12 +517,17 @@ func runDaemonBrowserTunnel(ctx context.Context, a daemonTunnelArgs) (string, er
 	return a.TunnelParams.TargetURL, tunnel.StartBrowserTunnel(ctx, a.TunnelParams)
 }
 
-// openBrowserWhenReachable polls the target URL's TCP port until it accepts
-// connections, then opens the browser. If ctx is cancelled before the port
-// is reachable the goroutine exits silently — the caller already gave up
-// (e.g. tunnel.StartBrowserTunnel failed) and warning about an unreachable
-// URL would only duplicate that error. The "didn't come up" warning is
-// reserved for the budget-expired case.
+// OpenBrowserWhenReachable polls the target URL's TCP port until it accepts
+// connections, then opens the browser. Exits silently when ctx is cancelled
+// (the caller already gave up — warning would duplicate the underlying
+// error); emits a "didn't come up" warning only when the budget expires.
+//
+// Exported so the long-lived browser-tunnel helper can own the probe-then-
+// open sequence rather than the short-lived parent CLI.
+func OpenBrowserWhenReachable(ctx context.Context, url string) {
+	openBrowserWhenReachable(ctx, url)
+}
+
 func openBrowserWhenReachable(ctx context.Context, url string) {
 	hostPort, err := hostPortFromURL(url)
 	if err != nil {

--- a/pkg/ide/opener/browser_tunnel_test.go
+++ b/pkg/ide/opener/browser_tunnel_test.go
@@ -36,7 +36,7 @@ func TestBuildHelperArgs_Basic(t *testing.T) {
 		AuthSockID:       "sock-abc",
 		User:             "test-user",
 		GitSSHSigningKey: "",
-	})
+	}, false)
 
 	if len(args) < 2 || args[0] != "helper" || args[1] != "browser-tunnel" {
 		t.Fatalf("expected args to start with [helper browser-tunnel], got %v", args)
@@ -57,7 +57,7 @@ func TestBuildHelperArgs_Basic(t *testing.T) {
 		}
 	}
 
-	for _, unwanted := range []string{"--forward-ports", "--extra-ports"} {
+	for _, unwanted := range []string{"--forward-ports", "--extra-ports", "--open-browser"} {
 		if containsArg(args, unwanted) {
 			t.Errorf("unexpected %s for default params: %v", unwanted, args)
 		}
@@ -68,7 +68,7 @@ func TestBuildHelperArgs_ForwardPorts(t *testing.T) {
 	args := buildHelperArgs("ctx", "ws", tunnel.BrowserTunnelParams{
 		TargetURL:    "http://localhost:1234",
 		ForwardPorts: true,
-	})
+	}, false)
 	if !containsArg(args, "--forward-ports") {
 		t.Errorf("expected --forward-ports in %v", args)
 	}
@@ -78,12 +78,30 @@ func TestBuildHelperArgs_ExtraPorts(t *testing.T) {
 	args := buildHelperArgs("ctx", "ws", tunnel.BrowserTunnelParams{
 		TargetURL:  "http://localhost:1234",
 		ExtraPorts: []string{"localhost:10800", "127.0.0.1:8443"},
-	})
+	}, false)
 	if !containsAdjacent(args, "--extra-ports", "localhost:10800") {
 		t.Errorf("missing --extra-ports localhost:10800 in %v", args)
 	}
 	if !containsAdjacent(args, "--extra-ports", "127.0.0.1:8443") {
 		t.Errorf("missing --extra-ports 127.0.0.1:8443 in %v", args)
+	}
+}
+
+// TestBuildHelperArgs_OpenBrowser asserts the --open-browser flag is
+// emitted iff openBrowser=true.
+func TestBuildHelperArgs_OpenBrowser(t *testing.T) {
+	withFlag := buildHelperArgs("ctx", "ws", tunnel.BrowserTunnelParams{
+		TargetURL: "http://localhost:1234",
+	}, true)
+	if !containsArg(withFlag, "--open-browser") {
+		t.Errorf("expected --open-browser in %v", withFlag)
+	}
+
+	withoutFlag := buildHelperArgs("ctx", "ws", tunnel.BrowserTunnelParams{
+		TargetURL: "http://localhost:1234",
+	}, false)
+	if containsArg(withoutFlag, "--open-browser") {
+		t.Errorf("did not expect --open-browser in %v", withoutFlag)
 	}
 }
 
@@ -290,6 +308,80 @@ func TestOpenBrowserWhenReachable_CtxCancelledSilently(t *testing.T) {
 			"openBrowserWhenReachable returned after %s; expected prompt return on ctx cancel",
 			elapsed,
 		)
+	}
+}
+
+// TestProbeTCPReachable_BudgetExceedsFiveSeconds proves the probe can wait
+// past the legacy 5s budget. Brings the listener up 6s into the probe and
+// asserts the probe succeeds rather than timing out.
+func TestProbeTCPReachable_BudgetExceedsFiveSeconds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("test waits >6s")
+	}
+
+	addr := allocateClosedAddr(t)
+	listenErr := relistenAfter(addr, 6*time.Second, 2*time.Second)
+
+	// Use a budget well above 5s but generous enough to handle CI slowness.
+	probeErr := probeTCPReachable(context.Background(), addr, 15*time.Second)
+
+	checkRelistenOrSkip(t, addr, listenErr)
+	if probeErr != nil {
+		t.Fatalf(
+			"probeTCPReachable should succeed once listener comes up at T+6s, got: %v",
+			probeErr,
+		)
+	}
+}
+
+// allocateClosedAddr returns a 127.0.0.1 address that was momentarily bound
+// then released, so the OS knows the port number but nothing is currently
+// listening on it. Used by probe-budget tests to set up a "listener arrives
+// later" scenario.
+func allocateClosedAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	return addr
+}
+
+// relistenAfter spawns a goroutine that, after delay, binds addr and holds
+// the listener open for hold before closing. The returned channel surfaces
+// any net.Listen error (e.g. EADDRINUSE) so the caller can convert a port-
+// reuse race into a Skip rather than a hang.
+func relistenAfter(addr string, delay, hold time.Duration) <-chan error {
+	listenErr := make(chan error, 1)
+	go func() {
+		time.Sleep(delay)
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			listenErr <- err
+			return
+		}
+		listenErr <- nil
+		time.Sleep(hold)
+		_ = ln.Close()
+	}()
+	return listenErr
+}
+
+// checkRelistenOrSkip drains a non-blocking read from listenErr. A non-nil
+// error means the OS reassigned the port in the close→relisten window;
+// skip rather than fail to avoid spurious CI failures on busy hosts.
+func checkRelistenOrSkip(t *testing.T, addr string, listenErr <-chan error) {
+	t.Helper()
+	select {
+	case lErr := <-listenErr:
+		if lErr != nil {
+			t.Skipf("port %s was reassigned between close and relisten: %v", addr, lErr)
+		}
+	default:
 	}
 }
 

--- a/pkg/tunnel/browser.go
+++ b/pkg/tunnel/browser.go
@@ -38,6 +38,12 @@ type BrowserTunnelParams struct {
 	// DaemonStartFunc is called when the client is a DaemonClient.
 	// If nil, the SSH tunnel path is always used.
 	DaemonStartFunc func(ctx context.Context) error
+
+	// DisableIdleTimeout opts forwarded ports out of the
+	// EXIT_AFTER_TIMEOUT idle shutdown. Set by callers whose lifecycle
+	// is managed out-of-band (e.g. the detached browser-tunnel helper,
+	// reaped by KillBrowserTunnel and devsy stop/delete).
+	DisableIdleTimeout bool
 }
 
 // StartBrowserTunnel sets up a browser tunnel for IDE access, either via daemon or SSH.
@@ -108,8 +114,9 @@ func runBrowserTunnelServices(
 			ConfigureGitSSHSignatureHelper: p.DevsyConfig.ContextOption(
 				config.ContextOptionGitSSHSignatureForwarding,
 			) == config.BoolTrue,
-			GitSSHSigningKey: p.GitSSHSigningKey,
-			ExtraListeners:   p.ExtraListeners,
+			GitSSHSigningKey:   p.GitSSHSigningKey,
+			ExtraListeners:     p.ExtraListeners,
+			DisableIdleTimeout: p.DisableIdleTimeout,
 		},
 	)
 	if err != nil {

--- a/pkg/tunnel/services.go
+++ b/pkg/tunnel/services.go
@@ -55,10 +55,19 @@ type RunServicesOptions struct {
 	// ExtraListeners holds pre-bound listeners keyed by "host:port" so the
 	// helper can skip net.Listen and avoid a probe-to-listen TOCTOU race.
 	ExtraListeners map[string]net.Listener
+	// DisableIdleTimeout forces a zero idle-shutdown duration regardless of
+	// the EXIT_AFTER_TIMEOUT context option. Used by callers reaped
+	// out-of-band rather than by idle activity.
+	DisableIdleTimeout bool
 }
 
-// getExitAfterTimeout calculates the timeout value based on configuration.
-func getExitAfterTimeout(devsyConfig *config.Config) time.Duration {
+// getExitAfterTimeout resolves the per-forward idle-shutdown duration.
+// Returns 0 (no idle shutdown) when disableIdleTimeout is set or when
+// EXIT_AFTER_TIMEOUT is not true in the active context.
+func getExitAfterTimeout(devsyConfig *config.Config, disableIdleTimeout bool) time.Duration {
+	if disableIdleTimeout {
+		return 0
+	}
 	if devsyConfig.ContextOption(config.ContextOptionExitAfterTimeout) != config.BoolTrue {
 		return 0
 	}
@@ -221,7 +230,7 @@ func runServicesIteration(
 // to run the credentials server remotely and the services server locally to
 // communicate with the container.
 func RunServices(ctx context.Context, opts RunServicesOptions) error {
-	exitAfterTimeout := getExitAfterTimeout(opts.DevsyConfig)
+	exitAfterTimeout := getExitAfterTimeout(opts.DevsyConfig, opts.DisableIdleTimeout)
 
 	fp := portForwardParams{
 		containerClient:  opts.ContainerClient,

--- a/pkg/tunnel/services_test.go
+++ b/pkg/tunnel/services_test.go
@@ -3,9 +3,56 @@ package tunnel
 import (
 	"encoding/base64"
 	"testing"
+	"time"
 
+	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
+
+const testCtxName = "default"
+
+// newConfigWithExitAfterTimeout returns a *config.Config whose default
+// context sets EXIT_AFTER_TIMEOUT to the given value.
+func newConfigWithExitAfterTimeout(value string) *config.Config {
+	return &config.Config{
+		DefaultContext: testCtxName,
+		Contexts: map[string]*config.ContextConfig{
+			testCtxName: {
+				Options: map[string]config.OptionValue{
+					config.ContextOptionExitAfterTimeout: {Value: value},
+				},
+			},
+		},
+	}
+}
+
+func TestGetExitAfterTimeout_EnabledByContextOption(t *testing.T) {
+	cfg := newConfigWithExitAfterTimeout(config.BoolTrue)
+	assert.Equal(t, defaultExitTimeout, getExitAfterTimeout(cfg, false))
+}
+
+func TestGetExitAfterTimeout_DisabledByContextOption(t *testing.T) {
+	cfg := newConfigWithExitAfterTimeout(config.BoolFalse)
+	assert.Equal(t, time.Duration(0), getExitAfterTimeout(cfg, false))
+}
+
+func TestGetExitAfterTimeout_DisableIdleTimeoutOverridesEnabled(t *testing.T) {
+	cfg := newConfigWithExitAfterTimeout(config.BoolTrue)
+	assert.Equal(
+		t,
+		time.Duration(0),
+		getExitAfterTimeout(cfg, true),
+	)
+}
+
+func TestGetExitAfterTimeout_DisableIdleTimeoutOverridesDisabled(t *testing.T) {
+	cfg := newConfigWithExitAfterTimeout(config.BoolFalse)
+	assert.Equal(
+		t,
+		time.Duration(0),
+		getExitAfterTimeout(cfg, true),
+	)
+}
 
 const testBaseCommand = "devsy agent container credentials-server --user root"
 


### PR DESCRIPTION
## Summary

Three user-confirmed bugs in the detached browser-IDE tunnel helper that surfaced after #444 merged:

1. **Browser never auto-opens.** The parent `devsy up` fired `go openBrowserAsync(url)` then exited ~3ms later, killing the goroutine before it could spawn the host browser.
2. **Port-forward dies ~5s after the browser tab goes quiet.** The detached helper inherited the 5s `EXIT_AFTER_TIMEOUT` SSH idle shutdown designed for interactive `devsy ssh`.
3. **`setup KubeConfig` logged on every `devsy up`**, even when the host had no kubeconfig to forward (the common case for plain devcontainers).

## What changed

| Concern | Fix |
| --- | --- |
| Browser auto-open | Parent CLI passes `--open-browser` to the long-lived helper; the helper kicks off a probe-then-open goroutine that waits for the local listener to be reachable before launching the OS browser. The user never sees "refused to connect" on a fresh launch. |
| Helper port-forward lifetime | `BrowserTunnelParams.DisableIdleTimeout` → `RunServicesOptions.DisableIdleTimeout` → `getExitAfterTimeout`. Helper opts out of `EXIT_AFTER_TIMEOUT` because its lifecycle is owned by `opener.KillBrowserTunnel` and `devsy stop`/`devsy delete`. Interactive `devsy ssh` path is unchanged. |
| KubeConfig log noise | Move `log.Info("setup KubeConfig")` past the empty-response check; debug-trace empty payloads so a missing `~/.kube/config` remains diagnosable on demand. |
| Cold-start probe budget | Bump `browserProbeBudget` 5s → 30s. First-launch path (agent injection + SSH session + listener bind) takes tens of seconds and was making the auto-open silently skip. The reuse path skips the probe entirely, so this only costs latency on first launch. |

## Tests

**Unit:**
- `pkg/tunnel/services_test.go` — 4 truth-table cases on `getExitAfterTimeout(DisableIdleTimeout × EXIT_AFTER_TIMEOUT)`.
- `cmd/helper/browser_tunnel_test.go` — `--open-browser` plumbs to `BrowserTunnelCmd.OpenBrowser`.
- `pkg/ide/opener/browser_tunnel_test.go` — `buildHelperArgs` emits `--open-browser` iff requested; probe budget can actually wait past the old 5s (listener brought up at T+6s, succeeds within 15s budget; surfaces rare port-reuse races as `Skip` rather than hang).
- `pkg/devcontainer/setup/setup_test.go` (new) — fake `TunnelClient` with compile-time interface guard; asserts empty-payload suppresses Info log and non-empty payload fires it.

**E2E (against docker, in `e2e/tests/ide/browser_returns.go`):**
- Port-forward survives 8s of confirmed idleness past the legacy 5s window. Uses `gomega.Eventually` to confirm bind first, so the sleep is real idleness rather than a race against the unarmed timer.
- Helper process is launched with `--open-browser` when `--ide-launch=auto` (verified via `/proc/<pid>/cmdline` on Linux).
- No `setup KubeConfig` log on a workspace without kubeconfig forwarding.

## Review history

Three full review-team passes were run on this branch before squash:

1. Initial — flagged 4 silent-failure / robustness items (probe-then-open ordering, daemon-path browser open, kubeconfig log demotion noise, idle-timeout regression). All addressed in the squashed commit.
2. After the e2e specs landed — flagged e2e idle-headroom thinness, cmdline trailing-NUL fragility, missing kubeconfig demotion unit, missing probe-budget unit. All addressed.
3. Final pass — surfaced a TOCTOU + hang risk in the probe-budget test and a missing compile-time interface guard on the fake `TunnelClient`. Both addressed.

Branch is now at zero HIGH-priority findings.

## Out of scope (follow-ups)

- `pkg/tunnel/services.go::forwardConfigPorts` logs async port-forward death only to the helper's tunnel.log with no host-visible signal. Pre-existing; now more visible since the helper survives idle. Worth a `tunnel.json` health field in a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional browser auto-open capability for IDE launches, with configurable TCP probe timing.
  * Added ability to disable idle timeout for persistent port forwarding connections.

* **Bug Fixes**
  * Improved kubeconfig setup logging to only display when configuration is actually available.

* **Tests**
  * Expanded test coverage for browser IDE behavior, idle timeout handling, and kubeconfig setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->