### PR TITLE
feat(desktop): auto-suggest workspace names on conflict

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@types/dompurify": "^3.0.5",
         "chokidar": "^4.0.0",
         "dompurify": "^3.4.7",
         "electron-updater": "^6.8.3",
         "node-pty": "^1.0.0",
         "posthog-node": "^5.34.2",
-        "svelte-spa-router": "^5.0.1"
+        "svelte-spa-router": "^5.0.1",
+        "unique-names-generator": "^4.7.1"
       },
       "devDependencies": {
         "@electron/rebuild": "^3.7.0",
@@ -26,6 +26,7 @@
         "@tailwindcss/vite": "^4.2.2",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.3.1",
+        "@types/dompurify": "^3.0.5",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "bits-ui": "^2.17.3",
@@ -2617,6 +2618,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
       "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/trusted-types": "*"
@@ -2699,6 +2701,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/verror": {
@@ -8672,6 +8675,15 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/unique-names-generator": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/unique-names-generator/-/unique-names-generator-4.7.1.tgz",
+      "integrity": "sha512-lMx9dX+KRmG8sq6gulYYpKWZc9RlGsgBR6aoO8Qsm3qvkSJ+3rAymr+TnV8EDMrIrwuFJ4kruzMWM/OpYzPoow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/unique-slug": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -26,11 +26,11 @@
     "electron-updater": "^6.8.3",
     "node-pty": "^1.0.0",
     "posthog-node": "^5.34.2",
-    "svelte-spa-router": "^5.0.1"
+    "svelte-spa-router": "^5.0.1",
+    "unique-names-generator": "^4.7.1"
   },
   "devDependencies": {
     "@electron/rebuild": "^3.7.0",
-    "@types/dompurify": "^3.0.5",
     "@internationalized/date": "^3.12.1",
     "@lucide/svelte": "^1.8.0",
     "@playwright/test": "^1.50.0",
@@ -38,6 +38,7 @@
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.3.1",
+    "@types/dompurify": "^3.0.5",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "bits-ui": "^2.17.3",

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -21,6 +21,7 @@ import { badgeVariants } from "$lib/components/ui/badge/index.js"
 import LanguageIcon from "$lib/components/workspace/LanguageIcon.svelte"
 import ConfirmDialog from "$lib/components/layout/ConfirmDialog.svelte"
 import LogTable from "$lib/components/log/LogTable.svelte"
+import { uniqueNamesGenerator, adjectives, animals } from "unique-names-generator"
 import { workspaceUp } from "$lib/ipc/commands.js"
 import { onCommandProgress } from "$lib/ipc/events.js"
 import type { CommandProgress } from "$lib/types/index.js"
@@ -364,6 +365,25 @@ function goToStep(step: Step) {
   currentStep = step
 }
 
+function randomName(): string {
+  return uniqueNamesGenerator({
+    dictionaries: [adjectives, animals],
+    separator: "-",
+    length: 2,
+    style: "lowerCase",
+  })
+}
+
+function uniquifyName(base: string): string {
+  const existing = new Set($workspaces.map((ws) => ws.id.toLowerCase()))
+  if (base && !existing.has(base.toLowerCase())) return base
+  for (let i = 0; i < 50; i++) {
+    const candidate = randomName()
+    if (!existing.has(candidate.toLowerCase())) return candidate
+  }
+  return `${randomName()}-${Date.now().toString(36)}`
+}
+
 function continueFromProvider() {
   if (!selectedProvider) return
   currentStep = "source"
@@ -371,6 +391,17 @@ function continueFromProvider() {
 
 function continueFromSource() {
   if (!source.trim()) return
+  if (!workspaceName.trim()) {
+    const derived =
+      source
+        .trim()
+        .split("/")
+        .pop()
+        ?.replace(/\.git$/, "") ?? ""
+    if (derived) workspaceName = uniquifyName(derived)
+  } else {
+    workspaceName = uniquifyName(workspaceName.trim())
+  }
   currentStep = "ide"
 }
 
@@ -387,7 +418,7 @@ function continueFromReview() {
 function selectTemplate(t: { name: string; source: string }) {
   source = t.source
   if (!workspaceName) {
-    workspaceName = t.name.toLowerCase().replace(/[^a-z0-9]/g, "-")
+    workspaceName = uniquifyName(t.name.toLowerCase().replace(/[^a-z0-9]/g, "-"))
   }
 }
 </script>
@@ -622,6 +653,9 @@ function selectTemplate(t: { name: string; source: string }) {
               value={workspaceName}
               oninput={(e) => (workspaceName = e.currentTarget.value)}
             />
+            <p class="text-xs text-muted-foreground">
+              Auto-suggested to avoid conflicts. Edit to use a custom name.
+            </p>
             <p class="text-xs text-muted-foreground">
               Resolved id: <span class="font-mono">{resolvedId || "—"}</span>
             </p>

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.test.ts
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.test.ts
@@ -205,7 +205,36 @@ describe("WorkspaceWizard", () => {
     unmount()
   })
 
-  it("review step shows summary and blocks Launch on name conflict", async () => {
+  it("review step auto-suggests a unique name when the derived id conflicts", async () => {
+    providers.set([makeProvider("docker")])
+    workspaces.set([{ id: "python" }])
+    const { getByText, queryByText, unmount } = render(WorkspaceWizard, {
+      props: { open: true },
+    })
+    await flushAsync()
+    await advanceToReview(getByText)
+
+    const heading = document.querySelector("h2")
+    expect(heading?.textContent).toBe("Review")
+
+    // Conflicting derived name ("python") should have been replaced with a
+    // generated unique name, not surface the "already exists" warning.
+    expect(queryByText(/already exists/i)).toBeNull()
+
+    const nameInput = document.querySelector(
+      'input[placeholder*="derived from source"]',
+    ) as HTMLInputElement
+    expect(nameInput.value).not.toBe("")
+    expect(nameInput.value).not.toBe("python")
+
+    const launchBtn = Array.from(
+      document.querySelectorAll("button"),
+    ).find((b) => b.textContent?.trim() === "Launch") as HTMLButtonElement
+    expect(launchBtn.disabled).toBe(false)
+    unmount()
+  })
+
+  it("blocks Launch when the user edits the name into a conflict", async () => {
     providers.set([makeProvider("docker")])
     workspaces.set([{ id: "python" }])
     const { getByText, unmount } = render(WorkspaceWizard, {
@@ -214,9 +243,12 @@ describe("WorkspaceWizard", () => {
     await flushAsync()
     await advanceToReview(getByText)
 
-    // Review heading + step indicator both contain "Review", so check the h2 specifically
-    const heading = document.querySelector("h2")
-    expect(heading?.textContent).toBe("Review")
+    const nameInput = document.querySelector(
+      'input[placeholder*="derived from source"]',
+    ) as HTMLInputElement
+    await fireEvent.input(nameInput, { target: { value: "python" } })
+    await flushAsync()
+
     expect(getByText(/already exists/i)).toBeTruthy()
     const launchBtn = Array.from(
       document.querySelectorAll("button"),


### PR DESCRIPTION
## Summary
- Workspace wizard no longer blocks when a derived name (e.g. `node-js`) collides with an existing workspace.
- Source-derived names are kept when free; on collision (or no derivable base), generate a random adjective-animal name like `focused-crab` via `unique-names-generator`.
- User can still freely edit the suggested name in the Review step; the existing collision warning remains as a safety net for manually-typed names.