### PR TITLE
fix(desktop): capture context name before awaits in handleDelete

### DIFF
--- a/desktop/src/renderer/src/lib/components/context/ContextSheet.svelte
+++ b/desktop/src/renderer/src/lib/components/context/ContextSheet.svelte
@@ -89,10 +89,13 @@ let confirmDeleteOpen = $state(false)
 
 async function handleDelete() {
   deleting = true
+  // Capture before awaits: refreshContexts() can null out the reactive
+  // `context` prop once this context is removed from the store.
+  const name = context.name
   try {
-    await contextDelete(context.name)
+    await contextDelete(name)
     await refreshContexts()
-    toasts.success(`Context "${context.name}" deleted`)
+    toasts.success(`Context "${name}" deleted`)
     open = false
   } catch (err) {
     toasts.error(`Failed to delete context: ${extractErrorMessage(err)}`)


### PR DESCRIPTION
## Summary
- Fixes the intermittent `Failed to delete context: Cannot read properties of undefined (reading 'name')` error when deleting a non-default context.
- Root cause: `handleDelete` in `ContextSheet.svelte` read `context.name` after `await refreshContexts()`. The `context` prop is reactive — derived in `ContextsPage.svelte` via `$contexts.find(...)`. Once the deleted context leaves the store, that derived returns `undefined`, nulling the prop, so the success line `context.name` throws. The deletion actually succeeded, so the user saw a false failure toast.
- Intermittent because it's a Svelte 5 reactive-timing race on whether the derived/prop propagation lands before the success line runs.
- Fix: hoist `const name = context.name` before the awaits and use it throughout.