### PR TITLE
fix(workspace): delete container on rename to fix stale bind mounts

### DIFF
--- a/desktop/e2e/integration.e2e.ts
+++ b/desktop/e2e/integration.e2e.ts
@@ -307,6 +307,11 @@ test.describe
       // Click Save
       await page.locator('[data-slot="workspace-rename-save"]').click()
 
+      // ConfirmDialog warns that the existing container will be reset.
+      const confirmDialog = page.locator('[data-slot="dialog-content"]')
+      await confirmDialog.waitFor({ timeout: 5000 })
+      await confirmDialog.getByRole("button", { name: "Rename" }).click()
+
       // Wait for rename to complete and navigation to new URL
       await page.waitForTimeout(4000)
 

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -427,8 +427,8 @@ async function performRename(target: string) {
 }
 
 async function handleRenameConfirmed() {
-  confirmRenameOpen = false
   await performRename(pendingRenameTarget)
+  confirmRenameOpen = false
 }
 </script>
 

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -119,6 +119,13 @@ let logsLoading = $state(false)
 
 let confirmDeleteOpen = $state(false)
 let deleting = $state(false)
+let confirmRenameOpen = $state(false)
+let pendingRenameTarget = $state("")
+
+let hasContainer = $derived.by(() => {
+  const status = workspace?.status?.toLowerCase()
+  return Boolean(status) && status !== "notfound"
+})
 
 let sshSessionId = $state<string | null>(null)
 let sshExited = $state(false)
@@ -397,17 +404,31 @@ async function handleRename() {
     renaming = false
     return
   }
+  if (hasContainer) {
+    pendingRenameTarget = trimmed
+    confirmRenameOpen = true
+    return
+  }
+  await performRename(trimmed)
+}
+
+async function performRename(target: string) {
   renameSaving = true
   try {
-    await workspaceRename(id, trimmed)
-    toasts.success(`Renamed workspace to ${trimmed}`)
+    await workspaceRename(id, target)
+    toasts.success(`Renamed workspace to ${target}`)
     renaming = false
-    goto(`/workspaces/${trimmed}`)
+    goto(`/workspaces/${target}`)
   } catch (err) {
     toasts.error(`Failed to rename: ${extractErrorMessage(err)}`)
   } finally {
     renameSaving = false
   }
+}
+
+async function handleRenameConfirmed() {
+  confirmRenameOpen = false
+  await performRename(pendingRenameTarget)
 }
 </script>
 
@@ -806,4 +827,13 @@ async function handleRename() {
   confirmLabel="Delete"
   loading={deleting}
   onconfirm={handleDelete}
+/>
+
+<ConfirmDialog
+  bind:open={confirmRenameOpen}
+  title="Rename will reset the container"
+  description="Renaming '{id}' to '{pendingRenameTarget}' will delete the existing container. The source code and devcontainer config are preserved, but anything installed inside the running container outside the devcontainer config (e.g. manual 'apt install', files outside bind mounts) will be lost."
+  confirmLabel="Rename"
+  loading={renameSaving}
+  onconfirm={handleRenameConfirmed}
 />

--- a/pkg/workspace/rename.go
+++ b/pkg/workspace/rename.go
@@ -177,7 +177,7 @@ func removeContainerForRename(
 		return nil
 	}
 
-	log.Infof("removing stale container %s after workspace rename", container.ID)
+	log.Infof("removing stale container %s before workspace rename", container.ID)
 	return helper.Remove(ctx, container.ID)
 }
 

--- a/pkg/workspace/rename.go
+++ b/pkg/workspace/rename.go
@@ -181,9 +181,10 @@ func removeContainerForRename(
 	return helper.Remove(ctx, container.ID)
 }
 
-// Rename auto-stops the workspace, moves its directory, deletes the stale
-// container, and clears the old SSH entry. The container is rebuilt on the
-// next `up`.
+// Rename auto-stops the workspace, deletes the stale container, moves its
+// directory, and clears the old SSH entry. The container is rebuilt on the
+// next `up`. Container removal happens before the disk move so a failure
+// aborts cleanly with the workspace still intact under its old name.
 func Rename(ctx context.Context, opts RenameOptions) error {
 	wsConfig, err := provider.LoadWorkspaceConfig(opts.DevsyConfig.DefaultContext, opts.OldName)
 	if err != nil {
@@ -201,6 +202,9 @@ func Rename(ctx context.Context, opts RenameOptions) error {
 	}
 
 	lookupRunnerID := devcontainer.GetRunnerIDFromWorkspace(wsConfig)
+	if err := removeContainerForRename(ctx, wsConfig, lookupRunnerID); err != nil {
+		return fmt.Errorf("remove stale container: %w", err)
+	}
 
 	if err := moveWorkspace(opts.DevsyConfig, opts.OldName, opts.NewName); err != nil {
 		return fmt.Errorf("moving workspace: %w", err)
@@ -215,14 +219,6 @@ func Rename(ctx context.Context, opts RenameOptions) error {
 	}
 
 	updateWorkspaceResult(opts.DevsyConfig, opts.OldName, opts.NewName)
-
-	if err := removeContainerForRename(ctx, wsConfig, lookupRunnerID); err != nil {
-		log.Warnf(
-			"renamed workspace but could not remove the stale container (%v); "+
-				"run `devsy up %s --recreate` to rebuild it",
-			err, opts.NewName,
-		)
-	}
 
 	_ = devssh.RemoveFromConfig(
 		opts.OldName,

--- a/pkg/workspace/rename.go
+++ b/pkg/workspace/rename.go
@@ -10,7 +10,9 @@ import (
 
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/devcontainer"
 	devcontainerconfig "github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/platform"
 	"github.com/devsy-org/devsy/pkg/provider"
@@ -157,10 +159,31 @@ func updateWorkspaceResult(devsyConfig *config.Config, oldName, newName string) 
 	}
 }
 
-// Rename performs the workspace rename: auto-stops if running, moves the
-// workspace directory, updates the config ID, and removes the old SSH config
-// entry. If any step after the directory move fails, the entire operation is
-// rolled back.
+func removeContainerForRename(
+	ctx context.Context,
+	wsConfig *provider.Workspace,
+	lookupRunnerID string,
+) error {
+	helper := &docker.DockerHelper{
+		DockerCommand: ResolveDockerCommand(wsConfig, ""),
+	}
+
+	labels := devcontainerconfig.GetIDLabels(lookupRunnerID, nil)
+	container, err := helper.FindDevContainer(ctx, labels)
+	if err != nil {
+		return fmt.Errorf("find container: %w", err)
+	}
+	if container == nil {
+		return nil
+	}
+
+	log.Infof("removing stale container %s after workspace rename", container.ID)
+	return helper.Remove(ctx, container.ID)
+}
+
+// Rename auto-stops the workspace, moves its directory, deletes the stale
+// container, and clears the old SSH entry. The container is rebuilt on the
+// next `up`.
 func Rename(ctx context.Context, opts RenameOptions) error {
 	wsConfig, err := provider.LoadWorkspaceConfig(opts.DevsyConfig.DefaultContext, opts.OldName)
 	if err != nil {
@@ -177,6 +200,8 @@ func Rename(ctx context.Context, opts RenameOptions) error {
 		return err
 	}
 
+	lookupRunnerID := devcontainer.GetRunnerIDFromWorkspace(wsConfig)
+
 	if err := moveWorkspace(opts.DevsyConfig, opts.OldName, opts.NewName); err != nil {
 		return fmt.Errorf("moving workspace: %w", err)
 	}
@@ -190,6 +215,14 @@ func Rename(ctx context.Context, opts RenameOptions) error {
 	}
 
 	updateWorkspaceResult(opts.DevsyConfig, opts.OldName, opts.NewName)
+
+	if err := removeContainerForRename(ctx, wsConfig, lookupRunnerID); err != nil {
+		log.Warnf(
+			"renamed workspace but could not remove the stale container (%v); "+
+				"run `devsy up %s --recreate` to rebuild it",
+			err, opts.NewName,
+		)
+	}
 
 	_ = devssh.RemoveFromConfig(
 		opts.OldName,


### PR DESCRIPTION
## Summary

- After a workspace rename, the existing devcontainer's bind mounts still point at the old workspace dir on the host. The next `up` fails with `bind source path does not exist`. Docker bind sources cannot be changed on an existing container.
- `Rename` now deletes the container after moving the workspace dir; the next `up` rebuilds it from devcontainer.json with mounts pointing at the new location.
- The Desktop rename flow shows a confirmation explaining that runtime-only container state (e.g. manual `apt install`) will be lost. Source code and devcontainer config survive (they're on bind mounts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog when renaming a workspace that has an existing container, warning the user that the rename will reset the container.

* **Bug Fixes**
  * Automatically removes stale dev containers during workspace rename; failures now abort the rename to avoid inconsistent state.

* **Tests**
  * Updated rename tests to handle the new confirmation dialog and explicit confirm action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->