### PR TITLE
fix(test): isolate rename integration tests via $HOME override

### DIFF
--- a/pkg/workspace/rename_integration_test.go
+++ b/pkg/workspace/rename_integration_test.go
@@ -22,11 +22,13 @@ const (
 func setupTestPathManager(t *testing.T) {
 	t.Helper()
 
-	t.Setenv("XDG_DATA_HOME", t.TempDir())
-	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
-	t.Setenv("XDG_CACHE_HOME", t.TempDir())
-	t.Setenv("XDG_STATE_HOME", t.TempDir())
-	t.Setenv("XDG_RUNTIME_DIR", t.TempDir())
+	// Linux and Darwin path managers derive paths from os.UserHomeDir(),
+	// which reads $HOME. Without overriding it, parallel test invocations
+	// (e.g., the macOS release job runs goreleaser hooks once per build
+	// target) collide on the real ~/.devsy and corrupt each other's state.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows fallback used by os.UserHomeDir.
 
 	config.ResetPathManager()
 	t.Cleanup(config.ResetPathManager)


### PR DESCRIPTION
## Summary

The macOS release job for `v1.10.0-beta.8` failed on `TestUpdateWorkspaceResult_BasicRename` with a doubled rename (`/home/user/my-project-renamed-renamed`). Root cause: `setupTestPathManager` in `pkg/workspace/rename_integration_test.go` set `XDG_*` env vars, but neither `pathmanager_linux.go` nor `pathmanager_darwin.go` reads them — both derive paths from `os.UserHomeDir()` (i.e. `$HOME`). Tests were writing into the real `~/.devsy` the whole time.

On macOS, `.goreleaser.yml` registers the `go test ./...` pre-hook on both the `devsy` and `devsy-darwin` builds, so two test processes run concurrently sharing the same `$HOME`. They race on `~/.devsy/contexts/default/workspaces/my-project-renamed/workspace_result.json`:

1. Process A saves `LocalWorkspaceFolder="/home/user/my-project-renamed"`.
2. Process B's `LoadWorkspaceResult` sees A's update.
3. B's replacer (pair `"/home/user/my-project" → "/home/user/my-project-renamed"`) applies again to B's already-renamed string, producing the doubled value.

This only manifests when `newName` contains `oldName` as a substring — which is why only `BasicRename` failed while the other tests in the same file passed.

Fix: override `HOME` (and `USERPROFILE` for Windows) to a per-test `t.TempDir()`, which is what `os.UserHomeDir()` actually reads, giving each test process an isolated devsy home.

Failing run: https://github.com/devsy-org/devsy/actions/runs/26543191204/job/78189213987