### PR TITLE
fix(desktop): repair SSH terminal and close workspace delete race

### DIFF
--- a/desktop/src/main/__tests__/log-store.test.ts
+++ b/desktop/src/main/__tests__/log-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, beforeEach, describe, expect, it } from "vitest"
@@ -19,11 +19,9 @@ describe("LogStore", () => {
     rmSync(tempDir, { recursive: true, force: true })
   })
 
-  it("creates a log file under the per-workspace dir", () => {
+  it("creates a log file under the desktop-owned per-workspace dir", () => {
     const logPath = store.createLogFile(CTX, "ws-1")
-    expect(logPath).toContain(
-      join("contexts", CTX, "workspaces", "ws-1", "logs"),
-    )
+    expect(logPath).toContain(join("workspaces", CTX, "ws-1"))
     expect(logPath).toMatch(/\.log$/)
   })
 
@@ -34,6 +32,12 @@ describe("LogStore", () => {
     const content = store.readLogByPath(logPath)
     expect(content).toContain("line 1")
     expect(content).toContain("line 2")
+  })
+
+  it("silently drops appends when the log file is gone", () => {
+    const logPath = store.createLogFile(CTX, "ws-1")
+    unlinkSync(logPath)
+    expect(() => store.appendLog(logPath, "late output")).not.toThrow()
   })
 
   it("lists logs for a workspace, newest first", () => {
@@ -83,7 +87,6 @@ describe("LogStore", () => {
   })
 
   it("rejects non-.log basenames after stripping traversal", () => {
-    // basename("../../etc/passwd") = "passwd" — no .log extension, rejected.
     expect(() => store.readLog(CTX, "ws-1", "../../etc/passwd")).toThrow(
       /invalid log filename/,
     )
@@ -96,24 +99,17 @@ describe("LogStore", () => {
   })
 
   it("confines traversal-shaped .log filenames to the workspace dir", () => {
-    // Plant a sibling.log OUTSIDE the workspace logs dir.
     const outside = join(tempDir, "sibling.log")
     writeFileSync(outside, "outside-content")
-    // basename("../sibling.log") = "sibling.log" → looked up INSIDE the
-    // workspace logs dir, where nothing of that name exists. The planted
-    // file outside the dir must NOT be reachable.
     expect(() => store.readLog(CTX, "ws-1", "../sibling.log")).toThrow(
       /ENOENT/,
     )
   })
 
   it("prune skips non-directory entries without aborting", () => {
-    // Create a normal log first.
     store.createLogFile(CTX, "ws-1")
-    // Plant a regular file where prune would expect a workspace dir.
-    const contextsRoot = join(tempDir, "contexts", CTX, "workspaces")
-    const stray = join(contextsRoot, "stray-file")
-    writeFileSync(stray, "")
+    const root = join(tempDir, "workspaces", CTX)
+    writeFileSync(join(root, "stray-file"), "")
     expect(() => store.prune(30)).not.toThrow()
     expect(store.listLogs(CTX, "ws-1")).toHaveLength(1)
   })

--- a/desktop/src/main/cli.ts
+++ b/desktop/src/main/cli.ts
@@ -176,6 +176,13 @@ export class CliRunner {
   }
 
   private activeChildren = new Set<ChildProcess>()
+  /**
+   * Tracks streaming children by workspace so callers can cancel everything
+   * tied to a workspace before destructive operations like delete. Without this,
+   * still-running children continue to emit output after the CLI has unlinked
+   * the workspace's log directory, causing ENOENT crashes in appendLog.
+   */
+  private childrenByWorkspace = new Map<string, Set<ChildProcess>>()
 
   async runStreaming(
     args: string[],
@@ -185,6 +192,7 @@ export class CliRunner {
       meta?: StreamLine,
     ) => void,
     onExit: (code: number, cliError?: CLIError) => void,
+    workspaceId?: string,
   ): Promise<ChildProcess> {
     await this.acquire()
     const child = spawn(
@@ -194,6 +202,14 @@ export class CliRunner {
     )
 
     this.activeChildren.add(child)
+    if (workspaceId) {
+      let bucket = this.childrenByWorkspace.get(workspaceId)
+      if (!bucket) {
+        bucket = new Set()
+        this.childrenByWorkspace.set(workspaceId, bucket)
+      }
+      bucket.add(child)
+    }
 
     let lastCliError: CLIError | undefined
 
@@ -221,6 +237,13 @@ export class CliRunner {
 
     child.on("close", (code) => {
       this.activeChildren.delete(child)
+      if (workspaceId) {
+        const bucket = this.childrenByWorkspace.get(workspaceId)
+        if (bucket) {
+          bucket.delete(child)
+          if (bucket.size === 0) this.childrenByWorkspace.delete(workspaceId)
+        }
+      }
       this.release()
       onExit(code ?? -1, lastCliError)
     })
@@ -232,6 +255,32 @@ export class CliRunner {
     for (const child of this.activeChildren) {
       child.kill("SIGTERM")
     }
+  }
+
+  /**
+   * Terminate every streaming child tied to a workspace and resolve once they
+   * have all closed. Resolves immediately if none are tracked. Must be awaited
+   * before invoking `workspace delete` so late stdout cannot land on an
+   * already-unlinked log file.
+   */
+  async cancelFor(workspaceId: string): Promise<void> {
+    const bucket = this.childrenByWorkspace.get(workspaceId)
+    if (!bucket || bucket.size === 0) return
+
+    const waits: Promise<void>[] = []
+    for (const child of bucket) {
+      waits.push(
+        new Promise<void>((resolve) => {
+          if (child.exitCode !== null || child.signalCode !== null) {
+            resolve()
+            return
+          }
+          child.once("close", () => resolve())
+        }),
+      )
+      child.kill("SIGTERM")
+    }
+    await Promise.all(waits)
   }
 
   static stripAnsi(str: string): string {

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -1,3 +1,4 @@
+import { homedir } from "node:os"
 import { join } from "node:path"
 import { app, BrowserWindow, session } from "electron"
 import { initAnalytics, shutdownAnalytics, trackEvent } from "./analytics.js"
@@ -124,8 +125,11 @@ app.whenReady().then(() => {
       : CliRunner.resolveBinaryPath(join(__dirname, "../../resources")))
   const cli = new CliRunner(binaryPath)
 
-  // Initialize log store and prune old logs
-  const logStore = LogStore.defaultPath()
+  // Initialize log store. Logs live under ~/.devsy/desktop/logs/ — inside the
+  // shared ~/.devsy root (no artifact sprawl) but outside the CLI-managed
+  // ~/.devsy/contexts/<ctx>/workspaces/<id>/ subtree that `workspace delete`
+  // unlinks. That separation closes the file-deletion race by construction.
+  const logStore = new LogStore(join(homedir(), ".devsy", "desktop", "logs"))
   try {
     const pruned = logStore.prune(30)
     if (pruned > 0) console.log(`Pruned ${pruned} old log files`)

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -67,8 +67,31 @@ export function registerIpcHandlers(deps: IpcDependencies): {
   scheduleProviderUpdateCheck: () => void
   runInitialProviderUpdateCheck: () => void
 } {
-  const { cli, state, logStore } = deps
+  const { cli, state, logStore, pty } = deps
   const tunnelProcesses = new Map<string, import("node:child_process").ChildProcess>()
+
+  /**
+   * Terminate every desktop-spawned process tied to a workspace and wait for
+   * them to actually exit. Called before stop/delete so destructive CLI runs
+   * don't race with in-flight children that are still appending to the
+   * workspace's log directory.
+   */
+  async function quiesceWorkspace(workspaceId: string): Promise<void> {
+    const tunnelProc = tunnelProcesses.get(workspaceId)
+    if (tunnelProc) {
+      tunnelProcesses.delete(workspaceId)
+      const tunnelExit = new Promise<void>((resolve) => {
+        if (tunnelProc.exitCode !== null || tunnelProc.signalCode !== null) {
+          resolve()
+          return
+        }
+        tunnelProc.once("close", () => resolve())
+      })
+      tunnelProc.kill("SIGTERM")
+      await tunnelExit
+    }
+    await Promise.all([cli.cancelFor(workspaceId), pty.cancelFor(workspaceId)])
+  }
 
   /**
    * Compute provider update information by querying the CLI for all installed providers.
@@ -519,6 +542,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
             done: true,
           })
         },
+        wsId,
       )
 
       return cmdId
@@ -529,12 +553,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
     "workspace_stop",
     async (_event, args: { workspaceId: string; debug?: boolean }) => {
       trackEvent("workspace_stop")
-      // Kill tunnel process for this workspace
-      const tunnelProc = tunnelProcesses.get(args.workspaceId)
-      if (tunnelProc) {
-        tunnelProc.kill("SIGTERM")
-        tunnelProcesses.delete(args.workspaceId)
-      }
+      await quiesceWorkspace(args.workspaceId)
       const cmdId = crypto.randomUUID()
       const logPath = logStore.createLogFile(state.workspaceContext(args.workspaceId), args.workspaceId)
       const win = deps.getMainWindow()
@@ -565,6 +584,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
             done: true,
           })
         },
+        args.workspaceId,
       )
 
       return cmdId
@@ -575,12 +595,12 @@ export function registerIpcHandlers(deps: IpcDependencies): {
     "workspace_delete",
     async (_event, args: { workspaceId: string; debug?: boolean }) => {
       trackEvent("workspace_delete")
-      // Kill tunnel process for this workspace
-      const tunnelProc = tunnelProcesses.get(args.workspaceId)
-      if (tunnelProc) {
-        tunnelProc.kill("SIGTERM")
-        tunnelProcesses.delete(args.workspaceId)
-      }
+      // Replaces the old `devsy down` command which the CLI overhaul removed:
+      // before invoking delete, terminate every desktop-spawned child tied to
+      // this workspace and wait for them to actually exit. Otherwise late
+      // stdout/stderr lands on a log file the CLI is about to unlink, causing
+      // an ENOENT crash in the main process.
+      await quiesceWorkspace(args.workspaceId)
       const cmdId = crypto.randomUUID()
       const logPath = logStore.createLogFile(state.workspaceContext(args.workspaceId), args.workspaceId)
       const win = deps.getMainWindow()
@@ -612,6 +632,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
             done: true,
           })
         },
+        args.workspaceId,
       )
 
       return cmdId
@@ -652,6 +673,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
             done: true,
           })
         },
+        args.workspaceId,
       )
 
       return cmdId
@@ -692,6 +714,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
             done: true,
           })
         },
+        args.workspaceId,
       )
 
       return cmdId

--- a/desktop/src/main/log-store.ts
+++ b/desktop/src/main/log-store.ts
@@ -8,7 +8,6 @@ import {
   unlinkSync,
   writeFileSync,
 } from "node:fs"
-import { homedir } from "node:os"
 import { basename, join } from "node:path"
 
 // safeLogFilename strips any directory components from filename so a caller
@@ -25,9 +24,6 @@ function safeLogFilename(filename: string): string {
   return clean
 }
 
-// isReadableDir returns true only when path exists AND is a regular
-// directory (not a symlink or file). Used by prune to skip non-directory
-// entries that would make readdirSync throw mid-pass.
 function isReadableDir(path: string): boolean {
   if (!existsSync(path)) return false
   try {
@@ -46,27 +42,18 @@ export interface LogEntry {
 
 let counter = 0
 
-// LogStore writes streaming command logs into the canonical per-workspace
-// directory (~/.devsy/contexts/<ctx>/workspaces/<id>/logs/), so `devsy delete`
-// wipes them via os.RemoveAll on the workspace dir. Callers must supply the
-// workspace's context for every operation; resolve it from DaemonState
-// (workspaceContext) before invoking.
+/**
+ * LogStore writes desktop-owned streaming command logs into a directory
+ * outside the CLI's workspace state subtree. The CLI's `workspace delete`
+ * unlinks ~/.devsy/contexts/<ctx>/workspaces/<id>/ wholesale, so co-locating
+ * desktop logs there created a file-deletion race when a still-running
+ * desktop child emitted output after the directory was gone.
+ */
 export class LogStore {
-  constructor(private devsyHomeDir: string) {}
-
-  static defaultPath(): LogStore {
-    return new LogStore(join(homedir(), ".devsy"))
-  }
+  constructor(private logsDir: string) {}
 
   private workspaceLogDir(context: string, workspaceId: string): string {
-    return join(
-      this.devsyHomeDir,
-      "contexts",
-      context,
-      "workspaces",
-      workspaceId,
-      "logs",
-    )
+    return join(this.logsDir, "workspaces", context, workspaceId)
   }
 
   createLogFile(context: string, workspaceId: string): string {
@@ -81,7 +68,14 @@ export class LogStore {
   }
 
   appendLog(logPath: string, line: string): void {
-    appendFileSync(logPath, `${line}\n`)
+    try {
+      appendFileSync(logPath, `${line}\n`)
+    } catch (err) {
+      // Defensive: the workspace dir under the desktop logs root is owned by
+      // this process, but a manual `rm -rf` of the logs tree (or any other
+      // out-of-band removal) shouldn't crash the main process.
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err
+    }
   }
 
   readLogByPath(logPath: string): string {
@@ -122,28 +116,29 @@ export class LogStore {
     )
   }
 
-  // prune walks every <devsyHome>/contexts/<ctx>/workspaces/<id>/logs/ tree
-  // and removes log files older than maxAgeDays. Missing trees or
-  // non-directory entries (files, dangling symlinks) are skipped without
-  // aborting the rest of the pass.
+  /**
+   * Walks every <logsDir>/workspaces/<ctx>/<id>/ tree and removes log files
+   * older than maxAgeDays. Missing trees or non-directory entries are skipped
+   * without aborting the rest of the pass.
+   */
   prune(maxAgeDays: number): number {
-    const contextsRoot = join(this.devsyHomeDir, "contexts")
-    if (!isReadableDir(contextsRoot)) return 0
+    const root = join(this.logsDir, "workspaces")
+    if (!isReadableDir(root)) return 0
 
     const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000
     let removed = 0
 
-    for (const ctx of readdirSync(contextsRoot)) {
-      const wsRoot = join(contextsRoot, ctx, "workspaces")
+    for (const ctx of readdirSync(root)) {
+      const wsRoot = join(root, ctx)
       if (!isReadableDir(wsRoot)) continue
 
       for (const wsDir of readdirSync(wsRoot)) {
-        const logDir = join(wsRoot, wsDir, "logs")
-        if (!isReadableDir(logDir)) continue
+        const dir = join(wsRoot, wsDir)
+        if (!isReadableDir(dir)) continue
 
-        for (const file of readdirSync(logDir)) {
+        for (const file of readdirSync(dir)) {
           if (!file.endsWith(".log")) continue
-          const filePath = join(logDir, file)
+          const filePath = join(dir, file)
           const fileStat = statSync(filePath)
           if (fileStat.birthtimeMs < cutoff) {
             unlinkSync(filePath)

--- a/desktop/src/main/pty.ts
+++ b/desktop/src/main/pty.ts
@@ -29,6 +29,12 @@ interface PtyDeps {
 
 export class PtyManager {
   private sessions = new Map<string, IPty>()
+  /**
+   * Reverse index from workspace ID to its active session IDs, so a workspace
+   * delete can terminate every SSH session tied to that workspace before the
+   * CLI unlinks the workspace state directory.
+   */
+  private sessionsByWorkspace = new Map<string, Set<string>>()
   private env: Record<string, string>
 
   constructor(private deps: PtyDeps) {
@@ -73,15 +79,40 @@ export class PtyManager {
   createSshSession(workspaceId: string, cols: number, rows: number): string {
     const pty = requirePty()
     const sessionId = crypto.randomUUID()
-    const proc = pty.spawn(this.deps.binaryPath, ["ssh", workspaceId], {
+    const proc = pty.spawn(this.deps.binaryPath, ["workspace", "ssh", workspaceId], {
       name: "xterm-256color",
       cols,
       rows,
       env: this.env,
     })
 
-    this.wire(sessionId, proc)
+    this.wire(sessionId, proc, workspaceId)
     return sessionId
+  }
+
+  /**
+   * Kill every SSH session for a workspace and resolve once all PTY children
+   * have exited. Resolves immediately if no sessions are tracked.
+   */
+  async cancelFor(workspaceId: string): Promise<void> {
+    const sessionIds = this.sessionsByWorkspace.get(workspaceId)
+    if (!sessionIds || sessionIds.size === 0) return
+
+    const waits: Promise<void>[] = []
+    for (const id of sessionIds) {
+      const proc = this.sessions.get(id)
+      if (!proc) continue
+      waits.push(
+        new Promise<void>((resolve) => {
+          const disposable = proc.onExit(() => {
+            disposable.dispose()
+            resolve()
+          })
+        }),
+      )
+      proc.kill()
+    }
+    await Promise.all(waits)
   }
 
   writeToSession(sessionId: string, data: string): void {
@@ -114,8 +145,16 @@ export class PtyManager {
     }
   }
 
-  private wire(sessionId: string, proc: IPty): void {
+  private wire(sessionId: string, proc: IPty, workspaceId?: string): void {
     this.sessions.set(sessionId, proc)
+    if (workspaceId) {
+      let bucket = this.sessionsByWorkspace.get(workspaceId)
+      if (!bucket) {
+        bucket = new Set()
+        this.sessionsByWorkspace.set(workspaceId, bucket)
+      }
+      bucket.add(sessionId)
+    }
 
     proc.onData((data) => {
       this.send("terminal:output", {
@@ -126,6 +165,13 @@ export class PtyManager {
 
     proc.onExit(({ exitCode, signal }) => {
       this.sessions.delete(sessionId)
+      if (workspaceId) {
+        const bucket = this.sessionsByWorkspace.get(workspaceId)
+        if (bucket) {
+          bucket.delete(sessionId)
+          if (bucket.size === 0) this.sessionsByWorkspace.delete(workspaceId)
+        }
+      }
       this.send("terminal:exit", { sessionId, exitCode, signal })
     })
   }


### PR DESCRIPTION
## Summary

Two related regressions in the desktop introduced by the CLI restructure in #466:

- **Blank black SSH terminal.** `PtyManager.createSshSession` still spawned `devsy ssh <id>`, but `ssh` is now a subcommand of `workspace`. The PTY exits immediately, leaving the renderer showing the dark xterm canvas with "Session ended".
- **`ENOENT` crash dialog on workspace delete.** The old atomic `devsy down` (stop + delete) is gone. The desktop now calls `workspace delete --force` directly, but doesn't quiesce children it spawned (`up`, `stop`, `rebuild`, `reset` streams + SSH PTY sessions). When the CLI unlinks `~/.devsy/contexts/<ctx>/workspaces/<id>/`, those still-running children's stdout lands on a log file that no longer exists, throwing uncaught `ENOENT` in the main process.

Fixed in three layers — quiesce, separate, defend:

1. **Quiesce.** `CliRunner` and `PtyManager` now track children by `workspaceId`. New `cancelFor(workspaceId)` SIGTERMs each child and **awaits its exit**. `ipc.ts` has a `quiesceWorkspace()` helper awaited at the top of `workspace_stop` and `workspace_delete`.
2. **Separate.** Desktop logs now live at `~/.devsy/desktop/logs/workspaces/<ctx>/<id>/`, outside the CLI-managed `contexts/<ctx>/workspaces/<id>/` subtree. Same `~/.devsy` root (no artifact sprawl, single uninstall point) but the file-deletion race is impossible by construction. Old logs at the legacy path are left where they are — the next CLI delete naturally cleans them up.
3. **Defend.** `appendLog` swallows `ENOENT` as a safety net for any out-of-band removal (manual `rm -rf`, etc.) that escapes the quiesce.

Plus the one-liner `["ssh", id]` → `["workspace", "ssh", id]` in `pty.ts` for the terminal.

## Files

- `desktop/src/main/pty.ts` — SSH command + per-workspace session tracking + `cancelFor`.
- `desktop/src/main/cli.ts` — per-workspace child tracking + `cancelFor`.
- `desktop/src/main/ipc.ts` — `quiesceWorkspace()`; workspaceId tag on all workspace-scoped `runStreaming` calls.
- `desktop/src/main/log-store.ts` — new desktop-owned logs path; ENOENT-tolerant `appendLog`.
- `desktop/src/main/index.ts` — constructs `LogStore` with the new path.
- `desktop/src/main/__tests__/log-store.test.ts` — updated for new layout + appendLog ENOENT-tolerance test.