### PR TITLE
feat(exec): accept positional workspace name

### DIFF
--- a/cmd/workspace/exec.go
+++ b/cmd/workspace/exec.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/devsy-org/devsy/cmd/completion"
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer"
@@ -35,12 +36,39 @@ type ExecCmd struct {
 func NewExecCmd(f *flags.GlobalFlags) *cobra.Command {
 	cmd := &ExecCmd{GlobalFlags: f}
 	execCmd := &cobra.Command{
-		Use:   "exec --workspace-folder <path> -- <cmd> [args...]",
+		Use:   "exec [workspace-name] [flags] -- <cmd> [args...]",
 		Short: "Executes a command in a running workspace container",
 		Args:  cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(
+			cobraCmd *cobra.Command, args []string, toComplete string,
+		) ([]string, cobra.ShellCompDirective) {
+			return completion.GetWorkspaceSuggestions(
+				cobraCmd.Root(), cmd.Context, cmd.Provider, args, toComplete, cmd.Owner,
+			)
+		},
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			ctx := cobraCmd.Context()
-			return cmd.Run(ctx, args)
+
+			dash := cobraCmd.ArgsLenAtDash()
+			var nameArgs, cmdArgs []string
+			if dash >= 0 {
+				nameArgs = args[:dash]
+				cmdArgs = args[dash:]
+			} else {
+				cmdArgs = args
+			}
+
+			if len(nameArgs) > 1 {
+				return fmt.Errorf("expected at most one workspace name, got %d", len(nameArgs))
+			}
+			if len(nameArgs) == 1 {
+				cmd.WorkspaceName = nameArgs[0]
+			}
+			if len(cmdArgs) == 0 {
+				return fmt.Errorf("a command to execute is required after --")
+			}
+
+			return cmd.Run(ctx, cmdArgs)
 		},
 	}
 
@@ -112,10 +140,6 @@ func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
 		log.Warnf("--skip-post-create is accepted but not yet implemented for exec")
 	}
 
-	if cmd.WorkspaceFolder == "" && cmd.ContainerID == "" {
-		return fmt.Errorf("either --workspace-folder or --container-id must be provided")
-	}
-
 	if err := cmd.validateRemoteEnv(); err != nil {
 		return err
 	}
@@ -127,8 +151,21 @@ func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	if cmd.WorkspaceName != "" && (cmd.WorkspaceFolder != "" || cmd.ContainerID != "") {
+		return errFolderNameConflict
+	}
+
 	if cmd.ContainerID != "" {
 		return cmd.runWithContainerID(ctx, args)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("determine current directory: %w", err)
+	}
+	getArgs, err := resolveExecTarget(cmd, cwd)
+	if err != nil {
+		return err
 	}
 
 	devsyConfig, err := config.LoadConfig(cmd.Context, cmd.Provider)
@@ -138,7 +175,7 @@ func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
 
 	client, err := workspace2.Get(ctx, workspace2.GetOptions{
 		DevsyConfig: devsyConfig,
-		Args:        []string{cmd.WorkspaceFolder},
+		Args:        getArgs,
 		Owner:       cmd.Owner,
 	})
 	if err != nil {

--- a/cmd/workspace/exec.go
+++ b/cmd/workspace/exec.go
@@ -151,6 +151,9 @@ func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	// Guard here (before the container-id branch) so name+container-id is rejected
+	// rather than silently taking the container path. resolveExecTarget repeats this
+	// check so it stays correct as a standalone unit.
 	if cmd.WorkspaceName != "" && (cmd.WorkspaceFolder != "" || cmd.ContainerID != "") {
 		return errFolderNameConflict
 	}

--- a/cmd/workspace/exec.go
+++ b/cmd/workspace/exec.go
@@ -151,9 +151,8 @@ func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
-	// Guard here (before the container-id branch) so name+container-id is rejected
-	// rather than silently taking the container path. resolveExecTarget repeats this
-	// check so it stays correct as a standalone unit.
+	// Must run before the container-id branch below, else name+container-id would
+	// silently take the container path instead of erroring.
 	if cmd.WorkspaceName != "" && (cmd.WorkspaceFolder != "" || cmd.ContainerID != "") {
 		return errFolderNameConflict
 	}
@@ -301,7 +300,6 @@ var errFolderNameConflict = fmt.Errorf(
 
 // resolveExecTarget decides what string is handed to workspace.Get.
 // Precedence: explicit name, then --workspace-folder, then the current dir.
-// A workspace name combined with --workspace-folder or --container-id is a conflict.
 func resolveExecTarget(cmd *ExecCmd, cwd string) ([]string, error) {
 	if cmd.WorkspaceName != "" && (cmd.WorkspaceFolder != "" || cmd.ContainerID != "") {
 		return nil, errFolderNameConflict

--- a/cmd/workspace/exec.go
+++ b/cmd/workspace/exec.go
@@ -21,6 +21,7 @@ import (
 type ExecCmd struct {
 	*flags.GlobalFlags
 
+	WorkspaceName       string
 	WorkspaceFolder     string
 	ContainerID         string
 	DockerPath          string
@@ -252,6 +253,27 @@ func (cmd *ExecCmd) runWithContainerID(ctx context.Context, args []string) error
 		})
 	}
 	return nil
+}
+
+var errFolderNameConflict = fmt.Errorf(
+	"specify either a workspace name or --workspace-folder/--container-id, not both",
+)
+
+// resolveExecTarget decides what string is handed to workspace.Get.
+// Precedence: explicit name, then --workspace-folder, then the current dir.
+// A workspace name combined with --workspace-folder or --container-id is a conflict.
+func resolveExecTarget(cmd *ExecCmd, cwd string) ([]string, error) {
+	if cmd.WorkspaceName != "" && (cmd.WorkspaceFolder != "" || cmd.ContainerID != "") {
+		return nil, errFolderNameConflict
+	}
+	switch {
+	case cmd.WorkspaceName != "":
+		return []string{cmd.WorkspaceName}, nil
+	case cmd.WorkspaceFolder != "":
+		return []string{cmd.WorkspaceFolder}, nil
+	default:
+		return []string{cwd}, nil
+	}
 }
 
 func (cmd *ExecCmd) validateRemoteEnv() error {

--- a/cmd/workspace/exec.go
+++ b/cmd/workspace/exec.go
@@ -161,9 +161,13 @@ func (cmd *ExecCmd) Run(ctx context.Context, args []string) error {
 		return cmd.runWithContainerID(ctx, args)
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("determine current directory: %w", err)
+	cwd := ""
+	if cmd.WorkspaceName == "" && cmd.WorkspaceFolder == "" {
+		var err error
+		cwd, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("determine current directory: %w", err)
+		}
 	}
 	getArgs, err := resolveExecTarget(cmd, cwd)
 	if err != nil {

--- a/cmd/workspace/exec_test.go
+++ b/cmd/workspace/exec_test.go
@@ -148,3 +148,61 @@ func TestExecCmd_SkipPostCreateFlagParsesValue(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, val)
 }
+
+func TestResolveExecTarget(t *testing.T) {
+	const cwd = "/current/dir"
+
+	cases := []struct {
+		name    string
+		cmd     *ExecCmd
+		want    []string
+		wantErr string
+	}{
+		{
+			name: "name only",
+			cmd:  &ExecCmd{GlobalFlags: &flags.GlobalFlags{}, WorkspaceName: "my-ws"},
+			want: []string{"my-ws"},
+		},
+		{
+			name: "folder only",
+			cmd:  &ExecCmd{GlobalFlags: &flags.GlobalFlags{}, WorkspaceFolder: "/some/path"},
+			want: []string{"/some/path"},
+		},
+		{
+			name: "cwd default when nothing specified",
+			cmd:  &ExecCmd{GlobalFlags: &flags.GlobalFlags{}},
+			want: []string{cwd},
+		},
+		{
+			name: "name and folder conflict",
+			cmd: &ExecCmd{
+				GlobalFlags:     &flags.GlobalFlags{},
+				WorkspaceName:   "my-ws",
+				WorkspaceFolder: "/some/path",
+			},
+			wantErr: "not both",
+		},
+		{
+			name: "name and container-id conflict",
+			cmd: &ExecCmd{
+				GlobalFlags:   &flags.GlobalFlags{},
+				WorkspaceName: "my-ws",
+				ContainerID:   "abc123",
+			},
+			wantErr: "not both",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveExecTarget(tc.cmd, cwd)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/cmd/workspace/exec_test.go
+++ b/cmd/workspace/exec_test.go
@@ -170,7 +170,9 @@ func TestExecCmd_ParsesPositionalName(t *testing.T) {
 	var gotCmdArgs []string
 
 	execCmd := NewExecCmd(&flags.GlobalFlags{})
-	// Replace RunE with a capture that mirrors the real split logic's outputs.
+	// Production RunE calls cmd.Run, which reaches Docker, so it can't run in a
+	// unit test. We mirror the ArgsLenAtDash split here to lock in the contract;
+	// the resolution behavior itself is covered by TestResolveExecTarget.
 	execCmd.RunE = func(cobraCmd *cobra.Command, args []string) error {
 		dash := cobraCmd.ArgsLenAtDash()
 		if dash >= 0 {

--- a/cmd/workspace/exec_test.go
+++ b/cmd/workspace/exec_test.go
@@ -151,6 +151,7 @@ func TestExecCmd_SkipPostCreateFlagParsesValue(t *testing.T) {
 
 func TestResolveExecTarget(t *testing.T) {
 	const cwd = "/current/dir"
+	const testWsName = "my-ws"
 
 	cases := []struct {
 		name    string
@@ -160,8 +161,8 @@ func TestResolveExecTarget(t *testing.T) {
 	}{
 		{
 			name: "name only",
-			cmd:  &ExecCmd{GlobalFlags: &flags.GlobalFlags{}, WorkspaceName: "my-ws"},
-			want: []string{"my-ws"},
+			cmd:  &ExecCmd{GlobalFlags: &flags.GlobalFlags{}, WorkspaceName: testWsName},
+			want: []string{testWsName},
 		},
 		{
 			name: "folder only",
@@ -177,7 +178,7 @@ func TestResolveExecTarget(t *testing.T) {
 			name: "name and folder conflict",
 			cmd: &ExecCmd{
 				GlobalFlags:     &flags.GlobalFlags{},
-				WorkspaceName:   "my-ws",
+				WorkspaceName:   testWsName,
 				WorkspaceFolder: "/some/path",
 			},
 			wantErr: "not both",
@@ -186,7 +187,7 @@ func TestResolveExecTarget(t *testing.T) {
 			name: "name and container-id conflict",
 			cmd: &ExecCmd{
 				GlobalFlags:   &flags.GlobalFlags{},
-				WorkspaceName: "my-ws",
+				WorkspaceName: testWsName,
 				ContainerID:   "abc123",
 			},
 			wantErr: "not both",

--- a/cmd/workspace/exec_test.go
+++ b/cmd/workspace/exec_test.go
@@ -58,9 +58,7 @@ func TestNewExecCmd_DefaultsToCwdWhenNoTarget(t *testing.T) {
 	execCmd := NewExecCmd(&flags.GlobalFlags{})
 	execCmd.SetArgs([]string{"--", testCmdEcho, testCmdHello})
 	err := execCmd.Execute()
-	// No --workspace-folder/--container-id and no name: the old hard error is gone.
-	// Execution proceeds to workspace resolution and fails there (no workspace at cwd),
-	// so we only assert the old error message is NOT what we get.
+	// No target now defaults to cwd instead of erroring; assert the old hard error is gone.
 	if err != nil {
 		assert.NotContains(
 			t, err.Error(),
@@ -116,12 +114,9 @@ func TestExecCmd_ContainerIDTakesPrecedenceOverWorkspaceFolder(t *testing.T) {
 		WorkspaceFolder: "/some/folder",
 		ContainerID:     "abc123",
 	}
-	// When both are set, ContainerID path is taken (runWithContainerID).
-	// We verify the logic by checking the Run method routes to containerID path.
-	// This test verifies the routing condition.
+	// Run checks `if cmd.ContainerID != ""` first, so container-id wins over folder.
 	assert.NotEmpty(t, cmd.ContainerID)
 	assert.NotEmpty(t, cmd.WorkspaceFolder)
-	// The Run method checks `if cmd.ContainerID != ""` first, so container-id wins.
 }
 
 func TestExecCmd_NonExistentContainerID(t *testing.T) {

--- a/cmd/workspace/exec_test.go
+++ b/cmd/workspace/exec_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,12 +54,19 @@ func TestValidateRemoteEnv_EmptyKey(t *testing.T) {
 	assert.Contains(t, err.Error(), "must be KEY=VALUE format")
 }
 
-func TestNewExecCmd_RequiresWorkspaceFolderOrContainerID(t *testing.T) {
+func TestNewExecCmd_DefaultsToCwdWhenNoTarget(t *testing.T) {
 	execCmd := NewExecCmd(&flags.GlobalFlags{})
 	execCmd.SetArgs([]string{"--", testCmdEcho, testCmdHello})
 	err := execCmd.Execute()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "either --workspace-folder or --container-id must be provided")
+	// No --workspace-folder/--container-id and no name: the old hard error is gone.
+	// Execution proceeds to workspace resolution and fails there (no workspace at cwd),
+	// so we only assert the old error message is NOT what we get.
+	if err != nil {
+		assert.NotContains(
+			t, err.Error(),
+			"either --workspace-folder or --container-id must be provided",
+		)
+	}
 }
 
 func TestNewExecCmd_RequiresArgs(t *testing.T) {
@@ -67,6 +75,14 @@ func TestNewExecCmd_RequiresArgs(t *testing.T) {
 	err := execCmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "requires at least 1 arg")
+}
+
+func TestNewExecCmd_RejectsMultipleNames(t *testing.T) {
+	execCmd := NewExecCmd(&flags.GlobalFlags{})
+	execCmd.SetArgs([]string{"ws-one", "ws-two", "--", testCmdEcho, testCmdHello})
+	err := execCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at most one workspace name")
 }
 
 func TestResolveDockerCommand_NilWorkspace(t *testing.T) {
@@ -147,6 +163,31 @@ func TestExecCmd_SkipPostCreateFlagParsesValue(t *testing.T) {
 	val, err := execCmd.Flags().GetBool("skip-post-create")
 	require.NoError(t, err)
 	assert.True(t, val)
+}
+
+func TestExecCmd_ParsesPositionalName(t *testing.T) {
+	var gotName string
+	var gotCmdArgs []string
+
+	execCmd := NewExecCmd(&flags.GlobalFlags{})
+	// Replace RunE with a capture that mirrors the real split logic's outputs.
+	execCmd.RunE = func(cobraCmd *cobra.Command, args []string) error {
+		dash := cobraCmd.ArgsLenAtDash()
+		if dash >= 0 {
+			if dash == 1 {
+				gotName = args[0]
+			}
+			gotCmdArgs = args[dash:]
+		} else {
+			gotCmdArgs = args
+		}
+		return nil
+	}
+	execCmd.SetArgs([]string{"my-ws", "--", testCmdEcho, testCmdHello})
+
+	require.NoError(t, execCmd.Execute())
+	assert.Equal(t, "my-ws", gotName)
+	assert.Equal(t, []string{testCmdEcho, testCmdHello}, gotCmdArgs)
 }
 
 func TestResolveExecTarget(t *testing.T) {

--- a/cmd/workspace/exec_test.go
+++ b/cmd/workspace/exec_test.go
@@ -152,6 +152,7 @@ func TestExecCmd_SkipPostCreateFlagParsesValue(t *testing.T) {
 func TestResolveExecTarget(t *testing.T) {
 	const cwd = "/current/dir"
 	const testWsName = "my-ws"
+	const testFolder = "/some/path"
 
 	cases := []struct {
 		name    string
@@ -166,8 +167,8 @@ func TestResolveExecTarget(t *testing.T) {
 		},
 		{
 			name: "folder only",
-			cmd:  &ExecCmd{GlobalFlags: &flags.GlobalFlags{}, WorkspaceFolder: "/some/path"},
-			want: []string{"/some/path"},
+			cmd:  &ExecCmd{GlobalFlags: &flags.GlobalFlags{}, WorkspaceFolder: testFolder},
+			want: []string{testFolder},
 		},
 		{
 			name: "cwd default when nothing specified",
@@ -179,7 +180,7 @@ func TestResolveExecTarget(t *testing.T) {
 			cmd: &ExecCmd{
 				GlobalFlags:     &flags.GlobalFlags{},
 				WorkspaceName:   testWsName,
-				WorkspaceFolder: "/some/path",
+				WorkspaceFolder: testFolder,
 			},
 			wantErr: "not both",
 		},

--- a/cmd/workspace/exec_test.go
+++ b/cmd/workspace/exec_test.go
@@ -110,13 +110,15 @@ func TestExecCmd_DockerPathFlag(t *testing.T) {
 
 func TestExecCmd_ContainerIDTakesPrecedenceOverWorkspaceFolder(t *testing.T) {
 	cmd := &ExecCmd{
-		GlobalFlags:     &flags.GlobalFlags{},
+		GlobalFlags:     &flags.GlobalFlags{ResultFormat: "auto"},
 		WorkspaceFolder: "/some/folder",
-		ContainerID:     "abc123",
+		ContainerID:     "nonexistent-container-id-12345",
 	}
-	// Run checks `if cmd.ContainerID != ""` first, so container-id wins over folder.
-	assert.NotEmpty(t, cmd.ContainerID)
-	assert.NotEmpty(t, cmd.WorkspaceFolder)
+	// With both set, Run must take the container-id branch: the error references the
+	// container id, proving it did not try to resolve the folder via workspace.Get.
+	err := cmd.Run(t.Context(), []string{testCmdEcho, testCmdHello})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-container-id-12345")
 }
 
 func TestExecCmd_NonExistentContainerID(t *testing.T) {

--- a/cmd/workspace/exec_test.go
+++ b/cmd/workspace/exec_test.go
@@ -85,6 +85,14 @@ func TestNewExecCmd_RejectsMultipleNames(t *testing.T) {
 	assert.Contains(t, err.Error(), "at most one workspace name")
 }
 
+func TestNewExecCmd_RequiresCommandAfterDash(t *testing.T) {
+	execCmd := NewExecCmd(&flags.GlobalFlags{})
+	execCmd.SetArgs([]string{"my-ws", "--"})
+	err := execCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "a command to execute is required after --")
+}
+
 func TestResolveDockerCommand_NilWorkspace(t *testing.T) {
 	result := workspace2.ResolveDockerCommand(nil, "")
 	assert.Equal(t, "docker", result)

--- a/e2e/tests/exec/exec.go
+++ b/e2e/tests/exec/exec.go
@@ -176,14 +176,14 @@ var _ = ginkgo.Describe("devsy exec test suite", ginkgo.Label("exec"), ginkgo.Or
 
 			wsName := workspace.ToID(tempDir)
 
-			_, _, err = f.ExecCommandCapture(ctx, []string{
+			_, stderr, err := f.ExecCommandCapture(ctx, []string{
 				cmdWorkspace, execCommand,
 				wsName,
 				workspaceFolderFlag, tempDir,
 				"--", echoCommand, "-n", "hello",
 			})
 			framework.ExpectError(err)
-			gomega.Expect(err.Error()).To(gomega.ContainSubstring(
+			gomega.Expect(stderr).To(gomega.ContainSubstring(
 				"specify either a workspace name or --workspace-folder/--container-id, not both",
 			))
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))

--- a/e2e/tests/exec/exec.go
+++ b/e2e/tests/exec/exec.go
@@ -183,6 +183,9 @@ var _ = ginkgo.Describe("devsy exec test suite", ginkgo.Label("exec"), ginkgo.Or
 				"--", echoCommand, "-n", "hello",
 			})
 			framework.ExpectError(err)
+			gomega.Expect(err.Error()).To(gomega.ContainSubstring(
+				"specify either a workspace name or --workspace-folder/--container-id, not both",
+			))
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
 	ginkgo.It("should find container by custom id-label",

--- a/e2e/tests/exec/exec.go
+++ b/e2e/tests/exec/exec.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/devsy-org/devsy/e2e/framework"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -152,13 +153,34 @@ var _ = ginkgo.Describe("devsy exec test suite", ginkgo.Label("exec"), ginkgo.Or
 			framework.ExpectNoError(err)
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
 
-	ginkgo.It("should fail without --workspace-folder flag",
+	ginkgo.It("should exec by workspace name",
 		func(ctx context.Context) {
-			f := framework.NewDefaultFramework(initialDir + "/bin")
+			tempDir, f, err := setupWorkspaceAndUp(ctx, "tests/exec/testdata/exec", initialDir)
+			framework.ExpectNoError(err)
 
-			_, _, err := f.ExecCommandCapture(ctx, []string{
+			wsName := workspace.ToID(tempDir)
+
+			stdout, _, err := f.ExecCommandCapture(ctx, []string{
 				cmdWorkspace, execCommand,
-				"--", echoCommand, "hello",
+				wsName,
+				"--", echoCommand, "-n", "hello",
+			})
+			framework.ExpectNoError(err)
+			gomega.Expect(stdout).To(gomega.Equal("hello"))
+		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+	ginkgo.It("should error when both name and --workspace-folder are given",
+		func(ctx context.Context) {
+			tempDir, f, err := setupWorkspaceAndUp(ctx, "tests/exec/testdata/exec", initialDir)
+			framework.ExpectNoError(err)
+
+			wsName := workspace.ToID(tempDir)
+
+			_, _, err = f.ExecCommandCapture(ctx, []string{
+				cmdWorkspace, execCommand,
+				wsName,
+				workspaceFolderFlag, tempDir,
+				"--", echoCommand, "-n", "hello",
 			})
 			framework.ExpectError(err)
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))


### PR DESCRIPTION
## Summary

- `devsy workspace exec` now accepts a positional `[workspace-name]` (e.g. `exec my-ws -- echo hi`), matching its siblings `ssh`/`status`/`describe`. The name is resolved through `workspace.Get`→`ToID`, the same path those commands already use.
- All existing devcontainer-CLI-compatible flags (`--workspace-folder`, `--container-id`, `--id-label`, `--remote-env`, etc.) remain fully backward-compatible.
- Parsing uses cobra's `ArgsLenAtDash()` to split the workspace name (before `--`) from the command to run (after `--`). More than one name before `--` is an error.
- Combining a name with `--workspace-folder`/`--container-id` is rejected with a clear conflict error; specifying no target now defaults to the current directory instead of the old hard error.
- Adds shell completion for the positional name via `ValidArgsFunction`.
- Unit tests cover the `resolveExecTarget` resolution helper, positional-name parsing, multiple-name rejection, and the cwd default; e2e gains an exec-by-name spec and a name/folder conflict spec, replacing the obsolete "fail without --workspace-folder" spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The exec command accepts an optional positional workspace name with shell completion.
  * Target resolution now prefers workspace name, then workspace-folder flag, then current directory.
  * Conflicting target specifications are rejected.

* **Bug Fixes**
  * Removed hard requirement for explicit workspace-folder or container-id when running exec (defaults to CWD).

* **Tests**
  * Added unit and end-to-end tests covering name/ID targeting, precedence, conflict errors, and required command parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->