### PR TITLE
chore(agent): clarify inject-source arch-mismatch log message

### DIFF
--- a/pkg/agent/binary.go
+++ b/pkg/agent/binary.go
@@ -138,18 +138,26 @@ func (c *BinaryCache) atomicWrite(path string, data io.Reader) error {
 type InjectSource struct{}
 
 func (s *InjectSource) GetBinary(ctx context.Context, arch string) (io.ReadCloser, error) {
-	if !s.matchesCurrentRuntime(arch) {
-		return nil, ErrArchMismatch
+	if runtime.GOOS != osLinux {
+		return nil, fmt.Errorf(
+			"%w: host OS %q cannot supply a linux binary for the container",
+			ErrArchMismatch,
+			runtime.GOOS,
+		)
+	}
+	if runtime.GOARCH != arch {
+		return nil, fmt.Errorf(
+			"%w: host GOARCH %q does not match container arch %q",
+			ErrArchMismatch,
+			runtime.GOARCH,
+			arch,
+		)
 	}
 	return s.openCurrentExecutable()
 }
 
 func (s *InjectSource) SourceName() string {
 	return "local executable"
-}
-
-func (s *InjectSource) matchesCurrentRuntime(arch string) bool {
-	return runtime.GOOS == osLinux && runtime.GOARCH == arch
 }
 
 func (s *InjectSource) openCurrentExecutable() (io.ReadCloser, error) {


### PR DESCRIPTION
## Summary
- The agent binary inject path logs `source local executable failed: architecture mismatch` whenever the host can't supply the linux binary needed inside the container. On macOS hosts this is misleading — the CPU arch matches (both ARM), but `runtime.GOOS != "linux"`, so the reuse is skipped.
- Split the check in `InjectSource.GetBinary` so the log identifies the actual cause: host OS not linux, or host GOARCH differs from the container arch. The error still wraps `ErrArchMismatch`, so `errors.Is` checks elsewhere keep working.