### PR TITLE
feat(desktop): provider update, version select, and Default label

### DIFF
--- a/desktop/e2e/providers.e2e.ts
+++ b/desktop/e2e/providers.e2e.ts
@@ -44,7 +44,7 @@ test.describe("Providers Page", () => {
 
   test("should show default badge on the default provider", async () => {
     const main = page.locator('[data-slot="sidebar-inset"] main')
-    await expect(main).toContainText("default")
+    await expect(main).toContainText("Default")
   })
 
   test("should show initialized badge on initialized providers", async () => {

--- a/desktop/src/renderer/src/lib/components/provider/ProviderCard.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { badgeVariants } from "$lib/components/ui/badge/index.js"
+import { Star } from "@lucide/svelte"
 import ProviderIcon from "./ProviderIcon.svelte"
 import ProviderSheet from "./ProviderSheet.svelte"
 import { providerVersions } from "$lib/stores/providerVersions.js"
@@ -32,7 +33,10 @@ function sourceDisplay(p: Provider): string {
       <ProviderIcon name={provider.name} class="size-8 shrink-0" />
       <h3 class="text-lg font-semibold truncate">{provider.name}</h3>
       {#if provider.isDefault}
-        <span class={badgeVariants({ variant: "default" })}>default</span>
+        <span class="{badgeVariants({ variant: 'default' })} gap-1">
+          <Star class="size-3" />
+          Default
+        </span>
       {/if}
     </div>
     <div class="flex gap-1.5 shrink-0">

--- a/desktop/src/renderer/src/lib/components/provider/ProviderCard.test.ts
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderCard.test.ts
@@ -1,0 +1,52 @@
+import { render } from "@testing-library/svelte"
+import { describe, expect, it, vi } from "vitest"
+import type { Provider } from "$lib/types/index.js"
+
+vi.mock("$lib/stores/providerVersions.js", async () => {
+  const { writable } = await import("svelte/store")
+  return {
+    providerVersions: writable({
+      byProvider: {},
+      updates: {},
+      lastCheckedAt: null,
+    }),
+  }
+})
+
+import ProviderCard from "./ProviderCard.svelte"
+
+function makeProvider(name: string, extras: Partial<Provider> = {}): Provider {
+  return {
+    name,
+    version: "0.1.0",
+    state: { initialized: true },
+    ...extras,
+  }
+}
+
+describe("ProviderCard", () => {
+  it("renders the Default pill with a star icon when provider.isDefault is true", () => {
+    const { container, unmount } = render(ProviderCard, {
+      props: { provider: makeProvider("ssh", { isDefault: true }) },
+    })
+
+    const pill = Array.from(container.querySelectorAll("span")).find((el) =>
+      el.textContent?.trim().toLowerCase().includes("default"),
+    )
+    expect(pill).toBeDefined()
+    expect(pill?.querySelector("svg")).not.toBeNull()
+    unmount()
+  })
+
+  it("does not render the Default pill when provider.isDefault is false", () => {
+    const { container, unmount } = render(ProviderCard, {
+      props: { provider: makeProvider("ssh", { isDefault: false }) },
+    })
+
+    const pill = Array.from(container.querySelectorAll("span")).find(
+      (el) => el.textContent?.trim().toLowerCase() === "default",
+    )
+    expect(pill).toBeUndefined()
+    unmount()
+  })
+})

--- a/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
 import { onMount } from "svelte"
+import { Star } from "@lucide/svelte"
 import { Button } from "$lib/components/ui/button/index.js"
 import { Input } from "$lib/components/ui/input/index.js"
 import { Label } from "$lib/components/ui/label/index.js"
 import { Separator } from "$lib/components/ui/separator/index.js"
 import * as Select from "$lib/components/ui/select/index.js"
+import * as Alert from "$lib/components/ui/alert/index.js"
 import { badgeVariants } from "$lib/components/ui/badge/index.js"
 import * as Sheet from "$lib/components/ui/sheet/index.js"
 import * as ButtonGroup from "$lib/components/ui/button-group/index.js"
 import { Spinner } from "$lib/components/ui/spinner/index.js"
 import ConfirmDialog from "$lib/components/layout/ConfirmDialog.svelte"
 import ErrorCard from "$lib/components/ErrorCard.svelte"
+import UpdateConfirmDialog from "./UpdateConfirmDialog.svelte"
 import type { CLIError } from "$shared/cli-error.js"
 import {
   providerUse,
@@ -21,8 +24,14 @@ import {
   providerOptions,
   providerSetOptions,
   providerRename,
+  providerSetVersion,
 } from "$lib/ipc/commands.js"
 import { providers } from "$lib/stores/providers.js"
+import {
+  providerVersions,
+  loadVersionsFor,
+  refreshUpdates,
+} from "$lib/stores/providerVersions.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
 import type { Provider, ProviderOption } from "$lib/types/index.js"
@@ -50,6 +59,16 @@ let renameSaving = $state(false)
 let initializing = $state(false)
 let initError = $state<CLIError | null>(null)
 let loadedFor = $state<string | null>(null)
+let confirmUpdateOpen = $state(false)
+let updating = $state(false)
+let confirmSwitchOpen = $state(false)
+let targetTag = $state("")
+let switching = $state(false)
+
+function openVersionSwitch(tag: string) {
+  targetTag = tag
+  confirmSwitchOpen = true
+}
 
 let isDirty = $derived.by(() => {
   for (const key of Object.keys(optionValues)) {
@@ -117,6 +136,7 @@ $effect(() => {
   if (loadedFor !== provider.name) {
     loadedFor = provider.name
     loadOptions()
+    loadVersionsFor(provider.name).catch(() => {})
   }
 })
 
@@ -129,12 +149,22 @@ async function handleSetDefault() {
   }
 }
 
-async function handleUpdate() {
+function handleUpdate() {
+  confirmUpdateOpen = true
+}
+
+async function runUpdate() {
+  updating = true
   try {
     await providerUpdate(provider.name)
     toasts.success(`Updated ${provider.name}`)
+    await loadVersionsFor(provider.name)
+    await refreshUpdates()
   } catch (err) {
     toasts.error(`Failed to update: ${extractErrorMessage(err)}`)
+  } finally {
+    updating = false
+    confirmUpdateOpen = false
   }
 }
 
@@ -268,11 +298,33 @@ async function handleSaveOptions() {
         {:else}
           {provider.name}
         {/if}
-        {#if provider.version}
+        {#if $providerVersions.byProvider[provider.name] && !$providerVersions.byProvider[provider.name].unsupported && ($providerVersions.byProvider[provider.name].versions?.length ?? 0) > 0}
+          {@const entry = $providerVersions.byProvider[provider.name]}
+          {@const currentTag = provider.version ?? entry.versions.find((v) => v.current)?.tag ?? ""}
+          <Select.Root
+            type="single"
+            value={currentTag}
+            onValueChange={(v) => {
+              if (v && v !== currentTag) openVersionSwitch(v)
+            }}
+          >
+            <Select.Trigger class="w-[140px] h-7">
+              <span>{currentTag || "Select version"}</span>
+            </Select.Trigger>
+            <Select.Content>
+              {#each entry.versions as v (v.tag)}
+                <Select.Item value={v.tag} label={v.tag} />
+              {/each}
+            </Select.Content>
+          </Select.Root>
+        {:else if provider.version}
           <span class={badgeVariants({ variant: "outline" })}>{provider.version}</span>
         {/if}
         {#if provider.isDefault}
-          <span class={badgeVariants({ variant: "default" })}>default</span>
+          <span class="{badgeVariants({ variant: 'default' })} gap-1">
+            <Star class="size-3" />
+            Default
+          </span>
         {/if}
         {#if provider.state?.initialized}
           <span class={badgeVariants({ variant: "secondary" })}>initialized</span>
@@ -301,6 +353,19 @@ async function handleSaveOptions() {
       </ButtonGroup.Root>
       <Button variant="destructive" size="sm" onclick={() => (confirmDeleteOpen = true)}>Delete</Button>
     </div>
+
+    {#if $providerVersions.updates[provider.name]?.updateAvailable === true}
+      <div class="px-6 pb-2">
+        <Alert.Root class="border-amber-500/50 bg-amber-500/10">
+          <Alert.Title>Update available: {$providerVersions.updates[provider.name].latest}</Alert.Title>
+          <Alert.Description>
+            <Button size="sm" class="mt-2" onclick={handleUpdate}>
+              Install update
+            </Button>
+          </Alert.Description>
+        </Alert.Root>
+      </div>
+    {/if}
 
     <Separator />
 
@@ -387,4 +452,35 @@ async function handleSaveOptions() {
   confirmLabel="Delete"
   loading={deleting}
   onconfirm={handleDelete}
+/>
+
+<UpdateConfirmDialog
+  bind:open={confirmUpdateOpen}
+  providerName={provider.name}
+  currentVersion={provider.version}
+  latestVersion={$providerVersions.updates[provider.name]?.latest}
+  loading={updating}
+  onconfirm={runUpdate}
+/>
+
+<ConfirmDialog
+  bind:open={confirmSwitchOpen}
+  title={`Switch '${provider.name}' from ${provider.version ?? ""} to ${targetTag}`}
+  description={`Workspaces created with ${provider.version ?? ""} may behave differently after this change. Existing workspaces will run against ${targetTag} the next time they're used.`}
+  confirmLabel="Switch"
+  loading={switching}
+  onconfirm={async () => {
+    switching = true
+    try {
+      await providerSetVersion(provider.name, targetTag)
+      toasts.success(`Switched ${provider.name} to ${targetTag}`)
+      await loadVersionsFor(provider.name)
+      await refreshUpdates()
+    } catch (err) {
+      toasts.error(`Failed to switch version: ${extractErrorMessage(err)}`)
+    } finally {
+      switching = false
+      confirmSwitchOpen = false
+    }
+  }}
 />

--- a/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
@@ -87,6 +87,8 @@ let hasUnfilledRequired = $derived.by(() => {
   return requiredOptions.some(([key]) => !optionValues[key]?.trim())
 })
 
+let versionEntry = $derived($providerVersions.byProvider[provider.name])
+
 let groupedOptions = $derived.by(() => {
   const groups: Record<string, [string, ProviderOption][]> = {}
   for (const [key, opt] of Object.entries(options)) {
@@ -165,6 +167,21 @@ async function runUpdate() {
   } finally {
     updating = false
     confirmUpdateOpen = false
+  }
+}
+
+async function runSwitch() {
+  switching = true
+  try {
+    await providerSetVersion(provider.name, targetTag)
+    toasts.success(`Switched ${provider.name} to ${targetTag}`)
+    await loadVersionsFor(provider.name)
+    await refreshUpdates()
+  } catch (err) {
+    toasts.error(`Failed to switch version: ${extractErrorMessage(err)}`)
+  } finally {
+    switching = false
+    confirmSwitchOpen = false
   }
 }
 
@@ -298,9 +315,8 @@ async function handleSaveOptions() {
         {:else}
           {provider.name}
         {/if}
-        {#if $providerVersions.byProvider[provider.name] && !$providerVersions.byProvider[provider.name].unsupported && ($providerVersions.byProvider[provider.name].versions?.length ?? 0) > 0}
-          {@const entry = $providerVersions.byProvider[provider.name]}
-          {@const currentTag = provider.version ?? entry.versions.find((v) => v.current)?.tag ?? ""}
+        {#if versionEntry && !versionEntry.unsupported && (versionEntry.versions?.length ?? 0) > 0}
+          {@const currentTag = provider.version ?? versionEntry.versions.find((v) => v.current)?.tag ?? ""}
           <Select.Root
             type="single"
             value={currentTag}
@@ -312,7 +328,7 @@ async function handleSaveOptions() {
               <span>{currentTag || "Select version"}</span>
             </Select.Trigger>
             <Select.Content>
-              {#each entry.versions as v (v.tag)}
+              {#each versionEntry.versions as v (v.tag)}
                 <Select.Item value={v.tag} label={v.tag} />
               {/each}
             </Select.Content>
@@ -469,18 +485,5 @@ async function handleSaveOptions() {
   description={`Workspaces created with ${provider.version ?? ""} may behave differently after this change. Existing workspaces will run against ${targetTag} the next time they're used.`}
   confirmLabel="Switch"
   loading={switching}
-  onconfirm={async () => {
-    switching = true
-    try {
-      await providerSetVersion(provider.name, targetTag)
-      toasts.success(`Switched ${provider.name} to ${targetTag}`)
-      await loadVersionsFor(provider.name)
-      await refreshUpdates()
-    } catch (err) {
-      toasts.error(`Failed to switch version: ${extractErrorMessage(err)}`)
-    } finally {
-      switching = false
-      confirmSwitchOpen = false
-    }
-  }}
+  onconfirm={runSwitch}
 />

--- a/desktop/src/renderer/src/lib/components/provider/ProviderSheet.test.ts
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderSheet.test.ts
@@ -11,6 +11,9 @@ const providerInit = vi.fn()
 const providerList = vi.fn()
 const providerSetOptions = vi.fn()
 const providerRename = vi.fn()
+const providerSetVersion = vi.fn()
+const loadVersionsFor = vi.fn()
+const refreshUpdates = vi.fn()
 
 vi.mock("$lib/ipc/commands.js", () => ({
   providerOptions: (...args: unknown[]) => providerOptions(...args),
@@ -21,11 +24,35 @@ vi.mock("$lib/ipc/commands.js", () => ({
   providerList: (...args: unknown[]) => providerList(...args),
   providerSetOptions: (...args: unknown[]) => providerSetOptions(...args),
   providerRename: (...args: unknown[]) => providerRename(...args),
+  providerSetVersion: (...args: unknown[]) => providerSetVersion(...args),
 }))
 
 vi.mock("$lib/stores/providers.js", async () => {
   const { writable } = await import("svelte/store")
   return { providers: writable([]) }
+})
+
+vi.mock("$lib/stores/providerVersions.js", async () => {
+  const { writable } = await import("svelte/store")
+  return {
+    providerVersions: writable({
+      byProvider: {
+        ssh: {
+          versions: [
+            { tag: "0.1.0", current: true },
+            { tag: "0.2.0", current: false },
+          ],
+          unsupported: false,
+        },
+      },
+      updates: {
+        ssh: { updateAvailable: true, current: "0.1.0", latest: "0.2.0" },
+      },
+      lastCheckedAt: null,
+    }),
+    loadVersionsFor: (...args: unknown[]) => loadVersionsFor(...args),
+    refreshUpdates: (...args: unknown[]) => refreshUpdates(...args),
+  }
 })
 
 vi.mock("$lib/stores/toasts.js", () => ({
@@ -78,6 +105,9 @@ describe("ProviderSheet", () => {
     providerList.mockResolvedValue([])
     providerSetOptions.mockResolvedValue(undefined)
     providerRename.mockResolvedValue(undefined)
+    providerSetVersion.mockResolvedValue(undefined)
+    loadVersionsFor.mockResolvedValue(undefined)
+    refreshUpdates.mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -199,6 +229,71 @@ describe("ProviderSheet", () => {
     const buttons = Array.from(document.querySelectorAll("button"))
     const setDefaultButton = buttons.find((btn) => btn.textContent?.trim() === "Set Default")
     expect(setDefaultButton).toBeDefined()
+    unmount()
+  })
+
+  it("renders the version selector when versions are known", async () => {
+    const { unmount } = render(ProviderSheet, {
+      props: { provider: makeProvider("ssh"), open: true },
+    })
+
+    await flushAsync()
+
+    // Select trigger contains the current tag.
+    const triggers = Array.from(document.querySelectorAll("button"))
+    const versionTrigger = triggers.find((b) => b.textContent?.includes("0.1.0"))
+    expect(versionTrigger).toBeDefined()
+    unmount()
+  })
+
+  it("clicking Update opens the update confirm dialog", async () => {
+    const { unmount } = render(ProviderSheet, {
+      props: { provider: makeProvider("ssh"), open: true },
+    })
+
+    await flushAsync()
+
+    const updateBtn = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Update",
+    )
+    updateBtn?.click()
+    await tick()
+
+    // Confirm dialog title mentions the latest tag from the mocked store.
+    const dialogs = Array.from(document.querySelectorAll("[role='dialog']"))
+    const confirmDialog = dialogs.find((d) =>
+      d.textContent?.includes("Update 'ssh' to 0.2.0"),
+    )
+    expect(confirmDialog).toBeDefined()
+    expect(providerUpdate).not.toHaveBeenCalled()
+    unmount()
+  })
+
+  it("confirming the update dialog calls providerUpdate exactly once", async () => {
+    const { unmount } = render(ProviderSheet, {
+      props: { provider: makeProvider("ssh"), open: true },
+    })
+
+    await flushAsync()
+
+    const updateBtn = Array.from(document.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Update",
+    )
+    updateBtn?.click()
+    await tick()
+
+    const dialogs2 = Array.from(document.querySelectorAll("[role='dialog']"))
+    const confirmDialog = dialogs2.find((d) =>
+      d.textContent?.includes("Update 'ssh' to 0.2.0"),
+    )
+    const confirmBtn = Array.from(
+      confirmDialog?.querySelectorAll("button") ?? [],
+    ).find((b) => b.textContent?.trim() === "Update")
+    confirmBtn?.click()
+    await flushAsync()
+
+    expect(providerUpdate).toHaveBeenCalledTimes(1)
+    expect(providerUpdate).toHaveBeenCalledWith("ssh")
     unmount()
   })
 })

--- a/desktop/src/renderer/src/lib/components/provider/UpdateConfirmDialog.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/UpdateConfirmDialog.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+import ConfirmDialog from "$lib/components/layout/ConfirmDialog.svelte"
+
+let {
+  providerName,
+  currentVersion,
+  latestVersion,
+  open = $bindable(false),
+  loading = false,
+  onconfirm,
+}: {
+  providerName: string
+  currentVersion?: string
+  latestVersion?: string
+  open?: boolean
+  loading?: boolean
+  onconfirm: () => void
+} = $props()
+
+let title = $derived(
+  latestVersion
+    ? `Update '${providerName}' to ${latestVersion}?`
+    : `Update '${providerName}'?`,
+)
+
+let description = $derived.by(() => {
+  if (currentVersion && latestVersion) {
+    return `This will update ${providerName} from ${currentVersion} to ${latestVersion}.`
+  }
+  return "Check for and install the latest version."
+})
+</script>
+
+<ConfirmDialog
+  bind:open
+  {title}
+  {description}
+  confirmLabel="Update"
+  variant="default"
+  {loading}
+  {onconfirm}
+/>

--- a/desktop/src/renderer/src/pages/ProviderDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/ProviderDetailPage.svelte
@@ -8,8 +8,9 @@ import { Separator } from "$lib/components/ui/separator/index.js"
 import * as Select from "$lib/components/ui/select/index.js"
 import { badgeVariants } from "$lib/components/ui/badge/index.js"
 import * as Alert from "$lib/components/ui/alert/index.js"
-import { TriangleAlert } from "@lucide/svelte"
+import { TriangleAlert, Star } from "@lucide/svelte"
 import ConfirmDialog from "$lib/components/layout/ConfirmDialog.svelte"
+import UpdateConfirmDialog from "$lib/components/provider/UpdateConfirmDialog.svelte"
 import ProviderIcon from "$lib/components/provider/ProviderIcon.svelte"
 import { providers } from "$lib/stores/providers.js"
 import {
@@ -49,6 +50,8 @@ let loading = $state(true)
 let confirmDeleteOpen = $state(false)
 let deleting = $state(false)
 let initializing = $state(false)
+let confirmUpdateOpen = $state(false)
+let updating = $state(false)
 let confirmSwitchOpen = $state(false)
 let targetTag = $state("")
 let switching = $state(false)
@@ -151,12 +154,22 @@ async function handleInitialize() {
   }
 }
 
-async function handleUpdate() {
+function handleUpdate() {
+  confirmUpdateOpen = true
+}
+
+async function runUpdate() {
+  updating = true
   try {
     await providerUpdate(id)
     toasts.success(`Updated ${id}`)
+    await loadVersionsFor(id)
+    await refreshUpdates()
   } catch (err) {
     toasts.error(`Failed to update: ${extractErrorMessage(err)}`)
+  } finally {
+    updating = false
+    confirmUpdateOpen = false
   }
 }
 
@@ -230,7 +243,10 @@ async function handleSaveOptions() {
       <span class={badgeVariants({ variant: "default" })}>initialized</span>
     {/if}
     {#if provider?.isDefault}
-      <span class={badgeVariants({ variant: "default" })}>Default</span>
+      <span class="{badgeVariants({ variant: 'default' })} gap-1">
+        <Star class="size-3" />
+        Default
+      </span>
     {/if}
   </div>
 
@@ -239,7 +255,7 @@ async function handleSaveOptions() {
       <Alert.Root class="border-amber-500/50 bg-amber-500/10">
         <Alert.Title>Update available: {$providerVersions.updates[id].latest}</Alert.Title>
         <Alert.Description>
-          <Button size="sm" class="mt-2" onclick={() => openVersionSwitch($providerVersions.updates[id].latest)}>
+          <Button size="sm" class="mt-2" onclick={handleUpdate}>
             Install update
           </Button>
         </Alert.Description>
@@ -381,6 +397,15 @@ async function handleSaveOptions() {
   confirmLabel="Delete"
   loading={deleting}
   onconfirm={handleDelete}
+/>
+
+<UpdateConfirmDialog
+  bind:open={confirmUpdateOpen}
+  providerName={id}
+  currentVersion={provider?.version}
+  latestVersion={$providerVersions.updates[id]?.latest}
+  loading={updating}
+  onconfirm={runUpdate}
 />
 
 <ConfirmDialog


### PR DESCRIPTION
## Summary

- Adds a version selector and update-confirm dialog to `ProviderSheet`, mirroring the experience already on `ProviderDetailPage`, so users can pick a specific provider version and confirm before installing an update from the slide-over.
- Promotes the "default provider" badge to a `Star`-iconed pill across `ProviderCard`, `ProviderSheet`, and `ProviderDetailPage` for a more visible indicator.
- Extracts a small shared `UpdateConfirmDialog` component used by both the sheet and the detail page, so the Update flow is identical wherever the user triggers it.