### PR TITLE
feat(desktop): show initializing badge during provider init

### DIFF
--- a/desktop/src/renderer/src/lib/components/provider/ProviderCard.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderCard.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
 import { badgeVariants } from "$lib/components/ui/badge/index.js"
-import { Star } from "@lucide/svelte"
+import { Star, Loader2 } from "@lucide/svelte"
 import ProviderIcon from "./ProviderIcon.svelte"
 import { providerVersions } from "$lib/stores/providerVersions.js"
+import { initializingProviders } from "$lib/stores/providers.js"
 import type { Provider } from "$lib/types/index.js"
 
 let {
   provider,
   onopen,
 }: { provider: Provider; onopen?: () => void } = $props()
+
+let isInitializing = $derived($initializingProviders.has(provider.name))
 
 function sourceDisplay(p: Provider): string {
   if (p.source?.github) return p.source.github
@@ -43,6 +46,11 @@ function sourceDisplay(p: Provider): string {
     <div class="flex gap-1.5 shrink-0">
       {#if provider.state?.initialized}
         <span class={badgeVariants({ variant: "secondary" })}>initialized</span>
+      {:else if isInitializing}
+        <span class="{badgeVariants({ variant: 'outline' })} gap-1">
+          <Loader2 class="size-3 animate-spin" />
+          initializing…
+        </span>
       {:else}
         <span class={badgeVariants({ variant: "destructive" })}>not initialized</span>
       {/if}

--- a/desktop/src/renderer/src/lib/components/provider/ProviderCard.test.ts
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderCard.test.ts
@@ -14,6 +14,11 @@ vi.mock("$lib/stores/providerVersions.js", async () => {
 })
 
 import ProviderCard from "./ProviderCard.svelte"
+import {
+  initializingProviders,
+  markInitializing,
+  clearInitializing,
+} from "$lib/stores/providers.js"
 
 function makeProvider(name: string, extras: Partial<Provider> = {}): Provider {
   return {
@@ -47,6 +52,32 @@ describe("ProviderCard", () => {
       (el) => el.textContent?.trim().toLowerCase() === "default",
     )
     expect(pill).toBeUndefined()
+    unmount()
+  })
+
+  it("shows the initializing badge while an uninitialized provider is in flight", () => {
+    initializingProviders.set(new Set())
+    markInitializing("ssh")
+    const { container, unmount } = render(ProviderCard, {
+      props: { provider: makeProvider("ssh", { state: { initialized: false } }) },
+    })
+
+    const text = container.textContent ?? ""
+    expect(text.toLowerCase()).toContain("initializing")
+    expect(text.toLowerCase()).not.toContain("not initialized")
+    clearInitializing("ssh")
+    unmount()
+  })
+
+  it("shows not initialized when no init is in flight", () => {
+    initializingProviders.set(new Set())
+    const { container, unmount } = render(ProviderCard, {
+      props: { provider: makeProvider("ssh", { state: { initialized: false } }) },
+    })
+
+    expect((container.textContent ?? "").toLowerCase()).toContain(
+      "not initialized",
+    )
     unmount()
   })
 })

--- a/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
@@ -26,7 +26,11 @@ import {
   providerRename,
   providerSetVersion,
 } from "$lib/ipc/commands.js"
-import { providers } from "$lib/stores/providers.js"
+import {
+  providers,
+  markInitializing,
+  clearInitializing,
+} from "$lib/stores/providers.js"
 import {
   providerVersions,
   loadVersionsFor,
@@ -204,6 +208,7 @@ function extractCliError(err: unknown): CLIError | null {
 async function handleInitialize() {
   initializing = true
   initError = null
+  markInitializing(provider.name)
   try {
     await providerInit(provider.name)
     const updated = await providerList()
@@ -224,6 +229,7 @@ async function handleInitialize() {
     }
   } finally {
     initializing = false
+    clearInitializing(provider.name)
   }
 }
 

--- a/desktop/src/renderer/src/lib/components/provider/ProviderSheet.test.ts
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderSheet.test.ts
@@ -29,7 +29,12 @@ vi.mock("$lib/ipc/commands.js", () => ({
 
 vi.mock("$lib/stores/providers.js", async () => {
   const { writable } = await import("svelte/store")
-  return { providers: writable([]) }
+  return {
+    providers: writable([]),
+    initializingProviders: writable(new Set()),
+    markInitializing: vi.fn(),
+    clearInitializing: vi.fn(),
+  }
 })
 
 vi.mock("$lib/stores/providerVersions.js", async () => {

--- a/desktop/src/renderer/src/lib/components/provider/ProviderWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderWizard.svelte
@@ -22,7 +22,11 @@ import {
   providerSetOptions,
 } from "$lib/ipc/commands.js"
 import { onCommandProgress } from "$lib/ipc/events.js"
-import { providers } from "$lib/stores/providers.js"
+import {
+  providers,
+  markInitializing,
+  clearInitializing,
+} from "$lib/stores/providers.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
 import { isCommandSuccess } from "$lib/utils/log-parser.js"
@@ -155,6 +159,7 @@ onMount(async () => {
       }
       if (progress.done) {
         initRunning = false
+        clearInitializing(providerName)
         if (isCommandSuccess(progress.message)) {
           refreshAndComplete()
         } else {
@@ -272,10 +277,12 @@ async function startInit() {
   initError = null
   initStartError = ""
   initLines = []
+  markInitializing(providerName)
   try {
     initCommandId = await providerInitStreaming(providerName)
   } catch (err) {
     initRunning = false
+    clearInitializing(providerName)
     initStartError = `Failed to start initialization: ${err instanceof Error ? err.message : String(err)}`
   }
 }

--- a/desktop/src/renderer/src/lib/stores/providers.ts
+++ b/desktop/src/renderer/src/lib/stores/providers.ts
@@ -7,6 +7,23 @@ import type { Provider } from "$lib/types/index.js"
 export const providers = writable<Provider[]>([])
 export const providersLoading = writable(true)
 
+// Names of providers whose initialization is currently in flight. Lets cards
+// show an "initializing…" state instead of the red "not initialized" badge
+// during the multi-second init that runs after a provider is added.
+export const initializingProviders = writable<Set<string>>(new Set())
+
+export function markInitializing(name: string) {
+  initializingProviders.update((set) => new Set(set).add(name))
+}
+
+export function clearInitializing(name: string) {
+  initializingProviders.update((set) => {
+    const next = new Set(set)
+    next.delete(name)
+    return next
+  })
+}
+
 let unlisten: UnlistenFn | null = null
 
 export async function initProviders() {


### PR DESCRIPTION
## Summary

When a provider is added or initialized in the desktop UI, init runs the provider's `Exec.Init` commands synchronously and takes several seconds. During that window the `ProviderCard` showed a red **"not initialized"** badge that only flipped to **"initialized"** once init completed — reading as an error state mid-operation and causing a confusing flash.

This adds an in-flight **"initializing…"** state so the transient window is represented honestly:

- New `initializingProviders` store (set of provider names) with `markInitializing` / `clearInitializing` helpers in `stores/providers.ts`.
- `ProviderWizard.svelte` marks the provider on init start and clears it on stream completion or error.
- `ProviderSheet.svelte` marks/clears around its `handleInitialize` flow.
- `ProviderCard.svelte` renders a spinner **"initializing…"** badge while the provider is in-flight and not yet initialized, taking precedence over the red "not initialized" badge.
- Tests updated (`ProviderSheet.test.ts` mock) and added (`ProviderCard.test.ts`).