### PR TITLE
fix(workspace): suppress benign warning for workspaces without config

### DIFF
--- a/pkg/workspace/list.go
+++ b/pkg/workspace/list.go
@@ -130,7 +130,11 @@ func ListLocalWorkspaces(
 
 		workspaceConfig, err := providerpkg.LoadWorkspaceConfig(contextName, entry.Name())
 		if err != nil {
-			log.Warnf("could not load workspace: workspace=%s, error=%v", entry.Name(), err)
+			if os.IsNotExist(err) {
+				log.Debugf("skipping workspace without config: workspace=%s", entry.Name())
+			} else {
+				log.Warnf("could not load workspace: workspace=%s, error=%v", entry.Name(), err)
+			}
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- When `up` creates a new workspace, `ListLocalWorkspaces` can scan the contexts directory before `workspace.json` is written, producing a confusing `could not load workspace … no such file or directory` warning.
- Demote the missing-file case to debug while keeping warnings for real load errors (e.g. JSON parse failures).