### PR TITLE
fix(agent): drop container env prefix for host-executed agent commands

### DIFF
--- a/pkg/agent/workspace.go
+++ b/pkg/agent/workspace.go
@@ -52,6 +52,17 @@ const EnvAgentInContainerTrue = "1"
 // is often disabled).
 const ContainerAgentEnvPrefix = EnvAgentInContainer + "=" + EnvAgentInContainerTrue + " "
 
+// AgentCommandEnvPrefix omits the container env prefix when the command
+// will be executed on the host (provider agent.local=true); prepending it
+// there would mislabel the host process and trip IsHostAgentInvocation's
+// stale-env warning.
+func AgentCommandEnvPrefix(isLocal bool) string {
+	if isLocal {
+		return ""
+	}
+	return ContainerAgentEnvPrefix
+}
+
 var ErrFindAgentHomeFolder = fmt.Errorf("couldn't find devsy home directory")
 
 // GetAgentDaemonLogFolder returns the folder that holds agent-daemon.log.

--- a/pkg/agent/workspace_test.go
+++ b/pkg/agent/workspace_test.go
@@ -8,6 +8,21 @@ import (
 // exercise the "explicit folder always wins" branch of IsHostAgentInvocation.
 const explicitAgentDir = "/some/dir"
 
+// TestAgentCommandEnvPrefix: regressions resurrect the stale-env warning
+// on every workspace op against a local provider (docker/podman/k8s).
+func TestAgentCommandEnvPrefix(t *testing.T) {
+	if got := AgentCommandEnvPrefix(true); got != "" {
+		t.Errorf("AgentCommandEnvPrefix(true) = %q, want \"\"", got)
+	}
+	if got := AgentCommandEnvPrefix(false); got != ContainerAgentEnvPrefix {
+		t.Errorf(
+			"AgentCommandEnvPrefix(false) = %q, want %q",
+			got,
+			ContainerAgentEnvPrefix,
+		)
+	}
+}
+
 // withContainerDetector swaps the package-level container detector for
 // the duration of the test, restoring the previous value on cleanup.
 func withContainerDetector(t *testing.T, fn func() bool) {

--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -84,12 +84,7 @@ func (s *workspaceClient) AgentLocal() bool {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	return options.ResolveAgentConfig(
-		s.devsyConfig,
-		s.config,
-		s.workspace,
-		s.machine,
-	).Local == config.BoolTrue
+	return s.agentLocalLocked()
 }
 
 func (s *workspaceClient) AgentPath() string {
@@ -384,7 +379,7 @@ func (s *workspaceClient) Delete(ctx context.Context, opt client.DeleteOptions) 
 			}
 			command := fmt.Sprintf(
 				"%s%q internal agent workspace delete --workspace-info %q",
-				agent.ContainerAgentEnvPrefix,
+				agent.AgentCommandEnvPrefix(s.agentLocalLocked()),
 				info.Agent.Path,
 				compressed,
 			)
@@ -493,7 +488,7 @@ func (s *workspaceClient) Stop(ctx context.Context, opt client.StopOptions) erro
 		}
 		command := fmt.Sprintf(
 			"%s%q internal agent workspace stop --workspace-info %q",
-			agent.ContainerAgentEnvPrefix,
+			agent.AgentCommandEnvPrefix(s.agentLocalLocked()),
 			info.Agent.Path,
 			compressed,
 		)
@@ -622,6 +617,17 @@ func (s *workspaceClient) Describe(ctx context.Context) (string, error) {
 	return client.DescriptionNotFound, nil
 }
 
+// agentLocalLocked is AgentLocal without re-acquiring s.m; callers must
+// already hold the lock.
+func (s *workspaceClient) agentLocalLocked() bool {
+	return options.ResolveAgentConfig(
+		s.devsyConfig,
+		s.config,
+		s.workspace,
+		s.machine,
+	).Local == config.BoolTrue
+}
+
 func (s *workspaceClient) initLock() error {
 	s.workspaceLockOnce.Do(func() {
 		s.m.Lock()
@@ -662,7 +668,7 @@ func (s *workspaceClient) getContainerStatus(ctx context.Context) (client.Status
 	}
 	command := fmt.Sprintf(
 		"%s%q internal agent workspace status --workspace-info %q",
-		agent.ContainerAgentEnvPrefix,
+		agent.AgentCommandEnvPrefix(s.agentLocalLocked()),
 		info.Agent.Path,
 		compressed,
 	)
@@ -994,7 +1000,7 @@ func buildAgentCommand(
 ) string {
 	command := fmt.Sprintf(
 		"%s%q internal agent workspace %s --workspace-info %q",
-		agent.ContainerAgentEnvPrefix,
+		agent.AgentCommandEnvPrefix(workspaceClient.AgentLocal()),
 		workspaceClient.AgentPath(),
 		agentCommand,
 		workspaceInfo,


### PR DESCRIPTION
## Summary

- Local providers (docker/podman/kubernetes; `agent.local: true`) build agent helper commands with the `DEVSY_AGENT_IN_CONTAINER=1` inline prefix and execute them on the host via the provider's `exec.command`. The spawned `devsy internal agent ...` process inherits the env var while running on the host, so `IsHostAgentInvocation` logs `"DEVSY_AGENT_IN_CONTAINER=1 is set but no container indicator file found; treating as host invocation"` on every workspace create/stop/delete/status — visible to anyone using the desktop UI against the docker provider.
- New `agent.AgentCommandEnvPrefix(isLocal bool)` helper returns `""` when `isLocal`, otherwise the existing prefix. Threaded through the four host-executed call sites in `workspace_client.go` (`Delete`, `Stop`, `getContainerStatus`, `buildAgentCommand`) via an internal `agentLocalLocked()` helper that avoids re-acquiring `s.m`.
- Container-side paths (`pkg/tunnel/*`, `cmd/workspace/up/agent.go`, `cmd/workspace/logs.go`, `cmd/internal/logs_daemon.go`) keep the prefix — those commands genuinely run inside the container via the in-container SSH server.