### PR TITLE
fix(ide): use relative path for IDE icons

### DIFF
--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -40,7 +40,7 @@ const STEPS: { id: Step; label: string }[] = [
   { id: "launch", label: "Launch" },
 ]
 
-const ideIcon = (name: string) => `/icons/ides/${name}.svg`
+const ideIcon = (name: string) => `./icons/ides/${name}.svg`
 
 const IDE_GROUPS = [
   {


### PR DESCRIPTION
## Summary
- PR #449 introduced IDE icons using absolute paths (`/icons/ides/...`), which resolve to filesystem root under Electron's `file://` protocol and fail to load.
- Switch to relative paths (`./icons/ides/...`) to match the existing `ProviderIcon.svelte` convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed IDE icon display in the workspace wizard to ensure development environment icons load correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->