### PR TITLE
fix(desktop): show code-server in workspace details IDE list

### DIFF
--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -62,6 +62,7 @@ const IDE_OPTIONS = [
   { value: "none", label: "None" },
   { value: "vscode", label: "VS Code" },
   { value: "openvscode", label: "VS Code Browser" },
+  { value: "code-server", label: "code-server" },
   { value: "cursor", label: "Cursor" },
   { value: "zed", label: "Zed" },
   { value: "codium", label: "VSCodium" },


### PR DESCRIPTION
## Summary
- `IDE_OPTIONS` in `WorkspaceDetailPage.svelte` was missing the `code-server` entry, so workspaces created with code-server displayed as "None" on the details page even though the workspace list showed the correct IDE.
- Added the `code-server` option to match the wizard's IDE list.