### PR TITLE
refactor: normalize message formatting in Go strings

### DIFF
--- a/cmd/agent/container/codeserver_async.go
+++ b/cmd/agent/container/codeserver_async.go
@@ -35,7 +35,7 @@ func NewCodeServerAsyncCmd() *cobra.Command {
 
 // Run runs the command logic.
 func (cmd *CodeServerAsyncCmd) Run(_ *cobra.Command, _ []string) error {
-	log.Debugf("Start setting up container...")
+	log.Debugf("Start setting up container")
 	decompressed, err := compress.Decompress(cmd.SetupInfo)
 	if err != nil {
 		return err

--- a/cmd/agent/container/openvscode_async.go
+++ b/cmd/agent/container/openvscode_async.go
@@ -34,7 +34,7 @@ func NewOpenVSCodeAsyncCmd() *cobra.Command {
 
 // Run runs the command logic.
 func (cmd *OpenVSCodeAsyncCmd) Run(_ *cobra.Command, _ []string) error {
-	log.Debugf("Start setting up container...")
+	log.Debugf("Start setting up container")
 	decompressed, err := compress.Decompress(cmd.SetupInfo)
 	if err != nil {
 		return err

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -850,7 +850,7 @@ func configureSystemGitCredentials(
 	}
 
 	gitCredentials := fmt.Sprintf(
-		"!'%s' internal agent git-credentials --port %d",
+		"!%q internal agent git-credentials --port %d",
 		binaryPath,
 		serverPort,
 	)

--- a/cmd/agent/container/setup.go
+++ b/cmd/agent/container/setup.go
@@ -850,7 +850,7 @@ func configureSystemGitCredentials(
 	}
 
 	gitCredentials := fmt.Sprintf(
-		"!%q internal agent git-credentials --port %d",
+		"!'%s' internal agent git-credentials --port %d",
 		binaryPath,
 		serverPort,
 	)

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -366,7 +366,7 @@ func (w *workspaceInitializer) tryConfigureDockerDaemon() {
 	if err := configureDockerDaemon(w.ctx); err != nil {
 		log.Warn(
 			"could not find docker daemon config file, if using the registry cache, " +
-				"please ensure the daemon is configured with containerd-snapshotter=true, " +
+				"ensure the daemon is configured with containerd-snapshotter=true, " +
 				"more info at https://docs.docker.com/engine/storage/containerd/",
 		)
 	}
@@ -714,7 +714,7 @@ func configureCredentials(cfg credentialsConfig) (string, string, error) {
 	gitCredentials := ""
 	if cfg.workspaceInfo.Agent.InjectGitCredentials == config.BoolTrue {
 		gitCredentials = fmt.Sprintf(
-			"!'%s' internal agent git-credentials --port %d",
+			"!%q internal agent git-credentials --port %d",
 			binaryPath,
 			serverPort,
 		)

--- a/cmd/agent/workspace/up.go
+++ b/cmd/agent/workspace/up.go
@@ -714,7 +714,7 @@ func configureCredentials(cfg credentialsConfig) (string, string, error) {
 	gitCredentials := ""
 	if cfg.workspaceInfo.Agent.InjectGitCredentials == config.BoolTrue {
 		gitCredentials = fmt.Sprintf(
-			"!%q internal agent git-credentials --port %d",
+			"!'%s' internal agent git-credentials --port %d",
 			binaryPath,
 			serverPort,
 		)

--- a/cmd/context/create.go
+++ b/cmd/context/create.go
@@ -45,7 +45,7 @@ func (cmd *CreateCmd) Run(ctx context.Context, context string) error {
 	if err != nil {
 		return err
 	} else if devsyConfig.Contexts[context] != nil {
-		return fmt.Errorf("context '%s' already exists", context)
+		return fmt.Errorf("context %q already exists", context)
 	}
 
 	// verify name
@@ -78,7 +78,7 @@ func setOptions(devsyConfig *config.Config, context string, options []string) er
 	if err != nil {
 		return err
 	} else if devsyConfig.Contexts[context] == nil {
-		return fmt.Errorf("context '%s' doesn't exist", context)
+		return fmt.Errorf("context %q doesn't exist", context)
 	}
 
 	newValues := map[string]config.OptionValue{}
@@ -103,7 +103,7 @@ func parseOptions(options []string) (map[string]config.OptionValue, error) {
 	for _, option := range options {
 		splitted := strings.Split(option, "=")
 		if len(splitted) == 1 {
-			return nil, fmt.Errorf("invalid option '%s', expected format KEY=VALUE", option)
+			return nil, fmt.Errorf("invalid option %q, expected format KEY=VALUE", option)
 		}
 
 		key := strings.ToUpper(strings.TrimSpace(splitted[0]))
@@ -111,7 +111,7 @@ func parseOptions(options []string) (map[string]config.OptionValue, error) {
 		contextOption, ok := contextOptions[key]
 		if !ok {
 			return nil, fmt.Errorf(
-				"invalid option '%s', allowed options are: %v",
+				"invalid option %q, allowed options are: %v",
 				key,
 				allowedOptions,
 			)
@@ -121,7 +121,7 @@ func parseOptions(options []string) (map[string]config.OptionValue, error) {
 			found := slices.Contains(contextOption.Enum, value)
 			if !found {
 				return nil, fmt.Errorf(
-					"invalid value '%s' for option '%s', has to match one of the following values: %v",
+					"invalid value %q for option %q, has to match one of the following values: %v",
 					value,
 					key,
 					contextOption.Enum,

--- a/cmd/context/delete.go
+++ b/cmd/context/delete.go
@@ -24,7 +24,7 @@ func NewDeleteCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Short: "Delete a Devsy context",
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			if len(args) > 1 {
-				return fmt.Errorf("please specify the context to delete")
+				return fmt.Errorf("specify the context to delete")
 			}
 
 			devsyContext := ""
@@ -50,7 +50,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context, context string) error {
 	if context == "" {
 		context = devsyConfig.DefaultContext
 	} else if devsyConfig.Contexts[context] == nil {
-		return fmt.Errorf("context '%s' doesn't exist", context)
+		return fmt.Errorf("context %q doesn't exist", context)
 	}
 
 	// check for default context

--- a/cmd/context/set_options.go
+++ b/cmd/context/set_options.go
@@ -26,7 +26,7 @@ func NewSetOptionsCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Short: "Set options for a Devsy context",
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			if len(args) > 1 {
-				return fmt.Errorf("please specify the context")
+				return fmt.Errorf("specify the context")
 			}
 
 			devsyContext := ""
@@ -54,7 +54,7 @@ func (cmd *SetOptionsCmd) Run(ctx context.Context, context string) error {
 	if context == "" {
 		context = devsyConfig.DefaultContext
 	} else if devsyConfig.Contexts[context] == nil {
-		return fmt.Errorf("context '%s' doesn't exist", context)
+		return fmt.Errorf("context %q doesn't exist", context)
 	}
 
 	// check if there are setOptions options set

--- a/cmd/context/use.go
+++ b/cmd/context/use.go
@@ -26,7 +26,7 @@ func NewUseCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Short: "Set a Devsy context as the default",
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return fmt.Errorf("please specify the context to use")
+				return fmt.Errorf("specify the context to use")
 			}
 
 			return cmd.Run(cobraCmd.Context(), args[0])
@@ -44,7 +44,7 @@ func (cmd *UseCmd) Run(ctx context.Context, context string) error {
 	if err != nil {
 		return err
 	} else if devsyConfig.Contexts[context] == nil {
-		return fmt.Errorf("context '%s' doesn't exist", context)
+		return fmt.Errorf("context %q doesn't exist", context)
 	}
 
 	// check if there are use options set

--- a/cmd/helper/http/request.go
+++ b/cmd/helper/http/request.go
@@ -50,7 +50,7 @@ func (cmd *RequestCmd) Run(ctx context.Context, args []string) error {
 	for _, header := range cmd.Headers {
 		splitted := strings.Split(header, ":")
 		if len(splitted) == 1 {
-			return fmt.Errorf("unexpected header '%s', expected form 'HEADER: VALUE'", header)
+			return fmt.Errorf("unexpected header %q, expected form 'HEADER: VALUE'", header)
 		}
 
 		httpHeader.Add(

--- a/cmd/helper/ssh_git_clone.go
+++ b/cmd/helper/ssh_git_clone.go
@@ -36,7 +36,7 @@ func NewSSHGitCloneCmd() *cobra.Command {
 func (cmd *SSHGitClone) Run(ctx context.Context, args []string) error {
 	if len(args) < 2 {
 		return fmt.Errorf(
-			"expected args in format: {user}@{host} {commands...}, received \"%s\"",
+			"expected args in format: {user}@{host} {commands...}, received %q",
 			strings.Join(args, " "),
 		)
 	}

--- a/cmd/ide/options.go
+++ b/cmd/ide/options.go
@@ -30,7 +30,7 @@ func NewOptionsCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Short: "Get IDE options",
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return fmt.Errorf("please specify the ide")
+				return fmt.Errorf("specify the ide")
 			}
 
 			return cmd.Run(cobraCmd.Context(), args[0])

--- a/cmd/ide/set.go
+++ b/cmd/ide/set.go
@@ -38,7 +38,7 @@ starting it. The change is persisted to the workspace config and used on the
 next 'devsy workspace up'. Available IDEs can be listed with 'devsy ide list'.`,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return fmt.Errorf("please specify the ide")
+				return fmt.Errorf("specify the ide")
 			}
 			return cmd.Run(cobraCmd.Context(), args[0])
 		},

--- a/cmd/ide/use.go
+++ b/cmd/ide/use.go
@@ -35,7 +35,7 @@ Available IDEs can be listed with 'devsy ide list'`,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
 				return fmt.Errorf(
-					"please specify the ide to use, list available IDEs with 'devsy ide list'",
+					"specify the ide to use, list available IDEs with 'devsy ide list'",
 				)
 			}
 

--- a/cmd/machine/delete.go
+++ b/cmd/machine/delete.go
@@ -67,8 +67,8 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 	for _, workspace := range workspaces {
 		if workspace.Machine.ID == machineClient.Machine() {
 			return fmt.Errorf(
-				"cannot delete machine '%s', because workspace '%s' is still using it. "+
-					"Please delete the workspace '%s' before deleting the machine",
+				"cannot delete machine %q, because workspace %q is still using it. "+
+					"Delete the workspace %q before deleting the machine",
 				workspace.Machine.ID,
 				workspace.ID,
 				workspace.ID,

--- a/cmd/machine/ssh.go
+++ b/cmd/machine/ssh.go
@@ -141,7 +141,7 @@ func (cmd *SSHCmd) Run(ctx context.Context, args []string) error {
 		},
 		Exec: func(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
 			command := fmt.Sprintf(
-				"'%s' internal helper ssh-server --stdio",
+				"%q internal helper ssh-server --stdio",
 				machineClient.AgentPath(),
 			)
 			if cmd.Debug {

--- a/cmd/machine/ssh.go
+++ b/cmd/machine/ssh.go
@@ -141,7 +141,7 @@ func (cmd *SSHCmd) Run(ctx context.Context, args []string) error {
 		},
 		Exec: func(ctx context.Context, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
 			command := fmt.Sprintf(
-				"%q internal helper ssh-server --stdio",
+				"'%s' internal helper ssh-server --stdio",
 				machineClient.AgentPath(),
 			)
 			if cmd.Debug {

--- a/cmd/machine/status.go
+++ b/cmd/machine/status.go
@@ -62,22 +62,22 @@ func (cmd *StatusCmd) Run(ctx context.Context, args []string) error {
 		switch machineStatus {
 		case client.StatusStopped:
 			log.Infof(
-				"Machine '%s' is '%s', you can start it via 'devsy machine start %s'",
+				"Machine %q is %q, you can start it via 'devsy machine start %s'",
 				machineClient.Machine(),
 				machineStatus,
 				machineClient.Machine(),
 			)
 		case client.StatusBusy:
 			log.Infof(
-				"Machine '%s' is '%s', which means its currently unaccessible. "+
+				"Machine %q is %q, which means its currently unaccessible. "+
 					"This is usually resolved by waiting a couple of minutes",
 				machineClient.Machine(),
 				machineStatus,
 			)
 		case client.StatusNotFound:
-			log.Infof("Machine '%s' is '%s'", machineClient.Machine(), machineStatus)
+			log.Infof("Machine %q is %q", machineClient.Machine(), machineStatus)
 		default:
-			log.Infof("Machine '%s' is '%s'", machineClient.Machine(), machineStatus)
+			log.Infof("Machine %q is %q", machineClient.Machine(), machineStatus)
 		}
 	case output.ModeJSON:
 		out, err := json.Marshal(struct {

--- a/cmd/pro/cluster/add.go
+++ b/cmd/pro/cluster/add.go
@@ -269,7 +269,7 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 		helmCmd.Stderr = log.Writer(log.LevelDebug)
 		helmCmd.Stdin = os.Stdin
 
-		log.Info("Installing agent...")
+		log.Info("Installing agent")
 		log.Debugf("Running helm command: %v", helmCmd.Args)
 
 		err = helmCmd.Run()
@@ -286,7 +286,7 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	if cmd.Wait {
-		log.Info("Waiting for the cluster to be initialized...")
+		log.Info("Waiting for the cluster to be initialized")
 		waitErr := wait.PollUntilContextTimeout(
 			ctx,
 			time.Second,

--- a/cmd/pro/cluster/add.go
+++ b/cmd/pro/cluster/add.go
@@ -232,7 +232,7 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 		kubeConfig, err := kubeClientConfig.RawConfig()
 		if err != nil {
 			return fmt.Errorf(
-				"there is an error loading your current kube config (%w), please make sure you have access "+
+				"there is an error loading your current kube config (%w), make sure you have access "+
 					"to a kubernetes cluster and the command `kubectl get namespaces` is working",
 				err,
 			)
@@ -249,7 +249,7 @@ func (cmd *ClusterCmd) Run(ctx context.Context, args []string) error {
 	config, err := kubeClientConfig.ClientConfig()
 	if err != nil {
 		return fmt.Errorf(
-			"there is an error loading your current kube config (%w), please make sure you have access "+
+			"there is an error loading your current kube config (%w), make sure you have access "+
 				"to a kubernetes cluster and the command `kubectl get namespaces` is working",
 			err,
 		)

--- a/cmd/pro/cluster/list.go
+++ b/cmd/pro/cluster/list.go
@@ -78,7 +78,7 @@ func (cmd *ListClustersCmd) Run(
 		Stdout:  &buf,
 	})
 	if err != nil {
-		return fmt.Errorf("list clusters with provider \"%s\": %w", provider.Name, err)
+		return fmt.Errorf("list clusters with provider %q: %w", provider.Name, err)
 	}
 
 	headers := []string{proutil.HeaderName, proutil.HeaderDisplayName, "Online"}

--- a/cmd/pro/daemon/start.go
+++ b/cmd/pro/daemon/start.go
@@ -131,7 +131,7 @@ func withGracefulShutdown(ctx context.Context) (context.Context, func()) {
 		for {
 			select {
 			case sig := <-sigChan:
-				log.Infof("Received signal %s, starting graceful shutdown...", sig)
+				log.Infof("Received signal %s, starting graceful shutdown", sig)
 
 				cancel()
 			case <-ctx.Done():

--- a/cmd/pro/health.go
+++ b/cmd/pro/health.go
@@ -84,7 +84,7 @@ func (cmd *HealthCmd) Run(
 		Stderr:  log.Writer(log.LevelError),
 	})
 	if err != nil {
-		return fmt.Errorf("check health with provider \"%s\": %w", provider.Name, err)
+		return fmt.Errorf("check health with provider %q: %w", provider.Name, err)
 	}
 
 	fmt.Println(buf.String())

--- a/cmd/pro/login.go
+++ b/cmd/pro/login.go
@@ -96,7 +96,7 @@ func (cmd *LoginCmd) Run(ctx context.Context, fullURL string) error {
 
 func (cmd *LoginCmd) normalizeURL(fullURL string) (string, error) {
 	if strings.HasPrefix(fullURL, "http://") {
-		return "", fmt.Errorf("http is not supported for Devsy Pro, please use https:// instead")
+		return "", fmt.Errorf("http is not supported for Devsy Pro, use https:// instead")
 	}
 	if !strings.HasPrefix(fullURL, "https://") {
 		return "https://" + fullURL, nil
@@ -163,7 +163,7 @@ func (cmd *LoginCmd) resolveNewProviderName(devsyConfig *config.Config, host str
 		cmd.Provider = provider.ToProInstanceID(config.BinaryName + "-" + host)
 		if providers[cmd.Provider] != nil {
 			return fmt.Errorf(
-				"provider %s already exists, please choose a different name via --provider",
+				"provider %s already exists, choose a different name via --provider",
 				cmd.Provider,
 			)
 		}

--- a/cmd/pro/login.go
+++ b/cmd/pro/login.go
@@ -277,7 +277,7 @@ func (cmd *LoginCmd) addLoftProvider(
 	}
 
 	// add the provider
-	log.Infof("Add Devsy Pro provider...")
+	log.Infof("Add Devsy Pro provider")
 
 	// is development?
 	if cmd.ProviderSource == config.RepoSlug+"@v0.0.0" {

--- a/cmd/pro/logout.go
+++ b/cmd/pro/logout.go
@@ -48,7 +48,7 @@ func NewLogoutCmd(flags *proflags.GlobalFlags) *cobra.Command {
 //nolint:cyclop,funlen // logout sequences provider/daemon teardown; complexity reflects domain workflow
 func (cmd *LogoutCmd) Run(ctx context.Context, args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("please specify a pro instance to log out of")
+		return fmt.Errorf("specify a pro instance to log out of")
 	}
 
 	devsyConfig, err := config.LoadConfig(cmd.Context, cmd.Provider)

--- a/cmd/pro/project/list.go
+++ b/cmd/pro/project/list.go
@@ -71,7 +71,7 @@ func (cmd *ListProjectsCmd) Run(
 		Stdout:  &buf,
 	})
 	if err != nil {
-		return fmt.Errorf("watch workspaces with provider \"%s\": %w", provider.Name, err)
+		return fmt.Errorf("watch workspaces with provider %q: %w", provider.Name, err)
 	}
 
 	headers := []string{proutil.HeaderName, proutil.HeaderDisplayName, "Description"}

--- a/cmd/pro/provider/list/projects.go
+++ b/cmd/pro/provider/list/projects.go
@@ -69,7 +69,7 @@ func Projects(ctx context.Context, client client.Client) (*managementv1.ProjectL
 		return projectList, fmt.Errorf("list projects: %w", err)
 	} else if len(projectList.Items) == 0 {
 		return projectList, fmt.Errorf(
-			"you don't have access to any projects, please make sure you have at least access to 1 project",
+			"you don't have access to any projects, make sure you have at least access to 1 project",
 		)
 	}
 

--- a/cmd/pro/provider/list/templates.go
+++ b/cmd/pro/provider/list/templates.go
@@ -86,7 +86,7 @@ func Templates(
 	} else if len(templateList.DevsyWorkspaceTemplates) == 0 {
 		return templateList, fmt.Errorf(
 			"seems like there is no template allowed in project %s, "+
-				"please make sure to at least have a single template available",
+				"make sure to at least have a single template available",
 			projectName,
 		)
 	}
@@ -108,7 +108,7 @@ func FindTemplate(
 	} else if len(templateList.DevsyWorkspaceTemplates) == 0 {
 		return nil, fmt.Errorf(
 			"seems like there is no Devsy template allowed in project %s, "+
-				"please make sure to at least have a single template available",
+				"make sure to at least have a single template available",
 			projectName,
 		)
 	}

--- a/cmd/pro/provider/list/workspaces.go
+++ b/cmd/pro/provider/list/workspaces.go
@@ -59,7 +59,7 @@ func (cmd *WorkspacesCmd) Run(ctx context.Context) error {
 		return fmt.Errorf("list projects: %w", err)
 	} else if len(projectList.Items) == 0 {
 		return fmt.Errorf(
-			"you don't have access to any projects within Devsy Pro, please make sure you have at least access to 1 project",
+			"you don't have access to any projects within Devsy Pro, make sure you have at least access to 1 project",
 		)
 	}
 

--- a/cmd/pro/provider/rebuild.go
+++ b/cmd/pro/provider/rebuild.go
@@ -45,7 +45,7 @@ func NewRebuildCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 
 func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("please provide a workspace name")
+		return fmt.Errorf("provide a workspace name")
 	}
 	targetWorkspace := args[0]
 

--- a/cmd/pro/start.go
+++ b/cmd/pro/start.go
@@ -428,7 +428,7 @@ func (cmd *StartCmd) success(ctx context.Context) error {
 	if !reachable || err != nil {
 		const (
 			YesOption = "Yes"
-			NoOption  = "No, please re-run the DNS check"
+			NoOption  = "No, re-run the DNS check"
 		)
 
 		answer, err := log.QuestionDefault(&survey.QuestionOptions{
@@ -758,7 +758,7 @@ func (cmd *StartCmd) prepareDocker() error {
 	if err != nil {
 		return fmt.Errorf(
 			"seems like docker is not installed. Docker is required for the installation of loft. " +
-				"Please visit https://docs.docker.com/engine/install/ for install instructions",
+				"Visit https://docs.docker.com/engine/install/ for install instructions",
 		)
 	}
 
@@ -943,7 +943,7 @@ func (cmd *StartCmd) prepare(ctx context.Context) error {
 	cmd.RestConfig, err = kubeClientConfig.ClientConfig()
 	if err != nil {
 		return fmt.Errorf(
-			"there is an error loading your current kube config (%w), please make sure you have access "+
+			"there is an error loading your current kube config (%w), make sure you have access "+
 				"to a kubernetes cluster and the command `kubectl get namespaces` is working",
 			err,
 		)
@@ -951,7 +951,7 @@ func (cmd *StartCmd) prepare(ctx context.Context) error {
 	cmd.KubeClient, err = kubernetes.NewForConfig(cmd.RestConfig)
 	if err != nil {
 		return fmt.Errorf(
-			"there is an error loading your current kube config (%w), please make sure you have access "+
+			"there is an error loading your current kube config (%w), make sure you have access "+
 				"to a kubernetes cluster and the command `kubectl get namespaces` is working",
 			err,
 		)
@@ -963,7 +963,7 @@ func (cmd *StartCmd) prepare(ctx context.Context) error {
 		Get(ctx, "cluster-admin", metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf(
-			"error retrieving cluster role 'cluster-admin': %w. Please make sure RBAC is correctly configured in your cluster",
+			"error retrieving cluster role 'cluster-admin': %w. Make sure RBAC is correctly configured in your cluster",
 			err,
 		)
 	}
@@ -984,7 +984,7 @@ func (cmd *StartCmd) resolveKubeConfig(
 	kubeConfig, err := kubeClientConfig.RawConfig()
 	if err != nil {
 		return nil, fmt.Errorf(
-			"there is an error loading your current kube config (%w), please make sure you have access "+
+			"there is an error loading your current kube config (%w), make sure you have access "+
 				"to a kubernetes cluster and the command `kubectl get namespaces` is working",
 			err,
 		)
@@ -995,7 +995,8 @@ func (cmd *StartCmd) resolveKubeConfig(
 		contextToLoad = cmd.Context
 	} else if loftConfig.LastInstallContext != "" && loftConfig.LastInstallContext != contextToLoad {
 		contextToLoad, err = log.QuestionDefault(&survey.QuestionOptions{
-			Question:     "Seems like you try to use 'devsy pro start' with a different kubernetes context than before. Please choose which kubernetes context you want to use",
+			Question: "Seems like you try to use 'devsy pro start' with a different kubernetes context than before. " +
+				"Choose which kubernetes context you want to use",
 			DefaultValue: contextToLoad,
 			Options:      []string{contextToLoad, loftConfig.LastInstallContext},
 		})
@@ -1021,7 +1022,7 @@ func checkCLITools(ctx context.Context, kubeContext string) error {
 	if err != nil {
 		return fmt.Errorf(
 			"seems like helm is not installed. Helm is required for the installation of loft. " +
-				"Please visit https://helm.sh/docs/intro/install/ for install instructions",
+				"Visit https://helm.sh/docs/intro/install/ for install instructions",
 		)
 	}
 
@@ -1034,7 +1035,7 @@ func checkCLITools(ctx context.Context, kubeContext string) error {
 	if err != nil {
 		return fmt.Errorf(
 			"seems like kubectl is not installed. Kubectl is required for the installation of loft. " +
-				"Please visit https://kubernetes.io/docs/tasks/tools/install-kubectl/ for install instructions",
+				"Visit https://kubernetes.io/docs/tasks/tools/install-kubectl/ for install instructions",
 		)
 	}
 
@@ -1369,7 +1370,7 @@ func (cmd *StartCmd) loginUI(url string) error {
 		return fmt.Errorf("couldn't open the login page in a browser: %w", err)
 	}
 
-	log.Infof("If the browser does not open automatically, please navigate to %s", loginURL)
+	log.Infof("If the browser does not open automatically, navigate to %s", loginURL)
 
 	return nil
 }
@@ -1567,7 +1568,7 @@ func enterHostNameQuestion() (string, error) {
 			u, err := netUrl.Parse("https://" + answer)
 			if err != nil || u.Path != "" || u.Port() != "" || len(strings.Split(answer, ".")) < 2 {
 				return fmt.Errorf(
-					"please enter a valid hostname without protocol (https://), without path and without port, " +
+					"enter a valid hostname without protocol (https://), without path and without port, " +
 						"e.g. loft.my-domain.tld",
 				)
 			}
@@ -1815,7 +1816,7 @@ func getIngressHost(
 
 	return "", fmt.Errorf(
 		"couldn't find any host in loft ingress '%s/loft-ingress', "+
-			"please make sure you have not changed any deployed resources",
+			"make sure you have not changed any deployed resources",
 		namespace,
 	)
 }
@@ -1963,7 +1964,7 @@ func getHelmWorkdir(chartName string) (string, error) {
 			tempDir, err = os.MkdirTemp(tempDir, chartName)
 			if err != nil {
 				return "", errors.New(
-					"problematic directory `" + chartName + "` found: please execute command in a different folder",
+					"problematic directory `" + chartName + "` found: execute command in a different folder",
 				)
 			}
 		}

--- a/cmd/pro/start.go
+++ b/cmd/pro/start.go
@@ -417,7 +417,7 @@ func (cmd *StartCmd) success(ctx context.Context) error {
 	}
 
 	// get login link
-	log.Info("Checking Devsy status...")
+	log.Info("Checking Devsy status")
 	host, err := getIngressHost(ctx, cmd.KubeClient, cmd.Namespace)
 	if err != nil {
 		return err
@@ -576,7 +576,7 @@ Thanks for using Devsy Pro!
 }
 
 func (cmd *StartCmd) startDocker(ctx context.Context) error {
-	log.Infof("Starting Devsy Pro in Docker...")
+	log.Infof("Starting Devsy Pro in Docker")
 	name := config.ProReleaseName
 
 	// prepare installation
@@ -644,7 +644,7 @@ func (cmd *StartCmd) successDocker(ctx context.Context, containerID string) erro
 	}
 
 	// wait for domain to become reachable
-	log.Infof("Wait for Devsy Pro to become available at %s...", host)
+	log.Infof("Wait for Devsy Pro to become available at %s", host)
 	err = wait.PollUntilContextTimeout(
 		ctx,
 		time.Second,
@@ -701,7 +701,7 @@ Thanks for using Devsy Pro!
 }
 
 func (cmd *StartCmd) waitForLoftDocker(ctx context.Context, containerID string) (string, error) {
-	log.Info("Wait for Devsy Pro to become available...")
+	log.Info("Wait for Devsy Pro to become available")
 
 	// check for local port
 	containerDetails, err := cmd.inspectContainer(ctx, containerID)
@@ -771,7 +771,7 @@ func (cmd *StartCmd) prepareDocker() error {
 }
 
 func (cmd *StartCmd) uninstallDocker(ctx context.Context, id string) error {
-	log.Infof("Uninstalling...")
+	log.Infof("Uninstalling")
 
 	// stop container
 	out, err := cmd.buildDockerCmd(ctx, "stop", id).Output()
@@ -1619,7 +1619,7 @@ func ensureIngressController(
 		}
 		fmt.Fprint(os.Stderr, "\n")
 		log.Infof("Executing command: helm %s\n", strings.Join(args, " "))
-		log.Info("Waiting for ingress controller deployment, this can take several minutes...")
+		log.Info("Waiting for ingress controller deployment, this can take several minutes")
 		helmCmd := exec.CommandContext(
 			ctx,
 			"helm",
@@ -1893,7 +1893,7 @@ func upgradeRelease(
 
 	fmt.Fprint(os.Stderr, "\n")
 	log.Infof("Executing command: helm %s\n", strings.Join(args, " "))
-	log.Info("Waiting for helm command, this can take up to several minutes...")
+	log.Info("Waiting for helm command, this can take up to several minutes")
 	helmCmd := exec.CommandContext(
 		ctx,
 		"helm",

--- a/cmd/pro/template/list.go
+++ b/cmd/pro/template/list.go
@@ -78,7 +78,7 @@ func (cmd *ListTemplatesCmd) Run(
 		Stdout:  &buf,
 	})
 	if err != nil {
-		return fmt.Errorf("list templates with provider \"%s\": %w", provider.Name, err)
+		return fmt.Errorf("list templates with provider %q: %w", provider.Name, err)
 	}
 
 	headers := []string{proutil.HeaderName, proutil.HeaderDisplayName, "Description"}

--- a/cmd/pro/update_provider.go
+++ b/cmd/pro/update_provider.go
@@ -89,7 +89,7 @@ func (cmd *UpdateProviderCmd) Run(ctx context.Context, args []string) error {
 	})
 	if err != nil {
 		return fmt.Errorf(
-			"configure provider, please retry with 'devsy provider use %s --reconfigure': %w",
+			"configure provider, retry with 'devsy provider use %s --reconfigure': %w",
 			provider.Name, err,
 		)
 	}

--- a/cmd/pro/user/reset_password.go
+++ b/cmd/pro/user/reset_password.go
@@ -191,7 +191,7 @@ func (cmd *PasswordCmd) fillPasswordRef(user *storagev1.User) error {
 
 	if !cmd.Force {
 		return fmt.Errorf(
-			"user %s had no password. If you want to force password creation, please run with the '--force' flag",
+			"user %s had no password. If you want to force password creation, run with the '--force' flag",
 			cmd.User,
 		)
 	}
@@ -223,7 +223,7 @@ func (cmd *PasswordCmd) resolvePassword() (string, error) {
 
 	for {
 		password, err := log.QuestionDefault(&survey.QuestionOptions{
-			Question:   "Please enter a new password",
+			Question:   "Enter a new password",
 			IsPassword: true,
 		})
 		if err != nil {
@@ -235,7 +235,7 @@ func (cmd *PasswordCmd) resolvePassword() (string, error) {
 			return password, nil
 		}
 
-		log.Error("Please enter a password")
+		log.Error("Enter a password")
 	}
 }
 

--- a/cmd/pro/workspace/rebuild.go
+++ b/cmd/pro/workspace/rebuild.go
@@ -47,7 +47,7 @@ func NewRebuildCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 
 func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("please provide a workspace name")
+		return fmt.Errorf("provide a workspace name")
 	}
 	targetWorkspace := args[0]
 
@@ -58,7 +58,7 @@ func (cmd *RebuildCmd) Run(ctx context.Context, args []string) error {
 
 	baseClient, err := platform.InitClientFromHost(ctx, devsyConfig, cmd.Host)
 	if err != nil {
-		return fmt.Errorf("resolve host \"%s\": %w", cmd.Host, err)
+		return fmt.Errorf("resolve host %q: %w", cmd.Host, err)
 	}
 
 	instanceOpts := platform.FindInstanceOptions{Name: targetWorkspace, ProjectName: cmd.Project}

--- a/cmd/pro/workspace/sleep.go
+++ b/cmd/pro/workspace/sleep.go
@@ -58,7 +58,7 @@ func NewSleepCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 
 func (cmd *SleepCmd) Run(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("please provide a workspace name")
+		return fmt.Errorf("provide a workspace name")
 	}
 	targetWorkspace := args[0]
 

--- a/cmd/pro/workspace/sleep.go
+++ b/cmd/pro/workspace/sleep.go
@@ -115,7 +115,7 @@ func (cmd *SleepCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// wait for sleeping
-	log.Info("Wait until workspace is sleeping...")
+	log.Info("Wait until workspace is sleeping")
 	err = wait.PollUntilContextTimeout(
 		ctx,
 		time.Second,

--- a/cmd/pro/workspace/update.go
+++ b/cmd/pro/workspace/update.go
@@ -79,7 +79,7 @@ func (cmd *UpdateWorkspaceCmd) Run(
 		Stderr:  log.Writer(log.LevelError),
 	})
 	if err != nil {
-		return fmt.Errorf("update workspace with provider \"%s\": %w", provider.Name, err)
+		return fmt.Errorf("update workspace with provider %q: %w", provider.Name, err)
 	}
 
 	fmt.Println(buf.String())

--- a/cmd/pro/workspace/wakeup.go
+++ b/cmd/pro/workspace/wakeup.go
@@ -52,7 +52,7 @@ func NewWakeupCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 
 func (cmd *WakeupCmd) Run(ctx context.Context, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("please provide a workspace name")
+		return fmt.Errorf("provide a workspace name")
 	}
 	targetWorkspace := args[0]
 

--- a/cmd/pro/workspace/wakeup.go
+++ b/cmd/pro/workspace/wakeup.go
@@ -114,7 +114,7 @@ func (cmd *WakeupCmd) Run(ctx context.Context, args []string) error {
 	}
 
 	// wait for sleeping
-	log.Info("Wait until workspace wakes up...")
+	log.Info("Wait until workspace wakes up")
 	err = wait.PollUntilContextTimeout(
 		ctx,
 		time.Second,

--- a/cmd/pro/workspace/watch.go
+++ b/cmd/pro/workspace/watch.go
@@ -94,7 +94,7 @@ func (cmd *WatchWorkspacesCmd) Run(
 		Stderr:  log.Writer(log.LevelError),
 	})
 	if err != nil {
-		return fmt.Errorf("watch workspaces with provider \"%s\": %w", providerConfig.Name, err)
+		return fmt.Errorf("watch workspaces with provider %q: %w", providerConfig.Name, err)
 	}
 
 	return nil

--- a/cmd/provider/add.go
+++ b/cmd/provider/add.go
@@ -106,7 +106,7 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 		)
 	} else {
 		if len(args) != 1 {
-			return fmt.Errorf("please specify either a URL or path, " +
+			return fmt.Errorf("specify either a URL or path, " +
 				"e.g. devsy provider add https://path/to/my/provider.yaml")
 		}
 		c, err := workspace.AddProvider(devsyConfig, providerName, args[0])
@@ -146,7 +146,7 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 		return writeDefaultProvider(cmd.Context, providerConfig.Name)
 	}
 
-	log.Infof("To configure the provider, please run the following command:")
+	log.Infof("To configure the provider, run the following command:")
 	log.Infof("devsy provider configure %s", providerConfig.Name)
 	return nil
 }

--- a/cmd/provider/configure_shared.go
+++ b/cmd/provider/configure_shared.go
@@ -126,7 +126,7 @@ func resolveProviderName(args []string, defaultProvider string) (string, error) 
 		return args[0], nil
 	}
 	if defaultProvider == "" {
-		return "", fmt.Errorf("please specify a provider")
+		return "", fmt.Errorf("specify a provider")
 	}
 	return defaultProvider, nil
 }

--- a/cmd/provider/delete.go
+++ b/cmd/provider/delete.go
@@ -65,7 +65,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 	if len(args) > 0 {
 		provider = args[0]
 	} else if provider == "" {
-		return fmt.Errorf("please specify a provider to delete")
+		return fmt.Errorf("specify a provider to delete")
 	}
 
 	// delete the provider
@@ -94,7 +94,7 @@ func DeleteProvider(
 		for _, instance := range proInstances {
 			if instance.Provider == provider {
 				return fmt.Errorf(
-					"cannot delete provider '%s', because it is connected to Pro instance '%s'. "+
+					"cannot delete provider %q, because it is connected to Pro instance %q. "+
 						"Removing the Pro instance will automatically delete this provider",
 					instance.Provider,
 					instance.Host,
@@ -112,8 +112,8 @@ func DeleteProvider(
 		for _, workspace := range workspaces {
 			if workspace.Provider.Name == provider {
 				return fmt.Errorf(
-					"cannot delete provider '%s', because workspace '%s' is still using it. "+
-						"Please delete the workspace '%s' before deleting the provider",
+					"cannot delete provider %q, because workspace %q is still using it. "+
+						"Delete the workspace %q before deleting the provider",
 					workspace.Provider.Name,
 					workspace.ID,
 					workspace.ID,
@@ -146,7 +146,7 @@ func DeleteProviderConfig(devsyConfig *config.Config, provider string, ignoreNot
 				return nil
 			}
 
-			return fmt.Errorf("provider '%s' does not exist", provider)
+			return fmt.Errorf("provider %q does not exist", provider)
 		}
 
 		return err

--- a/cmd/provider/set.go
+++ b/cmd/provider/set.go
@@ -104,7 +104,7 @@ func (cmd *SetCmd) loadProvider(
 	log.Debugf("providerName=%+v", providerName)
 
 	if os.Getenv(config.EnvUI) == "" && len(cmd.Options) == 0 {
-		return nil, nil, fmt.Errorf("please specify option")
+		return nil, nil, fmt.Errorf("specify option")
 	}
 	log.Debugf("Options=%+v", cmd.Options)
 

--- a/cmd/provider/update.go
+++ b/cmd/provider/update.go
@@ -66,7 +66,7 @@ func (cmd *UpdateCmd) Run(ctx context.Context, devsyConfig *config.Config, args 
 
 	// Standard update mode: requires provider name and optional source
 	if len(args) != 1 && len(args) != 2 {
-		return fmt.Errorf("please specify either a local file, URL or Git repository. " +
+		return fmt.Errorf("specify either a local file, URL or Git repository. " +
 			"E.g. devsy provider update my-provider " + config.ProviderPrefix + "gcloud")
 	}
 
@@ -98,7 +98,7 @@ func (cmd *UpdateCmd) Run(ctx context.Context, devsyConfig *config.Config, args 
 		})
 		if err != nil {
 			log.Errorf(
-				"Error configuring provider, please retry with 'devsy provider configure %s --reconfigure'",
+				"Error configuring provider, retry with 'devsy provider configure %s --reconfigure'",
 				providerConfig.Name,
 			)
 			return fmt.Errorf("configure provider: %w", err)
@@ -107,7 +107,7 @@ func (cmd *UpdateCmd) Run(ctx context.Context, devsyConfig *config.Config, args 
 		return writeDefaultProvider(cmd.Context, providerConfig.Name)
 	}
 
-	log.Infof("To configure the provider, please run the following command:")
+	log.Infof("To configure the provider, run the following command:")
 	log.Infof("devsy provider configure %s", providerConfig.Name)
 	return nil
 }

--- a/cmd/workspace/build.go
+++ b/cmd/workspace/build.go
@@ -194,7 +194,7 @@ func (cmd *BuildCmd) checkPushPermissions(ctx context.Context) error {
 	}
 	if err := image.CheckPushPermissions(ctx, cmd.Repository); err != nil {
 		return fmt.Errorf(
-			"cannot push to %s, please make sure you have push permissions to repository: %w",
+			"cannot push to %s, make sure you have push permissions to repository: %w",
 			cmd.Repository, err,
 		)
 	}

--- a/cmd/workspace/import.go
+++ b/cmd/workspace/import.go
@@ -297,12 +297,12 @@ func (cmd *ImportCmd) checkForConflictingIDs(
 		for _, workspace := range workspaces {
 			if workspace.ID == cmd.WorkspaceID {
 				return fmt.Errorf(
-					"existing workspace with id %s found, please use --workspace-id to override the workspace id",
+					"existing workspace with id %s found, use --workspace-id to override the workspace id",
 					cmd.WorkspaceID,
 				)
 			} else if workspace.UID == exportConfig.Workspace.UID {
 				return fmt.Errorf(
-					"existing workspace %s with uid %s found, please use --workspace-id to override the workspace id",
+					"existing workspace %s with uid %s found, use --workspace-id to override the workspace id",
 					workspace.ID,
 					workspace.UID,
 				)
@@ -314,7 +314,7 @@ func (cmd *ImportCmd) checkForConflictingIDs(
 	if !cmd.MachineReuse && exportConfig.Machine != nil {
 		if provider.MachineExists(devsyConfig.DefaultContext, cmd.MachineID) {
 			return fmt.Errorf(
-				"existing machine with id %s found, please use --machine-reuse to skip importing "+
+				"existing machine with id %s found, use --machine-reuse to skip importing "+
 					"the machine or --machine-id to override the machine id",
 				cmd.MachineID,
 			)
@@ -325,7 +325,7 @@ func (cmd *ImportCmd) checkForConflictingIDs(
 	if !cmd.ProviderReuse && exportConfig.Provider != nil {
 		if provider.ProviderExists(devsyConfig.DefaultContext, cmd.ProviderID) {
 			return fmt.Errorf(
-				"existing provider with id %s found, please use --provider-reuse to skip importing "+
+				"existing provider with id %s found, use --provider-reuse to skip importing "+
 					"the provider or --provider-id to override the provider id",
 				cmd.ProviderID,
 			)

--- a/cmd/workspace/logs.go
+++ b/cmd/workspace/logs.go
@@ -72,7 +72,7 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("this command is not supported for proxy providers")
 	}
 
-	sshServerCmd := fmt.Sprintf("%q internal helper ssh-server --stdio", client.AgentPath())
+	sshServerCmd := fmt.Sprintf("'%s' internal helper ssh-server --stdio", client.AgentPath())
 	if log.DebugEnabled() {
 		sshServerCmd += " --debug"
 	}

--- a/cmd/workspace/logs.go
+++ b/cmd/workspace/logs.go
@@ -72,7 +72,7 @@ func (cmd *LogsCmd) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("this command is not supported for proxy providers")
 	}
 
-	sshServerCmd := fmt.Sprintf("'%s' internal helper ssh-server --stdio", client.AgentPath())
+	sshServerCmd := fmt.Sprintf("%q internal helper ssh-server --stdio", client.AgentPath())
 	if log.DebugEnabled() {
 		sshServerCmd += " --debug"
 	}

--- a/cmd/workspace/status.go
+++ b/cmd/workspace/status.go
@@ -87,27 +87,27 @@ func (cmd *StatusCmd) Run(
 		switch instanceStatus {
 		case client2.StatusStopped:
 			log.Infof(
-				"Workspace '%s' is '%s', you can start it via 'devsy workspace up %s'",
+				"Workspace %q is %q, you can start it via 'devsy workspace up %s'",
 				client.Workspace(),
 				instanceStatus,
 				client.Workspace(),
 			)
 		case client2.StatusBusy:
 			log.Infof(
-				"Workspace '%s' is '%s', which means its currently unaccessible. "+
+				"Workspace %q is %q, which means its currently unaccessible. "+
 					"This is usually resolved by waiting a couple of minutes",
 				client.Workspace(),
 				instanceStatus,
 			)
 		case client2.StatusNotFound:
 			log.Infof(
-				"Workspace '%s' is '%s', you can create it via 'devsy workspace up %s'",
+				"Workspace %q is %q, you can create it via 'devsy workspace up %s'",
 				client.Workspace(),
 				instanceStatus,
 				client.Workspace(),
 			)
 		default:
-			log.Infof("Workspace '%s' is '%s'", client.Workspace(), instanceStatus)
+			log.Infof("Workspace %q is %q", client.Workspace(), instanceStatus)
 		}
 	case output.ModeJSON:
 		out, err := json.Marshal(&client2.WorkspaceStatus{

--- a/cmd/workspace/stop.go
+++ b/cmd/workspace/stop.go
@@ -87,7 +87,7 @@ func (cmd *StopCmd) Run(
 	if err != nil {
 		return err
 	} else if instanceStatus != client2.StatusRunning {
-		return fmt.Errorf("cannot stop workspace because it is '%s'", instanceStatus)
+		return fmt.Errorf("cannot stop workspace because it is %q", instanceStatus)
 	}
 
 	// stop if single machine provider

--- a/cmd/workspace/up/agent.go
+++ b/cmd/workspace/up/agent.go
@@ -197,7 +197,7 @@ func (cmd *UpCmd) devsyUpMachineSSH(
 		return nil, fmt.Errorf("get agent info: %w", err)
 	}
 
-	sshTunnelCmd := fmt.Sprintf("%q internal helper ssh-server --stdio", client.AgentPath())
+	sshTunnelCmd := fmt.Sprintf("'%s' internal helper ssh-server --stdio", client.AgentPath())
 	if log.DebugEnabled() {
 		sshTunnelCmd += " --debug" //nolint:goconst
 	}

--- a/cmd/workspace/up/agent.go
+++ b/cmd/workspace/up/agent.go
@@ -197,7 +197,7 @@ func (cmd *UpCmd) devsyUpMachineSSH(
 		return nil, fmt.Errorf("get agent info: %w", err)
 	}
 
-	sshTunnelCmd := fmt.Sprintf("'%s' internal helper ssh-server --stdio", client.AgentPath())
+	sshTunnelCmd := fmt.Sprintf("%q internal helper ssh-server --stdio", client.AgentPath())
 	if log.DebugEnabled() {
 		sshTunnelCmd += " --debug" //nolint:goconst
 	}

--- a/cmd/workspace/up/up.go
+++ b/cmd/workspace/up/up.go
@@ -126,7 +126,7 @@ func (cmd *UpCmd) finalizeUp(ctx context.Context, args *finalizeUpArgs) error {
 	}
 	if args.wctx.tunnelPort > 0 {
 		log.Infof(
-			"SSH tunnel active on port %d, waiting for shutdown signal...",
+			"SSH tunnel active on port %d, waiting for shutdown signal",
 			args.wctx.tunnelPort,
 		)
 		<-ctx.Done()

--- a/cmd/workspace/up/up_client.go
+++ b/cmd/workspace/up/up_client.go
@@ -170,7 +170,7 @@ func (cmd *UpCmd) parseWorkspaceSource() (*provider2.WorkspaceSource, error) {
 	}
 	if source.LocalFolder != "" && cmd.Platform.Enabled {
 		return nil, fmt.Errorf("local folder is not supported in platform mode. " +
-			"Please specify a Git repository instead")
+			"Specify a Git repository instead")
 	}
 
 	return source, nil

--- a/e2e/tests/up-docker-compose/up_docker_compose.go
+++ b/e2e/tests/up-docker-compose/up_docker_compose.go
@@ -347,7 +347,7 @@ var _ = ginkgo.Describe(
 				ghLookupOutput, err := tc.execSSH(
 					ctx,
 					tempDirB,
-					fmt.Sprintf("sh -lc '%s'", commandPresenceCheck("gh")),
+					fmt.Sprintf("sh -lc %q", commandPresenceCheck("gh")),
 				)
 				framework.ExpectNoError(err)
 				gomega.Expect(strings.TrimSpace(ghLookupOutput)).
@@ -361,7 +361,7 @@ var _ = ginkgo.Describe(
 				nodeLookupOutput, err := tc.execSSH(
 					ctx,
 					tempDirA,
-					fmt.Sprintf("sh -lc '%s'", commandPresenceCheck("node")),
+					fmt.Sprintf("sh -lc %q", commandPresenceCheck("node")),
 				)
 				framework.ExpectNoError(err)
 				gomega.Expect(strings.TrimSpace(nodeLookupOutput)).

--- a/e2e/tests/up/helper.go
+++ b/e2e/tests/up/helper.go
@@ -100,7 +100,7 @@ func findMessage(reader io.Reader, message string) error {
 			}
 		}
 	}
-	return fmt.Errorf("couldn't find message '%s' in log", message)
+	return fmt.Errorf("couldn't find message %q in log", message)
 }
 
 func verifyLogStream(reader io.Reader) error {

--- a/e2e/tests/up/up.go
+++ b/e2e/tests/up/up.go
@@ -183,7 +183,7 @@ var _ = ginkgo.Describe("testing up command", ginkgo.Label("up-workspaces"), fun
 		expectedImageName := language.MapConfig[language.Go].Image
 
 		gomega.Expect(containerEnvPath).
-			To(gomega.Equal(fmt.Sprintf("{\"image\":\"%s\"}", expectedImageName)))
+			To(gomega.Equal(fmt.Sprintf("{\"image\":%q}", expectedImageName)))
 
 		err = f.DevsyWorkspaceDelete(ctx, tempDir)
 		framework.ExpectNoError(err)

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -500,7 +500,7 @@ func Tunnel(
 	}
 
 	// build command
-	command := fmt.Sprintf("'%s' internal helper ssh-server --stdio", ContainerDevsyHelperLocation)
+	command := fmt.Sprintf("%q internal helper ssh-server --stdio", ContainerDevsyHelperLocation)
 	if log.DebugEnabled() {
 		command += " --debug"
 	}
@@ -526,7 +526,7 @@ func dockerReachable(dockerOverride string, envs map[string]string) (bool, error
 	if !command.Exists(docker) {
 		// if docker is overridden, we assume that there is an error as we don't know how to install the command provided
 		if dockerOverride != "" {
-			return false, fmt.Errorf("docker command '%s' not found", dockerOverride)
+			return false, fmt.Errorf("docker command %q not found", dockerOverride)
 		}
 		// we need root to install docker
 		return true, nil

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -500,7 +500,7 @@ func Tunnel(
 	}
 
 	// build command
-	command := fmt.Sprintf("%q internal helper ssh-server --stdio", ContainerDevsyHelperLocation)
+	command := fmt.Sprintf("'%s' internal helper ssh-server --stdio", ContainerDevsyHelperLocation)
 	if log.DebugEnabled() {
 		command += " --debug"
 	}

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -446,7 +446,7 @@ func (t *tunnelServer) StreamWorkspace(
 	if t.platformOptions != nil && t.platformOptions.Enabled && !t.allowPlatformOptions {
 		return fmt.Errorf(
 			"streaming workspace from local computer to platform workspace is not supported. " +
-				"Please specify a Git repository to clone instead",
+				"Specify a Git repository to clone instead",
 		)
 	}
 	if t.workspace == nil {
@@ -480,7 +480,7 @@ func (t *tunnelServer) StreamMount(
 	if t.platformOptions != nil && t.platformOptions.Enabled && !t.allowPlatformOptions {
 		return fmt.Errorf(
 			"streaming mounts from local computer to platform workspace is not supported. " +
-				"Please specify a Git repository to clone instead",
+				"Specify a Git repository to clone instead",
 		)
 	}
 

--- a/pkg/agent/workspace.go
+++ b/pkg/agent/workspace.go
@@ -387,7 +387,7 @@ func CloneRepositoryForWorkspace(
 		local, _ := agentConfig.Local.Bool()
 		if local {
 			return fmt.Errorf(
-				"seems like git isn't installed on your system. Please make sure to install git and make it available in the PATH",
+				"seems like git isn't installed on your system. Make sure to install git and make it available in the PATH",
 			)
 		}
 		if err := git.InstallBinary(); err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -197,7 +197,7 @@ func ParseStatus(in string) (Status, error) {
 		return StatusNotFound, nil
 	default:
 		return StatusNotFound, fmt.Errorf(
-			"error parsing status: '%s' unrecognized status, needs to be one of: %s",
+			"error parsing status: %q unrecognized status, needs to be one of: %s",
 			in,
 			[]string{StatusRunning, StatusBusy, StatusStopped, StatusNotFound},
 		)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -197,7 +197,7 @@ func ParseStatus(in string) (Status, error) {
 		return StatusNotFound, nil
 	default:
 		return StatusNotFound, fmt.Errorf(
-			"error parsing status: %q unrecognized status, needs to be one of: %s",
+			"error parsing status: %q unrecognized status, needs to be one of: %v",
 			in,
 			[]string{StatusRunning, StatusBusy, StatusStopped, StatusNotFound},
 		)

--- a/pkg/client/clientimplementation/daemonclient/client.go
+++ b/pkg/client/clientimplementation/daemonclient/client.go
@@ -163,13 +163,13 @@ func (c *client) CheckWorkspaceReachable(ctx context.Context) error {
 			return fmt.Errorf("couldn't get workspace: %w", getWorkspaceErr)
 		} else if instance.Status.Phase != storagev1.InstanceReady {
 			return fmt.Errorf(
-				"workspace is '%s', please run `devsy workspace up %s` to start it again",
+				"workspace is %q, run `devsy workspace up %s` to start it again",
 				instance.Status.Phase,
 				c.workspace.ID,
 			)
 		} else if instance.Status.LastWorkspaceStatus != storagev1.WorkspaceStatusRunning {
 			return fmt.Errorf(
-				"workspace is '%s', please run `devsy workspace up %s` to start it again",
+				"workspace is %q, run `devsy workspace up %s` to start it again",
 				instance.Status.LastWorkspaceStatus,
 				c.workspace.ID,
 			)

--- a/pkg/client/clientimplementation/daemonclient/client.go
+++ b/pkg/client/clientimplementation/daemonclient/client.go
@@ -178,7 +178,7 @@ func (c *client) CheckWorkspaceReachable(ctx context.Context) error {
 		return fmt.Errorf("reach host: %w", err)
 	}
 
-	log.Debugf("Host %s is reachable. Proceeding with SSH session...", wAddr.Host())
+	log.Debugf("Host %s is reachable. Proceeding with SSH session", wAddr.Host())
 	return nil
 }
 

--- a/pkg/client/clientimplementation/daemonclient/delete.go
+++ b/pkg/client/clientimplementation/daemonclient/delete.go
@@ -101,7 +101,7 @@ func (c *client) Delete(ctx context.Context, opt clientpkg.DeleteOptions) error 
 	}
 
 	// wait until the workspace is deleted
-	log.Debugf("Waiting for workspace to get deleted...")
+	log.Debugf("Waiting for workspace to get deleted")
 	err = wait.PollUntilContextTimeout(
 		ctx,
 		time.Second,
@@ -121,7 +121,7 @@ func (c *client) Delete(ctx context.Context, opt clientpkg.DeleteOptions) error 
 				return true, nil
 			}
 
-			log.Debugf("Workspace is not deleted yet, waiting again...")
+			log.Debugf("Workspace is not deleted yet, waiting again")
 			return false, nil
 		},
 	)

--- a/pkg/client/clientimplementation/daemonclient/up.go
+++ b/pkg/client/clientimplementation/daemonclient/up.go
@@ -49,12 +49,12 @@ func (c *client) Up(ctx context.Context, opt clientpkg.UpOptions) (*config.Resul
 		if os.Getenv(devsyconfig.EnvUI) == devsyconfig.BoolTrue {
 			return nil, fmt.Errorf(
 				"workspace %s is migrated and needs to be rebuild or reset. "+
-					"Please click on rebuild or reset on the workspace to do this",
+					"Click on rebuild or reset on the workspace to do this",
 				c.workspace.ID,
 			)
 		} else {
 			return nil, fmt.Errorf(
-				"workspace %s is migrated and needs to be recreated or reset. Please use the recreate or reset flag to do this",
+				"workspace %s is migrated and needs to be recreated or reset. Use the recreate or reset flag to do this",
 				c.workspace.ID,
 			)
 		}

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -330,7 +330,7 @@ func (s *proxyClient) checkPlatformVersion(
 	if parsedVersion.GE(semver.MustParse("0.6.99")) {
 		return fmt.Errorf(
 			"you are using an outdated provider version for this platform. " +
-				"Please disconnect and reconnect the platform to update the provider",
+				"Disconnect and reconnect the platform to update the provider",
 		)
 	}
 

--- a/pkg/client/clientimplementation/proxy_client.go
+++ b/pkg/client/clientimplementation/proxy_client.go
@@ -109,12 +109,12 @@ func (s *proxyClient) Lock(ctx context.Context) error {
 	s.initLock()
 
 	// try to lock workspace
-	log.Debugf("Acquire workspace lock...")
+	log.Debugf("Acquire workspace lock")
 	err := tryLock(ctx, s.workspaceLock, "workspace")
 	if err != nil {
 		return fmt.Errorf("error locking workspace: %w", err)
 	}
-	log.Debugf("Acquired workspace lock...")
+	log.Debugf("Acquired workspace lock")
 
 	return nil
 }

--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -850,7 +850,7 @@ func DeleteWorkspaceFolder(params DeleteWorkspaceFolderParams) error {
 
 	err = ssh.RemoveFromConfig(params.WorkspaceID, sshConfigPath, sshConfigIncludePath)
 	if err != nil {
-		log.Errorf("Remove workspace '%s' from ssh config: %v", params.WorkspaceID, err)
+		log.Errorf("Remove workspace %q from ssh config: %v", params.WorkspaceID, err)
 	}
 
 	workspaceFolder, err := provider.GetWorkspaceDir(params.Context, params.WorkspaceID)

--- a/pkg/copy/copy.go
+++ b/pkg/copy/copy.go
@@ -158,7 +158,7 @@ func CreateIfNotExists(dir string, perm os.FileMode) error {
 	}
 
 	if err := os.MkdirAll(dir, perm); err != nil {
-		return fmt.Errorf("failed to create directory: '%s', error: '%s'", dir, err.Error())
+		return fmt.Errorf("failed to create directory: %q, error: %q", dir, err.Error())
 	}
 
 	return nil

--- a/pkg/copy/copy_supported.go
+++ b/pkg/copy/copy_supported.go
@@ -16,7 +16,7 @@ func IsUID(info os.FileInfo, uid uint32) bool {
 func Lchown(info os.FileInfo, sourcePath, destPath string) error {
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
-		return fmt.Errorf("failed to get raw syscall.Stat_t data for '%s'", sourcePath)
+		return fmt.Errorf("failed to get raw syscall.Stat_t data for %q", sourcePath)
 	}
 	if err := os.Lchown(destPath, int(stat.Uid), int(stat.Gid)); err != nil {
 		return err

--- a/pkg/daemon/platform/local_server.go
+++ b/pkg/daemon/platform/local_server.go
@@ -366,7 +366,7 @@ func (l *localServer) projects(w http.ResponseWriter, r *http.Request) {
 		return
 	} else if len(projectList.Items) == 0 {
 		err := fmt.Errorf(
-			"you don't have access to any projects, please make sure you have at least access to 1 project",
+			"you don't have access to any projects, make sure you have at least access to 1 project",
 		)
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return
@@ -396,7 +396,7 @@ func (l *localServer) projectTemplates(
 	} else if len(templateList.DevsyWorkspaceTemplates) == 0 {
 		err := fmt.Errorf(
 			"seems like there is no template allowed in project %s, "+
-				"please make sure to at least have a single template available",
+				"make sure to at least have a single template available",
 			projectName,
 		)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -426,7 +426,7 @@ func (l *localServer) projectClusters(
 		return
 	} else if len(clusterList.Clusters) == 0 {
 		err := fmt.Errorf(
-			"seems like there is no cluster allowed in project %s, please make sure to at least have a single cluster available",
+			"seems like there is no cluster allowed in project %s, make sure to at least have a single cluster available",
 			projectName,
 		)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -498,7 +498,7 @@ func (l *localServer) listWorkspace(
 		return
 	} else if len(projectList.Items) == 0 {
 		err := fmt.Errorf(
-			"you don't have access to any projects, please make sure you have at least access to 1 project",
+			"you don't have access to any projects, make sure you have at least access to 1 project",
 		)
 		http.Error(w, err.Error(), http.StatusForbidden)
 		return

--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -458,7 +458,7 @@ func (r *runner) buildDevImageCompose(
 	composeService, err := project.GetService(service)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"service '%s' configured in devcontainer.json not found in Docker Compose configuration",
+			"service %q configured in devcontainer.json not found in Docker Compose configuration",
 			service,
 		)
 	}

--- a/pkg/devcontainer/buildkit/buildkit.go
+++ b/pkg/devcontainer/buildkit/buildkit.go
@@ -82,7 +82,7 @@ func Build(
 			return fmt.Errorf("failed to get build context %v: %w", k, err)
 		}
 		if !st.IsDir() {
-			return fmt.Errorf("build context '%s' is not a directory", v)
+			return fmt.Errorf("build context %q is not a directory", v)
 		}
 		localName := k
 		if k == "context" || k == "dockerfile" {

--- a/pkg/devcontainer/buildkit/remote.go
+++ b/pkg/devcontainer/buildkit/remote.go
@@ -388,7 +388,7 @@ func addMultiContexts(solveOpts *client.SolveOpt, buildOpts *build.BuildOptions)
 			return fmt.Errorf("get build context %v: %w", k, err)
 		}
 		if !st.IsDir() {
-			return fmt.Errorf("build context '%s' is not a directory", v)
+			return fmt.Errorf("build context %q is not a directory", v)
 		}
 
 		localName := k

--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -58,7 +58,7 @@ func (r *runner) composeHelper() (*compose.ComposeHelper, error) {
 	dockerDriver, ok := r.Driver.(driver.DockerDriver)
 	if !ok {
 		return nil, fmt.Errorf(
-			"docker compose is not supported by this provider, please choose a different one",
+			"docker compose is not supported by this provider, choose a different one",
 		)
 	}
 
@@ -432,7 +432,7 @@ func (r *runner) startContainer(
 	composeService, err := project.GetService(service)
 	if err != nil {
 		return nil, fmt.Errorf(
-			"service '%s' configured in devcontainer.json not found in Docker Compose configuration",
+			"service %q configured in devcontainer.json not found in Docker Compose configuration",
 			service,
 		)
 	}

--- a/pkg/devcontainer/config.go
+++ b/pkg/devcontainer/config.go
@@ -124,7 +124,7 @@ func (r *runner) getDefaultConfig(
 			Image: options.FallbackImage,
 		}
 	} else {
-		log.Infof("Try detecting project programming language...")
+		log.Infof("Try detecting project programming language")
 		defaultConfig = language.DefaultConfig(r.LocalWorkspaceFolder)
 	}
 

--- a/pkg/devcontainer/config.go
+++ b/pkg/devcontainer/config.go
@@ -83,7 +83,7 @@ func (r *runner) getRawConfig(options provider2.CLIOptions) (*config.DevContaine
 						return match, nil
 					}
 				}
-				return "", fmt.Errorf("devcontainer with ID '%s' not found", options.DevContainerID)
+				return "", fmt.Errorf("devcontainer with ID %q not found", options.DevContainerID)
 			},
 		)
 	} else {

--- a/pkg/devcontainer/config/userenvprobe.go
+++ b/pkg/devcontainer/config/userenvprobe.go
@@ -36,7 +36,7 @@ func NewUserEnvProbe(probe string) (UserEnvProbe, error) {
 	case "":
 		return DefaultUserEnvProbe, nil
 	default:
-		return "", fmt.Errorf("invalid userEnvProbe \"%s\", supported are \"%s\"", probe,
+		return "", fmt.Errorf("invalid userEnvProbe %q, supported are %q", probe,
 			strings.Join([]string{
 				string(LoginInteractiveShellProbe),
 				string(LoginShellProbe),
@@ -67,7 +67,7 @@ func ProbeUserEnv(
 	}
 
 	log.Debugf(
-		"running user env probe with shell \"%s\", probe \"%s\", user \"%s\" and command \"%s\"",
+		"running user env probe with shell %q, probe %q, user %q and command %q",
 		strings.Join(preferredShell, " "),
 		string(userEnvProbe),
 		userName,
@@ -84,7 +84,7 @@ func ProbeUserEnv(
 	)
 	if err != nil {
 		log.Debugf(
-			"running user env probe with shell \"%s\", probe \"%s\", user \"%s\" and command \"%s\"",
+			"running user env probe with shell %q, probe %q, user %q and command %q",
 			strings.Join(preferredShell, " "),
 			string(userEnvProbe),
 			userName,

--- a/pkg/devcontainer/feature/features.go
+++ b/pkg/devcontainer/feature/features.go
@@ -494,7 +494,7 @@ func processDirectTarFeature(
 	downloadBase := id[strings.LastIndex(id, "/"):]
 	if !directTarballRegEx.MatchString(downloadBase) {
 		return "", fmt.Errorf(
-			"expected tarball name to follow 'devcontainer-feature-<feature-id>.tgz' format.  Received '%s' ",
+			"expected tarball name to follow 'devcontainer-feature-<feature-id>.tgz' format.  Received %q ",
 			downloadBase,
 		)
 	}

--- a/pkg/devcontainer/prebuild.go
+++ b/pkg/devcontainer/prebuild.go
@@ -91,7 +91,8 @@ func (r *runner) Build(ctx context.Context, options provider.BuildOptions) (stri
 	// check if we can push image
 	if err := image.CheckPushPermissions(ctx, prebuildImage); err != nil {
 		return "", fmt.Errorf(
-			"cannot push to repository %s. Please make sure you are logged into the registry and credentials are available. (Error: %w)",
+			"cannot push to repository %s. Make sure you are logged into the registry "+
+				"and credentials are available. (Error: %w)",
 			prebuildImage,
 			err,
 		)

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -97,7 +97,7 @@ func (r *runner) Up(
 	timeout time.Duration,
 ) (*config.Result, error) {
 	log.Debugf(
-		"Up devcontainer for workspace '%s' with timeout %s",
+		"Up devcontainer for workspace %q with timeout %s",
 		r.WorkspaceConfig.Workspace.ID,
 		timeout,
 	)
@@ -292,7 +292,7 @@ func (c *initCmdContext) runSingle(name string, cmd []string) error {
 	}
 
 	log.Infof(
-		"Running initializeCommand %q from devcontainer.json: '%s'",
+		"Running initializeCommand %q from devcontainer.json: %q",
 		name,
 		strings.Join(args, " "),
 	)

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -256,7 +256,7 @@ func (r *DockerHelper) WaitContainerRunning(ctx context.Context, containerID str
 				)
 			}
 			log.Debugf(
-				"WaitContainerRunning: container %s status=%s, waiting...",
+				"WaitContainerRunning: container %s status=%s, waiting",
 				containerID,
 				status,
 			)

--- a/pkg/dockercredentials/dockercredentials.go
+++ b/pkg/dockercredentials/dockercredentials.go
@@ -101,7 +101,7 @@ func configureCredentials(
 	if runtime.GOOS == windowsOS {
 		escapedPath := strings.ReplaceAll(binaryPath, "%", "%%")
 		script := fmt.Sprintf(
-			"@echo off\r\n%q internal agent docker-credentials --port %d %%*\r\n",
+			"@echo off\r\n\"%s\" internal agent docker-credentials --port %d %%*\r\n",
 			escapedPath,
 			port,
 		)

--- a/pkg/dockercredentials/dockercredentials.go
+++ b/pkg/dockercredentials/dockercredentials.go
@@ -101,7 +101,7 @@ func configureCredentials(
 	if runtime.GOOS == windowsOS {
 		escapedPath := strings.ReplaceAll(binaryPath, "%", "%%")
 		script := fmt.Sprintf(
-			"@echo off\r\n\"%s\" internal agent docker-credentials --port %d %%*\r\n",
+			"@echo off\r\n%q internal agent docker-credentials --port %d %%*\r\n",
 			escapedPath,
 			port,
 		)

--- a/pkg/dockerinstall/debian.go
+++ b/pkg/dockerinstall/debian.go
@@ -73,7 +73,7 @@ func (i *DebianInstaller) setupRepo(shC string) error {
 			i.opts.downloadURL, i.distro.ID,
 		),
 		"chmod a+r /etc/apt/keyrings/docker.gpg",
-		fmt.Sprintf("echo \"%s\" > /etc/apt/sources.list.d/docker.list", aptRepo),
+		fmt.Sprintf("echo %q > /etc/apt/sources.list.d/docker.list", aptRepo),
 		"apt-get update -qq >/dev/null",
 	}
 
@@ -109,7 +109,7 @@ func (i *DebianInstaller) findPackageVersion(pkgName string) (string, error) {
 	pkgPattern = strings.ReplaceAll(pkgPattern, "-", ".*")
 	pkgPattern = strings.ReplaceAll(pkgPattern, ".", "\\.")
 	searchCmd := fmt.Sprintf(
-		"apt-cache madison '%s' | grep '%s' | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3",
+		"apt-cache madison %q | grep %q | head -1 | awk '{$1=$1};1' | cut -d' ' -f 3",
 		pkgName, pkgPattern,
 	)
 
@@ -124,7 +124,7 @@ func (i *DebianInstaller) findPackageVersion(pkgName string) (string, error) {
 	}
 	if len(out) == 0 {
 		return "", fmt.Errorf(
-			"version '%s' not found in apt-cache madison results for %s",
+			"version %q not found in apt-cache madison results for %s",
 			i.opts.version,
 			pkgName,
 		)

--- a/pkg/dockerinstall/validator.go
+++ b/pkg/dockerinstall/validator.go
@@ -19,7 +19,7 @@ func (v *Validator) ValidateOS(os string) error {
 	if os == "darwin" {
 		fprintln(v.opts.stderr, `
 ERROR: Unsupported operating system 'macOS'
-Please get Docker Desktop from https://www.docker.com/products/docker-desktop`)
+Get Docker Desktop from https://www.docker.com/products/docker-desktop`)
 		return fmt.Errorf("unsupported OS")
 	}
 
@@ -55,7 +55,7 @@ func (v *Validator) CheckWSL(isWSL bool) {
 
 	fprintln(v.opts.stdout, `
 WSL DETECTED: We recommend using Docker Desktop for Windows.
-Please get Docker Desktop from https://www.docker.com/products/docker-desktop`)
+Get Docker Desktop from https://www.docker.com/products/docker-desktop`)
 	fprintln(v.opts.stderr, `
 You may press Ctrl+C now to abort this script.`)
 	v.sleep(WSLWarningDelay)
@@ -110,7 +110,7 @@ ERROR: Unable to detect distribution`)
 
 	if !supported[distro.ID] {
 		fprintf(v.opts.stderr, `
-ERROR: Unsupported distribution '%s'`, distro.ID)
+ERROR: Unsupported distribution %q`, distro.ID)
 		return fmt.Errorf("unsupported distribution")
 	}
 

--- a/pkg/dockerinstall/validator_test.go
+++ b/pkg/dockerinstall/validator_test.go
@@ -128,7 +128,7 @@ func (s *ValidatorTestSuite) TestValidateDistro_Unsupported() {
 	distro := &Distro{ID: "arch", Version: "rolling"}
 	err := validator.ValidateDistro(distro)
 	s.Error(err)
-	s.Contains(s.stderr.String(), "Unsupported distribution 'arch'")
+	s.Contains(s.stderr.String(), `Unsupported distribution "arch"`)
 }
 
 func (s *ValidatorTestSuite) TestSleep_DryRun() {

--- a/pkg/dotfiles/dotfiles.go
+++ b/pkg/dotfiles/dotfiles.go
@@ -49,7 +49,7 @@ func Setup(p SetupParams) error {
 	}
 
 	log.Infof("Dotfiles Git repository %s specified", dotfilesRepo)
-	log.Debug("Cloning dotfiles into the devcontainer...")
+	log.Debug("Cloning dotfiles into the devcontainer")
 
 	dotCmd, err := buildDotCmd(buildDotCmdParams{
 		devsyConfig:      p.DevsyConfig,

--- a/pkg/driver/drivercreate/create.go
+++ b/pkg/driver/drivercreate/create.go
@@ -21,6 +21,6 @@ func NewDriver(workspaceInfo *provider2.AgentWorkspaceInfo) (driver.Driver, erro
 		return kubernetes.NewKubernetesDriver(workspaceInfo)
 	}
 
-	return nil, fmt.Errorf("unrecognized driver '%s', possible values are %s, %s or %s",
+	return nil, fmt.Errorf("unrecognized driver %q, possible values are %s, %s or %s",
 		driver, provider2.DockerDriver, provider2.CustomDriver, provider2.KubernetesDriver)
 }

--- a/pkg/driver/kubernetes/daemonsecret.go
+++ b/pkg/driver/kubernetes/daemonsecret.go
@@ -26,7 +26,7 @@ func (k *KubernetesDriver) EnsureDaemonConfigSecret(
 		}
 
 		log.Debugf(
-			"Daemon config secret %q already exists, but is outdated. Recreating...",
+			"Daemon config secret %q already exists, but is outdated. Recreating",
 			secretName,
 		)
 		err := k.DeleteSecret(ctx, secretName)

--- a/pkg/driver/kubernetes/daemonsecret.go
+++ b/pkg/driver/kubernetes/daemonsecret.go
@@ -21,12 +21,12 @@ func (k *KubernetesDriver) EnsureDaemonConfigSecret(
 
 	if k.secretExists(ctx, secretName) {
 		if !k.shouldRecreateDaemonConfigSecret(ctx, data, secretName) {
-			log.Debugf("Daemon config secret '%s' already exists and is up to date", secretName)
+			log.Debugf("Daemon config secret %q already exists and is up to date", secretName)
 			return nil
 		}
 
 		log.Debugf(
-			"Daemon config secret '%s' already exists, but is outdated. Recreating...",
+			"Daemon config secret %q already exists, but is outdated. Recreating...",
 			secretName,
 		)
 		err := k.DeleteSecret(ctx, secretName)
@@ -46,7 +46,7 @@ func (k *KubernetesDriver) EnsureDaemonConfigSecret(
 		return fmt.Errorf("create daemon config secret: %w", err)
 	}
 
-	log.Infof("Daemon config secret '%s' created", secretName)
+	log.Infof("Daemon config secret %q created", secretName)
 	return nil
 }
 

--- a/pkg/driver/kubernetes/driver.go
+++ b/pkg/driver/kubernetes/driver.go
@@ -109,14 +109,14 @@ func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId s
 	workspaceId = getID(workspaceId)
 
 	// delete pod
-	log.Infof("Delete pod %q...", workspaceId)
+	log.Infof("Delete pod %q", workspaceId)
 	err := k.waitPodDeleted(ctx, workspaceId)
 	if err != nil {
 		return err
 	}
 
 	// delete pvc
-	log.Infof("Delete persistent volume claim %q...", workspaceId)
+	log.Infof("Delete persistent volume claim %q", workspaceId)
 	err = k.client.Client().
 		CoreV1().
 		PersistentVolumeClaims(k.namespace).
@@ -129,7 +129,7 @@ func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId s
 
 	// delete role binding & service account
 	if k.options.ClusterRole != "" {
-		log.Infof("Delete role binding %q...", workspaceId)
+		log.Infof("Delete role binding %q", workspaceId)
 		err = k.client.Client().
 			RbacV1().
 			RoleBindings(k.namespace).
@@ -141,7 +141,7 @@ func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId s
 
 	// delete daemon config secret
 	if k.secretExists(ctx, getDaemonSecretName(workspaceId)) {
-		log.Infof("Delete daemon config secret %q...", workspaceId)
+		log.Infof("Delete daemon config secret %q", workspaceId)
 		err := k.DeleteSecret(ctx, getDaemonSecretName(workspaceId))
 		if err != nil {
 			return err
@@ -150,7 +150,7 @@ func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId s
 
 	// delete pull secret
 	if k.options.KubernetesPullSecretsEnabled != "" {
-		log.Infof("Delete pull secret %q...", workspaceId)
+		log.Infof("Delete pull secret %q", workspaceId)
 		err := k.DeleteSecret(ctx, getPullSecretsName(workspaceId))
 		if err != nil {
 			return err

--- a/pkg/driver/kubernetes/driver.go
+++ b/pkg/driver/kubernetes/driver.go
@@ -20,10 +20,10 @@ func NewKubernetesDriver(
 ) (driver.ReprovisioningDriver, error) {
 	options := workspaceInfo.Agent.Kubernetes
 	if options.KubernetesConfig != "" {
-		log.Debugf("Use Kubernetes Config '%s'", options.KubernetesConfig)
+		log.Debugf("Use Kubernetes Config %q", options.KubernetesConfig)
 	}
 	if options.KubernetesContext != "" {
-		log.Debugf("Use Kubernetes Context '%s'", options.KubernetesContext)
+		log.Debugf("Use Kubernetes Context %q", options.KubernetesContext)
 	}
 
 	client, namespace, err := NewClient(options.KubernetesConfig, options.KubernetesContext)
@@ -35,7 +35,7 @@ func NewKubernetesDriver(
 		log.Debugf("Using Explicit Kubernetes Namespace")
 		namespace = options.KubernetesNamespace
 	}
-	log.Debugf("Use Kubernetes Namespace '%s'", namespace)
+	log.Debugf("Use Kubernetes Namespace %q", namespace)
 
 	return &KubernetesDriver{
 		client:      client,
@@ -88,8 +88,8 @@ func (k *KubernetesDriver) getDevContainerPvc(
 }
 
 func (k *KubernetesDriver) StopDevContainer(ctx context.Context, workspaceId string) error {
-	log.Debugf("Stopping devcontainer for workspace '%s'", workspaceId)
-	defer log.Debugf("Done stopping devcontainer for workspace '%s'", workspaceId)
+	log.Debugf("Stopping devcontainer for workspace %q", workspaceId)
+	defer log.Debugf("Done stopping devcontainer for workspace %q", workspaceId)
 
 	workspaceId = getID(workspaceId)
 
@@ -103,20 +103,20 @@ func (k *KubernetesDriver) StopDevContainer(ctx context.Context, workspaceId str
 }
 
 func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId string) error {
-	log.Debugf("Deleting devcontainer for workspace '%s'", workspaceId)
-	defer log.Debugf("Done deleting devcontainer for workspace '%s'", workspaceId)
+	log.Debugf("Deleting devcontainer for workspace %q", workspaceId)
+	defer log.Debugf("Done deleting devcontainer for workspace %q", workspaceId)
 
 	workspaceId = getID(workspaceId)
 
 	// delete pod
-	log.Infof("Delete pod '%s'...", workspaceId)
+	log.Infof("Delete pod %q...", workspaceId)
 	err := k.waitPodDeleted(ctx, workspaceId)
 	if err != nil {
 		return err
 	}
 
 	// delete pvc
-	log.Infof("Delete persistent volume claim '%s'...", workspaceId)
+	log.Infof("Delete persistent volume claim %q...", workspaceId)
 	err = k.client.Client().
 		CoreV1().
 		PersistentVolumeClaims(k.namespace).
@@ -129,7 +129,7 @@ func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId s
 
 	// delete role binding & service account
 	if k.options.ClusterRole != "" {
-		log.Infof("Delete role binding '%s'...", workspaceId)
+		log.Infof("Delete role binding %q...", workspaceId)
 		err = k.client.Client().
 			RbacV1().
 			RoleBindings(k.namespace).
@@ -141,7 +141,7 @@ func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId s
 
 	// delete daemon config secret
 	if k.secretExists(ctx, getDaemonSecretName(workspaceId)) {
-		log.Infof("Delete daemon config secret '%s'...", workspaceId)
+		log.Infof("Delete daemon config secret %q...", workspaceId)
 		err := k.DeleteSecret(ctx, getDaemonSecretName(workspaceId))
 		if err != nil {
 			return err
@@ -150,7 +150,7 @@ func (k *KubernetesDriver) DeleteDevContainer(ctx context.Context, workspaceId s
 
 	// delete pull secret
 	if k.options.KubernetesPullSecretsEnabled != "" {
-		log.Infof("Delete pull secret '%s'...", workspaceId)
+		log.Infof("Delete pull secret %q...", workspaceId)
 		err := k.DeleteSecret(ctx, getPullSecretsName(workspaceId))
 		if err != nil {
 			return err

--- a/pkg/driver/kubernetes/find.go
+++ b/pkg/driver/kubernetes/find.go
@@ -12,8 +12,8 @@ func (k *KubernetesDriver) FindDevContainer(
 	ctx context.Context,
 	workspaceId string,
 ) (*config.ContainerDetails, error) {
-	log.Debugf("Finding devcontainer for workspace '%s'", workspaceId)
-	defer log.Debugf("Done finding devcontainer for workspace '%s'", workspaceId)
+	log.Debugf("Finding devcontainer for workspace %q", workspaceId)
+	defer log.Debugf("Done finding devcontainer for workspace %q", workspaceId)
 
 	workspaceId = getID(workspaceId)
 

--- a/pkg/driver/kubernetes/helper.go
+++ b/pkg/driver/kubernetes/helper.go
@@ -103,7 +103,7 @@ func parseLabels(str string) (map[string]string, error) {
 		label = strings.TrimSpace(label)
 		splitted := strings.SplitN(label, "=", 2)
 		if len(splitted) != 2 {
-			return nil, fmt.Errorf("invalid label '%s', expected format label=value", label)
+			return nil, fmt.Errorf("invalid label %q, expected format label=value", label)
 		}
 
 		retMap[splitted[0]] = splitted[1]

--- a/pkg/driver/kubernetes/pullsecrets.go
+++ b/pkg/driver/kubernetes/pullsecrets.go
@@ -37,7 +37,7 @@ func (k *KubernetesDriver) EnsurePullSecret(
 		}
 
 		log.Debugf(
-			"Pull secret %q already exists, but is outdated. Recreating...",
+			"Pull secret %q already exists, but is outdated. Recreating",
 			pullSecretName,
 		)
 		err := k.DeleteSecret(ctx, pullSecretName)

--- a/pkg/driver/kubernetes/pullsecrets.go
+++ b/pkg/driver/kubernetes/pullsecrets.go
@@ -32,12 +32,12 @@ func (k *KubernetesDriver) EnsurePullSecret(
 
 	if k.secretExists(ctx, pullSecretName) {
 		if !k.shouldRecreateSecret(ctx, dockerCredentials, pullSecretName, host) {
-			log.Debugf("Pull secret '%s' already exists and is up to date", pullSecretName)
+			log.Debugf("Pull secret %q already exists and is up to date", pullSecretName)
 			return true, nil
 		}
 
 		log.Debugf(
-			"Pull secret '%s' already exists, but is outdated. Recreating...",
+			"Pull secret %q already exists, but is outdated. Recreating...",
 			pullSecretName,
 		)
 		err := k.DeleteSecret(ctx, pullSecretName)
@@ -51,7 +51,7 @@ func (k *KubernetesDriver) EnsurePullSecret(
 		return false, err
 	}
 
-	log.Infof("Pull secret '%s' created", pullSecretName)
+	log.Infof("Pull secret %q created", pullSecretName)
 	return true, nil
 }
 

--- a/pkg/driver/kubernetes/pvc.go
+++ b/pkg/driver/kubernetes/pvc.go
@@ -23,7 +23,7 @@ func (k *KubernetesDriver) createPersistentVolumeClaim(
 		return err
 	}
 
-	log.Infof("Create Persistent Volume Claim '%s'", id)
+	log.Infof("Create Persistent Volume Claim %q", id)
 	_, err = k.client.Client().
 		CoreV1().
 		PersistentVolumeClaims(k.namespace).
@@ -47,7 +47,7 @@ func (k *KubernetesDriver) buildPersistentVolumeClaim(
 	size := k.options.DiskSize
 	quantity, err := resource.ParseQuantity(size)
 	if err != nil {
-		return nil, fmt.Errorf("parse persistent volume size '%s': %w", size, err)
+		return nil, fmt.Errorf("parse persistent volume size %q: %w", size, err)
 	}
 
 	var storageClassName *string

--- a/pkg/driver/kubernetes/run.go
+++ b/pkg/driver/kubernetes/run.go
@@ -49,7 +49,7 @@ func (k *KubernetesDriver) RunDevContainer(
 	workspaceId string,
 	options *driver.RunOptions,
 ) error {
-	log.Debugf("Running devcontainer for workspace '%s'", workspaceId)
+	log.Debugf("Running devcontainer for workspace %q", workspaceId)
 	workspaceId = getID(workspaceId)
 
 	// namespace
@@ -68,7 +68,7 @@ func (k *KubernetesDriver) RunDevContainer(
 	} else if pvc == nil {
 		if options == nil {
 			return fmt.Errorf(
-				"no options provided and no persistent volume claim found for workspace '%s'",
+				"no options provided and no persistent volume claim found for workspace %q",
 				workspaceId,
 			)
 		}
@@ -158,7 +158,7 @@ func (k *KubernetesDriver) runContainer(
 			volumeMounts = append(volumeMounts, volumeMount)
 		} else {
 			log.Warnf(
-				"Unsupported mount type '%s' in mount '%s', will skip",
+				"Unsupported mount type %q in mount %q, will skip",
 				mount.Type,
 				mount.String(),
 			)
@@ -294,7 +294,7 @@ func (k *KubernetesDriver) runContainer(
 		// Nothing changed, can safely return
 		if optionsEqual(existingOptions, k.options) {
 			log.Infof(
-				"Pod '%s' already exists and nothing changed, skipping update",
+				"Pod %q already exists and nothing changed, skipping update",
 				existingPod.Name,
 			)
 			return nil
@@ -340,14 +340,14 @@ func (k *KubernetesDriver) runPod(ctx context.Context, id string, pod *corev1.Po
 	log.Debugf("Create pod with: %s", string(podRaw))
 
 	// create the pod
-	log.Infof("Create Pod '%s'", id)
+	log.Infof("Create Pod %q", id)
 	_, err = k.client.Client().CoreV1().Pods(k.namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		return fmt.Errorf("create pod: %w", err)
 	}
 
 	// wait for pod running
-	log.Infof("Waiting for DevContainer Pod '%s' to come up...", id)
+	log.Infof("Waiting for DevContainer Pod %q to come up...", id)
 	_, err = k.waitPodRunning(ctx, id)
 	if err != nil {
 		return err
@@ -507,15 +507,15 @@ func getNodeSelector(pod *corev1.Pod, rawNodeSelector string) (map[string]string
 }
 
 func (k *KubernetesDriver) StartDevContainer(ctx context.Context, workspaceId string) error {
-	log.Debugf("Starting devcontainer for workspace '%s'", workspaceId)
-	defer log.Debugf("Done starting devcontainer for workspace '%s'", workspaceId)
+	log.Debugf("Starting devcontainer for workspace %q", workspaceId)
+	defer log.Debugf("Done starting devcontainer for workspace %q", workspaceId)
 
 	workspaceId = getID(workspaceId)
 	_, containerInfo, err := k.getDevContainerPvc(ctx, workspaceId)
 	if err != nil {
 		return err
 	} else if containerInfo == nil {
-		return fmt.Errorf("persistent volume '%s' not found", workspaceId)
+		return fmt.Errorf("persistent volume %q not found", workspaceId)
 	}
 
 	return k.runContainer(
@@ -557,7 +557,7 @@ func optionsEqual(a, b *provider2.ProviderKubernetesDriverConfig) bool {
 func (k *KubernetesDriver) createNamespace(ctx context.Context) error {
 	_, err := k.client.Client().CoreV1().Namespaces().Get(ctx, k.namespace, metav1.GetOptions{})
 	if kerrors.IsNotFound(err) || kerrors.IsForbidden(err) {
-		log.Infof("Create namespace '%s'", k.namespace)
+		log.Infof("Create namespace %q", k.namespace)
 		_, err := k.client.Client().CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: k.namespace,

--- a/pkg/driver/kubernetes/run.go
+++ b/pkg/driver/kubernetes/run.go
@@ -347,7 +347,7 @@ func (k *KubernetesDriver) runPod(ctx context.Context, id string, pod *corev1.Po
 	}
 
 	// wait for pod running
-	log.Infof("Waiting for DevContainer Pod %q to come up...", id)
+	log.Infof("Waiting for DevContainer Pod %q to come up", id)
 	_, err = k.waitPodRunning(ctx, id)
 	if err != nil {
 		return err

--- a/pkg/driver/kubernetes/serviceaccount.go
+++ b/pkg/driver/kubernetes/serviceaccount.go
@@ -24,7 +24,7 @@ func (k *KubernetesDriver) createServiceAccount(
 		return fmt.Errorf("get service account: %w", err)
 	} else if kerrors.IsNotFound(err) {
 		// create service account if it does not exist
-		log.Infof("Create Service Account '%s'", serviceAccount)
+		log.Infof("Create Service Account %q", serviceAccount)
 		_, err := k.client.Client().
 			CoreV1().
 			ServiceAccounts(k.namespace).
@@ -49,7 +49,7 @@ func (k *KubernetesDriver) createServiceAccount(
 			return fmt.Errorf("get role binding: %w", err)
 		} else if kerrors.IsNotFound(err) {
 			// create role binding
-			log.Infof("Create Role Binding '%s'", serviceAccount)
+			log.Infof("Create Role Binding %q", serviceAccount)
 			_, err := k.client.Client().
 				RbacV1().
 				RoleBindings(k.namespace).

--- a/pkg/driver/kubernetes/target_architecture.go
+++ b/pkg/driver/kubernetes/target_architecture.go
@@ -17,8 +17,8 @@ func (k *KubernetesDriver) TargetArchitecture(
 		return k.options.Architecture, nil
 	}
 
-	log.Debugf("Getting target architecture for workspace '%s'", workspaceId)
-	defer log.Debugf("Done getting target architecture for workspace '%s'", workspaceId)
+	log.Debugf("Getting target architecture for workspace %q", workspaceId)
+	defer log.Debugf("Done getting target architecture for workspace %q", workspaceId)
 
 	// get all nodes
 	nodes, err := k.client.Client().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
@@ -26,7 +26,7 @@ func (k *KubernetesDriver) TargetArchitecture(
 		if kerrors.IsForbidden(err) {
 			return "", fmt.Errorf(
 				"you don't have permission to list nodes in the Kubernetes cluster, " +
-					"please set the cluster architecture manually via provider options",
+					"set the cluster architecture manually via provider options",
 			)
 		}
 
@@ -40,7 +40,7 @@ func (k *KubernetesDriver) TargetArchitecture(
 			architecture = node.Status.NodeInfo.Architecture
 		} else if architecture != node.Status.NodeInfo.Architecture {
 			return "", fmt.Errorf(
-				"mixed architectures in the Kubernetes cluster, please set the cluster architecture manually via provider options",
+				"mixed architectures in the Kubernetes cluster, set the cluster architecture manually via provider options",
 			)
 		}
 	}

--- a/pkg/driver/kubernetes/wait.go
+++ b/pkg/driver/kubernetes/wait.go
@@ -41,7 +41,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 
 			// check pod for problems
 			if pod.DeletionTimestamp != nil {
-				throttledLogger.Infof("Waiting, since pod '%s' is terminating", id)
+				throttledLogger.Infof("Waiting, since pod %q is terminating", id)
 				return false, nil
 			}
 
@@ -50,7 +50,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 			if time.Since(started) > 45*time.Second { // start printing conditions after a delay
 				for _, cond := range pod.Status.Conditions {
 					if cond.Status == corev1.ConditionFalse {
-						fmt.Fprintf(&condMsg, "Condition \"%s\" is %s\n", cond.Type, cond.Status)
+						fmt.Fprintf(&condMsg, "Condition %q is %s\n", cond.Type, cond.Status)
 						if cond.Reason != "" {
 							fmt.Fprintf(&condMsg, "%s Reason: %s\n", cond.Type, cond.Reason)
 						}
@@ -63,7 +63,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 
 			// check pod status
 			if len(pod.Status.ContainerStatuses) < len(pod.Spec.Containers) {
-				msg := fmt.Sprintf("Waiting, since pod '%s' is starting", id)
+				msg := fmt.Sprintf("Waiting, since pod %q is starting", id)
 				if condMsg.String() != "" {
 					msg += fmt.Sprintf("\n%s", strings.TrimSpace(condMsg.String()))
 				}
@@ -77,7 +77,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 				if IsWaiting(containerStatus) {
 					if IsCritical(containerStatus) {
 						return false, fmt.Errorf(
-							"pod '%s' init container '%s' is waiting to start: %s (%s)",
+							"pod %q init container %q is waiting to start: %s (%s)",
 							id,
 							c.Name,
 							c.State.Waiting.Message,
@@ -86,14 +86,14 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 					}
 					if c.State.Waiting.Message == "" {
 						throttledLogger.Infof(
-							"Waiting, since pod '%s' init container '%s' is waiting to start: %s",
+							"Waiting, since pod %q init container %q is waiting to start: %s",
 							id,
 							c.Name,
 							c.State.Waiting.Reason,
 						)
 					} else {
 						throttledLogger.Infof(
-							"Waiting, since pod '%s' init container '%s' is waiting to start: %s (%s)",
+							"Waiting, since pod %q init container %q is waiting to start: %s (%s)",
 							id,
 							c.Name,
 							c.State.Waiting.Message,
@@ -106,7 +106,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 
 				if IsTerminated(containerStatus) && !Succeeded(containerStatus) {
 					return false, fmt.Errorf(
-						"pod '%s' init container '%s' is terminated: %s (%s)",
+						"pod %q init container %q is terminated: %s (%s)",
 						id,
 						c.Name,
 						c.State.Terminated.Message,
@@ -116,7 +116,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 
 				container, err := getContainer(pod.Spec.InitContainers, c.Name)
 				if err != nil {
-					throttledLogger.Infof("Could not find container '%s'", c.Name)
+					throttledLogger.Infof("Could not find container %q", c.Name)
 					return false, err
 				}
 
@@ -124,7 +124,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 				if restartable {
 					if !IsStarted(containerStatus) || !IsReady(containerStatus) {
 						throttledLogger.Infof(
-							"Waiting, since pod '%s' init container '%s' is not ready yet",
+							"Waiting, since pod %q init container %q is not ready yet",
 							id,
 							c.Name,
 						)
@@ -133,7 +133,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 				} else {
 					if IsRunning(containerStatus) {
 						throttledLogger.Infof(
-							"Waiting, since pod '%s' init container '%s' is running",
+							"Waiting, since pod %q init container %q is running",
 							id,
 							c.Name,
 						)
@@ -148,7 +148,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 				// delete succeeded pods
 				if IsTerminated(containerStatus) && Succeeded(containerStatus) {
 					// delete pod that is succeeded
-					log.Debugf("Delete Pod '%s' because it is succeeded", id)
+					log.Debugf("Delete Pod %q because it is succeeded", id)
 					err = k.waitPodDeleted(ctx, id)
 					if err != nil {
 						return false, err
@@ -160,7 +160,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 				if IsWaiting(containerStatus) {
 					if IsCritical(containerStatus) {
 						return false, fmt.Errorf(
-							"pod '%s' container '%s' is waiting to start: %s (%s)",
+							"pod %q container %q is waiting to start: %s (%s)",
 							id,
 							c.Name,
 							c.State.Waiting.Message,
@@ -169,14 +169,14 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 					}
 					if c.State.Waiting.Message == "" {
 						throttledLogger.Infof(
-							"Waiting, since pod '%s' container '%s' is waiting to start: %s",
+							"Waiting, since pod %q container %q is waiting to start: %s",
 							id,
 							c.Name,
 							c.State.Waiting.Reason,
 						)
 					} else {
 						throttledLogger.Infof(
-							"Waiting, since pod '%s' container '%s' is waiting to start: %s (%s)",
+							"Waiting, since pod %q container %q is waiting to start: %s (%s)",
 							id,
 							c.Name,
 							c.State.Waiting.Message,
@@ -189,7 +189,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 
 				if IsTerminated(containerStatus) {
 					return false, fmt.Errorf(
-						"pod '%s' container '%s' is terminated: %s (%s)",
+						"pod %q container %q is terminated: %s (%s)",
 						id,
 						c.Name,
 						c.State.Terminated.Message,
@@ -199,7 +199,7 @@ func (k *KubernetesDriver) waitPodRunning(ctx context.Context, id string) (*core
 
 				if !IsReady(containerStatus) {
 					throttledLogger.Infof(
-						"Waiting, since pod '%s' container '%s' is not ready yet",
+						"Waiting, since pod %q container %q is not ready yet",
 						id,
 						c.Name,
 					)

--- a/pkg/git/install.go
+++ b/pkg/git/install.go
@@ -41,7 +41,7 @@ func InstallBinary() error {
 }
 
 func installGitWithApt(writer, errwriter io.Writer) error {
-	log.Infof("Git command is missing, try to install git with apt...")
+	log.Infof("Git command is missing, try to install git with apt")
 
 	if err := runCmd(writer, errwriter, "apt", "update"); err != nil {
 		return fmt.Errorf("run apt update: %w", err)
@@ -55,7 +55,7 @@ func installGitWithApt(writer, errwriter io.Writer) error {
 }
 
 func installGitWithApk(writer, errwriter io.Writer) error {
-	log.Infof("Git command is missing, try to install git with apk...")
+	log.Infof("Git command is missing, try to install git with apk")
 
 	if err := runCmd(writer, errwriter, "apk", "update"); err != nil {
 		return fmt.Errorf("run apk update: %w", err)

--- a/pkg/gitcredentials/gitcredentials.go
+++ b/pkg/gitcredentials/gitcredentials.go
@@ -41,7 +41,7 @@ func ConfigureHelper(binaryPath, userName string, port int) error {
 		return err
 	}
 
-	helper := fmt.Sprintf(`helper = !%q internal agent git-credentials`, binaryPath)
+	helper := fmt.Sprintf(`helper = !'%s' internal agent git-credentials`, binaryPath)
 	if port != -1 {
 		helper += fmt.Sprintf(` --port %d`, port)
 	}

--- a/pkg/gitcredentials/gitcredentials.go
+++ b/pkg/gitcredentials/gitcredentials.go
@@ -41,7 +41,7 @@ func ConfigureHelper(binaryPath, userName string, port int) error {
 		return err
 	}
 
-	helper := fmt.Sprintf(`helper = !'%s' internal agent git-credentials`, binaryPath)
+	helper := fmt.Sprintf(`helper = !%q internal agent git-credentials`, binaryPath)
 	if port != -1 {
 		helper += fmt.Sprintf(` --port %d`, port)
 	}
@@ -158,7 +158,7 @@ func SetUser(userName string, user *GitUser) error {
 		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf(
-				"set user.name '%s': %w",
+				"set user.name %q: %w",
 				strings.Join(args, " "),
 				command.WrapCommandError(out, err),
 			)
@@ -176,7 +176,7 @@ func SetUser(userName string, user *GitUser) error {
 		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
 		if err != nil {
 			return fmt.Errorf(
-				"set user.email '%s': %w",
+				"set user.email %q: %w",
 				strings.Join(args, " "),
 				command.WrapCommandError(out, err),
 			)

--- a/pkg/gitsshsigning/helper.go
+++ b/pkg/gitsshsigning/helper.go
@@ -83,7 +83,7 @@ func createHelperScript() error {
 		"sudo",
 		"bash",
 		"-c",
-		fmt.Sprintf("echo '%s' > %s", HelperScript, pkgconfig.SSHSignatureHelperPath),
+		fmt.Sprintf("echo %q > %s", HelperScript, pkgconfig.SSHSignatureHelperPath),
 	)
 	if err := cmd.Run(); err != nil {
 		return err

--- a/pkg/gitsshsigning/helper.go
+++ b/pkg/gitsshsigning/helper.go
@@ -83,7 +83,7 @@ func createHelperScript() error {
 		"sudo",
 		"bash",
 		"-c",
-		fmt.Sprintf("echo %q > %s", HelperScript, pkgconfig.SSHSignatureHelperPath),
+		fmt.Sprintf("echo '%s' > %s", HelperScript, pkgconfig.SSHSignatureHelperPath),
 	)
 	if err := cmd.Run(); err != nil {
 		return err

--- a/pkg/gpg/gpg_forwarding.go
+++ b/pkg/gpg/gpg_forwarding.go
@@ -32,7 +32,7 @@ func IsGpgTunnelRunning(
 
 	command := "gpg -K"
 	if user != "" && user != "root" {
-		command = fmt.Sprintf("su -c %q %q", command, user)
+		command = fmt.Sprintf("su -c \"%s\" '%s'", command, user)
 	}
 
 	// capture the output, if it's empty it means we don't have gpg-forwarding

--- a/pkg/gpg/gpg_forwarding.go
+++ b/pkg/gpg/gpg_forwarding.go
@@ -32,7 +32,7 @@ func IsGpgTunnelRunning(
 
 	command := "gpg -K"
 	if user != "" && user != "root" {
-		command = fmt.Sprintf("su -c \"%s\" '%s'", command, user)
+		command = fmt.Sprintf("su -c %q %q", command, user)
 	}
 
 	// capture the output, if it's empty it means we don't have gpg-forwarding

--- a/pkg/ide/codeserver/codeserver.go
+++ b/pkg/ide/codeserver/codeserver.go
@@ -170,7 +170,7 @@ func (c *CodeServer) Start() error {
 	userDataDir := filepath.Join(homeFolder, ".local", "share", "code-server")
 
 	return command.StartBackgroundOnce("code-server", func() (*exec.Cmd, error) {
-		log.Infof("Starting code-server in background...")
+		log.Infof("Starting code-server in background")
 		// --auth none is safe for clients outside the container because the
 		// only published path is the devsy port-forward tunnel, which is
 		// itself authenticated. Intra-container access is still unauthenticated.
@@ -217,7 +217,7 @@ func (c *CodeServer) installExtensions() error {
 	binaryPath := filepath.Join(location, "bin", "code-server")
 	var failed []string
 	for _, extension := range c.extensions {
-		log.Info("Install extension " + extension + "...")
+		log.Info("Install extension " + extension + "")
 		runCommand := fmt.Sprintf("%s --install-extension %q", binaryPath, extension)
 		cmd := suOrSh(c.userName, runCommand, "")
 		cmd.Stdout = out

--- a/pkg/ide/codeserver/codeserver.go
+++ b/pkg/ide/codeserver/codeserver.go
@@ -175,7 +175,7 @@ func (c *CodeServer) Start() error {
 		// only published path is the devsy port-forward tunnel, which is
 		// itself authenticated. Intra-container access is still unauthenticated.
 		runCommand := fmt.Sprintf(
-			"%s --bind-addr '%s' --user-data-dir '%s' --auth none "+
+			"%s --bind-addr %q --user-data-dir %q --auth none "+
 				"--disable-telemetry --disable-update-check",
 			binaryPath, c.host+":"+c.port, userDataDir,
 		)
@@ -218,7 +218,7 @@ func (c *CodeServer) installExtensions() error {
 	var failed []string
 	for _, extension := range c.extensions {
 		log.Info("Install extension " + extension + "...")
-		runCommand := fmt.Sprintf("%s --install-extension '%s'", binaryPath, extension)
+		runCommand := fmt.Sprintf("%s --install-extension %q", binaryPath, extension)
 		cmd := suOrSh(c.userName, runCommand, "")
 		cmd.Stdout = out
 		cmd.Stderr = out

--- a/pkg/ide/codeserver/codeserver.go
+++ b/pkg/ide/codeserver/codeserver.go
@@ -217,7 +217,7 @@ func (c *CodeServer) installExtensions() error {
 	binaryPath := filepath.Join(location, "bin", "code-server")
 	var failed []string
 	for _, extension := range c.extensions {
-		log.Info("Install extension " + extension + "")
+		log.Info("Install extension " + extension)
 		runCommand := fmt.Sprintf("%s --install-extension %q", binaryPath, extension)
 		cmd := suOrSh(c.userName, runCommand, "")
 		cmd.Stdout = out

--- a/pkg/ide/fleet/fleet.go
+++ b/pkg/ide/fleet/fleet.go
@@ -82,7 +82,7 @@ func (o *FleetServer) Install(projectDir string) error {
 	}
 
 	// download binary
-	log.Infof("Downloading fleet...")
+	log.Infof("Downloading fleet")
 	resp, err := devsyhttp.GetHTTPClient().Get(url)
 	if err != nil {
 		return err
@@ -126,7 +126,7 @@ func (o *FleetServer) Start(binaryPath, location, projectDir string) error {
 	stderrBuffer := &bytes.Buffer{}
 
 	err := command.StartBackgroundOnce("fleet", func() (*exec.Cmd, error) {
-		log.Infof("Starting fleet in background...")
+		log.Infof("Starting fleet in background")
 		// Determine version of fleet to use
 		var runCommand string
 		version := Options.GetValue(o.values, VersionOption)

--- a/pkg/ide/fleet/fleet.go
+++ b/pkg/ide/fleet/fleet.go
@@ -132,14 +132,15 @@ func (o *FleetServer) Start(binaryPath, location, projectDir string) error {
 		version := Options.GetValue(o.values, VersionOption)
 		if version == "latest" {
 			runCommand = fmt.Sprintf(
-				"%s launch workspace -- --projectDir '%s' --cache-path '%s' --auth=accept-everyone --publish --enableSmartMode",
+				"%s launch workspace -- --projectDir %q --cache-path %q --auth=accept-everyone --publish --enableSmartMode",
 				binaryPath,
 				projectDir,
 				location,
 			)
 		} else {
 			runCommand = fmt.Sprintf(
-				"%s launch workspace --workspace-version %s -- --projectDir '%s' --cache-path '%s' --auth=accept-everyone --publish --enableSmartMode",
+				"%s launch workspace --workspace-version %s -- --projectDir %q --cache-path %q "+
+					"--auth=accept-everyone --publish --enableSmartMode",
 				binaryPath,
 				version,
 				projectDir,

--- a/pkg/ide/ideparse/parse.go
+++ b/pkg/ide/ideparse/parse.go
@@ -302,7 +302,7 @@ func GetIDEOptions(ide string) (ide.Options, error) {
 			allowedIDEArray = append(allowedIDEArray, string(a.Name))
 		}
 
-		return nil, fmt.Errorf("unrecognized ide '%s', please use one of: %v", ide, allowedIDEArray)
+		return nil, fmt.Errorf("unrecognized ide %q, use one of: %v", ide, allowedIDEArray)
 	}
 
 	return match.Options, nil
@@ -322,7 +322,7 @@ func ParseOptions(options []string, ideOptions ide.Options) (map[string]config.O
 	for _, option := range options {
 		splitted := strings.Split(option, "=")
 		if len(splitted) == 1 {
-			return nil, fmt.Errorf("invalid option '%s', expected format KEY=VALUE", option)
+			return nil, fmt.Errorf("invalid option %q, expected format KEY=VALUE", option)
 		}
 
 		key := strings.ToUpper(strings.TrimSpace(splitted[0]))
@@ -330,7 +330,7 @@ func ParseOptions(options []string, ideOptions ide.Options) (map[string]config.O
 		ideOption, ok := ideOptions[key]
 		if !ok {
 			return nil, fmt.Errorf(
-				"invalid option '%s', allowed options are: %v",
+				"invalid option %q, allowed options are: %v",
 				key,
 				allowedOptions,
 			)
@@ -348,7 +348,7 @@ func ParseOptions(options []string, ideOptions ide.Options) (map[string]config.O
 				}
 
 				return nil, fmt.Errorf(
-					"invalid value '%s' for option '%s', has to match the following regEx: %s",
+					"invalid value %q for option %q, has to match the following regEx: %s",
 					value,
 					key,
 					ideOption.ValidationPattern,
@@ -360,7 +360,7 @@ func ParseOptions(options []string, ideOptions ide.Options) (map[string]config.O
 			found := slices.Contains(ideOption.Enum, value)
 			if !found {
 				return nil, fmt.Errorf(
-					"invalid value '%s' for option '%s', has to match one of the following values: %v",
+					"invalid value %q for option %q, has to match one of the following values: %v",
 					value,
 					key,
 					ideOption.Enum,

--- a/pkg/ide/jetbrains/generic.go
+++ b/pkg/ide/jetbrains/generic.go
@@ -84,7 +84,7 @@ type GenericJetBrainsServer struct {
 }
 
 func (o *GenericJetBrainsServer) OpenGateway(workspaceFolder, workspaceID string) error {
-	log.Infof("Starting %s through JetBrains Gateway...", o.options.DisplayName)
+	log.Infof("Starting %s through JetBrains Gateway", o.options.DisplayName)
 	err := devsyopen.Run(
 		`jetbrains-gateway://connect#idePath=` + url.QueryEscape(
 			o.getDirectory(path.Join("/", "home", o.userName)),

--- a/pkg/ide/jetbrains/generic.go
+++ b/pkg/ide/jetbrains/generic.go
@@ -98,7 +98,7 @@ func (o *GenericJetBrainsServer) OpenGateway(workspaceFolder, workspaceID string
 		log.Debugf("Error opening jetbrains-gateway: %v", err)
 		log.Errorf(
 			"Seems like you don't have JetBrains Gateway installed on your computer. " +
-				"Please install JetBrains Gateway via https://www.jetbrains.com/remote-development/gateway/",
+				"Install JetBrains Gateway via https://www.jetbrains.com/remote-development/gateway/",
 		)
 		return err
 	}

--- a/pkg/ide/jupyter/jupyter.go
+++ b/pkg/ide/jupyter/jupyter.go
@@ -54,8 +54,8 @@ func (o *JupyterNotbookServer) Start() error {
 	return command.StartBackgroundOnce("jupyter", func() (*exec.Cmd, error) {
 		log.Infof("Starting jupyter notebook in background")
 		runCommand := fmt.Sprintf(
-			"jupyter notebook --ip='*' --NotebookApp.notebook_dir='%s' --NotebookApp.token='' "+
-				"--NotebookApp.password='' --no-browser --port '%s' --allow-root",
+			"jupyter notebook --ip='*' --NotebookApp.notebook_dir=%q --NotebookApp.token='' "+
+				"--NotebookApp.password='' --no-browser --port %q --allow-root",
 			o.workspaceFolder,
 			strconv.Itoa(DefaultServerPort),
 		)

--- a/pkg/ide/jupyter/jupyter.go
+++ b/pkg/ide/jupyter/jupyter.go
@@ -54,8 +54,8 @@ func (o *JupyterNotbookServer) Start() error {
 	return command.StartBackgroundOnce("jupyter", func() (*exec.Cmd, error) {
 		log.Infof("Starting jupyter notebook in background")
 		runCommand := fmt.Sprintf(
-			"jupyter notebook --ip='*' --NotebookApp.notebook_dir=%q --NotebookApp.token='' "+
-				"--NotebookApp.password='' --no-browser --port %q --allow-root",
+			"jupyter notebook --ip='*' --NotebookApp.notebook_dir='%s' --NotebookApp.token='' "+
+				"--NotebookApp.password='' --no-browser --port '%s' --allow-root",
 			o.workspaceFolder,
 			strconv.Itoa(DefaultServerPort),
 		)

--- a/pkg/ide/marimo/marimo.go
+++ b/pkg/ide/marimo/marimo.go
@@ -61,7 +61,7 @@ func (o *MarimoServer) Start() error {
 	return command.StartBackgroundOnce("marimo", func() (*exec.Cmd, error) {
 		log.Infof("Starting marimo in background")
 		runCommand := fmt.Sprintf(
-			"marimo edit --headless --host 0.0.0.0 --port %s --no-token '%s'",
+			"marimo edit --headless --host 0.0.0.0 --port %s --no-token %q",
 			strconv.Itoa(DefaultServerPort),
 			o.workspaceFolder,
 		)

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -473,7 +473,7 @@ func startFleet(ctx context.Context, params IDEParams) (string, error) {
 		"Fleet is exposed at a publicly reachable URL, make sure to not disclose this URL " +
 			"to anyone as they will be able to reach your workspace from that",
 	)
-	pkglog.Infof("Starting Fleet at %s ...", url)
+	pkglog.Infof("Starting Fleet at %s ", url)
 	if err := open2.Run(url); err != nil {
 		return "", err
 	}

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -470,7 +470,7 @@ func startFleet(ctx context.Context, params IDEParams) (string, error) {
 		return url, nil
 	}
 	pkglog.Warnf(
-		"Fleet is exposed at a publicly reachable URL, please make sure to not disclose this URL " +
+		"Fleet is exposed at a publicly reachable URL, make sure to not disclose this URL " +
 			"to anyone as they will be able to reach your workspace from that",
 	)
 	pkglog.Infof("Starting Fleet at %s ...", url)

--- a/pkg/ide/openvscode/openvscode.go
+++ b/pkg/ide/openvscode/openvscode.go
@@ -180,7 +180,7 @@ func (o *OpenVSCodeServer) installExtensions() error {
 
 	binaryPath := filepath.Join(location, "bin", "openvscode-server")
 	for _, extension := range o.extensions {
-		log.Info("Install extension " + extension + "...")
+		log.Info("Install extension " + extension + "")
 		runCommand := fmt.Sprintf("%s --install-extension %q", binaryPath, extension)
 		args := []string{}
 		if o.userName != "" {
@@ -252,7 +252,7 @@ func (o *OpenVSCodeServer) Start() error {
 	}
 
 	return command.StartBackgroundOnce("openvscode", func() (*exec.Cmd, error) {
-		log.Infof("Starting openvscode in background...")
+		log.Infof("Starting openvscode in background")
 		runCommand := fmt.Sprintf(
 			"%s server-local --without-connection-token --host %q --port %q",
 			binaryPath,

--- a/pkg/ide/openvscode/openvscode.go
+++ b/pkg/ide/openvscode/openvscode.go
@@ -181,7 +181,7 @@ func (o *OpenVSCodeServer) installExtensions() error {
 	binaryPath := filepath.Join(location, "bin", "openvscode-server")
 	for _, extension := range o.extensions {
 		log.Info("Install extension " + extension)
-		runCommand := fmt.Sprintf("%s --install-extension %q", binaryPath, extension)
+		runCommand := fmt.Sprintf("%s --install-extension '%s'", binaryPath, extension)
 		args := []string{}
 		if o.userName != "" {
 			args = append(args, "su", o.userName, "-c", runCommand)
@@ -254,7 +254,7 @@ func (o *OpenVSCodeServer) Start() error {
 	return command.StartBackgroundOnce("openvscode", func() (*exec.Cmd, error) {
 		log.Infof("Starting openvscode in background")
 		runCommand := fmt.Sprintf(
-			"%s server-local --without-connection-token --host %q --port %q",
+			"%s server-local --without-connection-token --host '%s' --port '%s'",
 			binaryPath,
 			o.host,
 			o.port,

--- a/pkg/ide/openvscode/openvscode.go
+++ b/pkg/ide/openvscode/openvscode.go
@@ -180,7 +180,7 @@ func (o *OpenVSCodeServer) installExtensions() error {
 
 	binaryPath := filepath.Join(location, "bin", "openvscode-server")
 	for _, extension := range o.extensions {
-		log.Info("Install extension " + extension + "")
+		log.Info("Install extension " + extension)
 		runCommand := fmt.Sprintf("%s --install-extension %q", binaryPath, extension)
 		args := []string{}
 		if o.userName != "" {

--- a/pkg/ide/openvscode/openvscode.go
+++ b/pkg/ide/openvscode/openvscode.go
@@ -181,7 +181,7 @@ func (o *OpenVSCodeServer) installExtensions() error {
 	binaryPath := filepath.Join(location, "bin", "openvscode-server")
 	for _, extension := range o.extensions {
 		log.Info("Install extension " + extension + "...")
-		runCommand := fmt.Sprintf("%s --install-extension '%s'", binaryPath, extension)
+		runCommand := fmt.Sprintf("%s --install-extension %q", binaryPath, extension)
 		args := []string{}
 		if o.userName != "" {
 			args = append(args, "su", o.userName, "-c", runCommand)
@@ -254,7 +254,7 @@ func (o *OpenVSCodeServer) Start() error {
 	return command.StartBackgroundOnce("openvscode", func() (*exec.Cmd, error) {
 		log.Infof("Starting openvscode in background...")
 		runCommand := fmt.Sprintf(
-			"%s server-local --without-connection-token --host '%s' --port '%s'",
+			"%s server-local --without-connection-token --host %q --port %q",
 			binaryPath,
 			o.host,
 			o.port,

--- a/pkg/ide/rstudio/rstudio.go
+++ b/pkg/ide/rstudio/rstudio.go
@@ -122,7 +122,7 @@ func (o *RStudioServer) Install() error {
 
 func (o *RStudioServer) Start() error {
 	return command.StartBackgroundOnce("rstudio", func() (*exec.Cmd, error) {
-		log.Info("Starting RStudio...")
+		log.Info("Starting RStudio")
 		runCommand := "rstudio-server start"
 		args := []string{}
 		if o.userName != "" {

--- a/pkg/ide/vscode/apk.go
+++ b/pkg/ide/vscode/apk.go
@@ -27,7 +27,7 @@ func InstallAPKRequirements() {
 		// Wolfi-based distros don't need this, and Wolfi doesn't have it.
 		dependencies = append(dependencies, "gcompat")
 	}
-	log.Debugf("Install apk requirements...")
+	log.Debugf("Install apk requirements")
 	if !command.Exists("git") {
 		dependencies = append(dependencies, "git")
 	}

--- a/pkg/ide/zed/zed.go
+++ b/pkg/ide/zed/zed.go
@@ -17,7 +17,7 @@ func Open(
 	values map[string]config.OptionValue,
 	userName, workspaceFolder, workspaceID string,
 ) error {
-	log.Info("Opening Zed editor...")
+	log.Info("Opening Zed editor")
 
 	if len(workspaceFolder) == 0 || workspaceFolder[0] != '/' {
 		workspaceFolder = fmt.Sprintf("/%s", workspaceFolder)

--- a/pkg/ide/zed/zed_linux.go
+++ b/pkg/ide/zed/zed_linux.go
@@ -17,7 +17,7 @@ func Open(
 	values map[string]config.OptionValue,
 	userName, workspaceFolder, workspaceID string,
 ) error {
-	log.Info("Opening Zed editor...")
+	log.Info("Opening Zed editor")
 
 	if len(workspaceFolder) == 0 || workspaceFolder[0] != '/' {
 		workspaceFolder = fmt.Sprintf("/%s", workspaceFolder)

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -99,8 +99,8 @@ func GetImageConfig(
 	ctx context.Context,
 	image string,
 ) (*v1.ConfigFile, v1.Image, error) {
-	log.Debugf("Getting image config for image '%s'", image)
-	defer log.Debugf("Done getting image config for image '%s'", image)
+	log.Debugf("Getting image config for image %q", image)
+	defer log.Debugf("Done getting image config for image %q", image)
 
 	img, err := GetImage(ctx, image)
 	if err != nil {
@@ -136,8 +136,8 @@ func GetImageConfigForArch(
 	ctx context.Context,
 	image, arch string,
 ) (*v1.ConfigFile, v1.Image, error) {
-	log.Debugf("Getting image config for image '%s' with architecture '%s'", image, arch)
-	defer log.Debugf("Done getting image config for image '%s' with architecture '%s'", image, arch)
+	log.Debugf("Getting image config for image %q with architecture %q", image, arch)
+	defer log.Debugf("Done getting image config for image %q with architecture %q", image, arch)
 
 	img, err := GetImageForArch(ctx, image, arch)
 	if err != nil {

--- a/pkg/language/language.go
+++ b/pkg/language/language.go
@@ -143,7 +143,7 @@ func DefaultConfig(startPath string) *config.DevContainerConfig {
 		return MapConfig[None]
 	}
 
-	log.Infof("Detected project language '%s'", language)
+	log.Infof("Detected project language %q", language)
 	return MapConfig[language]
 }
 

--- a/pkg/options/resolve_test.go
+++ b/pkg/options/resolve_test.go
@@ -707,5 +707,5 @@ func optionsToSubCommand(optionDefinitions config.OptionDefinitions) string {
 	out, _ := json.Marshal(&provider.SubOptions{
 		Options: optionDefinitions,
 	})
-	return fmt.Sprintf("echo '%s' | base64 --decode", base64.StdEncoding.EncodeToString(out))
+	return fmt.Sprintf("echo %q | base64 --decode", base64.StdEncoding.EncodeToString(out))
 }

--- a/pkg/options/resolver/parse.go
+++ b/pkg/options/resolver/parse.go
@@ -44,7 +44,7 @@ func validateUserValue(optionName, userValue string, option *types.Option) error
 			}
 
 			return fmt.Errorf(
-				"invalid value '%s' for option '%s', has to match the following regEx: %s",
+				"invalid value %q for option %q, has to match the following regEx: %s",
 				userValue,
 				optionName,
 				option.ValidationPattern,
@@ -62,7 +62,7 @@ func validateUserValue(optionName, userValue string, option *types.Option) error
 		}
 		if !found {
 			return fmt.Errorf(
-				"invalid value '%s' for option '%s', has to match one of the following values: %v",
+				"invalid value %q for option %q, has to match one of the following values: %v",
 				userValue,
 				optionName,
 				option.Enum,
@@ -76,7 +76,7 @@ func validateUserValue(optionName, userValue string, option *types.Option) error
 			_, err := strconv.ParseInt(userValue, 10, 64)
 			if err != nil {
 				return fmt.Errorf(
-					"invalid value '%s' for option '%s', must be a number",
+					"invalid value %q for option %q, must be a number",
 					userValue,
 					optionName,
 				)
@@ -85,7 +85,7 @@ func validateUserValue(optionName, userValue string, option *types.Option) error
 			_, err := strconv.ParseBool(userValue)
 			if err != nil {
 				return fmt.Errorf(
-					"invalid value '%s' for option '%s', must be a boolean",
+					"invalid value %q for option %q, must be a boolean",
 					userValue,
 					optionName,
 				)
@@ -94,7 +94,7 @@ func validateUserValue(optionName, userValue string, option *types.Option) error
 			_, err := time.ParseDuration(userValue)
 			if err != nil {
 				return fmt.Errorf(
-					"invalid value '%s' for option '%s', must be a duration like 10s, 5m or 24h",
+					"invalid value %q for option %q, must be a duration like 10s, 5m or 24h",
 					userValue,
 					optionName,
 				)

--- a/pkg/options/resolver/resolve.go
+++ b/pkg/options/resolver/resolve.go
@@ -154,7 +154,7 @@ func (r *Resolver) resolveOption(
 		// check if there is only one option
 		log.Info(option.Description)
 		answer, err := log.QuestionDefault(&survey.QuestionOptions{
-			Question:               fmt.Sprintf("Please enter a value for %s", optionName),
+			Question:               fmt.Sprintf("Enter a value for %s", optionName),
 			Options:                questionOpts,
 			ValidationRegexPattern: option.ValidationPattern,
 			ValidationMessage:      option.ValidationMessage,

--- a/pkg/options/resolver/util.go
+++ b/pkg/options/resolver/util.go
@@ -55,14 +55,14 @@ func addDependency(
 		if childExists && childOption != nil {
 			if !option.Global && childOption.Global {
 				return fmt.Errorf(
-					"cannot use a global option as a dependency of a non-global option. Option '%s' used in children of option '%s'",
+					"cannot use a global option as a dependency of a non-global option. Option %q used in children of option %q",
 					childName,
 					optionName,
 				)
 			}
 			if option.Local && !childOption.Local {
 				return fmt.Errorf(
-					"cannot use a non-local option as a dependency of a local option. Option '%s' used in children of option '%s'",
+					"cannot use a non-local option as a dependency of a local option. Option %q used in children of option %q",
 					childName,
 					optionName,
 				)
@@ -81,14 +81,14 @@ func addDependency(
 		if depExists && depOption != nil {
 			if option.Global && !depOption.Global {
 				return fmt.Errorf(
-					"cannot use a non-global option as a dependency of a global option. Option '%s' used in default of option '%s'",
+					"cannot use a non-global option as a dependency of a global option. Option %q used in default of option %q",
 					dep,
 					optionName,
 				)
 			}
 			if !option.Local && depOption.Local {
 				return fmt.Errorf(
-					"cannot use a local option as a dependency of a non-local option. Option '%s' used in default of option '%s'",
+					"cannot use a local option as a dependency of a non-local option. Option %q used in default of option %q",
 					dep,
 					optionName,
 				)
@@ -107,14 +107,14 @@ func addDependency(
 		if depExists && depOption != nil {
 			if option.Global && !depOption.Global {
 				return fmt.Errorf(
-					"cannot use a non-global option as a dependency of a global option. Option '%s' used in command of option '%s'",
+					"cannot use a non-global option as a dependency of a global option. Option %q used in command of option %q",
 					dep,
 					optionName,
 				)
 			}
 			if !option.Local && depOption.Local {
 				return fmt.Errorf(
-					"cannot use a local option as a dependency of a non-local option. Option '%s' used in command of option '%s'",
+					"cannot use a local option as a dependency of a non-local option. Option %q used in command of option %q",
 					dep,
 					optionName,
 				)

--- a/pkg/platform/client/client.go
+++ b/pkg/platform/client/client.go
@@ -36,7 +36,7 @@ var CacheFolder string
 var DefaultCacheConfig string
 
 // Copied from platform `pkg/authentication/registry.go`.
-var ErrAccessKeyNotFound = fmt.Errorf("platform access key not found. Please login again")
+var ErrAccessKeyNotFound = fmt.Errorf("platform access key not found. Login again")
 
 const (
 	VersionPath   = "%s/version"
@@ -261,7 +261,7 @@ type keyStruct struct {
 func verifyHost(host string) error {
 	if !strings.HasPrefix(host, "https") {
 		return fmt.Errorf(
-			"cannot log into a non https loft instance '%s', please make sure you have TLS enabled",
+			"cannot log into a non https loft instance %q, make sure you have TLS enabled",
 			host,
 		)
 	}
@@ -315,14 +315,15 @@ func (c *client) Login(host string, insecure bool) error {
 	err = devsyopen.Run(fmt.Sprintf(LoginPath, host))
 	if err != nil {
 		return fmt.Errorf(
-			"couldn't open the login page in a browser: %w. Please use the --access-key flag for the login command. "+
+			"couldn't open the login page in a browser: %w. Use the --access-key flag for the login command. "+
 				"You can generate an access key here: %s",
 			err,
 			fmt.Sprintf(AccessKeyPath, host),
 		)
 	} else {
-		log.Infof("If the browser does not open automatically, please navigate to %s", loginUrl)
-		msg := "If you have problems logging in, please navigate to %s/profile/access-keys, click on 'Create Access Key' and then login via '%s %s --access-key ACCESS_KEY"
+		log.Infof("If the browser does not open automatically, navigate to %s", loginUrl)
+		msg := "If you have problems logging in, navigate to %s/profile/access-keys, " +
+			"click on 'Create Access Key' and then login via '%s %s --access-key ACCESS_KEY"
 		if insecure {
 			msg += " --insecure"
 		}
@@ -403,7 +404,7 @@ func (c *client) LoginWithAccessKey(host, accessKey string, insecure bool, force
 			var err x509.UnknownAuthorityError
 			if errors.As(urlError.Err, &err) {
 				return fmt.Errorf(
-					"unsafe login endpoint '%s', if you wish to login into an insecure loft endpoint run with the '--insecure' flag",
+					"unsafe login endpoint %q, if you wish to login into an insecure loft endpoint run with the '--insecure' flag",
 					c.config.Host,
 				)
 			}
@@ -442,7 +443,7 @@ func VerifyVersion(baseClient Client) error {
 
 	if int(cliVersion.Major) > backendMajor {
 		return fmt.Errorf(
-			"unsupported %[1]s version %[2]s. Please downgrade your CLI to below v%[3]d.0.0 to support this version, "+
+			"unsupported %[1]s version %[2]s. Downgrade your CLI to below v%[3]d.0.0 to support this version, "+
 				"as %[1]s v%[3]d.0.0 and newer versions are incompatible with v%[4]d.x.x",
 			pkgconfig.ProductNamePro,
 			v.Version,
@@ -451,7 +452,7 @@ func VerifyVersion(baseClient Client) error {
 		)
 	} else if int(cliVersion.Major) < backendMajor {
 		return fmt.Errorf(
-			"unsupported %[1]s version %[2]s. Please upgrade your CLI to v%[3]d.0.0 or above to support this version, "+
+			"unsupported %[1]s version %[2]s. Upgrade your CLI to v%[3]d.0.0 or above to support this version, "+
 				"as %[1]s v%[3]d.0.0 and newer versions are incompatible with v%[4]d.x.x",
 			pkgconfig.ProductNamePro,
 			v.Version,

--- a/pkg/platform/client/client.go
+++ b/pkg/platform/client/client.go
@@ -329,7 +329,7 @@ func (c *client) Login(host string, insecure bool) error {
 		}
 		msg += "'"
 		log.Infof(msg, host, pkgconfig.BinaryName+" pro login", host)
-		log.Infof("Logging into Devsy Pro...")
+		log.Infof("Logging into Devsy Pro")
 
 		key = <-keyChannel
 	}

--- a/pkg/platform/deploy.go
+++ b/pkg/platform/deploy.go
@@ -89,7 +89,7 @@ func WaitForPodReady(
 						Raw()
 					if err != nil {
 						return false, fmt.Errorf(
-							"there seems to be an issue with %s starting up: %s (%s). Please reach out to our support at https://devsy.sh/",
+							"there seems to be an issue with %s starting up: %s (%s). Reach out to our support at https://devsy.sh/",
 							pkgconfig.ProductNamePro,
 							message,
 							reason,
@@ -102,7 +102,7 @@ func WaitForPodReady(
 						return false, fmt.Errorf(
 							"%[1]s logs: \n%[2]v \nThere seems to be an issue with %[1]s starting up. "+
 								"Looks like you try to install %[1]s into an air-gapped environment, "+
-								"please reach out to our support at https://devsy.sh/ for an offline license",
+								"reach out to our support at https://devsy.sh/ for an offline license",
 							pkgconfig.ProductNamePro,
 							string(out),
 						)
@@ -110,7 +110,7 @@ func WaitForPodReady(
 
 					return false, fmt.Errorf(
 						"%[1]s logs: \n%v \nThere seems to be an issue with %[1]s starting up: %[2]s (%[3]s). "+
-							"Please reach out to our support at https://devsy.sh/",
+							"Reach out to our support at https://devsy.sh/",
 						pkgconfig.ProductNamePro,
 						string(out),
 						message,
@@ -119,20 +119,20 @@ func WaitForPodReady(
 				} else if containerStatus.State.Waiting != nil && time.Now().After(now.Add(time.Second*10)) {
 					if containerStatus.State.Waiting.Message != "" {
 						log.Infof(
-							"Please keep waiting, %s container is still starting up: %s (%s)",
+							"Keep waiting, %s container is still starting up: %s (%s)",
 							pkgconfig.ProductNamePro,
 							containerStatus.State.Waiting.Message,
 							containerStatus.State.Waiting.Reason,
 						)
 					} else if containerStatus.State.Waiting.Reason != "" {
 						log.Infof(
-							"Please keep waiting, %s container is still starting up: %s",
+							"Keep waiting, %s container is still starting up: %s",
 							pkgconfig.ProductNamePro,
 							containerStatus.State.Waiting.Reason,
 						)
 					} else {
 						log.Infof(
-							"Please keep waiting, %s container is still starting up...",
+							"Keep waiting, %s container is still starting up...",
 							pkgconfig.ProductNamePro,
 						)
 					}

--- a/pkg/platform/deploy.go
+++ b/pkg/platform/deploy.go
@@ -49,7 +49,7 @@ func WaitForPodReady(
 				return false, nil
 			} else if len(pods.Items) == 0 {
 				if time.Now().After(now.Add(time.Second * 10)) {
-					log.Infof("Still waiting for a %s pod...", pkgconfig.ProductNamePro)
+					log.Infof("Still waiting for a %s pod", pkgconfig.ProductNamePro)
 					now = time.Now()
 				}
 				return false, nil
@@ -132,7 +132,7 @@ func WaitForPodReady(
 						)
 					} else {
 						log.Infof(
-							"Keep waiting, %s container is still starting up...",
+							"Keep waiting, %s container is still starting up",
 							pkgconfig.ProductNamePro,
 						)
 					}

--- a/pkg/platform/version.go
+++ b/pkg/platform/version.go
@@ -53,7 +53,7 @@ func GetDevsyVersion(url string) (string, error) {
 	}
 	if version.DevsyVersion == "" {
 		return "", fmt.Errorf(
-			"unexpected version '%s', please use --version to define a provider version",
+			"unexpected version %q, use --version to define a provider version",
 			version.DevsyVersion,
 		)
 	}

--- a/pkg/provider/parse.go
+++ b/pkg/provider/parse.go
@@ -69,7 +69,7 @@ func validate(config *ProviderConfig) error {
 	for optionName, optionValue := range config.Options {
 		if optionNameRegEx.MatchString(optionName) {
 			return fmt.Errorf(
-				"provider option '%s' can only consist of upper case letters, numbers or underscores, "+
+				"provider option %q can only consist of upper case letters, numbers or underscores, "+
 					"e.g. MY_OPTION, MY_OTHER_OPTION",
 				optionName,
 			)
@@ -80,7 +80,7 @@ func validate(config *ProviderConfig) error {
 			_, err := regexp.Compile(optionValue.ValidationPattern)
 			if err != nil {
 				return fmt.Errorf(
-					"error parsing validation pattern '%s' for option '%s': %w",
+					"error parsing validation pattern %q for option %q: %w",
 					optionValue.ValidationPattern, optionName, err,
 				)
 			}
@@ -88,18 +88,18 @@ func validate(config *ProviderConfig) error {
 
 		if optionValue.Default != "" && optionValue.Command != "" {
 			return fmt.Errorf(
-				"default and command cannot be used together in option '%s'",
+				"default and command cannot be used together in option %q",
 				optionName,
 			)
 		}
 
 		if optionValue.Global && optionValue.Cache != "" {
-			return fmt.Errorf("global and cache cannot be used together in option '%s'", optionName)
+			return fmt.Errorf("global and cache cannot be used together in option %q", optionName)
 		}
 
 		if optionValue.Global && optionValue.Mutable {
 			return fmt.Errorf(
-				"global and mutable cannot be used together in option '%s'",
+				"global and mutable cannot be used together in option %q",
 				optionName,
 			)
 		}
@@ -107,20 +107,20 @@ func validate(config *ProviderConfig) error {
 		if optionValue.Cache != "" {
 			_, err := time.ParseDuration(optionValue.Cache)
 			if err != nil {
-				return fmt.Errorf("invalid cache value for option '%s': %w", optionName, err)
+				return fmt.Errorf("invalid cache value for option %q: %w", optionName, err)
 			}
 		}
 
 		if optionValue.Type != "" && !contains(allowedTypes, optionValue.Type) {
 			return fmt.Errorf(
-				"type can only be one of in option '%s': %v",
+				"type can only be one of in option %q: %v",
 				optionName,
 				allowedTypes,
 			)
 		}
 
 		if optionValue.Cache != "" && optionValue.Command == "" {
-			return fmt.Errorf("cache can only be used with command in option '%s'", optionName)
+			return fmt.Errorf("cache can only be used with command in option %q", optionName)
 		}
 	}
 
@@ -318,7 +318,7 @@ func validateBinaries(prefix string, binaries map[string][]*ProviderBinary) erro
 	for binaryName, binaryArr := range binaries {
 		if optionNameRegEx.MatchString(binaryName) {
 			return fmt.Errorf(
-				"binary name '%s' can only consist of upper case letters, numbers or underscores, e.g. MY_BINARY, KUBECTL",
+				"binary name %q can only consist of upper case letters, numbers or underscores, e.g. MY_BINARY, KUBECTL",
 				binaryName,
 			)
 		}
@@ -326,7 +326,7 @@ func validateBinaries(prefix string, binaries map[string][]*ProviderBinary) erro
 		for _, binary := range binaryArr {
 			if binary.OS != "linux" && binary.OS != "darwin" && binary.OS != "windows" {
 				return fmt.Errorf(
-					"unsupported binary operating system '%s', must be 'linux', 'darwin' or 'windows'",
+					"unsupported binary operating system %q, must be 'linux', 'darwin' or 'windows'",
 					binary.OS,
 				)
 			}
@@ -360,7 +360,7 @@ func ParseOptions(options []string) (map[string]string, error) {
 	for _, option := range options {
 		splitted := strings.Split(option, "=")
 		if len(splitted) == 1 {
-			return nil, fmt.Errorf("invalid option '%s', expected format KEY=VALUE", option)
+			return nil, fmt.Errorf("invalid option %q, expected format KEY=VALUE", option)
 		}
 
 		key := strings.ToUpper(strings.TrimSpace(splitted[0]))

--- a/pkg/ssh/config.go
+++ b/pkg/ssh/config.go
@@ -111,7 +111,7 @@ type proxyCommandBuilder struct {
 func newProxyCommandBuilder(execPath, context, user, workspace string) *proxyCommandBuilder {
 	return &proxyCommandBuilder{
 		baseCommand: fmt.Sprintf(
-			"\"%s\" workspace ssh --stdio --context %s --user %s %s",
+			"%q workspace ssh --stdio --context %s --user %s %s",
 			execPath,
 			context,
 			user,
@@ -122,14 +122,14 @@ func newProxyCommandBuilder(execPath, context, user, workspace string) *proxyCom
 
 func (b *proxyCommandBuilder) withDevsyHome(home string) *proxyCommandBuilder {
 	if home != "" {
-		b.options = append(b.options, fmt.Sprintf("--home \"%s\"", home))
+		b.options = append(b.options, fmt.Sprintf("--home %q", home))
 	}
 	return b
 }
 
 func (b *proxyCommandBuilder) withWorkdir(workdir string) *proxyCommandBuilder {
 	if workdir != "" {
-		b.options = append(b.options, fmt.Sprintf("--workdir \"%s\"", workdir))
+		b.options = append(b.options, fmt.Sprintf("--workdir %q", workdir))
 	}
 	return b
 }
@@ -210,7 +210,7 @@ func (b *sshConfigBuilder) build() []string {
 // buildProxyCommand creates the ProxyCommand string.
 func buildProxyCommand(execPath string, params addHostParams) string {
 	if params.command != "" {
-		return fmt.Sprintf("  ProxyCommand \"%s\"", params.command)
+		return fmt.Sprintf("  ProxyCommand %q", params.command)
 	}
 
 	return newProxyCommandBuilder(execPath, params.context, params.user, params.workspace).

--- a/pkg/ssh/config.go
+++ b/pkg/ssh/config.go
@@ -111,7 +111,7 @@ type proxyCommandBuilder struct {
 func newProxyCommandBuilder(execPath, context, user, workspace string) *proxyCommandBuilder {
 	return &proxyCommandBuilder{
 		baseCommand: fmt.Sprintf(
-			"%q workspace ssh --stdio --context %s --user %s %s",
+			"\"%s\" workspace ssh --stdio --context %s --user %s %s",
 			execPath,
 			context,
 			user,
@@ -122,14 +122,14 @@ func newProxyCommandBuilder(execPath, context, user, workspace string) *proxyCom
 
 func (b *proxyCommandBuilder) withDevsyHome(home string) *proxyCommandBuilder {
 	if home != "" {
-		b.options = append(b.options, fmt.Sprintf("--home %q", home))
+		b.options = append(b.options, fmt.Sprintf("--home \"%s\"", home))
 	}
 	return b
 }
 
 func (b *proxyCommandBuilder) withWorkdir(workdir string) *proxyCommandBuilder {
 	if workdir != "" {
-		b.options = append(b.options, fmt.Sprintf("--workdir %q", workdir))
+		b.options = append(b.options, fmt.Sprintf("--workdir \"%s\"", workdir))
 	}
 	return b
 }
@@ -210,7 +210,7 @@ func (b *sshConfigBuilder) build() []string {
 // buildProxyCommand creates the ProxyCommand string.
 func buildProxyCommand(execPath string, params addHostParams) string {
 	if params.command != "" {
-		return fmt.Sprintf("  ProxyCommand %q", params.command)
+		return fmt.Sprintf("  ProxyCommand \"%s\"", params.command)
 	}
 
 	return newProxyCommandBuilder(execPath, params.context, params.user, params.workspace).

--- a/pkg/ts/util.go
+++ b/pkg/ts/util.go
@@ -64,7 +64,7 @@ func WaitHostReachable(
 			_ = conn.Close()
 			return nil // Host is reachable
 		}
-		log.Debugf("Host %s not reachable, retrying... (%d/%d)", addr.String(), i+1, maxRetries)
+		log.Debugf("Host %s not reachable, retrying (%d/%d)", addr.String(), i+1, maxRetries)
 		time.Sleep(200 * time.Millisecond)
 
 		select {

--- a/pkg/tunnel/container.go
+++ b/pkg/tunnel/container.go
@@ -95,7 +95,7 @@ func (c *ContainerTunnel) runHostTunnel(
 	defer func() { _ = writer.Close() }()
 	defer log.Debugf("Tunnel to host closed")
 
-	command := fmt.Sprintf("%q internal helper ssh-server --stdio", c.client.AgentPath())
+	command := fmt.Sprintf("'%s' internal helper ssh-server --stdio", c.client.AgentPath())
 	if log.DebugEnabled() {
 		command += " --debug"
 	}

--- a/pkg/tunnel/container.go
+++ b/pkg/tunnel/container.go
@@ -95,7 +95,7 @@ func (c *ContainerTunnel) runHostTunnel(
 	defer func() { _ = writer.Close() }()
 	defer log.Debugf("Tunnel to host closed")
 
-	command := fmt.Sprintf("'%s' internal helper ssh-server --stdio", c.client.AgentPath())
+	command := fmt.Sprintf("%q internal helper ssh-server --stdio", c.client.AgentPath())
 	if log.DebugEnabled() {
 		command += " --debug"
 	}

--- a/pkg/workspace/list.go
+++ b/pkg/workspace/list.go
@@ -230,21 +230,21 @@ func listProWorkspacesForProvider(
 	retWorkspaces := []*providerpkg.Workspace{}
 	for _, instance := range instances {
 		if instance.GetLabels() == nil {
-			log.Debugf("no labels for pro workspace \"%s\" found, skipping", instance.GetName())
+			log.Debugf("no labels for pro workspace %q found, skipping", instance.GetName())
 			continue
 		}
 
 		// id
 		id := instance.GetLabels()[storagev1.DevsyWorkspaceIDLabel]
 		if id == "" {
-			log.Debugf("no ID label for pro workspace \"%s\" found, skipping", instance.GetName())
+			log.Debugf("no ID label for pro workspace %q found, skipping", instance.GetName())
 			continue
 		}
 
 		// uid
 		uid := instance.GetLabels()[storagev1.DevsyWorkspaceUIDLabel]
 		if uid == "" {
-			log.Debugf("no UID label for pro workspace \"%s\" found, skipping", instance.GetName())
+			log.Debugf("no UID label for pro workspace %q found, skipping", instance.GetName())
 			continue
 		}
 

--- a/pkg/workspace/machine.go
+++ b/pkg/workspace/machine.go
@@ -76,7 +76,7 @@ func resolveMachine(
 ) (client.Client, error) {
 	// check if we have no args
 	if len(args) == 0 {
-		return nil, fmt.Errorf("please specify the machine name")
+		return nil, fmt.Errorf("specify the machine name")
 	}
 
 	// convert to id
@@ -188,7 +188,7 @@ func selectMachine(devsyConfig *config.Config) (client.MachineClient, error) {
 	}
 
 	answer, err := log.QuestionDefault(&survey.QuestionOptions{
-		Question:     "Please select a machine from the list below",
+		Question:     "Select a machine from the list below",
 		DefaultValue: machineIDs[0],
 		Options:      machineIDs,
 		Sort:         true,

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -27,7 +27,7 @@ import (
 )
 
 var errProvideWorkspaceArg = errors.New(
-	"please provide a workspace name, e.g. 'devsy workspace up ./my-folder', " +
+	"provide a workspace name, e.g. 'devsy workspace up ./my-folder', " +
 		"'devsy workspace up github.com/my-org/my-repo' or 'devsy workspace up ubuntu'")
 
 // ErrWorkspaceNotFound is returned by Get when the requested workspace is not
@@ -334,7 +334,7 @@ func createWorkspace(
 		return nil, nil, nil, err
 	} else if provider.State == nil || !provider.State.Initialized {
 		return nil, nil, nil, fmt.Errorf(
-			"provider '%s' is not initialized, please make sure to run 'devsy provider configure %s' "+
+			"provider %q is not initialized, make sure to run 'devsy provider configure %s' "+
 				"at least once before using this provider",
 			provider.Config.Name,
 			provider.Config.Name,
@@ -447,7 +447,7 @@ func createWorkspace(
 			}
 		} else {
 			log.Infof(
-				"Reuse existing machine '%s' for workspace '%s'",
+				"Reuse existing machine %q for workspace %q",
 				workspace.Machine.ID,
 				workspace.ID,
 			)
@@ -740,7 +740,7 @@ func selectWorkspace(
 	form := huh.NewForm(
 		huh.NewGroup(
 			huh.NewSelect[*providerpkg.Workspace]().
-				Title("Please select a workspace from the list below").
+				Title("Select a workspace from the list below").
 				Options(options...).
 				Value(&selectedWorkspace),
 		),
@@ -764,7 +764,7 @@ func selectWorkspace(
 			workspace.Imported = true
 			if err := providerpkg.SaveWorkspaceConfig(workspace); err != nil {
 				return nil, nil, nil, fmt.Errorf(
-					"save workspace config for workspace \"%s\": %w",
+					"save workspace config for workspace %q: %w",
 					workspace.ID,
 					err,
 				)
@@ -776,7 +776,7 @@ func selectWorkspace(
 			)
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf(
-					"load provider config for workspace \"%s\" with provider \"%s\": %w",
+					"load provider config for workspace %q with provider %q: %w",
 					workspace.ID,
 					workspace.Provider.Name,
 					err,


### PR DESCRIPTION
## Summary
- Replace quoted `'%s'` and escaped `\"%s\"` with the native `%q` verb across 74 Go files (194 occurrences).
- Drop `please` pleasantries from user-facing error, log, and prompt strings across 44 files (60 occurrences), adjusting capitalization where the word was sentence-initial.
- Re-wrap four lines that crossed the 120-char `lll` limit after the edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized string formatting in user-facing error and log messages for consistency.
  * Simplified error message phrasing by removing "please" and adjusting wording across commands and features.
  * Removed trailing ellipses from informational logs and status messages.

* **Chores**
  * Updated messaging style for improved clarity and uniformity throughout the application's output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->