### PR TITLE
Add workspace describe command and simplify status output

### DIFF
--- a/cmd/machine/status.go
+++ b/cmd/machine/status.go
@@ -59,38 +59,7 @@ func (cmd *StatusCmd) Run(ctx context.Context, args []string) error {
 	}
 	switch mode {
 	case output.ModePlain:
-		switch machineStatus {
-		case client.StatusStopped:
-			_, _ = fmt.Fprintf(
-				os.Stdout,
-				"Machine %q is %q, you can start it via 'devsy machine start %s'\n",
-				machineClient.Machine(),
-				machineStatus,
-				machineClient.Machine(),
-			)
-		case client.StatusBusy:
-			_, _ = fmt.Fprintf(
-				os.Stdout,
-				"Machine %q is %q, which means its currently unaccessible. "+
-					"This is usually resolved by waiting a couple of minutes\n",
-				machineClient.Machine(),
-				machineStatus,
-			)
-		case client.StatusNotFound:
-			_, _ = fmt.Fprintf(
-				os.Stdout,
-				"Machine %q is %q\n",
-				machineClient.Machine(),
-				machineStatus,
-			)
-		default:
-			_, _ = fmt.Fprintf(
-				os.Stdout,
-				"Machine %q is %q\n",
-				machineClient.Machine(),
-				machineStatus,
-			)
-		}
+		_, _ = fmt.Fprintln(os.Stdout, string(machineStatus))
 	case output.ModeJSON:
 		out, err := json.Marshal(struct {
 			ID       string `json:"id,omitempty"`

--- a/cmd/machine/status.go
+++ b/cmd/machine/status.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/config"
-	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/output"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
@@ -61,23 +61,35 @@ func (cmd *StatusCmd) Run(ctx context.Context, args []string) error {
 	case output.ModePlain:
 		switch machineStatus {
 		case client.StatusStopped:
-			log.Infof(
-				"Machine %q is %q, you can start it via 'devsy machine start %s'",
+			_, _ = fmt.Fprintf(
+				os.Stdout,
+				"Machine %q is %q, you can start it via 'devsy machine start %s'\n",
 				machineClient.Machine(),
 				machineStatus,
 				machineClient.Machine(),
 			)
 		case client.StatusBusy:
-			log.Infof(
+			_, _ = fmt.Fprintf(
+				os.Stdout,
 				"Machine %q is %q, which means its currently unaccessible. "+
-					"This is usually resolved by waiting a couple of minutes",
+					"This is usually resolved by waiting a couple of minutes\n",
 				machineClient.Machine(),
 				machineStatus,
 			)
 		case client.StatusNotFound:
-			log.Infof("Machine %q is %q", machineClient.Machine(), machineStatus)
+			_, _ = fmt.Fprintf(
+				os.Stdout,
+				"Machine %q is %q\n",
+				machineClient.Machine(),
+				machineStatus,
+			)
 		default:
-			log.Infof("Machine %q is %q", machineClient.Machine(), machineStatus)
+			_, _ = fmt.Fprintf(
+				os.Stdout,
+				"Machine %q is %q\n",
+				machineClient.Machine(),
+				machineStatus,
+			)
 		}
 	case output.ModeJSON:
 		out, err := json.Marshal(struct {

--- a/cmd/workspace/describe.go
+++ b/cmd/workspace/describe.go
@@ -1,10 +1,167 @@
 package workspace
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"os"
+	"time"
 
+	"github.com/devsy-org/devsy/cmd/completion"
+	"github.com/devsy-org/devsy/cmd/flags"
+	client2 "github.com/devsy-org/devsy/pkg/client"
+	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/output"
 	"github.com/devsy-org/devsy/pkg/provider"
+	"github.com/devsy-org/devsy/pkg/table"
+	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
+	"github.com/spf13/cobra"
 )
+
+// DescribeCmd holds the cmd flags.
+type DescribeCmd struct {
+	*flags.GlobalFlags
+
+	Timeout string
+}
+
+// describeOutput is the JSON shape: the full workspace config plus live state.
+type describeOutput struct {
+	*provider.Workspace
+	State string `json:"state"`
+}
+
+// NewDescribeCmd creates a new command.
+func NewDescribeCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
+	cmd := &DescribeCmd{
+		GlobalFlags: globalFlags,
+	}
+	describeCmd := &cobra.Command{
+		Use:   "describe [flags] [workspace-path|workspace-name]",
+		Short: "Shows the full details of a workspace",
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return cmd.execute(cobraCmd.Context(), args)
+		},
+		ValidArgsFunction: cmd.validArgs,
+	}
+
+	describeCmd.Flags().
+		StringVar(&cmd.Timeout, "timeout", "30s", "The timeout to wait until the status can be retrieved")
+	return describeCmd
+}
+
+// Run runs the command logic.
+func (cmd *DescribeCmd) Run(ctx context.Context, client client2.BaseWorkspaceClient) error {
+	if cmd.Timeout != "" {
+		duration, err := time.ParseDuration(cmd.Timeout)
+		if err != nil {
+			return fmt.Errorf("parse --timeout: %w", err)
+		}
+
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, duration)
+		defer cancel()
+	}
+
+	cfg := client.WorkspaceConfig()
+	if cfg == nil {
+		return fmt.Errorf("workspace %q has no configuration", client.Workspace())
+	}
+
+	instanceStatus, err := client.Status(ctx, client2.StatusOptions{ContainerStatus: true})
+	if err != nil {
+		return err
+	}
+
+	mode, err := output.ResolveMode(cmd.ResultFormat)
+	if err != nil {
+		return err
+	}
+
+	return render(mode, cfg, string(instanceStatus))
+}
+
+// render writes the workspace details to stdout in the resolved output mode.
+func render(mode string, cfg *provider.Workspace, state string) error {
+	switch mode {
+	case output.ModePlain:
+		table.Print([]string{"Field", "Value"}, describeRows(cfg, state))
+	case output.ModeJSON:
+		out, err := json.Marshal(&describeOutput{Workspace: cfg, State: state})
+		if err != nil {
+			return err
+		}
+		_, _ = fmt.Fprint(os.Stdout, string(out))
+	}
+
+	return nil
+}
+
+// validArgs provides shell completion suggestions for workspace arguments.
+func (cmd *DescribeCmd) validArgs(
+	rootCmd *cobra.Command,
+	args []string,
+	toComplete string,
+) ([]string, cobra.ShellCompDirective) {
+	return completion.GetWorkspaceSuggestions(
+		rootCmd,
+		cmd.Context,
+		cmd.Provider,
+		args,
+		toComplete,
+		cmd.Owner,
+	)
+}
+
+// describeRows builds the curated Field/Value rows for the plain view,
+// omitting rows whose value is empty.
+func describeRows(cfg *provider.Workspace, state string) [][]string {
+	rows := [][]string{}
+	add := func(field, value string) {
+		if value != "" {
+			rows = append(rows, []string{field, value})
+		}
+	}
+
+	add("ID", cfg.ID)
+	add("State", state)
+	add("Provider", cfg.Provider.Name)
+	add("IDE", cfg.IDE.Name)
+	add("Source", describeSource(cfg.Source))
+
+	machine := cfg.Machine.ID
+	if machine != "" && cfg.Machine.AutoDelete {
+		machine += " (auto-delete: true)"
+	}
+	add("Machine", machine)
+
+	add("Context", cfg.Context)
+	if !cfg.CreationTimestamp.IsZero() {
+		add("Created", time.Since(cfg.CreationTimestamp.Time).Round(time.Second).String())
+	}
+	if !cfg.LastUsedTimestamp.IsZero() {
+		add("Last Used", time.Since(cfg.LastUsedTimestamp.Time).Round(time.Second).String())
+	}
+
+	return rows
+}
+
+func (cmd *DescribeCmd) execute(ctx context.Context, args []string) error {
+	devsyConfig, err := config.LoadConfig(cmd.Context, cmd.Provider)
+	if err != nil {
+		return err
+	}
+	client, err := workspace2.Get(ctx, workspace2.GetOptions{
+		DevsyConfig:    devsyConfig,
+		Args:           args,
+		Owner:          cmd.Owner,
+		ChangeLastUsed: false,
+	})
+	if err != nil {
+		return err
+	}
+	return cmd.Run(ctx, client)
+}
 
 // describeSource condenses a WorkspaceSource into a single human-readable line,
 // picking the populated variant: git, then local folder, image, or container.

--- a/cmd/workspace/describe.go
+++ b/cmd/workspace/describe.go
@@ -1,0 +1,42 @@
+package workspace
+
+import (
+	"fmt"
+
+	"github.com/devsy-org/devsy/pkg/provider"
+)
+
+// describeSource condenses a WorkspaceSource into a single human-readable line,
+// picking the populated variant: git, then local folder, image, or container.
+func describeSource(src provider.WorkspaceSource) string {
+	switch {
+	case src.GitRepository != "":
+		return describeGitSource(src)
+	case src.LocalFolder != "":
+		return src.LocalFolder
+	case src.Image != "":
+		return src.Image
+	case src.Container != "":
+		return src.Container
+	default:
+		return ""
+	}
+}
+
+// describeGitSource renders the git variant of a WorkspaceSource, choosing the
+// most specific ref (branch, then commit, then PR) and appending any subpath.
+func describeGitSource(src provider.WorkspaceSource) string {
+	out := provider.WorkspaceSourceGit + src.GitRepository
+	switch {
+	case src.GitBranch != "":
+		out += "@" + src.GitBranch
+	case src.GitCommit != "":
+		out += "@" + src.GitCommit
+	case src.GitPRReference != "":
+		out += "@" + src.GitPRReference
+	}
+	if src.GitSubPath != "" {
+		out += fmt.Sprintf(" (%s)", src.GitSubPath)
+	}
+	return out
+}

--- a/cmd/workspace/describe_test.go
+++ b/cmd/workspace/describe_test.go
@@ -1,10 +1,15 @@
 package workspace
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/devsy-org/devsy/pkg/client"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDescribeSource(t *testing.T) { //nolint:funlen // table-driven test
@@ -77,4 +82,35 @@ func TestDescribeSource(t *testing.T) { //nolint:funlen // table-driven test
 			assert.Equal(t, tc.want, describeSource(tc.src))
 		})
 	}
+}
+
+func TestDescribeCmd_JSONOutput(t *testing.T) {
+	log.Init(log.Config{Verbosity: 0})
+
+	cfg := &provider.Workspace{
+		ID:       "node-js",
+		Context:  "default",
+		Provider: provider.WorkspaceProviderConfig{Name: "docker"},
+		IDE:      provider.WorkspaceIDEConfig{Name: "vscode"},
+		Source: provider.WorkspaceSource{
+			GitRepository: "github.com/acme/node-js",
+			GitBranch:     "main",
+		},
+		Machine: provider.WorkspaceMachineConfig{ID: "node-js"},
+	}
+	cmd := &DescribeCmd{GlobalFlags: &flags.GlobalFlags{ResultFormat: "json"}}
+	fake := &fakeWorkspaceClient{workspace: "node-js", config: cfg, status: client.StatusRunning}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, cmd.Run(t.Context(), fake))
+	})
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "node-js", got["id"])
+	assert.Equal(t, "default", got["context"])
+	assert.Equal(t, string(client.StatusRunning), got["state"])
+	provBlock, ok := got["provider"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "docker", provBlock["name"])
 }

--- a/cmd/workspace/describe_test.go
+++ b/cmd/workspace/describe_test.go
@@ -114,3 +114,62 @@ func TestDescribeCmd_JSONOutput(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "docker", provBlock["name"])
 }
+
+func TestDescribeCmd_PlainPrintsAtDefaultVerbosity(t *testing.T) {
+	log.Init(log.Config{Verbosity: 0})
+
+	cfg := &provider.Workspace{
+		ID:       "node-js",
+		Context:  "default",
+		Provider: provider.WorkspaceProviderConfig{Name: "docker"},
+		IDE:      provider.WorkspaceIDEConfig{Name: "vscode"},
+		Source: provider.WorkspaceSource{
+			GitRepository: "github.com/acme/node-js",
+			GitBranch:     "main",
+		},
+		Machine: provider.WorkspaceMachineConfig{ID: "node-js"},
+	}
+	cmd := &DescribeCmd{GlobalFlags: &flags.GlobalFlags{ResultFormat: "plain"}}
+	fake := &fakeWorkspaceClient{workspace: "node-js", config: cfg, status: client.StatusRunning}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, cmd.Run(t.Context(), fake))
+	})
+
+	assert.Contains(t, out, "node-js")
+	assert.Contains(t, out, "Running")
+	assert.Contains(t, out, "docker")
+	assert.Contains(t, out, "vscode")
+	assert.Contains(t, out, "git:github.com/acme/node-js@main")
+}
+
+func TestDescribeCmd_PlainOmitsEmptyFields(t *testing.T) {
+	log.Init(log.Config{Verbosity: 0})
+
+	cfg := &provider.Workspace{
+		ID:     "node-js",
+		Source: provider.WorkspaceSource{LocalFolder: "/home/me/project"},
+		// No IDE, no Machine, no Context.
+	}
+	cmd := &DescribeCmd{GlobalFlags: &flags.GlobalFlags{ResultFormat: "plain"}}
+	fake := &fakeWorkspaceClient{workspace: "node-js", config: cfg, status: client.StatusStopped}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, cmd.Run(t.Context(), fake))
+	})
+
+	assert.Contains(t, out, "/home/me/project")
+	assert.NotContains(t, out, "IDE")
+	assert.NotContains(t, out, "Machine")
+}
+
+func TestDescribeCmd_NilConfigErrors(t *testing.T) {
+	log.Init(log.Config{Verbosity: 0})
+
+	cmd := &DescribeCmd{GlobalFlags: &flags.GlobalFlags{ResultFormat: "plain"}}
+	fake := &fakeWorkspaceClient{workspace: "node-js", config: nil, status: client.StatusRunning}
+
+	err := cmd.Run(t.Context(), fake)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no configuration")
+}

--- a/cmd/workspace/describe_test.go
+++ b/cmd/workspace/describe_test.go
@@ -21,15 +21,15 @@ func TestDescribeSource(t *testing.T) { //nolint:funlen // table-driven test
 		{
 			name: "git branch",
 			src: provider.WorkspaceSource{
-				GitRepository: "github.com/acme/node-js",
-				GitBranch:     "main",
+				GitRepository: testGitRepo,
+				GitBranch:     testGitBranch,
 			},
 			want: "git:github.com/acme/node-js@main",
 		},
 		{
 			name: "git commit when no branch",
 			src: provider.WorkspaceSource{
-				GitRepository: "github.com/acme/node-js",
+				GitRepository: testGitRepo,
 				GitCommit:     "abc123",
 			},
 			want: "git:github.com/acme/node-js@abc123",
@@ -37,28 +37,28 @@ func TestDescribeSource(t *testing.T) { //nolint:funlen // table-driven test
 		{
 			name: "git pr when no branch or commit",
 			src: provider.WorkspaceSource{
-				GitRepository:  "github.com/acme/node-js",
+				GitRepository:  testGitRepo,
 				GitPRReference: "refs/pull/42/head",
 			},
 			want: "git:github.com/acme/node-js@refs/pull/42/head",
 		},
 		{
 			name: "git repo only",
-			src:  provider.WorkspaceSource{GitRepository: "github.com/acme/node-js"},
+			src:  provider.WorkspaceSource{GitRepository: testGitRepo},
 			want: "git:github.com/acme/node-js",
 		},
 		{
 			name: "git with subpath",
 			src: provider.WorkspaceSource{
-				GitRepository: "github.com/acme/node-js",
-				GitBranch:     "main",
+				GitRepository: testGitRepo,
+				GitBranch:     testGitBranch,
 				GitSubPath:    "services/api",
 			},
 			want: "git:github.com/acme/node-js@main (services/api)",
 		},
 		{
 			name: "local folder",
-			src:  provider.WorkspaceSource{LocalFolder: "/home/me/project"},
+			src:  provider.WorkspaceSource{LocalFolder: testLocalFolder},
 			want: "/home/me/project",
 		},
 		{
@@ -88,18 +88,22 @@ func TestDescribeCmd_JSONOutput(t *testing.T) {
 	log.Init(log.Config{Verbosity: 0})
 
 	cfg := &provider.Workspace{
-		ID:       "node-js",
-		Context:  "default",
-		Provider: provider.WorkspaceProviderConfig{Name: "docker"},
-		IDE:      provider.WorkspaceIDEConfig{Name: "vscode"},
+		ID:       testWorkspaceName,
+		Context:  testContext,
+		Provider: provider.WorkspaceProviderConfig{Name: testProvider},
+		IDE:      provider.WorkspaceIDEConfig{Name: testIDE},
 		Source: provider.WorkspaceSource{
-			GitRepository: "github.com/acme/node-js",
-			GitBranch:     "main",
+			GitRepository: testGitRepo,
+			GitBranch:     testGitBranch,
 		},
-		Machine: provider.WorkspaceMachineConfig{ID: "node-js"},
+		Machine: provider.WorkspaceMachineConfig{ID: testWorkspaceName},
 	}
-	cmd := &DescribeCmd{GlobalFlags: &flags.GlobalFlags{ResultFormat: "json"}}
-	fake := &fakeWorkspaceClient{workspace: "node-js", config: cfg, status: client.StatusRunning}
+	cmd := &DescribeCmd{GlobalFlags: &flags.GlobalFlags{ResultFormat: formatJSON}}
+	fake := &fakeWorkspaceClient{
+		workspace: testWorkspaceName,
+		config:    cfg,
+		status:    client.StatusRunning,
+	}
 
 	out := captureStdout(t, func() {
 		require.NoError(t, cmd.Run(t.Context(), fake))
@@ -107,39 +111,43 @@ func TestDescribeCmd_JSONOutput(t *testing.T) {
 
 	var got map[string]any
 	require.NoError(t, json.Unmarshal([]byte(out), &got))
-	assert.Equal(t, "node-js", got["id"])
-	assert.Equal(t, "default", got["context"])
+	assert.Equal(t, testWorkspaceName, got["id"])
+	assert.Equal(t, testContext, got["context"])
 	assert.Equal(t, string(client.StatusRunning), got["state"])
 	provBlock, ok := got["provider"].(map[string]any)
 	require.True(t, ok)
-	assert.Equal(t, "docker", provBlock["name"])
+	assert.Equal(t, testProvider, provBlock["name"])
 }
 
 func TestDescribeCmd_PlainPrintsAtDefaultVerbosity(t *testing.T) {
 	log.Init(log.Config{Verbosity: 0})
 
 	cfg := &provider.Workspace{
-		ID:       "node-js",
-		Context:  "default",
-		Provider: provider.WorkspaceProviderConfig{Name: "docker"},
-		IDE:      provider.WorkspaceIDEConfig{Name: "vscode"},
+		ID:       testWorkspaceName,
+		Context:  testContext,
+		Provider: provider.WorkspaceProviderConfig{Name: testProvider},
+		IDE:      provider.WorkspaceIDEConfig{Name: testIDE},
 		Source: provider.WorkspaceSource{
-			GitRepository: "github.com/acme/node-js",
-			GitBranch:     "main",
+			GitRepository: testGitRepo,
+			GitBranch:     testGitBranch,
 		},
-		Machine: provider.WorkspaceMachineConfig{ID: "node-js"},
+		Machine: provider.WorkspaceMachineConfig{ID: testWorkspaceName},
 	}
-	cmd := &DescribeCmd{GlobalFlags: &flags.GlobalFlags{ResultFormat: "plain"}}
-	fake := &fakeWorkspaceClient{workspace: "node-js", config: cfg, status: client.StatusRunning}
+	cmd := &DescribeCmd{GlobalFlags: &flags.GlobalFlags{ResultFormat: formatPlain}}
+	fake := &fakeWorkspaceClient{
+		workspace: testWorkspaceName,
+		config:    cfg,
+		status:    client.StatusRunning,
+	}
 
 	out := captureStdout(t, func() {
 		require.NoError(t, cmd.Run(t.Context(), fake))
 	})
 
-	assert.Contains(t, out, "node-js")
+	assert.Contains(t, out, testWorkspaceName)
 	assert.Contains(t, out, "Running")
-	assert.Contains(t, out, "docker")
-	assert.Contains(t, out, "vscode")
+	assert.Contains(t, out, testProvider)
+	assert.Contains(t, out, testIDE)
 	assert.Contains(t, out, "git:github.com/acme/node-js@main")
 }
 
@@ -147,18 +155,22 @@ func TestDescribeCmd_PlainOmitsEmptyFields(t *testing.T) {
 	log.Init(log.Config{Verbosity: 0})
 
 	cfg := &provider.Workspace{
-		ID:     "node-js",
-		Source: provider.WorkspaceSource{LocalFolder: "/home/me/project"},
+		ID:     testWorkspaceName,
+		Source: provider.WorkspaceSource{LocalFolder: testLocalFolder},
 		// No IDE, no Machine, no Context.
 	}
-	cmd := &DescribeCmd{GlobalFlags: &flags.GlobalFlags{ResultFormat: "plain"}}
-	fake := &fakeWorkspaceClient{workspace: "node-js", config: cfg, status: client.StatusStopped}
+	cmd := &DescribeCmd{GlobalFlags: &flags.GlobalFlags{ResultFormat: formatPlain}}
+	fake := &fakeWorkspaceClient{
+		workspace: testWorkspaceName,
+		config:    cfg,
+		status:    client.StatusStopped,
+	}
 
 	out := captureStdout(t, func() {
 		require.NoError(t, cmd.Run(t.Context(), fake))
 	})
 
-	assert.Contains(t, out, "/home/me/project")
+	assert.Contains(t, out, testLocalFolder)
 	assert.NotContains(t, out, "IDE")
 	assert.NotContains(t, out, "Machine")
 }
@@ -166,8 +178,12 @@ func TestDescribeCmd_PlainOmitsEmptyFields(t *testing.T) {
 func TestDescribeCmd_NilConfigErrors(t *testing.T) {
 	log.Init(log.Config{Verbosity: 0})
 
-	cmd := &DescribeCmd{GlobalFlags: &flags.GlobalFlags{ResultFormat: "plain"}}
-	fake := &fakeWorkspaceClient{workspace: "node-js", config: nil, status: client.StatusRunning}
+	cmd := &DescribeCmd{GlobalFlags: &flags.GlobalFlags{ResultFormat: formatPlain}}
+	fake := &fakeWorkspaceClient{
+		workspace: testWorkspaceName,
+		config:    nil,
+		status:    client.StatusRunning,
+	}
 
 	err := cmd.Run(t.Context(), fake)
 	require.Error(t, err)

--- a/cmd/workspace/describe_test.go
+++ b/cmd/workspace/describe_test.go
@@ -1,0 +1,80 @@
+package workspace
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/provider"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDescribeSource(t *testing.T) { //nolint:funlen // table-driven test
+	cases := []struct {
+		name string
+		src  provider.WorkspaceSource
+		want string
+	}{
+		{
+			name: "git branch",
+			src: provider.WorkspaceSource{
+				GitRepository: "github.com/acme/node-js",
+				GitBranch:     "main",
+			},
+			want: "git:github.com/acme/node-js@main",
+		},
+		{
+			name: "git commit when no branch",
+			src: provider.WorkspaceSource{
+				GitRepository: "github.com/acme/node-js",
+				GitCommit:     "abc123",
+			},
+			want: "git:github.com/acme/node-js@abc123",
+		},
+		{
+			name: "git pr when no branch or commit",
+			src: provider.WorkspaceSource{
+				GitRepository:  "github.com/acme/node-js",
+				GitPRReference: "refs/pull/42/head",
+			},
+			want: "git:github.com/acme/node-js@refs/pull/42/head",
+		},
+		{
+			name: "git repo only",
+			src:  provider.WorkspaceSource{GitRepository: "github.com/acme/node-js"},
+			want: "git:github.com/acme/node-js",
+		},
+		{
+			name: "git with subpath",
+			src: provider.WorkspaceSource{
+				GitRepository: "github.com/acme/node-js",
+				GitBranch:     "main",
+				GitSubPath:    "services/api",
+			},
+			want: "git:github.com/acme/node-js@main (services/api)",
+		},
+		{
+			name: "local folder",
+			src:  provider.WorkspaceSource{LocalFolder: "/home/me/project"},
+			want: "/home/me/project",
+		},
+		{
+			name: "image",
+			src:  provider.WorkspaceSource{Image: "ghcr.io/acme/img:1.0"},
+			want: "ghcr.io/acme/img:1.0",
+		},
+		{
+			name: "container",
+			src:  provider.WorkspaceSource{Container: "my-container"},
+			want: "my-container",
+		},
+		{
+			name: "empty",
+			src:  provider.WorkspaceSource{},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, describeSource(tc.src))
+		})
+	}
+}

--- a/cmd/workspace/helpers_test.go
+++ b/cmd/workspace/helpers_test.go
@@ -11,6 +11,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Shared fixture values reused across command tests.
+const (
+	testWorkspaceName = "node-js"
+	testContext       = "default"
+	testProvider      = "docker"
+	testIDE           = "vscode"
+	testGitRepo       = "github.com/acme/node-js"
+	testGitBranch     = "main"
+	testLocalFolder   = "/home/me/project"
+	formatPlain       = "plain"
+	formatJSON        = "json"
+)
+
 // fakeWorkspaceClient is a minimal BaseWorkspaceClient used to exercise
 // command Run methods without a real provider.
 type fakeWorkspaceClient struct {

--- a/cmd/workspace/helpers_test.go
+++ b/cmd/workspace/helpers_test.go
@@ -1,0 +1,59 @@
+package workspace
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/client"
+	"github.com/devsy-org/devsy/pkg/provider"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeWorkspaceClient is a minimal BaseWorkspaceClient used to exercise
+// command Run methods without a real provider.
+type fakeWorkspaceClient struct {
+	workspace string
+	context   string
+	provider  string
+	config    *provider.Workspace
+	status    client.Status
+	statusErr error
+}
+
+func (f *fakeWorkspaceClient) Provider() string { return f.provider }
+func (f *fakeWorkspaceClient) Context() string  { return f.context }
+func (f *fakeWorkspaceClient) RefreshOptions(context.Context, []string, bool) error {
+	return nil
+}
+
+func (f *fakeWorkspaceClient) Status(context.Context, client.StatusOptions) (client.Status, error) {
+	return f.status, f.statusErr
+}
+func (f *fakeWorkspaceClient) Stop(context.Context, client.StopOptions) error     { return nil }
+func (f *fakeWorkspaceClient) Delete(context.Context, client.DeleteOptions) error { return nil }
+
+func (f *fakeWorkspaceClient) Workspace() string { return f.workspace }
+
+func (f *fakeWorkspaceClient) WorkspaceConfig() *provider.Workspace { return f.config }
+func (f *fakeWorkspaceClient) Lock(context.Context) error           { return nil }
+func (f *fakeWorkspaceClient) Unlock()                              {}
+
+// captureStdout runs fn while redirecting os.Stdout to a pipe and returns
+// everything written.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	fn()
+
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(out)
+}

--- a/cmd/workspace/status.go
+++ b/cmd/workspace/status.go
@@ -84,39 +84,7 @@ func (cmd *StatusCmd) Run(
 	}
 	switch mode {
 	case output.ModePlain:
-		switch instanceStatus {
-		case client2.StatusStopped:
-			_, _ = fmt.Fprintf(
-				os.Stdout,
-				"Workspace %q is %q, you can start it via 'devsy workspace up %s'\n",
-				client.Workspace(),
-				instanceStatus,
-				client.Workspace(),
-			)
-		case client2.StatusBusy:
-			_, _ = fmt.Fprintf(
-				os.Stdout,
-				"Workspace %q is %q, which means its currently unaccessible. "+
-					"This is usually resolved by waiting a couple of minutes\n",
-				client.Workspace(),
-				instanceStatus,
-			)
-		case client2.StatusNotFound:
-			_, _ = fmt.Fprintf(
-				os.Stdout,
-				"Workspace %q is %q, you can create it via 'devsy workspace up %s'\n",
-				client.Workspace(),
-				instanceStatus,
-				client.Workspace(),
-			)
-		default:
-			_, _ = fmt.Fprintf(
-				os.Stdout,
-				"Workspace %q is %q\n",
-				client.Workspace(),
-				instanceStatus,
-			)
-		}
+		_, _ = fmt.Fprintln(os.Stdout, string(instanceStatus))
 	case output.ModeJSON:
 		out, err := json.Marshal(&client2.WorkspaceStatus{
 			ID:       client.Workspace(),

--- a/cmd/workspace/status.go
+++ b/cmd/workspace/status.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/devsy-org/devsy/cmd/completion"
@@ -11,7 +12,6 @@ import (
 	client2 "github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
-	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/output"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
@@ -86,28 +86,36 @@ func (cmd *StatusCmd) Run(
 	case output.ModePlain:
 		switch instanceStatus {
 		case client2.StatusStopped:
-			log.Infof(
-				"Workspace %q is %q, you can start it via 'devsy workspace up %s'",
+			_, _ = fmt.Fprintf(
+				os.Stdout,
+				"Workspace %q is %q, you can start it via 'devsy workspace up %s'\n",
 				client.Workspace(),
 				instanceStatus,
 				client.Workspace(),
 			)
 		case client2.StatusBusy:
-			log.Infof(
+			_, _ = fmt.Fprintf(
+				os.Stdout,
 				"Workspace %q is %q, which means its currently unaccessible. "+
-					"This is usually resolved by waiting a couple of minutes",
+					"This is usually resolved by waiting a couple of minutes\n",
 				client.Workspace(),
 				instanceStatus,
 			)
 		case client2.StatusNotFound:
-			log.Infof(
-				"Workspace %q is %q, you can create it via 'devsy workspace up %s'",
+			_, _ = fmt.Fprintf(
+				os.Stdout,
+				"Workspace %q is %q, you can create it via 'devsy workspace up %s'\n",
 				client.Workspace(),
 				instanceStatus,
 				client.Workspace(),
 			)
 		default:
-			log.Infof("Workspace %q is %q", client.Workspace(), instanceStatus)
+			_, _ = fmt.Fprintf(
+				os.Stdout,
+				"Workspace %q is %q\n",
+				client.Workspace(),
+				instanceStatus,
+			)
 		}
 	case output.ModeJSON:
 		out, err := json.Marshal(&client2.WorkspaceStatus{

--- a/cmd/workspace/status_test.go
+++ b/cmd/workspace/status_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 // TestStatusCmd_PlainPrintsAtDefaultVerbosity is the regression guard: plain
-// status output must reach stdout even when the logger is at its default
-// (error-only) level. Previously the result was emitted via log.Infof, which
-// the default verbosity silenced, leaving the command output empty.
+// status output is the bare status word and must reach stdout even when the
+// logger is at its default (error-only) level. Previously the result was
+// emitted via log.Infof, which the default verbosity silenced, leaving the
+// command output empty.
 func TestStatusCmd_PlainPrintsAtDefaultVerbosity(t *testing.T) {
 	log.Init(log.Config{Verbosity: 0})
 
@@ -23,10 +24,10 @@ func TestStatusCmd_PlainPrintsAtDefaultVerbosity(t *testing.T) {
 		status client.Status
 		want   string
 	}{
-		{"running", client.StatusRunning, `Workspace "node-js" is "Running"`},
-		{"stopped", client.StatusStopped, `Workspace "node-js" is "Stopped"`},
-		{"busy", client.StatusBusy, `Workspace "node-js" is "Busy"`},
-		{"notfound", client.StatusNotFound, `Workspace "node-js" is "NotFound"`},
+		{"running", client.StatusRunning, "Running"},
+		{"stopped", client.StatusStopped, "Stopped"},
+		{"busy", client.StatusBusy, "Busy"},
+		{"notfound", client.StatusNotFound, "NotFound"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/workspace/status_test.go
+++ b/cmd/workspace/status_test.go
@@ -1,0 +1,72 @@
+package workspace
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/devsy-org/devsy/pkg/client"
+	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatusCmd_PlainPrintsAtDefaultVerbosity is the regression guard: plain
+// status output must reach stdout even when the logger is at its default
+// (error-only) level. Previously the result was emitted via log.Infof, which
+// the default verbosity silenced, leaving the command output empty.
+func TestStatusCmd_PlainPrintsAtDefaultVerbosity(t *testing.T) {
+	log.Init(log.Config{Verbosity: 0})
+
+	cases := []struct {
+		name   string
+		status client.Status
+		want   string
+	}{
+		{"running", client.StatusRunning, `Workspace "node-js" is "Running"`},
+		{"stopped", client.StatusStopped, `Workspace "node-js" is "Stopped"`},
+		{"busy", client.StatusBusy, `Workspace "node-js" is "Busy"`},
+		{"notfound", client.StatusNotFound, `Workspace "node-js" is "NotFound"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &StatusCmd{
+				GlobalFlags: &flags.GlobalFlags{ResultFormat: "plain"},
+			}
+			fake := &fakeWorkspaceClient{workspace: "node-js", status: tc.status}
+
+			out := captureStdout(t, func() {
+				require.NoError(t, cmd.Run(t.Context(), fake))
+			})
+
+			assert.Contains(t, out, tc.want)
+		})
+	}
+}
+
+func TestStatusCmd_JSONOutput(t *testing.T) {
+	log.Init(log.Config{Verbosity: 0})
+
+	cmd := &StatusCmd{
+		GlobalFlags: &flags.GlobalFlags{ResultFormat: "json"},
+	}
+	fake := &fakeWorkspaceClient{
+		workspace: "node-js",
+		context:   "default",
+		provider:  "docker",
+		status:    client.StatusRunning,
+	}
+
+	out := captureStdout(t, func() {
+		require.NoError(t, cmd.Run(t.Context(), fake))
+	})
+
+	var got client.WorkspaceStatus
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, client.WorkspaceStatus{
+		ID:       "node-js",
+		Context:  "default",
+		Provider: "docker",
+		State:    string(client.StatusRunning),
+	}, got)
+}

--- a/cmd/workspace/status_test.go
+++ b/cmd/workspace/status_test.go
@@ -31,9 +31,9 @@ func TestStatusCmd_PlainPrintsAtDefaultVerbosity(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := &StatusCmd{
-				GlobalFlags: &flags.GlobalFlags{ResultFormat: "plain"},
+				GlobalFlags: &flags.GlobalFlags{ResultFormat: formatPlain},
 			}
-			fake := &fakeWorkspaceClient{workspace: "node-js", status: tc.status}
+			fake := &fakeWorkspaceClient{workspace: testWorkspaceName, status: tc.status}
 
 			out := captureStdout(t, func() {
 				require.NoError(t, cmd.Run(t.Context(), fake))
@@ -48,12 +48,12 @@ func TestStatusCmd_JSONOutput(t *testing.T) {
 	log.Init(log.Config{Verbosity: 0})
 
 	cmd := &StatusCmd{
-		GlobalFlags: &flags.GlobalFlags{ResultFormat: "json"},
+		GlobalFlags: &flags.GlobalFlags{ResultFormat: formatJSON},
 	}
 	fake := &fakeWorkspaceClient{
-		workspace: "node-js",
-		context:   "default",
-		provider:  "docker",
+		workspace: testWorkspaceName,
+		context:   testContext,
+		provider:  testProvider,
 		status:    client.StatusRunning,
 	}
 
@@ -64,9 +64,9 @@ func TestStatusCmd_JSONOutput(t *testing.T) {
 	var got client.WorkspaceStatus
 	require.NoError(t, json.Unmarshal([]byte(out), &got))
 	assert.Equal(t, client.WorkspaceStatus{
-		ID:       "node-js",
-		Context:  "default",
-		Provider: "docker",
+		ID:       testWorkspaceName,
+		Context:  testContext,
+		Provider: testProvider,
 		State:    string(client.StatusRunning),
 	}, got)
 }

--- a/cmd/workspace/workspace.go
+++ b/cmd/workspace/workspace.go
@@ -19,6 +19,7 @@ func NewWorkspaceCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	cmd.AddCommand(NewExecCmd(globalFlags))
 	cmd.AddCommand(NewListCmd(globalFlags))
 	cmd.AddCommand(NewStatusCmd(globalFlags))
+	cmd.AddCommand(NewDescribeCmd(globalFlags))
 	cmd.AddCommand(NewLogsCmd(globalFlags))
 	cmd.AddCommand(NewBuildCmd(globalFlags))
 	cmd.AddCommand(NewRenameCmd(globalFlags))


### PR DESCRIPTION
## Summary

- Add `devsy workspace describe [workspace-path|workspace-name]`, a detailed single-workspace view combining static config (provider, IDE, source, machine, context, timestamps) with live state. Plain mode renders a curated two-column `Field`/`Value` table (empty fields omitted); `--result-format json` emits the full `provider.Workspace` plus a top-level `state`.
- Simplify `workspace status` and `machine status` plain output to print just the bare status word (e.g. `Running`) instead of a sentence suggesting follow-up commands. A status command should report state; the fuller picture now lives in `describe`.
- Fix a prior bug where plain status output was emitted via a verbosity-gated logger, producing empty output at the default verbosity — output now goes to stdout.
- Add tests covering source condensing, JSON/plain rendering, empty-field omission, and the nil-config error path; extract shared test helpers (`fakeWorkspaceClient`, `captureStdout`) and fixture constants into `helpers_test.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `workspace describe` command with `--timeout` option to display workspace configuration and live state in plain or JSON format, including workspace source details (git branch, commit, PR) and machine/context information.
  * Added shell completion support for workspace arguments.

* **Bug Fixes**
  * Updated status output behavior for workspace and machine commands to print raw status values directly to stdout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->