### PR TITLE
refactor(telemetry): update CLI and desktop telemetry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
           args: build --id devsy-${{ steps.os.outputs.runner_os }} --snapshot
         env:
           DEVSY_CLI_VERSION: ${{ inputs.tag || github.ref_name }}
+          DEVSY_POSTHOG_API_KEY: ${{ secrets.DEVSY_POSTHOG_API_KEY }}
 
       - uses: actions/upload-artifact@v7
         with:
@@ -177,6 +178,8 @@ jobs:
       - name: build desktop app
         working-directory: desktop
         run: npx electron-vite build
+        env:
+          DEVSY_POSTHOG_API_KEY: ${{ secrets.DEVSY_POSTHOG_API_KEY }}
 
       - name: package and publish with electron-builder (macOS, signed)
         if: runner.os == 'macOS'

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,4 +1,0 @@
-# PostHog project tokens are public write-only keys safe to commit.
-# See: https://posthog.com/docs/libraries/js#config
-pkg/telemetry/analytics/client.go:generic-api-key:9
-desktop/src/main/analytics.ts:generic-api-key:7

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,17 +15,17 @@ builds:
     overrides:
       - goos: linux
         goarch: amd64
-        ldflags: -s -w -extldflags '-static' -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }}
+        ldflags: -s -w -extldflags '-static' -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }} -X github.com/devsy-org/devsy/pkg/telemetry/analytics.posthogAPIKey={{ envOrDefault "DEVSY_POSTHOG_API_KEY" "" }}
         tags:
           - netgo
           - osusergo
       - goos: linux
         goarch: arm64
-        ldflags: -s -w -extldflags '-static' -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }}
+        ldflags: -s -w -extldflags '-static' -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }} -X github.com/devsy-org/devsy/pkg/telemetry/analytics.posthogAPIKey={{ envOrDefault "DEVSY_POSTHOG_API_KEY" "" }}
         tags:
           - netgo
           - osusergo
-    ldflags: -s -w -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }}
+    ldflags: -s -w -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }} -X github.com/devsy-org/devsy/pkg/telemetry/analytics.posthogAPIKey={{ envOrDefault "DEVSY_POSTHOG_API_KEY" "" }}
     env:
       - CGO_ENABLED=0
 
@@ -36,7 +36,7 @@ builds:
     goos: [linux]
     goarch: [amd64, arm64]
     binary: devsy-{{ .Os }}-{{ .Arch }}
-    ldflags: -s -w -extldflags '-static' -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }}
+    ldflags: -s -w -extldflags '-static' -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }} -X github.com/devsy-org/devsy/pkg/telemetry/analytics.posthogAPIKey={{ envOrDefault "DEVSY_POSTHOG_API_KEY" "" }}
     env:
       - CGO_ENABLED=0
     tags:
@@ -50,7 +50,7 @@ builds:
     goos: [darwin]
     goarch: [amd64, arm64]
     binary: devsy-{{ .Os }}-{{ .Arch }}
-    ldflags: -s -w -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }}
+    ldflags: -s -w -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }} -X github.com/devsy-org/devsy/pkg/telemetry/analytics.posthogAPIKey={{ envOrDefault "DEVSY_POSTHOG_API_KEY" "" }}
     env:
       - CGO_ENABLED=0
 
@@ -58,7 +58,7 @@ builds:
     goos: [windows]
     goarch: [amd64, arm64]
     binary: devsy-{{ .Os }}-{{ .Arch }}
-    ldflags: -s -w -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }}
+    ldflags: -s -w -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }} -X github.com/devsy-org/devsy/pkg/telemetry/analytics.posthogAPIKey={{ envOrDefault "DEVSY_POSTHOG_API_KEY" "" }}
     env:
       - CGO_ENABLED=0
 
@@ -66,7 +66,7 @@ builds:
     goos: [linux, darwin]
     goarch: [amd64, arm64]
     binary: devsy-{{ .Os }}-{{ .Arch }}
-    ldflags: -s -w -extldflags '-static' -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }}
+    ldflags: -s -w -extldflags '-static' -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }} -X github.com/devsy-org/devsy/pkg/telemetry/analytics.posthogAPIKey={{ envOrDefault "DEVSY_POSTHOG_API_KEY" "" }}
     env:
       - CGO_ENABLED=0
     tags:
@@ -77,7 +77,7 @@ builds:
     goos: [linux]
     goarch: [amd64]
     binary: devsy-{{ .Os }}-{{ .Arch }}-pro
-    ldflags: -s -w -extldflags '-static' -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }}
+    ldflags: -s -w -extldflags '-static' -X main.build={{ .Env.DEVSY_CLI_VERSION }} -X main.commit={{ .Commit }} -X main.date={{ .Date }} -X github.com/devsy-org/devsy/pkg/version.version={{ .Env.DEVSY_CLI_VERSION }} -X github.com/devsy-org/devsy/pkg/telemetry/analytics.posthogAPIKey={{ envOrDefault "DEVSY_POSTHOG_API_KEY" "" }}
     env:
       - CGO_ENABLED=0
     tags:

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -27,7 +27,7 @@ func NewOptionsCmd(flags *flags.GlobalFlags) *cobra.Command {
 	optionsCmd := &cobra.Command{
 		Use:         "get",
 		Short:       "Show options of a context",
-		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
+		Annotations: telemetry.SkipInUIAnnotation(),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context(), args)
 		},

--- a/cmd/context/options.go
+++ b/cmd/context/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/output"
 	"github.com/devsy-org/devsy/pkg/table"
+	"github.com/devsy-org/devsy/pkg/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -24,8 +25,9 @@ func NewOptionsCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	optionsCmd := &cobra.Command{
-		Use:   "get",
-		Short: "Show options of a context",
+		Use:         "get",
+		Short:       "Show options of a context",
+		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context(), args)
 		},

--- a/cmd/ide/list.go
+++ b/cmd/ide/list.go
@@ -31,7 +31,7 @@ func NewListCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Aliases:     []string{"ls"},
 		Short:       "List available IDEs",
 		Args:        cobra.NoArgs,
-		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
+		Annotations: telemetry.SkipInUIAnnotation(),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context())
 		},

--- a/cmd/ide/list.go
+++ b/cmd/ide/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/ide/ideparse"
 	"github.com/devsy-org/devsy/pkg/output"
 	"github.com/devsy-org/devsy/pkg/table"
+	"github.com/devsy-org/devsy/pkg/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -26,10 +27,11 @@ func NewListCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	listCmd := &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
-		Short:   "List available IDEs",
-		Args:    cobra.NoArgs,
+		Use:         "list",
+		Aliases:     []string{"ls"},
+		Short:       "List available IDEs",
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context())
 		},

--- a/cmd/pro/check_update.go
+++ b/cmd/pro/check_update.go
@@ -32,7 +32,7 @@ func NewCheckUpdateCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		Use:         "check-update",
 		Short:       "Check platform provider update",
 		Hidden:      true,
-		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
+		Annotations: telemetry.SkipInUIAnnotation(),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			devsyConfig, provider, err := proutil.FindProProvider(
 				cobraCmd.Context(),

--- a/cmd/pro/check_update.go
+++ b/cmd/pro/check_update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
+	"github.com/devsy-org/devsy/pkg/telemetry"
 	versionpkg "github.com/devsy-org/devsy/pkg/version"
 	"github.com/spf13/cobra"
 )
@@ -28,9 +29,10 @@ func NewCheckUpdateCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: globalFlags,
 	}
 	c := &cobra.Command{
-		Use:    "check-update",
-		Short:  "Check platform provider update",
-		Hidden: true,
+		Use:         "check-update",
+		Short:       "Check platform provider update",
+		Hidden:      true,
+		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			devsyConfig, provider, err := proutil.FindProProvider(
 				cobraCmd.Context(),

--- a/cmd/pro/health.go
+++ b/cmd/pro/health.go
@@ -12,6 +12,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
+	"github.com/devsy-org/devsy/pkg/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -30,9 +31,10 @@ func NewHealthCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: globalFlags,
 	}
 	c := &cobra.Command{
-		Use:    "health",
-		Short:  "Check platform health",
-		Hidden: true,
+		Use:         "health",
+		Short:       "Check platform health",
+		Hidden:      true,
+		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			devsyConfig, provider, err := proutil.FindProProvider(
 				cobraCmd.Context(),

--- a/cmd/pro/health.go
+++ b/cmd/pro/health.go
@@ -34,7 +34,7 @@ func NewHealthCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		Use:         "health",
 		Short:       "Check platform health",
 		Hidden:      true,
-		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
+		Annotations: telemetry.SkipInUIAnnotation(),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			devsyConfig, provider, err := proutil.FindProProvider(
 				cobraCmd.Context(),

--- a/cmd/pro/list.go
+++ b/cmd/pro/list.go
@@ -12,6 +12,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/output"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/table"
+	"github.com/devsy-org/devsy/pkg/telemetry"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
 )
@@ -29,10 +30,11 @@ func NewListCmd(flags *proflags.GlobalFlags) *cobra.Command {
 		GlobalFlags: *flags,
 	}
 	listCmd := &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
-		Short:   "List available Devsy Pro instances",
-		Args:    cobra.NoArgs,
+		Use:         "list",
+		Aliases:     []string{"ls"},
+		Short:       "List available Devsy Pro instances",
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context())
 		},

--- a/cmd/pro/list.go
+++ b/cmd/pro/list.go
@@ -34,7 +34,7 @@ func NewListCmd(flags *proflags.GlobalFlags) *cobra.Command {
 		Aliases:     []string{"ls"},
 		Short:       "List available Devsy Pro instances",
 		Args:        cobra.NoArgs,
-		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
+		Annotations: telemetry.SkipInUIAnnotation(),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context())
 		},

--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -16,6 +16,7 @@ import (
 	devsyhttp "github.com/devsy-org/devsy/pkg/http"
 	"github.com/devsy-org/devsy/pkg/output"
 	"github.com/devsy-org/devsy/pkg/table"
+	"github.com/devsy-org/devsy/pkg/telemetry"
 	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
@@ -33,10 +34,11 @@ func NewListCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	listCmd := &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
-		Short:   "List providers",
-		Args:    cobra.NoArgs,
+		Use:         "list",
+		Aliases:     []string{"ls"},
+		Short:       "List providers",
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context())
 		},

--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -38,7 +38,7 @@ func NewListCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Aliases:     []string{"ls"},
 		Short:       "List providers",
 		Args:        cobra.NoArgs,
-		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
+		Annotations: telemetry.SkipInUIAnnotation(),
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd.Context())
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	gocontext "context"
 	"errors"
 	"fmt"
 	"os"
@@ -55,9 +56,27 @@ func isMachineLogFormat(format string) bool {
 func Execute() {
 	rootCmd, globalFlags := BuildRoot()
 
+	// Bootstrap pre-Execute so subcommands that override PersistentPreRunE
+	// without chaining (e.g. pro, agent) still get telemetry.
+	target := rootCmd
+	if found, _, findErr := rootCmd.Find(os.Args[1:]); findErr == nil && found != nil {
+		target = found
+	}
+	collector := telemetry.BootstrapCLI(target)
+	rootCmd.SetContext(telemetry.WithCollector(gocontext.Background(), collector))
+
 	err := rootCmd.Execute()
-	telemetry.CollectorCLI.RecordCLI(err)
-	telemetry.CollectorCLI.Flush()
+
+	// Re-apply opt-out post-Execute for the same PreRunE-bypass case.
+	if devsyConfig, cfgErr := config.LoadConfig(
+		globalFlags.Context,
+		globalFlags.Provider,
+	); cfgErr == nil {
+		collector = telemetry.ApplyCLIConfig(devsyConfig, collector)
+	}
+
+	collector.RecordCLI(err)
+	collector.Flush()
 	if err != nil {
 		//nolint:all
 		if sshExitErr, ok := err.(*ssh.ExitError); ok {
@@ -129,7 +148,11 @@ func BuildRoot() (*cobra.Command, *flags.GlobalFlags) {
 
 		devsyConfig, err := config.LoadConfig(globalFlags.Context, globalFlags.Provider)
 		if err == nil {
-			telemetry.StartCLI(devsyConfig, cobraCmd)
+			current := telemetry.FromContext(cobraCmd.Context())
+			cobraCmd.SetContext(telemetry.WithCollector(
+				cobraCmd.Context(),
+				telemetry.ApplyCLIConfig(devsyConfig, current),
+			))
 		}
 		return nil
 	}

--- a/cmd/workspace/list.go
+++ b/cmd/workspace/list.go
@@ -33,7 +33,7 @@ func NewListCmd(flags *flags.GlobalFlags) *cobra.Command {
 		Aliases:     []string{"ls"},
 		Short:       "Lists existing workspaces",
 		Args:        cobra.NoArgs,
-		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
+		Annotations: telemetry.SkipInUIAnnotation(),
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
 			return cmd.Run(cobraCmd.Context())
 		},

--- a/cmd/workspace/list.go
+++ b/cmd/workspace/list.go
@@ -11,6 +11,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/output"
 	"github.com/devsy-org/devsy/pkg/table"
+	"github.com/devsy-org/devsy/pkg/telemetry"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
 )
@@ -28,10 +29,11 @@ func NewListCmd(flags *flags.GlobalFlags) *cobra.Command {
 		GlobalFlags: flags,
 	}
 	listCmd := &cobra.Command{
-		Use:     "list",
-		Aliases: []string{"ls"},
-		Short:   "Lists existing workspaces",
-		Args:    cobra.NoArgs,
+		Use:         "list",
+		Aliases:     []string{"ls"},
+		Short:       "Lists existing workspaces",
+		Args:        cobra.NoArgs,
+		Annotations: map[string]string{telemetry.AnnotationSkipInUI: "true"},
 		RunE: func(cobraCmd *cobra.Command, _ []string) error {
 			return cmd.Run(cobraCmd.Context())
 		},

--- a/cmd/workspace/up/up.go
+++ b/cmd/workspace/up/up.go
@@ -208,7 +208,7 @@ func (cmd *UpCmd) execute(cobraCmd *cobra.Command, args []string) error {
 		return fmt.Errorf("extra devcontainer file is only supported with local provider")
 	}
 
-	telemetry.CollectorCLI.SetClient(client)
+	telemetry.FromContext(cobraCmd.Context()).SetClient(client)
 	return cmd.Run(ctx, devsyConfig, client, args)
 }
 

--- a/desktop/electron.vite.config.ts
+++ b/desktop/electron.vite.config.ts
@@ -3,9 +3,15 @@ import { svelte } from "@sveltejs/vite-plugin-svelte"
 import tailwindcss from "@tailwindcss/vite"
 import { defineConfig, externalizeDepsPlugin } from "electron-vite"
 
+// Empty in local builds, which makes the analytics module no-op.
+const posthogApiKeyDefine = {
+  __DEVSY_POSTHOG_API_KEY__: JSON.stringify(process.env.DEVSY_POSTHOG_API_KEY ?? ""),
+}
+
 export default defineConfig({
   main: {
     plugins: [externalizeDepsPlugin()],
+    define: posthogApiKeyDefine,
     build: {
       outDir: "dist/main",
       rollupOptions: {

--- a/desktop/src/main/analytics.ts
+++ b/desktop/src/main/analytics.ts
@@ -4,8 +4,11 @@ import { PostHog } from "posthog-node"
 import { app } from "electron"
 import { machineIdSync } from "./machine-id.js"
 
-declare const __DEVSY_POSTHOG_API_KEY__: string
-const DEVSY_POSTHOG_API_KEY = __DEVSY_POSTHOG_API_KEY__
+declare const __DEVSY_POSTHOG_API_KEY__: string | undefined
+// `typeof` guard keeps the module loadable under vitest, which doesn't
+// apply Vite's `define` replacement at test time.
+const DEVSY_POSTHOG_API_KEY =
+  typeof __DEVSY_POSTHOG_API_KEY__ === "string" ? __DEVSY_POSTHOG_API_KEY__ : ""
 const POSTHOG_HOST = "https://us.i.posthog.com"
 
 let client: PostHog | null = null

--- a/desktop/src/main/analytics.ts
+++ b/desktop/src/main/analytics.ts
@@ -4,11 +4,16 @@ import { PostHog } from "posthog-node"
 import { app } from "electron"
 import { machineIdSync } from "./machine-id.js"
 
-const POSTHOG_API_KEY = "phc_u3TY39zxfrRcyXJoqZ5WRFVTr75gZBHi2AUrfqJ6GCj2"
+declare const __DEVSY_POSTHOG_API_KEY__: string
+const DEVSY_POSTHOG_API_KEY = __DEVSY_POSTHOG_API_KEY__
 const POSTHOG_HOST = "https://us.i.posthog.com"
 
 let client: PostHog | null = null
 let distinctId = ""
+
+export function getAnalyticsDistinctId(): string {
+  return distinctId || getDistinctId()
+}
 
 function getDistinctId(): string {
   const id = machineIdSync()
@@ -24,13 +29,13 @@ function isTelemetryDisabled(): boolean {
 
 export function initAnalytics(): void {
   if (isTelemetryDisabled()) return
-  if (!POSTHOG_API_KEY || POSTHOG_API_KEY === "phc_PLACEHOLDER") {
+  if (!DEVSY_POSTHOG_API_KEY) {
     console.warn("[telemetry] PostHog API key not configured; analytics disabled")
     return
   }
 
   distinctId = getDistinctId()
-  client = new PostHog(POSTHOG_API_KEY, {
+  client = new PostHog(DEVSY_POSTHOG_API_KEY, {
     host: POSTHOG_HOST,
     flushAt: 20,
     flushInterval: 30_000,

--- a/desktop/src/main/cli.ts
+++ b/desktop/src/main/cli.ts
@@ -3,6 +3,7 @@ import { execFile as execFileCb, spawn } from "node:child_process"
 import { createInterface } from "node:readline"
 import { promisify } from "node:util"
 import type { CLIError, CliLogLine } from "../shared/cli-error.js"
+import { getAnalyticsDistinctId } from "./analytics.js"
 
 const execFile = promisify(execFileCb)
 const MAX_CONCURRENT = 50
@@ -76,7 +77,13 @@ function parseStderrLine(line: string): CliLogLine | undefined {
  * We augment PATH so all spawned CLI processes can find these tools.
  */
 function buildEnv(): NodeJS.ProcessEnv {
-  if (process.platform !== "darwin") return { ...process.env, DEVSY_UI: "true" }
+  const baseEnv = {
+    ...process.env,
+    DEVSY_UI: "true",
+    DEVSY_TELEMETRY_DISTINCT_ID: getAnalyticsDistinctId(),
+  }
+
+  if (process.platform !== "darwin") return baseEnv
 
   const currentPath = process.env.PATH ?? ""
   const extraDirs = [
@@ -85,11 +92,10 @@ function buildEnv(): NodeJS.ProcessEnv {
     "/opt/homebrew/sbin",
   ]
   const missing = extraDirs.filter((d) => !currentPath.split(":").includes(d))
-  if (missing.length === 0) return { ...process.env, DEVSY_UI: "true" }
+  if (missing.length === 0) return baseEnv
 
   return {
-    ...process.env,
-    DEVSY_UI: "true",
+    ...baseEnv,
     PATH: `${missing.join(":")}:${currentPath}`,
   }
 }

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -28,6 +28,13 @@ const (
 	// EnvDisableTelemetry disables telemetry collection.
 	EnvDisableTelemetry = "DEVSY_DISABLE_TELEMETRY"
 
+	// EnvProRunner is set by the Devsy Pro runner pod to mark runner-side CLI invocations.
+	EnvProRunner = "DEVSY_PRO_RUNNER"
+
+	// EnvTelemetryDistinctID is set by the desktop app on spawned CLI
+	// processes so their events share the desktop's analytics identity.
+	EnvTelemetryDistinctID = "DEVSY_TELEMETRY_DISTINCT_ID"
+
 	// EnvAgentURL overrides the agent download URL.
 	EnvAgentURL = "DEVSY_AGENT_URL"
 

--- a/pkg/telemetry/analytics/client.go
+++ b/pkg/telemetry/analytics/client.go
@@ -1,20 +1,26 @@
 package analytics
 
 import (
+	"sync"
+	"time"
+
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/posthog/posthog-go"
 )
 
-const (
-	posthogAPIKey = "phc_u3TY39zxfrRcyXJoqZ5WRFVTr75gZBHi2AUrfqJ6GCj2"
+// Cap CLI exit delay on slow networks; dropping a queued event beats
+// blocking the user's shell.
+const flushTimeout = 2 * time.Second
 
-	posthogEndpoint = "https://us.i.posthog.com"
-)
+// Injected at build time via -ldflags -X. Empty in local builds yields a noop client.
+var posthogAPIKey = ""
+
+const posthogEndpoint = "https://us.i.posthog.com"
 
 var Dry = false
 
 func NewClient() Client {
-	if posthogAPIKey == "" || posthogAPIKey == "phc_PLACEHOLDER" {
+	if posthogAPIKey == "" {
 		log.Debugf("PostHog API key not configured; analytics disabled")
 		return NewNoopClient()
 	}
@@ -31,7 +37,8 @@ func NewClient() Client {
 }
 
 type client struct {
-	phClient posthog.Client
+	phClient  posthog.Client
+	closeOnce sync.Once
 }
 
 func (c *client) RecordEvent(event Event) {
@@ -90,7 +97,17 @@ func (c *client) Flush() {
 	if Dry {
 		return
 	}
-	if err := c.phClient.Close(); err != nil {
-		log.Debugf("error flushing PostHog client: %v", err)
-	}
+	// posthog-go's Close drains the queue but can only be called once.
+	c.closeOnce.Do(func() {
+		done := make(chan error, 1)
+		go func() { done <- c.phClient.Close() }()
+		select {
+		case err := <-done:
+			if err != nil {
+				log.Debugf("error flushing PostHog client: %v", err)
+			}
+		case <-time.After(flushTimeout):
+			log.Debugf("PostHog flush timed out after %s; dropping queued events", flushTimeout)
+		}
+	})
 }

--- a/pkg/telemetry/collect.go
+++ b/pkg/telemetry/collect.go
@@ -1,21 +1,25 @@
 package telemetry
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"runtime"
-	"slices"
-	"strings"
 	"time"
 
 	devsyclient "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
+	cliErrors "github.com/devsy-org/devsy/pkg/errors"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/telemetry/analytics"
 	"github.com/devsy-org/devsy/pkg/version"
 	"github.com/moby/term"
 	"github.com/spf13/cobra"
 )
+
+// Set on cobra commands the desktop polls frequently so their invocations
+// don't drown out meaningful CLI activity.
+const AnnotationSkipInUI = "telemetry.skip-in-ui"
 
 type ErrorSeverityType string
 
@@ -26,22 +30,6 @@ const (
 	PanicSeverity   ErrorSeverityType = "panic"
 )
 
-var UIEventsExceptions []string = []string{
-	config.BinaryName + " list",
-	config.BinaryName + " status",
-	config.BinaryName + " provider list",
-	config.BinaryName + " pro list",
-	config.BinaryName + " pro health",
-	config.BinaryName + " pro check-update",
-	config.BinaryName + " ide list",
-	config.BinaryName + " ide use",
-	config.BinaryName + " version",
-	config.BinaryName + " context get",
-}
-
-// skip everything in pro mode.
-var CollectorCLI CLICollector = &noopCollector{}
-
 type CLICollector interface {
 	RecordCLI(err error)
 	SetClient(client devsyclient.BaseWorkspaceClient)
@@ -50,22 +38,45 @@ type CLICollector interface {
 	Flush()
 }
 
-// StartCLI starts collecting events and sending them to the backend from the CLI.
-func StartCLI(devsyConfig *config.Config, cmd *cobra.Command) {
-	telemetryOpt := devsyConfig.ContextOption(config.ContextOptionTelemetry)
-	if telemetryOpt == config.BoolFalse || version.GetVersion() == version.DevVersion ||
+type ctxKey struct{}
+
+func WithCollector(ctx context.Context, c CLICollector) context.Context {
+	return context.WithValue(ctx, ctxKey{}, c)
+}
+
+// Returns a noop collector when none is present so callers can use it unguarded.
+func FromContext(ctx context.Context) CLICollector {
+	if c, ok := ctx.Value(ctxKey{}).(CLICollector); ok && c != nil {
+		return c
+	}
+	return &noopCollector{}
+}
+
+// Call before LoadConfig so config-load failures still get recorded.
+// Always returns a non-nil collector.
+func BootstrapCLI(cmd *cobra.Command) CLICollector {
+	if version.GetVersion() == version.DevVersion ||
 		os.Getenv(config.EnvDisableTelemetry) == config.BoolTrue {
-		return
+		return &noopCollector{}
 	}
 
-	// create a new default collector
 	collector, err := newCLICollector(cmd)
 	if err != nil {
-		// Log the problem but don't fail - use disabled Collector instead
 		log.Infof("telemetry: %s", err.Error())
-	} else {
-		CollectorCLI = collector
+		return &noopCollector{}
 	}
+	return collector
+}
+
+// Swaps current for a noop collector if the user has opted out via context.
+func ApplyCLIConfig(devsyConfig *config.Config, current CLICollector) CLICollector {
+	if devsyConfig == nil {
+		return current
+	}
+	if devsyConfig.ContextOption(config.ContextOptionTelemetry) == config.BoolFalse {
+		return &noopCollector{}
+	}
+	return current
 }
 
 func newCLICollector(cmd *cobra.Command) (*cliCollector, error) {
@@ -98,11 +109,8 @@ func (d *cliCollector) RecordCLI(err error) {
 	}
 	cmd := d.cmd.CommandPath()
 	isUI := os.Getenv(config.EnvUI) == config.BoolTrue
-	// Ignore certain commands triggered by Devsy Desktop
-	if isUI {
-		if slices.Contains(UIEventsExceptions, cmd) {
-			return
-		}
+	if isUI && d.cmd.Annotations[AnnotationSkipInUI] == "true" {
+		return
 	}
 
 	isCI := false
@@ -136,20 +144,15 @@ func (d *cliCollector) RecordCLI(err error) {
 		"os_arch":  runtime.GOARCH,
 		"timezone": timezone,
 	}
+	// Raw err.Error() strings can leak paths, hostnames, tokens.
 	if err != nil {
-		eventProperties["error"] = err.Error()
+		eventProperties["error_code"] = string(
+			cliErrors.Classify(err, cliErrors.ClassifyContext{}).Code,
+		)
 	}
 
-	// Check if we're on the runner
-	isPro := false
-	wd, wdErr := os.Getwd()
-	if wdErr == nil {
-		if strings.HasPrefix(wd, "/var/lib/loft/devsy") {
-			isPro = true
-		}
-	}
 	eventType := config.BinaryName + "_cli"
-	if isPro {
+	if os.Getenv(config.EnvProRunner) == config.BoolTrue {
 		eventType = config.BinaryName + "_cli_runner"
 	}
 

--- a/pkg/telemetry/collect.go
+++ b/pkg/telemetry/collect.go
@@ -21,6 +21,12 @@ import (
 // don't drown out meaningful CLI activity.
 const AnnotationSkipInUI = "telemetry.skip-in-ui"
 
+// SkipInUIAnnotation returns the cobra Annotations map that flags a command
+// as one the desktop polls frequently.
+func SkipInUIAnnotation() map[string]string {
+	return map[string]string{AnnotationSkipInUI: config.BoolTrue}
+}
+
 type ErrorSeverityType string
 
 const (
@@ -109,7 +115,7 @@ func (d *cliCollector) RecordCLI(err error) {
 	}
 	cmd := d.cmd.CommandPath()
 	isUI := os.Getenv(config.EnvUI) == config.BoolTrue
-	if isUI && d.cmd.Annotations[AnnotationSkipInUI] == "true" {
+	if isUI && d.cmd.Annotations[AnnotationSkipInUI] == config.BoolTrue {
 		return
 	}
 

--- a/pkg/telemetry/helpers.go
+++ b/pkg/telemetry/helpers.go
@@ -2,29 +2,45 @@ package telemetry
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"os"
 
+	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/machineid"
 	"github.com/devsy-org/devsy/pkg/util"
 )
 
-// GetMachineID retrieves machine ID and encodes it together with users $HOME path and
-// extra key to protect privacy. Returns a hex-encoded string.
+// HMAC(machine-id, $HOME), hex-encoded. Returns the injected distinct ID
+// when DEVSY_TELEMETRY_DISTINCT_ID is set (desktop-spawned CLI).
 func GetMachineID() string {
-	id, err := machineid.ID()
-	if err != nil {
-		id = "error"
+	if injected := os.Getenv(config.EnvTelemetryDistinctID); injected != "" {
+		return injected
 	}
 
-	// get $HOME to distinguish two users on the same machine
-	// will be hashed later together with the ID
+	id, err := machineid.ID()
+	if err != nil {
+		// Random fallback prevents every failure-path user from collapsing
+		// into a single HMAC bucket.
+		id = randomFallbackID()
+	}
+
 	home, err := util.UserHomeDir()
 	if err != nil {
-		home = "error"
+		home = ""
 	}
 
 	mac := hmac.New(sha256.New, []byte(id))
 	mac.Write([]byte(home))
 	return fmt.Sprintf("%x", mac.Sum(nil))
+}
+
+func randomFallbackID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "rand-error"
+	}
+	return hex.EncodeToString(b[:])
 }

--- a/pkg/telemetry/helpers.go
+++ b/pkg/telemetry/helpers.go
@@ -7,10 +7,16 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/machineid"
 	"github.com/devsy-org/devsy/pkg/util"
+)
+
+var (
+	fallbackIDOnce sync.Once
+	fallbackID     string
 )
 
 // HMAC(machine-id, $HOME), hex-encoded. Returns the injected distinct ID
@@ -23,8 +29,9 @@ func GetMachineID() string {
 	id, err := machineid.ID()
 	if err != nil {
 		// Random fallback prevents every failure-path user from collapsing
-		// into a single HMAC bucket.
-		id = randomFallbackID()
+		// into a single HMAC bucket. Cached so the two GetMachineID calls
+		// within one event agree.
+		id = cachedFallbackID()
 	}
 
 	home, err := util.UserHomeDir()
@@ -35,6 +42,13 @@ func GetMachineID() string {
 	mac := hmac.New(sha256.New, []byte(id))
 	mac.Write([]byte(home))
 	return fmt.Sprintf("%x", mac.Sum(nil))
+}
+
+func cachedFallbackID() string {
+	fallbackIDOnce.Do(func() {
+		fallbackID = randomFallbackID()
+	})
+	return fallbackID
 }
 
 func randomFallbackID() string {


### PR DESCRIPTION
## Summary

CLI telemetry hardening pass alongside desktop correlation. Touches build/CI, the telemetry package, command annotations, and the desktop's CLI subprocess spawner.

**Build & secret hygiene**
- PostHog API key removed from source; injected at build time via `-ldflags -X` from CI secret `DEVSY_POSTHOG_API_KEY` (`.goreleaser.yml`, `.github/workflows/release.yml`). Local/dev builds without the secret ship with analytics disabled (noop client).
- Same treatment for the desktop main process via `electron-vite` `define`.
- `.gitleaksignore` entries removed.

**Telemetry reliability fixes**
- Collector bootstraps in `Execute()` before `rootCmd.Execute()`, using `cobra.Find()` to resolve the target command. This fixes a real existing bug: subcommands that override `PersistentPreRunE` without chaining (e.g. `pro`, `agent`, `helper`) were producing zero telemetry.
- Bootstrap precedes `LoadConfig` so config-load failures themselves get recorded (previously short-circuited).
- Per-context opt-out re-applied post-`Execute` as a safety net for the same PreRunE-bypass case.
- PostHog `Close()` wrapped in `sync.Once` (idempotent) and capped at 2s via goroutine + select so CLI exit isn't blocked on slow networks.

**Architecture**
- Global `CollectorCLI` replaced with context-based DI: `WithCollector(ctx, c)` / `FromContext(ctx) CLICollector`. `BootstrapCLI` returns a non-nil collector; `ApplyCLIConfig` is value-returning rather than side-effecting.
- Static `UIEventsExceptions` slice (which had drifted post-CLI-restructure with stale entries like `devsy list`, `devsy version`) replaced with a `telemetry.skip-in-ui` annotation set directly on commands: `workspace list`, `provider list`, `pro list/health/check-update`, `ide list`, `context get`.

**Privacy**
- Raw `err.Error()` strings replaced with classified `cliErrors.Code` so paths/hostnames/tokens in error messages don't ship to PostHog.
- `machineid` lookup failures now substitute crypto/rand bytes instead of a constant `"error"` sentinel that collapsed every failing user into a single HMAC bucket.

**Pro-runner detection**
- Hardcoded `/var/lib/loft/devsy` working-directory prefix replaced with `DEVSY_PRO_RUNNER=true` env-var check.

**Desktop ↔ CLI correlation**
- Desktop hashes the raw machine-id with SHA-256 before HMAC; CLI does not. So the two pipelines were producing **different** distinct IDs for the same user/machine.
- Fix: desktop's `CliRunner` now forwards `DEVSY_TELEMETRY_DISTINCT_ID` (its own distinct ID) to every spawned CLI process; CLI's `GetMachineID()` prefers the injected value. Standalone CLI invocations unaffected.

## Action items before merging

1. Add `DEVSY_POSTHOG_API_KEY` as a GitHub org/repo secret. Without it release builds compile cleanly but ship with analytics disabled (silent).
2. Rotate the PostHog project key — the previous value lived in git history and is still publicly recoverable.
3. Configure the Devsy Pro runner pod to set `DEVSY_PRO_RUNNER=true` (replaces the path heuristic); otherwise runner events get miscategorized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics infrastructure to properly inject and manage API credentials across build targets.
  * Improved telemetry tracking for the desktop application and CLI by enabling analytics distinct ID sharing and context-based collection.
  * Updated security configurations to enforce proper API key handling during build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->