### PR TITLE
fix(desktop): repair macOS auto-updater (ESM autoUpdater + app_ready handler)

### DIFF
--- a/desktop/src/main/__tests__/updater.test.ts
+++ b/desktop/src/main/__tests__/updater.test.ts
@@ -20,7 +20,10 @@ const electronUpdaterMock = {
   },
 }
 
-vi.mock("electron-updater", () => electronUpdaterMock)
+vi.mock("electron-updater", () => ({
+  ...electronUpdaterMock,
+  default: electronUpdaterMock,
+}))
 vi.mock("electron", () => ({
   app: {
     isPackaged: true,

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -18,6 +18,7 @@ import {
   checkForUpdatesWithChannel,
   downloadUpdate,
   getAutoDownloadEnabled,
+  getLastStatus,
   getReleaseChannel,
   installUpdate,
   setAutoDownloadEnabled,
@@ -806,6 +807,16 @@ export function registerIpcHandlers(deps: IpcDependencies): { tunnelProcesses: M
 
   ipcMain.handle("check_for_updates", async () => {
     await checkForUpdates()
+  })
+
+  // Deferred so the renderer's update-status listener (registered after this
+  // call resolves) is attached before the replay arrives.
+  ipcMain.handle("app_ready", (event) => {
+    setImmediate(() => {
+      if (!event.sender.isDestroyed()) {
+        event.sender.send("update-status", getLastStatus())
+      }
+    })
   })
 
   ipcMain.handle("install_update", async () => {

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -89,11 +89,15 @@ export function getLastStatus(): UpdateStatus {
 }
 
 function normalizeReleaseNotes(
-  notes: string | { note: string }[] | null | undefined,
+  notes: string | { note: string | null }[] | null | undefined,
 ): string | undefined {
   if (!notes) return undefined
   if (typeof notes === "string") return notes
-  if (Array.isArray(notes)) return notes.map((n) => n.note).join("\n")
+  if (Array.isArray(notes))
+    return notes
+      .map((n) => n.note)
+      .filter((n): n is string => !!n)
+      .join("\n")
   return undefined
 }
 
@@ -119,14 +123,25 @@ export function setAutoDownloadEnabled(enabled: boolean): void {
   // Update the live autoUpdater too so the change takes effect this session.
   // electron-updater reads autoDownload at the moment update-available fires.
   if (app.isPackaged) {
-    import("electron-updater")
-      .then(({ autoUpdater }) => {
-        if (autoUpdater && typeof autoUpdater === "object") {
+    loadAutoUpdater()
+      .then((autoUpdater) => {
+        if (autoUpdater) {
           autoUpdater.autoDownload = enabled
         }
       })
       .catch(() => {})
   }
+}
+
+// electron-updater exposes `autoUpdater` via a CJS getter that Node's
+// cjs-module-lexer doesn't surface as a named export under ESM. We have to
+// reach it through `default` (the CJS module.exports), which invokes the
+// getter and returns the platform-specific updater instance.
+async function loadAutoUpdater(): Promise<
+  (typeof import("electron-updater"))["autoUpdater"] | null
+> {
+  const mod = await import("electron-updater")
+  return mod.default?.autoUpdater ?? mod.autoUpdater ?? null
 }
 
 export function getAutoDownloadEnabled(): boolean {
@@ -147,7 +162,7 @@ export async function initAutoUpdater(
     return
   }
 
-  const { autoUpdater } = await import("electron-updater")
+  const autoUpdater = await loadAutoUpdater()
 
   if (!autoUpdater || typeof autoUpdater.checkForUpdates !== "function") {
     setStatus({
@@ -230,7 +245,7 @@ async function getUpdater() {
     setStatus({ state: "not-available", code: "dev-mode" })
     return null
   }
-  const { autoUpdater } = await import("electron-updater")
+  const autoUpdater = await loadAutoUpdater()
   if (!autoUpdater || typeof autoUpdater.checkForUpdates !== "function") {
     setStatus({
       state: "error",


### PR DESCRIPTION
## Summary

Two independent bugs were preventing the desktop auto-updater from working on macOS in v1.10.0-beta.14 (and earlier):

1. **`autoUpdater` was undefined under ESM.** `desktop/package.json` has `"type": "module"`, so the main bundle runs as ESM. `await import("electron-updater")` against electron-updater's CJS module does not surface `autoUpdater` as a named export — it's defined via `Object.defineProperty(exports, "autoUpdater", { get })`, which Node's cjs-module-lexer doesn't detect. Result: `const { autoUpdater } = await import("electron-updater")` was always `undefined`, the `!autoUpdater` guard in `updater.ts` always fired, and the UI showed *"Update check failed: Updates require a packaged build"* even on properly signed/notarized builds.

   Verified directly:

   ```
   $ node --input-type=module -e "const m=await import('electron-updater'); console.log(typeof m.autoUpdater)"
   undefined
   ```

   Fixed by introducing a small `loadAutoUpdater()` helper that reads `mod.default?.autoUpdater ?? mod.autoUpdater` (the `default` path invokes the CJS getter). Used at all three call sites in `updater.ts`.

   Prior PRs (#391, #459) misread the symptom as a code-signing limitation; the real cause is the ESM/CJS interop.

2. **`app_ready` IPC handler was never registered.** The renderer invokes `appReady()` on mount (`App.svelte:111`), but no `ipcMain.handle("app_ready", ...)` existed in main. The promise rejection was silently swallowed until #459 added a `console.warn` surfacing it. Handler added next to the other update IPCs; it replays the current updater status so a freshly-mounted UI immediately sees state main already knows.

Also widened `normalizeReleaseNotes` to accept `note: string | null` to match electron-updater's real `ReleaseNoteInfo` type (the helper's stricter return type surfaced this).

## Not fixed here

- The `https://dl.devsy.sh/desktop/latest-mac.yml` 404 turned out to be expected — beta releases publish `beta-mac.yml` only (release.yml gates `latest-*` on non-prerelease), and `beta-mac.yml` returns 200 with a healthy manifest. No publishing-pipeline change needed.

## Verification

- `npx tsc --noEmit` net-improves type errors (2 updater.ts errors removed; 3 pre-existing errors in `cli.test.ts` / `analytics.ts` unchanged).
- Needs a fresh signed + notarized build to verify end-to-end in the installed app on macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced release notes handling to gracefully manage missing or invalid content.
  * Improved auto-updater module initialization for better reliability.

* **New Features**
  * App now communicates update status information immediately upon becoming ready, enabling faster update notifications to users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->