### PR TITLE
fix(desktop): handle missing channel manifest gracefully

### DIFF
--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -20,6 +20,7 @@ export type UpdateErrorCode =
   | "network"
   | "feed-error"
   | "verification"
+  | "channel-missing"
 
 export interface UpdateProgress {
   percent: number
@@ -103,6 +104,9 @@ function normalizeReleaseNotes(
 
 function classifyError(err: Error): UpdateErrorCode {
   const m = err.message.toLowerCase()
+  if (m.includes("cannot find channel") || (m.includes("404") && m.includes(".yml"))) {
+    return "channel-missing"
+  }
   if (m.includes("net::") || m.includes("network") || m.includes("enotfound")) return "network"
   if (m.includes("sha512") || m.includes("checksum") || m.includes("integrity")) return "verification"
   return "feed-error"
@@ -224,10 +228,19 @@ export async function initAutoUpdater(
   })
 
   autoUpdater.on("error", (err) => {
+    const code = classifyError(err)
     trackEvent("update_error", { error_type: err.name })
+    if (code === "channel-missing") {
+      setStatus({
+        state: "not-available",
+        code,
+      })
+      console.warn("Auto-update: channel manifest missing:", err.message)
+      return
+    }
     setStatus({
       state: "error",
-      code: classifyError(err),
+      code,
       error: err.message,
     })
     console.error("Auto-update error:", err.message)
@@ -271,7 +284,15 @@ export async function checkForUpdatesWithChannel(channel: ReleaseChannel): Promi
   if (!autoUpdater) return
   autoUpdater.allowPrerelease = channel === "beta"
   autoUpdater.channel = channel === "beta" ? "beta" : "latest"
-  await autoUpdater.checkForUpdates()
+  try {
+    await autoUpdater.checkForUpdates()
+  } catch (err) {
+    // A missing channel manifest is surfaced via the 'error' event as a
+    // friendly not-available status; don't let the rejected promise bubble
+    // up and trigger a channel rollback in the IPC caller.
+    if (err instanceof Error && classifyError(err) === "channel-missing") return
+    throw err
+  }
 }
 
 export async function downloadUpdate(): Promise<void> {

--- a/desktop/src/renderer/src/lib/components/update/UpdateDialog.svelte
+++ b/desktop/src/renderer/src/lib/components/update/UpdateDialog.svelte
@@ -101,6 +101,16 @@ async function onInstall() {
 		{:else if s.state === "not-available"}
 			{#if s.code === "dev-mode"}
 				<p class="text-sm text-muted-foreground">Updates are available in packaged builds.</p>
+			{:else if s.code === "channel-missing"}
+				<div class="space-y-2">
+					<p class="text-sm text-muted-foreground">No releases are available on this channel yet.</p>
+					{#if lastChecked}
+						<p class="text-xs text-muted-foreground">Last checked at {fmtTime(lastChecked)}</p>
+					{/if}
+					<Button variant="outline" size="sm" onclick={onCheck} disabled={isChecking()}>
+						Check Again
+					</Button>
+				</div>
 			{:else}
 				<div class="space-y-2">
 					<p class="text-sm text-muted-foreground">You're on the latest version.</p>

--- a/desktop/src/renderer/src/lib/components/update/update-toasts.ts
+++ b/desktop/src/renderer/src/lib/components/update/update-toasts.ts
@@ -59,9 +59,13 @@ function fireError(s: UpdateStatus): void {
   userInitiated = false
 }
 
-function fireNotAvailable(): void {
+function fireNotAvailable(s: UpdateStatus): void {
   if (!userInitiated) return
-  toast.success("You're on the latest version.")
+  if (s.code === "channel-missing") {
+    toast.info("No releases are available on this channel yet.")
+  } else {
+    toast.success("You're on the latest version.")
+  }
   userInitiated = false
 }
 
@@ -74,6 +78,6 @@ export function initUpdateToasts(getAutoDownload: () => boolean): () => void {
     if (s.state === "available") fireAvailable(s, getAutoDownload())
     else if (s.state === "downloaded") fireDownloaded(s)
     else if (s.state === "error") fireError(s)
-    else if (s.state === "not-available") fireNotAvailable()
+    else if (s.state === "not-available") fireNotAvailable(s)
   })
 }

--- a/desktop/src/renderer/src/lib/ipc/events.ts
+++ b/desktop/src/renderer/src/lib/ipc/events.ts
@@ -23,6 +23,7 @@ export type UpdateErrorCode =
   | "network"
   | "feed-error"
   | "verification"
+  | "channel-missing"
 
 export interface UpdateProgress {
   percent: number


### PR DESCRIPTION
## Summary
- Switching to a channel that has no published manifest (e.g. `latest-mac.yml` doesn't exist yet on `dl.devsy.sh/desktop`) surfaced a raw `HttpError: 404 ...` blob in the desktop UI.
- Classify the missing-manifest case (`"Cannot find channel"` / 404 on `.yml`) as a new `channel-missing` code and emit `state: "not-available"` instead of `state: "error"`.
- `checkForUpdatesWithChannel` now swallows the rejection for that code so the IPC handler doesn't roll back the user's channel choice.
- Dialog and toast show "No releases are available on this channel yet." in place of the verbose error / misleading "You're on the latest version."

Note: this is the UX patch only — the underlying root cause is that no stable macOS manifest has been published to `dl.devsy.sh/desktop`. Cutting a stable release will make the channel start serving real updates.