### PR TITLE
chore: remove .claude from version control

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"65da1927-3851-45d0-bb3b-43c54d4332ca","pid":1201948,"procStart":"94713473","acquiredAt":1779638740909}


### PR DESCRIPTION
## Summary
- Remove `.claude/scheduled_tasks.lock` from version control; `.claude/` is now ignored locally via `.git/info/exclude`.