### PR TITLE
fix(desktop): hide redundant 'latest version' status in settings

### DIFF
--- a/desktop/src/renderer/src/lib/components/update/UpdatesSection.svelte
+++ b/desktop/src/renderer/src/lib/components/update/UpdatesSection.svelte
@@ -128,7 +128,7 @@ onMount(async () => {
     </Button>
   </div>
 
-  {#if liveStatus.state !== "idle"}
+  {#if liveStatus.state !== "idle" && liveStatus.state !== "not-available"}
     <div class="rounded-md border p-3 flex items-center justify-between">
       <p class="text-sm">
         {#if liveStatus.state === "checking"}
@@ -139,8 +139,6 @@ onMount(async () => {
           Downloading v{liveStatus.version} · {(liveStatus.progress?.percent ?? 0).toFixed(0)}%
         {:else if liveStatus.state === "downloaded"}
           Update v{liveStatus.version} ready to install
-        {:else if liveStatus.state === "not-available"}
-          {liveStatus.code === "dev-mode" ? "Updates available in packaged builds" : "You're on the latest version"}
         {:else if liveStatus.state === "error"}
           Update error: {liveStatus.error}
         {/if}


### PR DESCRIPTION
## Summary
- Removes the inline "You're on the latest version" status block from the Updates section of the desktop settings page, which was redundant alongside the version display and Check for Updates button.
- Inline status still appears for actionable states (checking, available, downloading, downloaded, error); the up-to-date case is now silent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version status section visibility to display only when relevant, preventing unnecessary UI elements from appearing when no update information is available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/devsy-org/devsy/pull/463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->