### PR TITLE
fix(ide): add set IDE command

### DIFF
--- a/cmd/ide/ide.go
+++ b/cmd/ide/ide.go
@@ -13,6 +13,7 @@ func NewIDECmd(flags *flags.GlobalFlags) *cobra.Command {
 	}
 
 	ideCmd.AddCommand(NewUseCmd(flags))
+	ideCmd.AddCommand(NewSetCmd(flags))
 	ideCmd.AddCommand(NewSetOptionsCmd(flags))
 	ideCmd.AddCommand(NewOptionsCmd(flags))
 	ideCmd.AddCommand(NewListCmd(flags))

--- a/cmd/ide/set.go
+++ b/cmd/ide/set.go
@@ -1,0 +1,78 @@
+package ide
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/ide/ideparse"
+	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/provider"
+	"github.com/spf13/cobra"
+)
+
+// SetCmd holds the set cmd flags.
+type SetCmd struct {
+	*flags.GlobalFlags
+
+	Options []string
+}
+
+// NewSetCmd creates a command that sets the IDE for an existing workspace
+// without starting the workspace.
+func NewSetCmd(flags *flags.GlobalFlags) *cobra.Command {
+	cmd := &SetCmd{
+		GlobalFlags: flags,
+	}
+	setCmd := &cobra.Command{
+		Use:   "set [workspace] [ide]",
+		Short: "Set the IDE for an existing workspace without starting it",
+		Long: `Set the IDE for an existing workspace without starting it.
+
+The change is persisted to the workspace config and will be used on the next
+'devsy up'. Available IDEs can be listed with 'devsy ide list'.`,
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("usage: devsy ide set <workspace> <ide>")
+			}
+			return cmd.Run(cobraCmd.Context(), args[0], args[1])
+		},
+	}
+
+	setCmd.Flags().
+		StringArrayVarP(&cmd.Options, "option", "o", []string{}, "IDE option in the form KEY=VALUE")
+	return setCmd
+}
+
+// Run runs the command logic.
+func (cmd *SetCmd) Run(_ context.Context, workspaceID, ideName string) error {
+	devsyConfig, err := config.LoadConfig(cmd.Context, cmd.Provider)
+	if err != nil {
+		return err
+	}
+
+	contextName := devsyConfig.DefaultContext
+	if !provider.WorkspaceExists(contextName, workspaceID) {
+		return fmt.Errorf("workspace %q not found in context %q", workspaceID, contextName)
+	}
+
+	workspace, err := provider.LoadWorkspaceConfig(contextName, workspaceID)
+	if err != nil {
+		return fmt.Errorf("load workspace config: %w", err)
+	}
+
+	ideName = strings.ToLower(ideName)
+	if _, err := ideparse.GetIDEOptions(ideName); err != nil {
+		return err
+	}
+
+	workspace, err = ideparse.RefreshIDEOptions(devsyConfig, workspace, ideName, cmd.Options)
+	if err != nil {
+		return fmt.Errorf("refresh ide options: %w", err)
+	}
+
+	log.Infof("set IDE for workspace %q to %q", workspace.ID, workspace.IDE.Name)
+	return nil
+}

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -79,6 +79,14 @@ export function registerIpcHandlers(deps: IpcDependencies): { tunnelProcesses: M
     },
   )
 
+  ipcMain.handle(
+    "workspace_set_ide",
+    async (_event, args: { workspaceId: string; ide: string }) => {
+      trackEvent("workspace_set_ide", { ide: args.ide })
+      await cli.runRaw(["ide", "set", args.workspaceId, args.ide])
+    },
+  )
+
   // ── Providers ──
   ipcMain.handle("provider_list", async () => {
     const raw = await cli.run<Record<string, ProviderEntry>>([

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -292,7 +292,7 @@ async function handleLaunch() {
       source: source.trim(),
       workspaceId,
       provider: selectedProvider || undefined,
-      ide: selectedIde && selectedIde !== "none" ? selectedIde : undefined,
+      ide: selectedIde || undefined,
       ideLaunch: "auto",
       workspaceFolder: workspaceFolder.trim() || undefined,
       debug: true,

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -292,7 +292,7 @@ async function handleLaunch() {
       source: source.trim(),
       workspaceId,
       provider: selectedProvider || undefined,
-      ide: selectedIde || undefined,
+      ide: selectedIde,
       ideLaunch: "auto",
       workspaceFolder: workspaceFolder.trim() || undefined,
       debug: true,

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -67,6 +67,13 @@ export async function workspaceRename(
   return invoke("workspace_rename", { workspaceId, newWorkspaceId })
 }
 
+export async function workspaceSetIde(
+  workspaceId: string,
+  ide: string,
+): Promise<void> {
+  return invoke("workspace_set_ide", { workspaceId, ide })
+}
+
 // Provider commands
 export async function providerList(): Promise<Provider[]> {
   return invoke<Provider[]>("provider_list")

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -459,7 +459,7 @@ async function handleRename() {
         </Button>
       {/if}
 
-      <Button variant="outline" size="sm" onclick={handleOpenIde} disabled={!isRunning || operationRunning}>
+      <Button variant="outline" size="sm" onclick={handleOpenIde} disabled={!isRunning || operationRunning || currentIde === "none"}>
         {#if operationRunning && operationLabel === "Open IDE"}<Spinner />{:else}<Monitor class="h-4 w-4" />{/if}
         Open IDE
       </Button>

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -125,6 +125,7 @@ let connecting = $state(false)
 let ideComboOpen = $state(false)
 let ideSearch = $state("")
 let selectedIde = $state<string | null>(null)
+let ideSetSeq = 0
 let renaming = $state(false)
 let renameValue = $state("")
 let renameSaving = $state(false)
@@ -554,6 +555,7 @@ async function handleRename() {
                           value={ide.value}
                           class="justify-start"
                           onSelect={async () => {
+                            const seq = ++ideSetSeq
                             const prev = selectedIde
                             selectedIde = ide.value
                             ideComboOpen = false
@@ -562,6 +564,7 @@ async function handleRename() {
                             try {
                               await workspaceSetIde(id, ide.value)
                             } catch (err) {
+                              if (seq !== ideSetSeq) return
                               selectedIde = prev
                               toasts.error(`Failed to set IDE: ${extractErrorMessage(err)}`)
                             }

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -41,6 +41,7 @@ import {
   workspaceReset,
   workspaceDelete,
   workspaceRename,
+  workspaceSetIde,
   workspaceLogsList,
   workspaceLogRead,
   workspaceLogDelete,
@@ -305,9 +306,16 @@ function startStreamingOp(label: string) {
 }
 
 async function handleStart() {
+  const ide = currentIde !== "none" ? currentIde : undefined
+  const folder = customFolder || undefined
   startStreamingOp("Start")
   try {
-    commandId = await workspaceUp({ source: id, debug: isDebug() })
+    commandId = await workspaceUp({
+      source: id,
+      ide,
+      debug: isDebug(),
+      workspaceFolder: folder,
+    })
   } catch (err) {
     operationRunning = false
     toasts.error(`Failed to start: ${extractErrorMessage(err)}`)
@@ -545,10 +553,18 @@ async function handleRename() {
                         <Command.Item
                           value={ide.value}
                           class="justify-start"
-                          onSelect={() => {
+                          onSelect={async () => {
+                            const prev = selectedIde
                             selectedIde = ide.value
                             ideComboOpen = false
                             ideSearch = ""
+                            if (ide.value === "none") return
+                            try {
+                              await workspaceSetIde(id, ide.value)
+                            } catch (err) {
+                              selectedIde = prev
+                              toasts.error(`Failed to set IDE: ${extractErrorMessage(err)}`)
+                            }
                           }}
                         >
                           <Check class="mr-2 h-4 w-4 {currentIde === ide.value ? 'opacity-100' : 'opacity-0'}" />

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -307,7 +307,7 @@ function startStreamingOp(label: string) {
 }
 
 async function handleStart() {
-  const ide = currentIde !== "none" ? currentIde : undefined
+  const ide = currentIde
   const folder = customFolder || undefined
   startStreamingOp("Start")
   try {
@@ -324,7 +324,7 @@ async function handleStart() {
 }
 
 async function handleOpenIde() {
-  const ide = currentIde !== "none" ? currentIde : undefined
+  const ide = currentIde
   const folder = customFolder || undefined
   startStreamingOp("Open IDE")
   try {
@@ -560,7 +560,6 @@ async function handleRename() {
                             selectedIde = ide.value
                             ideComboOpen = false
                             ideSearch = ""
-                            if (ide.value === "none") return
                             try {
                               await workspaceSetIde(id, ide.value)
                             } catch (err) {

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -57,6 +57,10 @@ func Open(
 	ideOptions map[string]config.OptionValue,
 	params IDEParams,
 ) (string, error) {
+	if ideName == string(config.IDENone) {
+		return "", nil
+	}
+
 	if fn, ok := browserIDEOpener(ideName); ok {
 		return fn(ctx, ideOptions, params)
 	}


### PR DESCRIPTION
## Summary

When the desktop app's Start button was clicked, the CLI received no `--ide` flag and fell back to the IDE persisted in `workspace.json`. Switching the dropdown after the workspace had been created with a different IDE had no effect — the old IDE launched anyway (e.g. browser VSCode kept opening after switching to desktop VSCode).

- `handleStart()` now forwards the current dropdown IDE (and workspace folder) to `workspaceUp`, matching `handleOpenIde()`.
- New CLI command `devsy ide set <workspace> <ide>` persists the IDE via `ideparse.RefreshIDEOptions` without starting the container. Lives next to `devsy ide use` (which is global-default only).
- Desktop dropdown `onSelect` calls the new command so the selection persists immediately, rolls back UI state on failure, and skips the call for the `"none"` sentinel (not a real IDE).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure and change IDE for individual workspaces from the workspace details page.
  * CLI support for managing and workspace IDE settings.
* **Behavioral Changes**
  * IDE preference is included when starting or creating workspaces so starts respect configured IDE and folder.
  * "Open IDE" is disabled when no IDE is selected.
* **Reliability**
  * IDE selection shows errors on failure and restores prior selection to avoid inconsistent UI states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->