### PR TITLE
feat(desktop): redesign update UX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,6 +210,14 @@ jobs:
             desktop/release/*.deb
             desktop/release/*.rpm
 
+      - name: rewrite manifest URLs to GitHub Release assets
+        if: hashFiles('desktop/release/latest*.yml', 'desktop/release/beta*.yml') != ''
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag || github.ref_name }}
+        run: |
+          go run hack/rewrite_manifest_urls/main.go desktop/release/ "$REPO" "$TAG"
+
       - name: upload update metadata artifact
         uses: actions/upload-artifact@v7
         with:
@@ -256,15 +264,11 @@ jobs:
           pattern: update-metadata-*
           path: metadata/
 
-      - name: fetch existing metadata from live site
-        run: |
-          mkdir -p publish-dir/desktop
-          for file in latest-mac.yml latest-linux.yml latest.yml beta-mac.yml beta-linux.yml beta.yml; do
-            curl -sSf "https://dl.devsy.sh/desktop/$file" -o "publish-dir/desktop/$file" 2>/dev/null || true
-          done
+      - name: prepare publish dir
+        run: mkdir -p publish-dir/desktop
 
       - name: merge macOS metadata from separate arch builds
-        run: go run hack/merge_mac_metadata.go metadata/ publish-dir/desktop/
+        run: go run hack/merge_mac_metadata/main.go metadata/ publish-dir/desktop/
 
       - name: overlay non-mac metadata files (stable release)
         if: ${{ !github.event.release.prerelease }}
@@ -279,6 +283,11 @@ jobs:
         run: |
           find metadata/ -name 'beta-linux.yml' -exec cp {} publish-dir/desktop/ \;
           find metadata/ -name 'beta.yml' -exec cp {} publish-dir/desktop/ \;
+
+      - name: smoke-test manifest URLs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: go run hack/smoke_test_manifests/main.go publish-dir/desktop/
 
       - name: deploy to Netlify (dl.devsy.sh)
         uses: nwtgck/actions-netlify@v3

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@types/dompurify": "^3.0.5",
         "chokidar": "^4.0.0",
+        "dompurify": "^3.4.7",
         "electron-updater": "^6.8.3",
         "node-pty": "^1.0.0",
         "posthog-node": "^5.34.2",
@@ -2611,6 +2613,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2688,7 +2699,6 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/verror": {
@@ -4380,6 +4390,15 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "chokidar": "^4.0.0",
+    "dompurify": "^3.4.7",
     "electron-updater": "^6.8.3",
     "node-pty": "^1.0.0",
     "posthog-node": "^5.34.2",
@@ -29,6 +30,7 @@
   },
   "devDependencies": {
     "@electron/rebuild": "^3.7.0",
+    "@types/dompurify": "^3.0.5",
     "@internationalized/date": "^3.12.1",
     "@lucide/svelte": "^1.8.0",
     "@playwright/test": "^1.50.0",

--- a/desktop/src/main/__tests__/tray.test.ts
+++ b/desktop/src/main/__tests__/tray.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from "vitest"
+import { buildUpdateMenuItems } from "../tray.js"
+
+vi.mock("electron", () => ({}))
+vi.mock("../updater.js", () => ({
+  getLastStatus: () => ({ state: "idle" }),
+  installUpdate: vi.fn(),
+}))
+
+describe("buildUpdateMenuItems", () => {
+  it("returns nothing when no update is downloaded", () => {
+    expect(buildUpdateMenuItems({ state: "idle" }, () => {})).toEqual([])
+    expect(buildUpdateMenuItems({ state: "checking" }, () => {})).toEqual([])
+    expect(buildUpdateMenuItems({ state: "available", version: "1" }, () => {})).toEqual([])
+    expect(buildUpdateMenuItems({ state: "downloading", version: "1" }, () => {})).toEqual([])
+    expect(buildUpdateMenuItems({ state: "not-available" }, () => {})).toEqual([])
+    expect(buildUpdateMenuItems({ state: "error", error: "x" }, () => {})).toEqual([])
+  })
+
+  it("adds Install Update item + separator when downloaded", () => {
+    const onInstall = vi.fn()
+    const items = buildUpdateMenuItems({ state: "downloaded", version: "9.9.9" }, onInstall)
+    expect(items).toHaveLength(2)
+    expect(items[0]).toMatchObject({ label: "Install Update v9.9.9" })
+    expect(items[1]).toEqual({ type: "separator" })
+
+    const click = (items[0] as { click?: () => void }).click
+    click?.()
+    expect(onInstall).toHaveBeenCalledTimes(1)
+  })
+
+  it("handles missing version gracefully", () => {
+    const items = buildUpdateMenuItems({ state: "downloaded" }, () => {})
+    expect(items[0]).toMatchObject({ label: "Install Update v" })
+  })
+})

--- a/desktop/src/main/__tests__/updater.test.ts
+++ b/desktop/src/main/__tests__/updater.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const electronUpdaterMock = {
+  autoUpdater: {
+    autoDownload: true,
+    autoInstallOnAppQuit: true,
+    allowPrerelease: false,
+    channel: "latest",
+    handlers: new Map<string, (...args: unknown[]) => void>(),
+    on(event: string, cb: (...args: unknown[]) => void) {
+      this.handlers.set(event, cb)
+      return this
+    },
+    emit(event: string, ...args: unknown[]) {
+      this.handlers.get(event)?.(...args)
+    },
+    checkForUpdates: vi.fn().mockResolvedValue(undefined),
+    downloadUpdate: vi.fn().mockResolvedValue(undefined),
+    quitAndInstall: vi.fn(),
+  },
+}
+
+vi.mock("electron-updater", () => electronUpdaterMock)
+vi.mock("electron", () => ({
+  app: {
+    isPackaged: true,
+    getPath: () => "/tmp/devsy-test",
+    getVersion: () => "1.0.0",
+  },
+  dialog: { showMessageBox: vi.fn() },
+}))
+vi.mock("../analytics.js", () => ({ trackEvent: vi.fn() }))
+
+describe("updater", () => {
+  beforeEach(async () => {
+    electronUpdaterMock.autoUpdater.handlers.clear()
+    electronUpdaterMock.autoUpdater.checkForUpdates.mockClear()
+    electronUpdaterMock.autoUpdater.downloadUpdate.mockClear()
+    vi.resetModules()
+    // Restore isPackaged on every test so an early throw in one test
+    // cannot silently flip later tests into the dev-mode branch.
+    const electron = await import("electron")
+    ;(electron.app as { isPackaged: boolean }).isPackaged = true
+  })
+
+  it("emits dev-mode status when app is not packaged", async () => {
+    const electron = await import("electron")
+    ;(electron.app as { isPackaged: boolean }).isPackaged = false
+    const { initAutoUpdater } = await import("../updater.js")
+    const send = vi.fn()
+    const win = { isDestroyed: () => false, webContents: { send } } as never
+    await initAutoUpdater(() => win)
+    expect(send).toHaveBeenCalledWith(
+      "update-status",
+      expect.objectContaining({ state: "not-available", code: "dev-mode" }),
+    )
+  })
+
+  it("emits downloading state with progress info", async () => {
+    const { initAutoUpdater } = await import("../updater.js")
+    const send = vi.fn()
+    const win = { isDestroyed: () => false, webContents: { send } } as never
+    await initAutoUpdater(() => win)
+    electronUpdaterMock.autoUpdater.emit("download-progress", {
+      percent: 42,
+      bytesPerSecond: 1000,
+      transferred: 100,
+      total: 200,
+    })
+    expect(send).toHaveBeenCalledWith(
+      "update-status",
+      expect.objectContaining({
+        state: "downloading",
+        progress: { percent: 42, bytesPerSecond: 1000, transferred: 100, total: 200 },
+      }),
+    )
+  })
+
+  it("respects autoDownload setting on update-available", async () => {
+    const { initAutoUpdater, setAutoDownloadEnabled } = await import("../updater.js")
+    const send = vi.fn()
+    const win = { isDestroyed: () => false, webContents: { send } } as never
+    await initAutoUpdater(() => win)
+    setAutoDownloadEnabled(false)
+    electronUpdaterMock.autoUpdater.emit("update-available", { version: "9.9.9" })
+    expect(electronUpdaterMock.autoUpdater.downloadUpdate).not.toHaveBeenCalled()
+  })
+
+  it("does not fire a native dialog on update-downloaded", async () => {
+    const electron = await import("electron")
+    const { initAutoUpdater } = await import("../updater.js")
+    const send = vi.fn()
+    const win = { isDestroyed: () => false, webContents: { send } } as never
+    await initAutoUpdater(() => win)
+    electronUpdaterMock.autoUpdater.emit("update-downloaded", { version: "9.9.9" })
+    expect((electron.dialog.showMessageBox as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os"
 import { join } from "node:path"
 import { promisify } from "node:util"
 import type { BrowserWindow } from "electron"
-import { ipcMain } from "electron"
+import { app, ipcMain } from "electron"
 import type { CLIError } from "../shared/cli-error.js"
 import { trackEvent } from "./analytics.js"
 import type { CliRunner } from "./cli.js"
@@ -16,8 +16,11 @@ import {
   type ReleaseChannel,
   checkForUpdates,
   checkForUpdatesWithChannel,
+  downloadUpdate,
+  getAutoDownloadEnabled,
   getReleaseChannel,
   installUpdate,
+  setAutoDownloadEnabled,
   setReleaseChannel,
 } from "./updater.js"
 import { type ProviderEntry, parseProviderEntries } from "./watcher.js"
@@ -787,8 +790,17 @@ export function registerIpcHandlers(deps: IpcDependencies): { tunnelProcesses: M
       if (args.channel !== "stable" && args.channel !== "beta") {
         throw new Error(`Invalid release channel: ${args.channel}`)
       }
-      setReleaseChannel(args.channel)
-      await checkForUpdatesWithChannel(args.channel)
+      const channel: ReleaseChannel = args.channel
+      const previous = getReleaseChannel()
+      setReleaseChannel(channel)
+      try {
+        await checkForUpdatesWithChannel(channel)
+      } catch (err) {
+        // Rollback persisted choice so disk + renderer stay in sync if
+        // the renderer reverts its UI state.
+        setReleaseChannel(previous)
+        throw err
+      }
     },
   )
 
@@ -799,6 +811,28 @@ export function registerIpcHandlers(deps: IpcDependencies): { tunnelProcesses: M
   ipcMain.handle("install_update", async () => {
     installUpdate()
   })
+
+  ipcMain.handle("download_update", async () => {
+    await downloadUpdate()
+  })
+
+  ipcMain.handle("get_app_version", () => {
+    return app.getVersion()
+  })
+
+  ipcMain.handle("get_auto_download", () => {
+    return getAutoDownloadEnabled()
+  })
+
+  ipcMain.handle(
+    "set_auto_download",
+    async (_event, args: { enabled: boolean }) => {
+      if (typeof args?.enabled !== "boolean") {
+        throw new Error("enabled must be boolean")
+      }
+      setAutoDownloadEnabled(args.enabled)
+    },
+  )
 
   // ── Analytics ──
   ipcMain.handle(

--- a/desktop/src/main/tray.ts
+++ b/desktop/src/main/tray.ts
@@ -2,6 +2,22 @@ import { join } from "node:path"
 import type { BrowserWindow } from "electron"
 import { app, Menu, nativeImage, nativeTheme, Tray } from "electron"
 import type { DaemonState } from "./state.js"
+import { getLastStatus, installUpdate, type UpdateStatus } from "./updater.js"
+
+/**
+ * Builds the menu items shown when an update is ready. Returns an empty
+ * array when no install action should be offered. Exported for unit testing.
+ */
+export function buildUpdateMenuItems(
+  status: UpdateStatus,
+  onInstall: () => void,
+): Electron.MenuItemConstructorOptions[] {
+  if (status.state !== "downloaded") return []
+  return [
+    { label: `Install Update v${status.version ?? ""}`, click: onInstall },
+    { type: "separator" },
+  ]
+}
 
 interface TrayDeps {
   state: DaemonState
@@ -86,6 +102,9 @@ export class AppTray {
         : `${count} workspace${count === 1 ? "" : "s"}`
 
     const template: Electron.MenuItemConstructorOptions[] = [
+      ...buildUpdateMenuItems(getLastStatus(), () => {
+        installUpdate().catch(() => {})
+      }),
       { label: statusLabel, enabled: false },
     ]
 

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -1,44 +1,91 @@
-import { readFileSync, writeFileSync } from "node:fs"
+import { readFileSync, renameSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
-import { app, dialog, type BrowserWindow } from "electron"
+import { app, type BrowserWindow } from "electron"
 import { trackEvent } from "./analytics.js"
 
 export type ReleaseChannel = "stable" | "beta"
 
+export type UpdateStateValue =
+  | "idle"
+  | "checking"
+  | "available"
+  | "downloading"
+  | "downloaded"
+  | "not-available"
+  | "error"
+
+export type UpdateErrorCode =
+  | "dev-mode"
+  | "unsupported"
+  | "network"
+  | "feed-error"
+  | "verification"
+
+export interface UpdateProgress {
+  percent: number
+  bytesPerSecond: number
+  transferred: number
+  total: number
+}
+
 export interface UpdateStatus {
-  state: "checking" | "available" | "not-available" | "downloading" | "downloaded" | "error"
+  state: UpdateStateValue
   version?: string
   releaseNotes?: string
   releaseName?: string
+  progress?: UpdateProgress
   error?: string
+  code?: UpdateErrorCode
+}
+
+interface PersistedSettings {
+  channel?: ReleaseChannel
+  autoDownload?: boolean
 }
 
 function settingsPath(): string {
   return join(app.getPath("userData"), "update-settings.json")
 }
 
-function loadChannel(): ReleaseChannel {
+function loadSettings(): PersistedSettings {
   try {
-    const data = JSON.parse(readFileSync(settingsPath(), "utf-8"))
-    if (data.channel === "beta") return "beta"
+    return JSON.parse(readFileSync(settingsPath(), "utf-8")) as PersistedSettings
   } catch {
-    // File doesn't exist or is corrupt
+    return {}
   }
-  return "stable"
 }
 
-function saveChannel(channel: ReleaseChannel): void {
-  writeFileSync(settingsPath(), JSON.stringify({ channel }))
+function saveSettings(patch: PersistedSettings): void {
+  try {
+    const current = loadSettings()
+    const target = settingsPath()
+    const tmp = `${target}.tmp`
+    writeFileSync(tmp, JSON.stringify({ ...current, ...patch }))
+    renameSync(tmp, target)
+  } catch (err) {
+    console.warn("[updater] failed to persist settings:", err)
+  }
 }
 
 let currentChannel: ReleaseChannel = "stable"
+let autoDownloadEnabled = true
 let getMainWindowFn: (() => BrowserWindow | null) | null = null
+let lastStatus: UpdateStatus = { state: "idle" }
 
 function sendUpdateStatus(status: UpdateStatus): void {
   const win = getMainWindowFn?.()
   if (win && !win.isDestroyed()) {
     win.webContents.send("update-status", status)
   }
+}
+
+function setStatus(status: UpdateStatus): void {
+  lastStatus = status
+  sendUpdateStatus(status)
+}
+
+export function getLastStatus(): UpdateStatus {
+  return lastStatus
 }
 
 function normalizeReleaseNotes(
@@ -50,40 +97,80 @@ function normalizeReleaseNotes(
   return undefined
 }
 
+function classifyError(err: Error): UpdateErrorCode {
+  const m = err.message.toLowerCase()
+  if (m.includes("net::") || m.includes("network") || m.includes("enotfound")) return "network"
+  if (m.includes("sha512") || m.includes("checksum") || m.includes("integrity")) return "verification"
+  return "feed-error"
+}
+
 export function setReleaseChannel(channel: ReleaseChannel): void {
   currentChannel = channel
-  saveChannel(channel)
+  saveSettings({ channel })
 }
 
 export function getReleaseChannel(): ReleaseChannel {
   return currentChannel
 }
 
+export function setAutoDownloadEnabled(enabled: boolean): void {
+  autoDownloadEnabled = enabled
+  saveSettings({ autoDownload: enabled })
+  // Update the live autoUpdater too so the change takes effect this session.
+  // electron-updater reads autoDownload at the moment update-available fires.
+  if (app.isPackaged) {
+    import("electron-updater")
+      .then(({ autoUpdater }) => {
+        if (autoUpdater && typeof autoUpdater === "object") {
+          autoUpdater.autoDownload = enabled
+        }
+      })
+      .catch(() => {})
+  }
+}
+
+export function getAutoDownloadEnabled(): boolean {
+  return autoDownloadEnabled
+}
+
 export async function initAutoUpdater(
   getMainWindow: () => BrowserWindow | null,
 ): Promise<void> {
   getMainWindowFn = getMainWindow
-  currentChannel = loadChannel()
-  const { autoUpdater } = await import("electron-updater")
 
-  if (!autoUpdater || typeof autoUpdater.checkForUpdates !== "function") {
-    console.warn("Auto-updater not available (app is not code-signed)")
+  const settings = loadSettings()
+  currentChannel = settings.channel ?? "stable"
+  autoDownloadEnabled = settings.autoDownload ?? true
+
+  if (!app.isPackaged) {
+    setStatus({ state: "not-available", code: "dev-mode" })
     return
   }
 
-  autoUpdater.autoDownload = true
+  const { autoUpdater } = await import("electron-updater")
+
+  if (!autoUpdater || typeof autoUpdater.checkForUpdates !== "function") {
+    setStatus({
+      state: "error",
+      code: "unsupported",
+      error: "Updates require a packaged build",
+    })
+    return
+  }
+
+  autoUpdater.autoDownload = autoDownloadEnabled
   autoUpdater.autoInstallOnAppQuit = true
   autoUpdater.allowPrerelease = currentChannel === "beta"
   autoUpdater.channel = currentChannel === "beta" ? "beta" : "latest"
 
   autoUpdater.on("checking-for-update", () => {
     trackEvent("update_check")
-    sendUpdateStatus({ state: "checking" })
+    setStatus({ state: "checking" })
   })
 
   autoUpdater.on("update-available", (info) => {
     trackEvent("update_available", { version: info.version })
-    sendUpdateStatus({
+    setStatus({
       state: "available",
       version: info.version,
       releaseName: info.releaseName ?? undefined,
@@ -92,44 +179,42 @@ export async function initAutoUpdater(
   })
 
   autoUpdater.on("update-not-available", (info) => {
-    sendUpdateStatus({
+    setStatus({
       state: "not-available",
       version: info.version,
     })
   })
 
+  autoUpdater.on("download-progress", (info) => {
+    setStatus({
+      ...lastStatus,
+      state: "downloading",
+      progress: {
+        percent: info.percent,
+        bytesPerSecond: info.bytesPerSecond,
+        transferred: info.transferred,
+        total: info.total,
+      },
+    })
+  })
+
   autoUpdater.on("update-downloaded", (info) => {
     trackEvent("update_downloaded", { version: info.version })
-    sendUpdateStatus({
+    setStatus({
       state: "downloaded",
       version: info.version,
       releaseName: info.releaseName ?? undefined,
       releaseNotes: normalizeReleaseNotes(info.releaseNotes),
     })
-
-    const win = getMainWindow()
-    if (!win) return
-
-    dialog
-      .showMessageBox(win, {
-        type: "info",
-        title: "Update Ready",
-        message: `Version ${info.version} has been downloaded and will be installed on restart.`,
-        buttons: ["Restart Now", "Later"],
-        defaultId: 0,
-        cancelId: 1,
-      })
-      .then(({ response }) => {
-        if (response === 0) {
-          trackEvent("update_installed", { version: info.version })
-          autoUpdater.quitAndInstall()
-        }
-      })
   })
 
   autoUpdater.on("error", (err) => {
     trackEvent("update_error", { error_type: err.name })
-    sendUpdateStatus({ state: "error", error: err.message })
+    setStatus({
+      state: "error",
+      code: classifyError(err),
+      error: err.message,
+    })
     console.error("Auto-update error:", err.message)
   })
 
@@ -140,40 +225,48 @@ export async function initAutoUpdater(
   }, 10_000)
 }
 
-export async function checkForUpdates(): Promise<void> {
+async function getUpdater() {
+  if (!app.isPackaged) {
+    setStatus({ state: "not-available", code: "dev-mode" })
+    return null
+  }
   const { autoUpdater } = await import("electron-updater")
   if (!autoUpdater || typeof autoUpdater.checkForUpdates !== "function") {
-    sendUpdateStatus({
+    setStatus({
       state: "error",
-      error: "Auto-update is not available (app is not code-signed)",
+      code: "unsupported",
+      error: "Updates require a packaged build",
     })
-    return
+    return null
   }
+  return autoUpdater
+}
+
+export async function checkForUpdates(): Promise<void> {
+  const autoUpdater = await getUpdater()
+  if (!autoUpdater) return
   await autoUpdater.checkForUpdates()
 }
 
-export async function checkForUpdatesWithChannel(
-  channel: ReleaseChannel,
-): Promise<void> {
-  const { autoUpdater } = await import("electron-updater")
+export async function checkForUpdatesWithChannel(channel: ReleaseChannel): Promise<void> {
+  // Caller (set_release_channel IPC) already persisted the channel choice.
+  // Just reconfigure the running autoUpdater and kick off a check.
   currentChannel = channel
-  saveChannel(channel)
-  if (!autoUpdater || typeof autoUpdater.checkForUpdates !== "function") {
-    sendUpdateStatus({
-      state: "error",
-      error: "Auto-update is not available (app is not code-signed)",
-    })
-    return
-  }
+  const autoUpdater = await getUpdater()
+  if (!autoUpdater) return
   autoUpdater.allowPrerelease = channel === "beta"
   autoUpdater.channel = channel === "beta" ? "beta" : "latest"
   await autoUpdater.checkForUpdates()
 }
 
+export async function downloadUpdate(): Promise<void> {
+  const autoUpdater = await getUpdater()
+  if (!autoUpdater) return
+  await autoUpdater.downloadUpdate()
+}
+
 export async function installUpdate(): Promise<void> {
-  const { autoUpdater } = await import("electron-updater")
-  if (!autoUpdater || typeof autoUpdater.quitAndInstall !== "function") {
-    return
-  }
+  const autoUpdater = await getUpdater()
+  if (!autoUpdater || typeof autoUpdater.quitAndInstall !== "function") return
   autoUpdater.quitAndInstall()
 }

--- a/desktop/src/renderer/src/App.svelte
+++ b/desktop/src/renderer/src/App.svelte
@@ -13,11 +13,15 @@ import { initWorkspaces, destroyWorkspaces } from "$lib/stores/workspaces.js"
 import { initProviders, destroyProviders } from "$lib/stores/providers.js"
 import { initMachines, destroyMachines } from "$lib/stores/machines.js"
 import { initContexts, destroyContexts } from "$lib/stores/contexts.js"
-import { initSettings } from "$lib/stores/settings.js"
+import { initSettings, syncAutoUpdateFromMain, autoUpdate } from "$lib/stores/settings.js"
 import { terminalCount } from "$lib/stores/terminals.js"
 import { togglePalette } from "$lib/stores/command-palette.js"
 import { appReady, analyticsTrack } from "$lib/ipc/commands.js"
 import { location } from "$lib/router.js"
+import UpdateBadge from "$lib/components/update/UpdateBadge.svelte"
+import UpdateDialog from "$lib/components/update/UpdateDialog.svelte"
+import { initUpdateStore, disposeUpdateStore } from "$lib/stores/updates.svelte.js"
+import { initUpdateToasts, bindDialogOpener } from "$lib/components/update/update-toasts.js"
 
 import DashboardPage from "./pages/DashboardPage.svelte"
 import WorkspacesPage from "./pages/WorkspacesPage.svelte"
@@ -51,6 +55,9 @@ const routes = {
 }
 
 let destroySettings: (() => void) | undefined
+
+let updateDialogOpen = $state(false)
+let unsubscribeToasts: (() => void) | null = null
 
 const NAV_KEYS: Record<string, string> = {
   1: "/",
@@ -89,7 +96,7 @@ function normalizeAnalyticsPath(path: string): string {
   return path
 }
 
-onMount(() => {
+onMount(async () => {
   initWorkspaces()
   initProviders()
   initMachines()
@@ -104,9 +111,20 @@ onMount(() => {
   appReady().catch((err) => {
     console.warn("[Devsy] appReady failed:", err)
   })
+
+  await initUpdateStore()
+  await syncAutoUpdateFromMain()
+  unsubscribeToasts = initUpdateToasts(() => {
+    let value = true
+    autoUpdate.subscribe((v) => (value = v))()
+    return value
+  })
+  bindDialogOpener(() => (updateDialogOpen = true))
 })
 
 onDestroy(() => {
+  unsubscribeToasts?.()
+  disposeUpdateStore()
   unsubLocation?.()
   destroyWorkspaces()
   destroyProviders()
@@ -128,6 +146,7 @@ onDestroy(() => {
         <Breadcrumbs />
       </div>
       <div class="ml-auto flex items-center gap-1">
+        <UpdateBadge onclick={() => (updateDialogOpen = true)} />
         <NotificationHistory />
         <ThemeSwitcher />
       </div>
@@ -139,5 +158,6 @@ onDestroy(() => {
   </SidebarUI.Inset>
 
   <Toaster richColors closeButton position="bottom-right" />
+  <UpdateDialog bind:open={updateDialogOpen} autoDownloadEnabled={$autoUpdate} />
   <CommandPalette />
 </SidebarUI.Provider>

--- a/desktop/src/renderer/src/lib/components/update/UpdateBadge.svelte
+++ b/desktop/src/renderer/src/lib/components/update/UpdateBadge.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { Button } from "$lib/components/ui/button/index.js"
+  import { Download, CheckCircle2 } from "@lucide/svelte"
+  import { hasUpdate, isReady, updateStatus } from "$lib/stores/updates.svelte.js"
+
+  let { onclick }: { onclick: () => void } = $props()
+
+  const s = $derived(updateStatus())
+  const show = $derived(hasUpdate())
+  const ready = $derived(isReady())
+  const downloading = $derived(s.state === "downloading")
+</script>
+
+{#if show}
+  <Button
+    variant="ghost"
+    size="sm"
+    {onclick}
+    class={"gap-2 " + (ready ? "text-primary" : "text-muted-foreground")}
+    title={ready
+      ? `Update v${s.version ?? ""} ready`
+      : downloading
+        ? `Update v${s.version ?? ""} downloading`
+        : `Update v${s.version ?? ""} available`}
+  >
+    {#if ready}
+      <CheckCircle2 class="h-4 w-4" />
+      <span class="text-xs">Update ready</span>
+    {:else if downloading}
+      <Download class="h-4 w-4 animate-pulse" />
+      <span class="text-xs">{(s.progress?.percent ?? 0).toFixed(0)}%</span>
+    {:else}
+      <Download class="h-4 w-4" />
+      <span class="text-xs">Update available</span>
+    {/if}
+  </Button>
+{/if}

--- a/desktop/src/renderer/src/lib/components/update/UpdateDialog.svelte
+++ b/desktop/src/renderer/src/lib/components/update/UpdateDialog.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+import DOMPurify from "dompurify"
+import * as Dialog from "$lib/components/ui/dialog/index.js"
+import { Button } from "$lib/components/ui/button/index.js"
+import { Progress } from "$lib/components/ui/progress/index.js"
+import {
+  checkForUpdates,
+  downloadUpdate,
+  installUpdate,
+} from "$lib/ipc/commands.js"
+import {
+  updateStatus,
+  isChecking,
+  lastCheckedAt,
+} from "$lib/stores/updates.svelte.js"
+import { markUserInitiated } from "./update-toasts.js"
+
+let {
+  open = $bindable(false),
+  autoDownloadEnabled = true,
+}: { open?: boolean; autoDownloadEnabled?: boolean } = $props()
+
+const s = $derived(updateStatus())
+const lastChecked = $derived(lastCheckedAt())
+const sanitizedNotes = $derived(
+  s.releaseNotes ? DOMPurify.sanitize(s.releaseNotes) : "",
+)
+
+function fmtMBps(bps: number): string {
+  if (!bps) return ""
+  const mbps = bps / 1_000_000
+  return `${mbps.toFixed(2)} MB/s`
+}
+
+function fmtTime(ts: number | null): string {
+  if (!ts) return ""
+  return new Date(ts).toLocaleTimeString()
+}
+
+async function onCheck() {
+  markUserInitiated()
+  await checkForUpdates()
+}
+
+async function onDownload() {
+  await downloadUpdate()
+}
+
+async function onInstall() {
+  await installUpdate()
+}
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="max-w-lg">
+		<Dialog.Header>
+			<Dialog.Title>Application Updates</Dialog.Title>
+		</Dialog.Header>
+
+		{#if s.state === "checking"}
+			<p class="text-sm text-muted-foreground">Checking for updates…</p>
+		{:else if s.state === "available"}
+			<div class="space-y-3">
+				<p class="text-sm">
+					<span class="font-medium">Version {s.version}</span> is available.
+				</p>
+				{#if s.releaseNotes}
+					<div class="prose prose-sm dark:prose-invert max-h-48 overflow-y-auto rounded-md border p-3">
+						{@html sanitizedNotes}
+					</div>
+				{/if}
+				{#if autoDownloadEnabled}
+					<p class="text-xs text-muted-foreground">Downloading in the background…</p>
+				{:else}
+					<Button onclick={onDownload}>Download</Button>
+				{/if}
+			</div>
+		{:else if s.state === "downloading"}
+			<div class="space-y-3">
+				<p class="text-sm font-medium">Downloading v{s.version}…</p>
+				<Progress value={s.progress?.percent ?? 0} max={100} />
+				<p class="text-xs text-muted-foreground">
+					{(s.progress?.percent ?? 0).toFixed(0)}% · {fmtMBps(s.progress?.bytesPerSecond ?? 0)}
+				</p>
+			</div>
+		{:else if s.state === "downloaded"}
+			<div class="space-y-3">
+				<p class="text-sm">
+					<span class="font-medium">Version {s.version}</span> is ready to install.
+				</p>
+				{#if s.releaseNotes}
+					<div class="prose prose-sm dark:prose-invert max-h-48 overflow-y-auto rounded-md border p-3">
+						{@html sanitizedNotes}
+					</div>
+				{/if}
+				<div class="flex gap-2 justify-end">
+					<Button variant="ghost" onclick={() => (open = false)}>Later</Button>
+					<Button onclick={onInstall}>Restart and Update</Button>
+				</div>
+			</div>
+		{:else if s.state === "not-available"}
+			{#if s.code === "dev-mode"}
+				<p class="text-sm text-muted-foreground">Updates are available in packaged builds.</p>
+			{:else}
+				<div class="space-y-2">
+					<p class="text-sm text-muted-foreground">You're on the latest version.</p>
+					{#if lastChecked}
+						<p class="text-xs text-muted-foreground">Last checked at {fmtTime(lastChecked)}</p>
+					{/if}
+					<Button variant="outline" size="sm" onclick={onCheck} disabled={isChecking()}>
+						Check Again
+					</Button>
+				</div>
+			{/if}
+		{:else if s.state === "error"}
+			<div class="space-y-2">
+				<p class="text-sm text-destructive">Update check failed: {s.error}</p>
+				<Button variant="outline" size="sm" onclick={onCheck} disabled={isChecking()}>
+					Check Again
+				</Button>
+			</div>
+		{:else}
+			<div class="space-y-2">
+				<p class="text-sm text-muted-foreground">No update check has run yet.</p>
+				<Button variant="outline" size="sm" onclick={onCheck} disabled={isChecking()}>
+					Check for Updates
+				</Button>
+			</div>
+		{/if}
+	</Dialog.Content>
+</Dialog.Root>

--- a/desktop/src/renderer/src/lib/components/update/UpdateDialog.test.ts
+++ b/desktop/src/renderer/src/lib/components/update/UpdateDialog.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render } from "@testing-library/svelte"
+
+vi.mock("$lib/ipc/commands.js", () => ({
+  checkForUpdates: vi.fn(),
+  downloadUpdate: vi.fn(),
+  installUpdate: vi.fn(),
+}))
+vi.mock("$lib/ipc/events.js", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("$lib/ipc/events.js")>()
+  return { ...mod, onUpdateStatus: async () => () => {} }
+})
+
+import UpdateDialog from "./UpdateDialog.svelte"
+import {
+  __setForTest,
+  initUpdateStore,
+} from "$lib/stores/updates.svelte.js"
+
+function bodyText(): string {
+  return document.body.textContent ?? ""
+}
+
+function queryButton(label: RegExp): HTMLButtonElement | null {
+  return (
+    Array.from(document.querySelectorAll("button")).find((b) =>
+      label.test(b.textContent ?? ""),
+    ) ?? null
+  )
+}
+
+describe("UpdateDialog", () => {
+  beforeEach(async () => {
+    await initUpdateStore()
+  })
+
+  it("renders 'checking' state", () => {
+    __setForTest({ state: "checking" })
+    render(UpdateDialog, { props: { open: true } })
+    expect(bodyText()).toMatch(/checking for updates/i)
+  })
+
+  it("renders 'downloaded' state with restart CTA", () => {
+    __setForTest({ state: "downloaded", version: "9.9.9" })
+    render(UpdateDialog, { props: { open: true } })
+    expect(bodyText()).toMatch(/version 9\.9\.9/i)
+    expect(queryButton(/restart and update/i)).toBeTruthy()
+  })
+
+  it("renders 'downloading' progress", () => {
+    __setForTest({
+      state: "downloading",
+      version: "9.9.9",
+      progress: {
+        percent: 42,
+        bytesPerSecond: 1_500_000,
+        transferred: 1,
+        total: 2,
+      },
+    })
+    render(UpdateDialog, { props: { open: true } })
+    expect(bodyText()).toMatch(/42%/)
+    expect(bodyText()).toMatch(/1\.50 MB\/s/)
+  })
+
+  it("renders 'error' with retry", () => {
+    __setForTest({
+      state: "error",
+      error: "404 from CDN",
+      code: "feed-error",
+    })
+    render(UpdateDialog, { props: { open: true } })
+    expect(bodyText()).toMatch(/404 from cdn/i)
+    expect(queryButton(/check again/i)).toBeTruthy()
+  })
+
+  it("renders dev-mode hint in not-available + dev-mode", () => {
+    __setForTest({ state: "not-available", code: "dev-mode" })
+    render(UpdateDialog, { props: { open: true } })
+    expect(bodyText()).toMatch(/packaged builds/i)
+  })
+})

--- a/desktop/src/renderer/src/lib/components/update/UpdatesSection.svelte
+++ b/desktop/src/renderer/src/lib/components/update/UpdatesSection.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+import { onMount } from "svelte"
+import { Check } from "@lucide/svelte"
+import { Button } from "$lib/components/ui/button/index.js"
+import { Label } from "$lib/components/ui/label/index.js"
+import { Separator } from "$lib/components/ui/separator/index.js"
+import { Switch } from "$lib/components/ui/switch/index.js"
+import { autoUpdate, setAutoUpdate } from "$lib/stores/settings.js"
+import {
+  getAppVersion,
+  getReleaseChannel,
+  setReleaseChannel as setReleaseChannelIpc,
+  checkForUpdates as checkForUpdatesIpc,
+  type ReleaseChannel,
+} from "$lib/ipc/commands.js"
+import { updateStatus as getUpdateStatusFn } from "$lib/stores/updates.svelte.js"
+import { markUserInitiated, openUpdateDialog } from "./update-toasts.js"
+import { toasts } from "$lib/stores/toasts.js"
+import { extractErrorMessage } from "$lib/utils/error.js"
+
+let appVersion = $state<string | null>(null)
+let releaseChannel = $state<ReleaseChannel>("stable")
+
+const liveStatus = $derived(getUpdateStatusFn())
+
+async function loadVersion(): Promise<void> {
+  try {
+    appVersion = await getAppVersion()
+  } catch {
+    appVersion = null
+  }
+}
+
+async function handleCheckForUpdates(): Promise<void> {
+  try {
+    markUserInitiated()
+    openUpdateDialog()
+    await checkForUpdatesIpc()
+  } catch (err) {
+    toasts.error(`Update check failed: ${extractErrorMessage(err)}`)
+  }
+}
+
+async function handleChannelChange(channel: ReleaseChannel): Promise<void> {
+  const previous = releaseChannel
+  releaseChannel = channel
+  try {
+    await setReleaseChannelIpc(channel)
+    toasts.success(`Switched to ${channel} update channel`)
+  } catch (err) {
+    releaseChannel = previous
+    toasts.error(`Failed to switch channel: ${extractErrorMessage(err)}`)
+  }
+}
+
+onMount(async () => {
+  await loadVersion()
+  try {
+    releaseChannel = await getReleaseChannel()
+  } catch {
+    // Ignore — defaults to stable
+  }
+})
+</script>
+
+<h2 class="text-lg font-semibold">Updates</h2>
+
+<div class="space-y-4">
+  <div class="flex items-center justify-between">
+    <div>
+      <Label>Automatic Updates</Label>
+      <p class="text-xs text-muted-foreground">Download and install updates in the background</p>
+    </div>
+    <Switch checked={$autoUpdate} onCheckedChange={(v) => setAutoUpdate(v)} />
+  </div>
+
+  <div class="space-y-3">
+    <Label>Release Channel</Label>
+    <div class="grid grid-cols-2 gap-3">
+      <button
+        class="rounded-lg border p-3 text-left transition-colors {releaseChannel === 'stable' ? 'border-primary bg-primary/5 ring-1 ring-primary' : 'border-border hover:border-muted-foreground/50'}"
+        onclick={() => handleChannelChange("stable")}
+      >
+        <div class="flex items-center gap-2">
+          <span class="font-medium text-sm">Stable</span>
+          {#if releaseChannel === "stable"}
+            <Check class="h-3.5 w-3.5 text-primary" />
+          {/if}
+        </div>
+        <p class="mt-1 text-xs text-muted-foreground">Production-ready releases</p>
+      </button>
+      <button
+        class="rounded-lg border p-3 text-left transition-colors {releaseChannel === 'beta' ? 'border-primary bg-primary/5 ring-1 ring-primary' : 'border-border hover:border-muted-foreground/50'}"
+        onclick={() => handleChannelChange("beta")}
+      >
+        <div class="flex items-center gap-2">
+          <span class="font-medium text-sm">Beta</span>
+          {#if releaseChannel === "beta"}
+            <Check class="h-3.5 w-3.5 text-primary" />
+          {/if}
+        </div>
+        <p class="mt-1 text-xs text-muted-foreground">Early access to new features</p>
+      </button>
+    </div>
+  </div>
+</div>
+
+<Separator />
+
+<div class="space-y-3">
+  <h2 class="text-lg font-semibold">Version</h2>
+  <div class="flex items-center justify-between rounded-lg border p-3">
+    <div>
+      <p class="text-sm font-medium">Devsy</p>
+      {#if appVersion}
+        <p class="text-xs font-mono text-muted-foreground">v{appVersion}</p>
+      {:else}
+        <p class="text-xs text-muted-foreground">Version unavailable</p>
+      {/if}
+    </div>
+    <Button
+      variant="outline"
+      size="sm"
+      onclick={handleCheckForUpdates}
+      disabled={liveStatus.state === "checking"}
+    >
+      {liveStatus.state === "checking" ? "Checking..." : "Check for Updates"}
+    </Button>
+  </div>
+
+  {#if liveStatus.state !== "idle"}
+    <div class="rounded-md border p-3 flex items-center justify-between">
+      <p class="text-sm">
+        {#if liveStatus.state === "checking"}
+          Checking for updates…
+        {:else if liveStatus.state === "available"}
+          Update v{liveStatus.version} available
+        {:else if liveStatus.state === "downloading"}
+          Downloading v{liveStatus.version} · {(liveStatus.progress?.percent ?? 0).toFixed(0)}%
+        {:else if liveStatus.state === "downloaded"}
+          Update v{liveStatus.version} ready to install
+        {:else if liveStatus.state === "not-available"}
+          {liveStatus.code === "dev-mode" ? "Updates available in packaged builds" : "You're on the latest version"}
+        {:else if liveStatus.state === "error"}
+          Update error: {liveStatus.error}
+        {/if}
+      </p>
+      <Button variant="outline" size="sm" onclick={openUpdateDialog}>
+        View
+      </Button>
+    </div>
+  {/if}
+</div>

--- a/desktop/src/renderer/src/lib/components/update/update-toasts.test.ts
+++ b/desktop/src/renderer/src/lib/components/update/update-toasts.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+const toastFns = {
+  info: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  default: vi.fn(),
+}
+
+vi.mock("svelte-sonner", () => {
+  const fn = Object.assign(
+    (...args: unknown[]) => toastFns.default(...args),
+    toastFns,
+  )
+  return { toast: fn }
+})
+
+vi.mock("$lib/ipc/commands.js", () => ({
+  installUpdate: vi.fn(),
+}))
+
+let listeners: Array<(s: unknown) => void> = []
+vi.mock("$lib/stores/updates.svelte.js", () => ({
+  subscribe(fn: (s: unknown) => void) {
+    listeners.push(fn)
+    return () => {
+      const i = listeners.indexOf(fn)
+      if (i >= 0) listeners.splice(i, 1)
+    }
+  },
+}))
+
+describe("update-toasts", () => {
+  beforeEach(() => {
+    listeners = []
+    toastFns.info.mockClear()
+    toastFns.success.mockClear()
+    toastFns.error.mockClear()
+    toastFns.default.mockClear()
+    vi.resetModules()
+  })
+
+  it("fires the available toast once per version even with repeat events", async () => {
+    const { initUpdateToasts } = await import("./update-toasts.js")
+    initUpdateToasts(() => true)
+    expect(listeners.length).toBe(1)
+    const emit = listeners[0]
+
+    emit({ state: "available", version: "1.0.0" })
+    emit({ state: "available", version: "1.0.0" })
+    emit({ state: "available", version: "1.0.0" })
+
+    expect(toastFns.info).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-fires when version changes", async () => {
+    const { initUpdateToasts } = await import("./update-toasts.js")
+    initUpdateToasts(() => true)
+    const emit = listeners[0]
+
+    emit({ state: "available", version: "1.0.0" })
+    emit({ state: "available", version: "1.0.1" })
+
+    expect(toastFns.info).toHaveBeenCalledTimes(2)
+  })
+
+  it("stays silent on background error (no markUserInitiated)", async () => {
+    const { initUpdateToasts } = await import("./update-toasts.js")
+    initUpdateToasts(() => true)
+    const emit = listeners[0]
+
+    emit({ state: "error", error: "feed down", code: "feed-error" })
+
+    expect(toastFns.error).not.toHaveBeenCalled()
+  })
+
+  it("fires error toast after markUserInitiated, then resets the flag", async () => {
+    const { initUpdateToasts, markUserInitiated } = await import("./update-toasts.js")
+    initUpdateToasts(() => true)
+    const emit = listeners[0]
+
+    markUserInitiated()
+    emit({ state: "error", error: "feed down", code: "feed-error" })
+    expect(toastFns.error).toHaveBeenCalledTimes(1)
+
+    // Different error to bypass dedupe; flag should already be reset, so silent.
+    emit({ state: "error", error: "different", code: "network" })
+    expect(toastFns.error).toHaveBeenCalledTimes(1)
+  })
+
+  it("suppresses error toast when code is dev-mode", async () => {
+    const { initUpdateToasts, markUserInitiated } = await import("./update-toasts.js")
+    initUpdateToasts(() => true)
+    const emit = listeners[0]
+
+    markUserInitiated()
+    emit({ state: "error", error: "x", code: "dev-mode" })
+
+    expect(toastFns.error).not.toHaveBeenCalled()
+  })
+
+  it("openUpdateDialog calls the bound opener", async () => {
+    const { bindDialogOpener, openUpdateDialog } = await import("./update-toasts.js")
+    const opener = vi.fn()
+    bindDialogOpener(opener)
+    openUpdateDialog()
+    expect(opener).toHaveBeenCalledTimes(1)
+  })
+
+  it("fires action toast (not info) when auto-download is off", async () => {
+    const { initUpdateToasts } = await import("./update-toasts.js")
+    initUpdateToasts(() => false)
+    const emit = listeners[0]
+
+    emit({ state: "available", version: "1.0.0" })
+
+    expect(toastFns.info).not.toHaveBeenCalled()
+    expect(toastFns.default).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-fires available after a downloading transition for a new version", async () => {
+    const { initUpdateToasts } = await import("./update-toasts.js")
+    initUpdateToasts(() => true)
+    const emit = listeners[0]
+
+    emit({ state: "available", version: "1.0.0" })
+    emit({ state: "downloading", version: "1.0.0", progress: { percent: 50, bytesPerSecond: 0, transferred: 0, total: 0 } })
+    emit({ state: "available", version: "2.0.0" })
+
+    expect(toastFns.info).toHaveBeenCalledTimes(2)
+  })
+})

--- a/desktop/src/renderer/src/lib/components/update/update-toasts.ts
+++ b/desktop/src/renderer/src/lib/components/update/update-toasts.ts
@@ -1,0 +1,79 @@
+import { toast } from "svelte-sonner"
+import { installUpdate } from "$lib/ipc/commands.js"
+import type { UpdateStatus } from "$lib/ipc/events.js"
+import { subscribe } from "$lib/stores/updates.svelte.js"
+
+let openDialog: (() => void) | null = null
+let lastKey = ""
+let userInitiated = false
+
+function dedupeKey(s: UpdateStatus): string {
+  // Include error text and code so consecutive errors (or a retry after
+  // an error) are not suppressed.
+  return [s.state, s.version ?? "", s.code ?? "", s.error ?? ""].join("")
+}
+
+export function bindDialogOpener(fn: () => void): void {
+  openDialog = fn
+}
+
+export function openUpdateDialog(): void {
+  openDialog?.()
+}
+
+export function markUserInitiated(): void {
+  userInitiated = true
+}
+
+function fireAvailable(s: UpdateStatus, autoDownload: boolean): void {
+  if (autoDownload) {
+    toast.info(`Update v${s.version} found, downloading…`, { duration: 4000 })
+    return
+  }
+  toast(`Update v${s.version} available`, {
+    action: { label: "View", onClick: () => openDialog?.() },
+    duration: 10000,
+  })
+}
+
+function fireDownloaded(s: UpdateStatus): void {
+  toast.success(`Update v${s.version} ready`, {
+    duration: Infinity,
+    action: {
+      label: "Restart and Update",
+      onClick: () => {
+        installUpdate().catch(() => {
+          toast.error("Failed to start update. Try restarting the app manually.")
+        })
+      },
+    },
+  })
+}
+
+function fireError(s: UpdateStatus): void {
+  if (!userInitiated) return
+  if (s.code === "dev-mode") return
+  toast.error(`Update check failed: ${s.error ?? "unknown error"}`, {
+    action: { label: "Retry", onClick: () => openDialog?.() },
+  })
+  userInitiated = false
+}
+
+function fireNotAvailable(): void {
+  if (!userInitiated) return
+  toast.success("You're on the latest version.")
+  userInitiated = false
+}
+
+export function initUpdateToasts(getAutoDownload: () => boolean): () => void {
+  return subscribe((s) => {
+    const key = dedupeKey(s)
+    if (key === lastKey) return
+    lastKey = key
+
+    if (s.state === "available") fireAvailable(s, getAutoDownload())
+    else if (s.state === "downloaded") fireDownloaded(s)
+    else if (s.state === "error") fireError(s)
+    else if (s.state === "not-available") fireNotAvailable()
+  })
+}

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -291,6 +291,22 @@ export async function installUpdate(): Promise<void> {
   return invoke("install_update")
 }
 
+export async function downloadUpdate(): Promise<void> {
+  return invoke("download_update")
+}
+
+export async function getAppVersion(): Promise<string> {
+  return invoke<string>("get_app_version")
+}
+
+export async function getAutoDownload(): Promise<boolean> {
+  return invoke<boolean>("get_auto_download")
+}
+
+export async function setAutoDownload(enabled: boolean): Promise<void> {
+  return invoke("set_auto_download", { enabled })
+}
+
 // Analytics
 export function analyticsTrack(
   name: string,

--- a/desktop/src/renderer/src/lib/ipc/events.ts
+++ b/desktop/src/renderer/src/lib/ipc/events.ts
@@ -8,12 +8,37 @@ import type {
 import { listen } from "./bridge.js"
 import type { UnlistenFn } from "./types.js"
 
+export type UpdateStateValue =
+  | "idle"
+  | "checking"
+  | "available"
+  | "downloading"
+  | "downloaded"
+  | "not-available"
+  | "error"
+
+export type UpdateErrorCode =
+  | "dev-mode"
+  | "unsupported"
+  | "network"
+  | "feed-error"
+  | "verification"
+
+export interface UpdateProgress {
+  percent: number
+  bytesPerSecond: number
+  transferred: number
+  total: number
+}
+
 export interface UpdateStatus {
-  state: "checking" | "available" | "not-available" | "downloading" | "downloaded" | "error"
+  state: UpdateStateValue
   version?: string
   releaseNotes?: string
   releaseName?: string
+  progress?: UpdateProgress
   error?: string
+  code?: UpdateErrorCode
 }
 
 export const EVENT_NAMES = {

--- a/desktop/src/renderer/src/lib/stores/settings.ts
+++ b/desktop/src/renderer/src/lib/stores/settings.ts
@@ -1,4 +1,5 @@
 import { writable } from "svelte/store"
+import { getAutoDownload, setAutoDownload } from "$lib/ipc/commands.js"
 
 const browser = typeof window !== "undefined"
 
@@ -132,14 +133,43 @@ export function setSidebarPosition(value: SidebarPosition) {
   sidebarPosition.set(value)
 }
 
-// Auto-update
+// Auto-update — main process owns the persistent value. localStorage
+// is a cache for instant first paint; `syncAutoUpdateFromMain` reconciles
+// it with the main-process truth at app boot.
 export const autoUpdate = writable<boolean>(
   getStoredBool(AUTO_UPDATE_KEY, true),
 )
 
-export function setAutoUpdate(value: boolean) {
+// Tracks whether the user has toggled the auto-update setting since boot.
+// If so, syncAutoUpdateFromMain skips its store update so the user's
+// in-flight choice is not clobbered by a slow IPC round-trip.
+let userTouchedAutoUpdate = false
+
+export async function syncAutoUpdateFromMain(): Promise<void> {
+  try {
+    const value = await getAutoDownload()
+    if (userTouchedAutoUpdate) return
+    if (browser) localStorage.setItem(AUTO_UPDATE_KEY, String(value))
+    autoUpdate.set(value)
+  } catch (err) {
+    console.warn("[settings] getAutoDownload failed; keeping cached value:", err)
+  }
+}
+
+export async function setAutoUpdate(value: boolean): Promise<void> {
+  userTouchedAutoUpdate = true
+  // Optimistic local update for instant feedback.
+  const previous = getStoredBool(AUTO_UPDATE_KEY, true)
   if (browser) localStorage.setItem(AUTO_UPDATE_KEY, String(value))
   autoUpdate.set(value)
+  try {
+    await setAutoDownload(value)
+  } catch (err) {
+    // Rollback so UI and main process stay aligned on IPC failure.
+    if (browser) localStorage.setItem(AUTO_UPDATE_KEY, String(previous))
+    autoUpdate.set(previous)
+    console.warn("[settings] setAutoDownload failed; rolled back:", err)
+  }
 }
 
 // Default IDE

--- a/desktop/src/renderer/src/lib/stores/updates.svelte.ts
+++ b/desktop/src/renderer/src/lib/stores/updates.svelte.ts
@@ -1,0 +1,66 @@
+import { onUpdateStatus, type UpdateStatus } from "$lib/ipc/events.js"
+import type { UnlistenFn } from "$lib/ipc/types.js"
+
+type Listener = (s: UpdateStatus) => void
+
+const state: { current: UpdateStatus; lastCheckedAt: number | null } = $state({
+  current: { state: "idle" },
+  lastCheckedAt: null,
+})
+
+const listeners: Listener[] = []
+let unlisten: UnlistenFn | null = null
+
+export function updateStatus(): UpdateStatus {
+  return state.current
+}
+
+export function lastCheckedAt(): number | null {
+  return state.lastCheckedAt
+}
+
+export function hasUpdate(): boolean {
+  const s = state.current.state
+  return s === "available" || s === "downloading" || s === "downloaded"
+}
+
+export function isReady(): boolean {
+  return state.current.state === "downloaded"
+}
+
+export function isChecking(): boolean {
+  return state.current.state === "checking"
+}
+
+export function isDevMode(): boolean {
+  return state.current.state === "not-available" && state.current.code === "dev-mode"
+}
+
+export function subscribe(fn: Listener): () => void {
+  listeners.push(fn)
+  return () => {
+    const i = listeners.indexOf(fn)
+    if (i >= 0) listeners.splice(i, 1)
+  }
+}
+
+function set(next: UpdateStatus): void {
+  state.current = next
+  if (next.state === "not-available" || next.state === "available") {
+    state.lastCheckedAt = Date.now()
+  }
+  for (const fn of listeners) fn(next)
+}
+
+export async function initUpdateStore(): Promise<void> {
+  if (unlisten) return
+  unlisten = await onUpdateStatus(set)
+}
+
+export function disposeUpdateStore(): void {
+  unlisten?.()
+  unlisten = null
+}
+
+// Test-only setter
+export const __setForTest = set

--- a/desktop/src/renderer/src/pages/SettingsPage.svelte
+++ b/desktop/src/renderer/src/pages/SettingsPage.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-import { onMount, onDestroy } from "svelte"
-import { Check } from "@lucide/svelte"
+import { onMount } from "svelte"
 import { Button } from "$lib/components/ui/button/index.js"
 import { Input } from "$lib/components/ui/input/index.js"
 import { Label } from "$lib/components/ui/label/index.js"
@@ -16,8 +15,6 @@ import {
   setColorScheme,
   uiScale,
   applyUIScale,
-  autoUpdate,
-  setAutoUpdate,
   defaultIde,
   setDefaultIde,
   fixedIde,
@@ -32,18 +29,7 @@ import type {
   UIScale,
   LocalOptions,
 } from "$lib/stores/settings.js"
-import {
-  devsyVersion,
-  devsyUpgrade,
-  devsyUpgradeDryRun,
-  getReleaseChannel,
-  setReleaseChannel as setReleaseChannelIpc,
-  checkForUpdates as checkForUpdatesIpc,
-  installUpdate as installUpdateIpc,
-  type ReleaseChannel,
-} from "$lib/ipc/commands.js"
-import { onUpdateStatus, type UpdateStatus } from "$lib/ipc/events.js"
-import type { UnlistenFn } from "$lib/ipc/types.js"
+import UpdatesSection from "$lib/components/update/UpdatesSection.svelte"
 import { Skeleton } from "$lib/components/ui/skeleton/index.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
@@ -116,7 +102,6 @@ const IDE_OPTIONS = [
 // ── State ───────────────────────────────────────────────────────────
 
 let activeTab = $state("general")
-let cliVersion = $state<string | null>(null)
 let loading = $state(true)
 let saving = $state(false)
 let ideComboOpen = $state(false)
@@ -142,75 +127,6 @@ let local = $state<LocalOptions>({
   experimentalMultiDevcontainer: false,
 })
 
-// ── Version management ──────────────────────────────────────────────
-
-let releaseChannel = $state<ReleaseChannel>("stable")
-let targetVersion = $state("")
-let upgrading = $state(false)
-let upgradeResult = $state<string | null>(null)
-let updateStatus = $state<UpdateStatus | null>(null)
-let unlistenUpdate: UnlistenFn | null = null
-
-async function handleCheckForUpdates() {
-  try {
-    await checkForUpdatesIpc()
-  } catch (err) {
-    toasts.error(`Update check failed: ${extractErrorMessage(err)}`)
-  }
-}
-
-async function handleInstallUpdate() {
-  try {
-    await installUpdateIpc()
-  } catch (err) {
-    toasts.error(`Failed to install update: ${extractErrorMessage(err)}`)
-  }
-}
-
-async function handleChannelChange(channel: ReleaseChannel) {
-  const previous = releaseChannel
-  releaseChannel = channel
-  try {
-    await setReleaseChannelIpc(channel)
-    toasts.success(`Switched to ${channel} update channel`)
-  } catch (err) {
-    releaseChannel = previous
-    toasts.error(`Failed to switch channel: ${extractErrorMessage(err)}`)
-  }
-}
-
-async function handleUpgrade() {
-  if (!targetVersion) return
-  const version = targetVersion.startsWith("v")
-    ? targetVersion
-    : `v${targetVersion}`
-
-  // Dry-run first to validate
-  try {
-    const info = await devsyUpgradeDryRun(version)
-    if (info.includes("already up-to-date")) {
-      toasts.info(`Already running ${version}`)
-      return
-    }
-  } catch (err) {
-    toasts.error(`Invalid version: ${extractErrorMessage(err)}`)
-    return
-  }
-
-  upgrading = true
-  upgradeResult = null
-  try {
-    await devsyUpgrade(version)
-    upgradeResult = version
-    cliVersion = version.trim()
-    toasts.success(`Upgraded to ${version}. Restart the app to complete.`)
-  } catch (err) {
-    toasts.error(`Upgrade failed: ${extractErrorMessage(err)}`)
-  } finally {
-    upgrading = false
-  }
-}
-
 // ── Keyboard shortcuts ──────────────────────────────────────────────
 
 const shortcuts = [
@@ -222,36 +138,11 @@ const shortcuts = [
 
 // ── Load / Save ─────────────────────────────────────────────────────
 
-onMount(async () => {
+onMount(() => {
   local = loadLocalOptions()
   localOptionsStore.set(local)
   loading = false
-  await loadVersion()
-  try {
-    releaseChannel = await getReleaseChannel()
-  } catch {
-    // Ignore — defaults to stable
-  }
-  try {
-    unlistenUpdate = await onUpdateStatus((status) => {
-      updateStatus = status
-    })
-  } catch {
-    // Event listener setup failed
-  }
 })
-
-onDestroy(() => {
-  unlistenUpdate?.()
-})
-
-async function loadVersion() {
-  try {
-    cliVersion = (await devsyVersion()).trim()
-  } catch {
-    cliVersion = null
-  }
-}
 
 function saveLocal(key: keyof LocalOptions, value: string | boolean) {
   saveLocalOption(key, value)
@@ -369,136 +260,7 @@ function toggleLocal(key: keyof LocalOptions) {
 
         <Separator />
 
-        <h2 class="text-lg font-semibold">Updates</h2>
-
-        <div class="space-y-4">
-          <div class="flex items-center justify-between">
-            <div>
-              <Label>Automatic Updates</Label>
-              <p class="text-xs text-muted-foreground">Download and install updates in the background</p>
-            </div>
-            <Switch checked={$autoUpdate} onCheckedChange={(v) => setAutoUpdate(v)} />
-          </div>
-
-          <div class="space-y-3">
-            <Label>Release Channel</Label>
-            <div class="grid grid-cols-2 gap-3">
-              <button
-                class="rounded-lg border p-3 text-left transition-colors {releaseChannel === 'stable' ? 'border-primary bg-primary/5 ring-1 ring-primary' : 'border-border hover:border-muted-foreground/50'}"
-                onclick={() => handleChannelChange("stable")}
-              >
-                <div class="flex items-center gap-2">
-                  <span class="font-medium text-sm">Stable</span>
-                  {#if releaseChannel === "stable"}
-                    <Check class="h-3.5 w-3.5 text-primary" />
-                  {/if}
-                </div>
-                <p class="mt-1 text-xs text-muted-foreground">Production-ready releases</p>
-              </button>
-              <button
-                class="rounded-lg border p-3 text-left transition-colors {releaseChannel === 'beta' ? 'border-primary bg-primary/5 ring-1 ring-primary' : 'border-border hover:border-muted-foreground/50'}"
-                onclick={() => handleChannelChange("beta")}
-              >
-                <div class="flex items-center gap-2">
-                  <span class="font-medium text-sm">Beta</span>
-                  {#if releaseChannel === "beta"}
-                    <Check class="h-3.5 w-3.5 text-primary" />
-                  {/if}
-                </div>
-                <p class="mt-1 text-xs text-muted-foreground">Early access to new features</p>
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <Separator />
-
-        <div class="space-y-3">
-          <h2 class="text-lg font-semibold">Version</h2>
-          <div class="flex items-center justify-between rounded-lg border p-3">
-            <div>
-              <p class="text-sm font-medium">Devsy Desktop</p>
-              {#if cliVersion}
-                <p class="text-xs font-mono text-muted-foreground">{cliVersion}</p>
-              {:else}
-                <p class="text-xs text-muted-foreground">Not available</p>
-              {/if}
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onclick={handleCheckForUpdates}
-              disabled={updateStatus?.state === "checking"}
-            >
-              {updateStatus?.state === "checking" ? "Checking..." : "Check for Updates"}
-            </Button>
-          </div>
-
-          {#if updateStatus?.state === "not-available"}
-            <div class="rounded-md border border-border bg-muted/50 p-3">
-              <p class="text-sm text-muted-foreground">You're on the latest version.</p>
-            </div>
-          {/if}
-
-          {#if updateStatus?.state === "available" || updateStatus?.state === "downloaded"}
-            <div class="rounded-md border border-primary/30 bg-primary/5 p-3 space-y-2">
-              <div class="flex items-center justify-between">
-                <div>
-                  <p class="text-sm font-medium">
-                    {updateStatus.state === "downloaded" ? "Update ready to install" : "Update available"}
-                  </p>
-                  <p class="text-xs text-muted-foreground">Version {updateStatus.version}</p>
-                </div>
-                {#if updateStatus.state === "downloaded"}
-                  <Button size="sm" onclick={handleInstallUpdate}>Restart & Update</Button>
-                {/if}
-              </div>
-              {#if updateStatus.releaseNotes}
-                <div class="border-t border-border/50 pt-2 mt-2">
-                  <p class="text-xs font-medium text-muted-foreground mb-1">Release Notes</p>
-                  <div class="text-xs text-muted-foreground prose prose-sm dark:prose-invert max-h-40 overflow-y-auto">
-                    {@html updateStatus.releaseNotes}
-                  </div>
-                </div>
-              {/if}
-            </div>
-          {/if}
-
-          {#if updateStatus?.state === "error"}
-            <div class="rounded-md border border-destructive/30 bg-destructive/5 p-3">
-              <p class="text-sm text-destructive">Update check failed: {updateStatus.error}</p>
-            </div>
-          {/if}
-
-          <div class="space-y-2">
-            <Label>Install Specific Version</Label>
-            <p class="text-xs text-muted-foreground">Downgrade or pin to a specific CLI version</p>
-            <div class="flex gap-2">
-              <Input
-                value={targetVersion}
-                placeholder="e.g. v1.4.0"
-                oninput={(e) => (targetVersion = e.currentTarget.value)}
-                onkeydown={(e) => { if (e.key === "Enter") handleUpgrade() }}
-                disabled={upgrading}
-                class="max-w-48 font-mono"
-              />
-              <Button
-                onclick={handleUpgrade}
-                disabled={upgrading || !targetVersion}
-                variant="outline"
-              >
-                {upgrading ? "Installing..." : "Install"}
-              </Button>
-            </div>
-          </div>
-          {#if upgradeResult}
-            <div class="rounded-md border border-green-600/30 bg-green-600/10 p-3">
-              <p class="text-sm text-green-700 dark:text-green-400">
-                Switched to {upgradeResult}. Restart to use the new version.
-              </p>
-            </div>
-          {/if}
-        </div>
+        <UpdatesSection />
 
         <Separator />
 

--- a/hack/merge_mac_metadata/main.go
+++ b/hack/merge_mac_metadata/main.go
@@ -44,6 +44,7 @@ func loadYAML(path string) (map[string]any, error) {
 }
 
 func mergeFileEntries(paths []string) (base map[string]any, files []any, err error) {
+	seen := map[string]int{} // url -> index in files
 	for _, p := range paths {
 		data, err := loadYAML(p)
 		if err != nil {
@@ -55,24 +56,64 @@ func mergeFileEntries(paths []string) (base map[string]any, files []any, err err
 		if base == nil {
 			base = data
 		}
-		if entries, ok := data["files"].([]any); ok {
-			files = append(files, entries...)
+		entries, ok := data["files"].([]any)
+		if !ok {
+			continue
+		}
+		for _, e := range entries {
+			// Defensive: electron-builder always emits maps; skip non-map entries
+			// (prior behavior appended raw entries via variadic spread).
+			entry, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			url, _ := entry["url"].(string)
+			if url == "" {
+				files = append(files, entry)
+				continue
+			}
+			if idx, exists := seen[url]; exists {
+				files[idx] = entry // last-write-wins
+				continue
+			}
+			seen[url] = len(files)
+			files = append(files, entry)
 		}
 	}
 	return base, files, nil
 }
 
+// applyTopLevelFromFirst sets the top-level path/sha512/size from the
+// files[] entry that matches the base file's own preferred path when
+// possible, falling back to the first entry. This avoids electron-updater
+// fallback consumers (e.g. Rosetta) downloading the wrong-arch binary
+// just because dedup iteration happened to land arm64 before x64.
 func applyTopLevelFromFirst(base map[string]any, files []any) {
 	if len(files) == 0 {
 		return
 	}
-	first, ok := files[0].(map[string]any)
-	if !ok {
-		return
+	preferred := pickPreferred(base, files)
+	base["path"] = preferred["url"]
+	base["sha512"] = preferred["sha512"]
+	base["size"] = preferred["size"]
+}
+
+func pickPreferred(base map[string]any, files []any) map[string]any {
+	if want, ok := base["path"].(string); ok && want != "" {
+		for _, e := range files {
+			entry, ok := e.(map[string]any)
+			if !ok {
+				continue
+			}
+			if u, ok := entry["url"].(string); ok && u == want {
+				return entry
+			}
+		}
 	}
-	base["path"] = first["url"]
-	base["sha512"] = first["sha512"]
-	base["size"] = first["size"]
+	if first, ok := files[0].(map[string]any); ok {
+		return first
+	}
+	return map[string]any{}
 }
 
 func writeYAML(path string, data map[string]any) error {

--- a/hack/merge_mac_metadata/main_test.go
+++ b/hack/merge_mac_metadata/main_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeManifest(t *testing.T, dir, arch, content string) {
+	t.Helper()
+	archDir := filepath.Join(dir, arch)
+	if err := os.MkdirAll(archDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(archDir, "latest-mac.yml"),
+		[]byte(content),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMergeDedupesByURL(t *testing.T) {
+	dir := t.TempDir()
+	meta := filepath.Join(dir, "metadata")
+	out := filepath.Join(dir, "out")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stale := `version: 1.0.0
+files:
+  - url: Devsy_mac_arm64.zip
+    sha512: STALE==
+    size: 1
+path: Devsy_mac_arm64.zip
+sha512: STALE==
+size: 1
+`
+	fresh := `version: 2.0.0
+files:
+  - url: Devsy_mac_arm64.zip
+    sha512: FRESH==
+    size: 99
+  - url: Devsy_mac_x64.zip
+    sha512: NEW==
+    size: 88
+path: Devsy_mac_arm64.zip
+sha512: FRESH==
+size: 99
+`
+	writeManifest(t, meta, "arm64", stale)
+	writeManifest(t, meta, "x64", fresh)
+
+	if err := mergeMacFiles(meta, out); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(filepath.Join(out, "latest-mac.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(got)
+	if strings.Contains(s, "STALE==") {
+		t.Fatalf("stale sha leaked through:\n%s", s)
+	}
+	if !strings.Contains(s, "FRESH==") || !strings.Contains(s, "NEW==") {
+		t.Fatalf("missing fresh entries:\n%s", s)
+	}
+	// arm64.zip should appear exactly twice: once in files[], once in top-level path
+	if strings.Count(s, "Devsy_mac_arm64.zip") != 2 {
+		t.Fatalf("duplicate arm64 entries (expected 2 occurrences):\n%s", s)
+	}
+}
+
+func setupMergeDir(t *testing.T) (meta, out string) {
+	t.Helper()
+	dir := t.TempDir()
+	meta = filepath.Join(dir, "metadata")
+	out = filepath.Join(dir, "out")
+	if err := os.MkdirAll(out, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return meta, out
+}
+
+func readMerged(t *testing.T, out string) string {
+	t.Helper()
+	got, err := os.ReadFile(filepath.Join(out, "latest-mac.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(got)
+}
+
+func TestMergeEmptyFiles(t *testing.T) {
+	meta, out := setupMergeDir(t)
+	content := `version: 1.0.0
+files: []
+`
+	writeManifest(t, meta, "arm64", content)
+
+	if err := mergeMacFiles(meta, out); err != nil {
+		t.Fatal(err)
+	}
+	s := readMerged(t, out)
+	if !strings.Contains(s, "files: []") {
+		t.Fatalf("expected empty files array in output:\n%s", s)
+	}
+}
+
+func TestMergeEntriesWithoutURL(t *testing.T) {
+	meta, out := setupMergeDir(t)
+	content := `version: 1.0.0
+files:
+  - sha512: NOURL==
+    size: 42
+`
+	writeManifest(t, meta, "arm64", content)
+
+	if err := mergeMacFiles(meta, out); err != nil {
+		t.Fatal(err)
+	}
+	s := readMerged(t, out)
+	if !strings.Contains(s, "NOURL==") {
+		t.Fatalf("entry without url should still appear in output:\n%s", s)
+	}
+}
+
+func TestMergeSingleSourceNoOp(t *testing.T) {
+	meta, out := setupMergeDir(t)
+	content := `version: 1.0.0
+files:
+  - url: Devsy_mac_arm64.zip
+    sha512: AAA==
+    size: 1
+  - url: Devsy_mac_x64.zip
+    sha512: BBB==
+    size: 2
+`
+	writeManifest(t, meta, "arm64", content)
+
+	if err := mergeMacFiles(meta, out); err != nil {
+		t.Fatal(err)
+	}
+	s := readMerged(t, out)
+	armIdx := strings.Index(s, "Devsy_mac_arm64.zip")
+	x64Idx := strings.Index(s, "Devsy_mac_x64.zip")
+	if armIdx < 0 || x64Idx < 0 {
+		t.Fatalf("missing url entries:\n%s", s)
+	}
+	if armIdx > x64Idx {
+		t.Fatalf("expected arm64 to precede x64 in output:\n%s", s)
+	}
+}

--- a/hack/rewrite_manifest_urls/main.go
+++ b/hack/rewrite_manifest_urls/main.go
@@ -1,0 +1,101 @@
+// Rewrites relative file URLs in electron-updater manifests to absolute
+// GitHub Release asset URLs so binaries can live on GitHub Releases while
+// the manifests are served from a CDN.
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func isAbsolute(u string) bool {
+	lu := strings.ToLower(u)
+	return strings.HasPrefix(lu, "http://") || strings.HasPrefix(lu, "https://")
+}
+
+func absURL(repo, tag, filename string) string {
+	return fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", repo, tag, filename)
+}
+
+func rewriteFilesEntries(data map[string]any, repo, tag string) {
+	entries, ok := data["files"].([]any)
+	if !ok {
+		return
+	}
+	for _, e := range entries {
+		entry, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+		u, ok := entry["url"].(string)
+		if !ok || isAbsolute(u) {
+			continue
+		}
+		entry["url"] = absURL(repo, tag, u)
+	}
+}
+
+func rewritePath(data map[string]any, repo, tag string) {
+	p, ok := data["path"].(string)
+	if !ok || isAbsolute(p) {
+		return
+	}
+	data["path"] = absURL(repo, tag, p)
+}
+
+func rewriteFile(path, repo, tag string) error {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	var data map[string]any
+	if err := yaml.Unmarshal(raw, &data); err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	rewriteFilesEntries(data, repo, tag)
+	rewritePath(data, repo, tag)
+	out, err := yaml.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("marshal %s: %w", path, err)
+	}
+	return os.WriteFile(path, out, 0o644)
+}
+
+func walkAndRewrite(root, repo, tag string) error {
+	return filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".yml") {
+			return nil
+		}
+		if !strings.HasPrefix(name, "latest") && !strings.HasPrefix(name, "beta") {
+			return nil
+		}
+		if err := rewriteFile(path, repo, tag); err != nil {
+			return err
+		}
+		fmt.Printf("rewrote %s\n", path)
+		return nil
+	})
+}
+
+func main() {
+	if len(os.Args) != 4 {
+		fmt.Fprintf(os.Stderr, "usage: %s <dir> <owner/repo> <tag>\n", os.Args[0])
+		os.Exit(2)
+	}
+	if err := walkAndRewrite(os.Args[1], os.Args[2], os.Args[3]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/hack/rewrite_manifest_urls/main_test.go
+++ b/hack/rewrite_manifest_urls/main_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRewriteRewritesRelativeURLs(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "beta-mac.yml")
+	yaml := `version: 1.10.0-beta.12
+files:
+  - url: Devsy_mac_arm64.zip
+    sha512: abc==
+    size: 100
+  - url: Devsy_mac_x64.dmg
+    sha512: def==
+    size: 200
+path: Devsy_mac_arm64.zip
+sha512: abc==
+size: 100
+`
+	if err := os.WriteFile(in, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := rewriteFile(in, "devsy-ai/devsy", "v1.10.0-beta.12"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(in)
+	want := "https://github.com/devsy-ai/devsy/releases/download/v1.10.0-beta.12/Devsy_mac_arm64.zip"
+	if !strings.Contains(string(got), want) {
+		t.Fatalf("missing rewritten url. got:\n%s", got)
+	}
+	if !strings.Contains(string(got), "Devsy_mac_x64.dmg") {
+		t.Fatal("second url missing")
+	}
+}
+
+func TestRewriteSkipsAbsoluteURLs(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "latest.yml")
+	yaml := `version: 1.0.0
+files:
+  - url: https://example.com/already-absolute.exe
+    sha512: zz==
+    size: 1
+path: https://example.com/already-absolute.exe
+`
+	if err := os.WriteFile(in, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := rewriteFile(in, "o/r", "v1"); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(in)
+	if strings.Contains(string(got), "github.com/o/r") {
+		t.Fatalf("should not rewrite absolute url. got:\n%s", got)
+	}
+}
+
+func TestRewriteSkipsNonMapFilesEntries(t *testing.T) {
+	dir := t.TempDir()
+	in := filepath.Join(dir, "latest.yml")
+	yaml := `version: 1.0.0
+files:
+  - scalar1
+  - scalar2
+`
+	if err := os.WriteFile(in, []byte(yaml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := rewriteFile(in, "o/r", "v1"); err != nil {
+		t.Fatalf("rewriteFile should not error on non-map files entries: %v", err)
+	}
+	got, _ := os.ReadFile(in)
+	if !strings.Contains(string(got), "scalar1") || !strings.Contains(string(got), "scalar2") {
+		t.Fatalf("scalar entries should round-trip unchanged. got:\n%s", got)
+	}
+	if strings.Contains(string(got), "github.com/o/r") {
+		t.Fatalf("non-map entries should not be rewritten. got:\n%s", got)
+	}
+}
+
+func TestWalkAndRewriteFilenameFilter(t *testing.T) {
+	dir := t.TempDir()
+	contents := `version: 1.0.0
+files:
+  - url: Devsy.zip
+    sha512: aa==
+    size: 1
+path: Devsy.zip
+`
+	names := []string{"latest.yml", "latest-mac.yml", "beta.yml", "random.yml", "latest.yaml"}
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(dir, n), []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := walkAndRewrite(dir, "o/r", "v1"); err != nil {
+		t.Fatal(err)
+	}
+
+	rewritten := []string{"latest.yml", "latest-mac.yml", "beta.yml"}
+	for _, n := range rewritten {
+		b, _ := os.ReadFile(filepath.Join(dir, n))
+		if !strings.Contains(string(b), "github.com/o/r") {
+			t.Fatalf("%s should have been rewritten. got:\n%s", n, b)
+		}
+	}
+
+	untouched := []string{"random.yml", "latest.yaml"}
+	for _, n := range untouched {
+		b, _ := os.ReadFile(filepath.Join(dir, n))
+		if strings.Contains(string(b), "github.com/o/r") {
+			t.Fatalf("%s should NOT have been rewritten. got:\n%s", n, b)
+		}
+	}
+}

--- a/hack/smoke_test_manifests/main.go
+++ b/hack/smoke_test_manifests/main.go
@@ -1,0 +1,145 @@
+// Smoke-tests electron-updater manifests by HEAD-checking every URL.
+// Fails on any non-2xx response or unreachable URL. Reads GITHUB_TOKEN
+// from the environment to authenticate requests to github.com (so
+// draft release assets are reachable).
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func isGitHubHost(u string) bool {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return false
+	}
+	// Only send the GITHUB_TOKEN over https to avoid leaking it via http.
+	if parsed.Scheme != "https" {
+		return false
+	}
+	host := parsed.Hostname()
+	return host == "github.com" || strings.HasSuffix(host, ".github.com")
+}
+
+type failure struct {
+	url    string
+	reason string
+}
+
+func extractFilesURLs(data map[string]any) []string {
+	entries, ok := data["files"].([]any)
+	if !ok {
+		return nil
+	}
+	var urls []string
+	for _, e := range entries {
+		entry, ok := e.(map[string]any)
+		if !ok {
+			continue
+		}
+		if u, ok := entry["url"].(string); ok && u != "" {
+			urls = append(urls, u)
+		}
+	}
+	return urls
+}
+
+func collectURLs(path string) ([]string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var data map[string]any
+	if err := yaml.Unmarshal(raw, &data); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	urls := extractFilesURLs(data)
+	if top, ok := data["path"].(string); ok && top != "" {
+		urls = append(urls, top)
+	}
+	return urls, nil
+}
+
+func checkURL(client *http.Client, u, token string) *failure {
+	if !strings.HasPrefix(u, "http://") && !strings.HasPrefix(u, "https://") {
+		return &failure{u, "relative"}
+	}
+	req, err := http.NewRequest(http.MethodHead, u, nil)
+	if err != nil {
+		return &failure{u, err.Error()}
+	}
+	if token != "" && isGitHubHost(u) {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return &failure{u, err.Error()}
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 400 {
+		return &failure{u, fmt.Sprintf("%d", resp.StatusCode)}
+	}
+	return nil
+}
+
+func checkManifest(client *http.Client, path, token string) []failure {
+	urls, err := collectURLs(path)
+	if err != nil {
+		return []failure{{path, err.Error()}}
+	}
+	if len(urls) == 0 {
+		fmt.Printf("WARN: no urls in %s\n", path)
+		return nil
+	}
+	var failures []failure
+	for _, u := range urls {
+		if f := checkURL(client, u, token); f != nil {
+			failures = append(failures, *f)
+		}
+	}
+	return failures
+}
+
+func run(dir string) error {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.yml"))
+	if err != nil {
+		return fmt.Errorf("glob %s: %w", dir, err)
+	}
+	if len(matches) == 0 {
+		fmt.Printf("no manifests found in %s\n", dir)
+		return nil
+	}
+	token := os.Getenv("GITHUB_TOKEN")
+	client := &http.Client{Timeout: 20 * time.Second}
+	var allFailures []failure
+	for _, m := range matches {
+		fmt.Printf("checking %s\n", m)
+		allFailures = append(allFailures, checkManifest(client, m, token)...)
+	}
+	if len(allFailures) > 0 {
+		for _, f := range allFailures {
+			fmt.Printf("FAIL %s: %s\n", f.url, f.reason)
+		}
+		return fmt.Errorf("%d url(s) failed smoke test", len(allFailures))
+	}
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: %s <manifest_dir>\n", os.Args[0])
+		os.Exit(2)
+	}
+	if err := run(os.Args[1]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/hack/smoke_test_manifests/main_test.go
+++ b/hack/smoke_test_manifests/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeManifest(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCollectURLs(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "latest.yml")
+	writeManifest(t, dir, "latest.yml", `version: 1.0.0
+files:
+  - url: https://example.com/a.zip
+    sha512: aa==
+  - url: https://example.com/b.dmg
+    sha512: bb==
+path: https://example.com/a.zip
+`)
+	urls, err := collectURLs(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(urls) != 3 {
+		t.Fatalf("want 3 urls (2 files + 1 path), got %d: %v", len(urls), urls)
+	}
+}
+
+func TestRunSucceedsWhenAllReachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer srv.Close()
+	dir := t.TempDir()
+	writeManifest(t, dir, "latest.yml", `version: 1.0.0
+files:
+  - url: `+srv.URL+`/a.zip
+    sha512: aa==
+path: `+srv.URL+`/a.zip
+`)
+	if err := run(dir); err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+}
+
+func TestRunFailsOn404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer srv.Close()
+	dir := t.TempDir()
+	writeManifest(t, dir, "latest.yml", `version: 1.0.0
+files:
+  - url: `+srv.URL+`/missing.zip
+    sha512: aa==
+path: `+srv.URL+`/missing.zip
+`)
+	err := run(dir)
+	if err == nil {
+		t.Fatal("expected failure on 404")
+	}
+	if !strings.Contains(err.Error(), "failed smoke test") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunFailsOnRelativeURL(t *testing.T) {
+	dir := t.TempDir()
+	writeManifest(t, dir, "beta-mac.yml", `version: 1.0.0
+files:
+  - url: not-absolute.zip
+    sha512: aa==
+path: not-absolute.zip
+`)
+	err := run(dir)
+	if err == nil {
+		t.Fatal("expected failure on relative URL")
+	}
+}
+
+func TestRunIgnoresMissingDir(t *testing.T) {
+	if err := run(filepath.Join(t.TempDir(), "nope")); err != nil {
+		t.Fatalf("missing dir should warn, not error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the broken auto-updater (manifest URLs pointed to a CDN that never had binaries) and ships a redesigned, coordinated update UX. Delivered as one PR per request.

### Root cause of the failed update check

The error users were seeing — *"Auto-update is not available (app is not code-signed)"* — was a misleading catch-all. Code signing was fine. Two real bugs were causing the failures:

1. **Manifests on `dl.devsy.sh` listed relative URLs** like `Devsy_mac_arm64.zip`, but the binaries lived only on GitHub Releases. `electron-updater` fetched the manifest fine, then 404'd on every binary download.
2. **`hack/merge_mac_metadata.go` accumulated stale duplicate `files[]` entries** because each release re-merged the deployed manifest with the new one. The deployed `beta-mac.yml` listed `Devsy_mac_arm64.zip` three times with three different sha512 hashes; `electron-updater` happened to pick a stale one.

## What changed

### Publish pipeline (`hack/` + `.github/workflows/release.yml`)
- New `hack/rewrite_manifest_urls/` Go helper rewrites manifest `files[].url` and `path` to absolute `https://github.com/<owner>/<repo>/releases/download/<tag>/<file>` URLs. Binaries stay on GitHub Releases (download stats preserved); manifests on the CDN now point to them.
- `hack/merge_mac_metadata/` (moved into subdir for layout consistency) now dedupes by URL with last-write-wins.
- Dropped the *"fetch existing metadata from live site"* step that was the source of stale entries.
- New `hack/smoke_test_manifests/` Go helper HEAD-checks every URL in every deployed manifest before Netlify deploy, with `GITHUB_TOKEN` auth for github.com hosts. Future regressions of this class fail the release job loudly instead of silently breaking users.

### Main process (`desktop/src/main/updater.ts`)
- Extended `UpdateStatus` with `progress`, `code` (`dev-mode`/`unsupported`/`network`/`feed-error`/`verification`), and an `idle` state.
- Wired `download-progress` events to the renderer.
- Replaced the misleading code-signed message with real error codes.
- Removed the native `dialog.showMessageBox` on `update-downloaded` — the renderer owns this UX now.
- Honors the user's auto-download setting end-to-end via new `set_auto_download` / `get_auto_download` IPC.

### Renderer UX
- New global Svelte 5 store at `$lib/stores/updates.svelte.ts`; subscribed once at App root.
- New `UpdateDialog.svelte` modal renders all six states (checking / available / downloading-with-progress-bar / downloaded-with-restart-CTA / not-available / error). Built on bits-ui Dialog.
- New `update-toasts.ts` fires svelte-sonner toasts for available / downloaded / error / not-available, gated on user-initiated checks so background errors stay silent.
- New `UpdateBadge.svelte` passive header indicator (appears only when an update is in flight).
- Tray menu shows "Install Update v…" item when ready.
- Settings page slimmed: removed the "Install Specific Version" CLI pin block, fixed the version row to show `app.getVersion()`, delegated inline status to the new dialog via a shared `openUpdateDialog()` helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added update notification badge in the header displaying availability and download progress.
  * Introduced a new update dialog showing release notes, progress tracking, and download/install actions.
  * Added automatic update download toggle in the settings.
  * Enabled stable and beta release channel selection.
  * Enhanced toast notifications for update events and status changes.
  * Added application version display in settings.

* **Tests**
  * Expanded test coverage for update functionality, dialogs, and manifest handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->