### PR TITLE
fix(desktop): scope wizard e2e template selectors to active tab panel

### DIFF
--- a/desktop/e2e/integration.e2e.ts
+++ b/desktop/e2e/integration.e2e.ts
@@ -371,8 +371,12 @@ test.describe
       await dialog.locator("button", { hasText: "docker" }).first().click()
       await dialog.getByRole("button", { name: /^continue$/i }).click()
 
-      // Step 2 — Source: click Python template
-      await dialog.locator("button", { hasText: "Python" }).click()
+      // Step 2 — Source: click Python template (scope to the active Git tab
+      // panel so it doesn't match the Image tab catalog's "Python 3.12" entry)
+      await dialog
+        .getByRole("tabpanel")
+        .locator("button", { hasText: "Python" })
+        .click()
       const sourceInput = dialog.locator('input[placeholder*="github"]')
       await expect(sourceInput).toHaveValue(
         "https://github.com/microsoft/vscode-remote-try-python",

--- a/desktop/e2e/workspaces.e2e.ts
+++ b/desktop/e2e/workspaces.e2e.ts
@@ -81,14 +81,17 @@ test.describe.serial("Create Workspace Wizard", () => {
       dialog.getByRole("heading", { name: /choose a source/i }),
     ).toBeVisible()
 
-    // Quick Start Templates section + 5 core templates
+    // Quick Start Templates section + 5 core templates. Scope to the active
+    // tab panel (Git) so the template buttons don't collide with the Image
+    // tab's catalog entries (e.g. "Python 3.12"), which share language names.
     await expect(dialog).toContainText("Quick Start Templates")
+    const gitPanel = dialog.getByRole("tabpanel")
     for (const lang of ["Python", "Node.js", "Go", "Rust", "Java"]) {
-      await expect(dialog.locator("button", { hasText: lang })).toBeVisible()
+      await expect(gitPanel.locator("button", { hasText: lang })).toBeVisible()
     }
 
     // Language icons render
-    const icons = dialog.locator("button img")
+    const icons = gitPanel.locator("button img")
     expect(await icons.count()).toBeGreaterThan(0)
     const firstIcon = icons.first()
     await expect(firstIcon).toBeVisible()
@@ -100,7 +103,7 @@ test.describe.serial("Create Workspace Wizard", () => {
 
   test("should select a template and populate the source field", async () => {
     const dialog = page.locator('[role="dialog"]').first()
-    await dialog.locator("button", { hasText: "Python" }).click()
+    await dialog.getByRole("tabpanel").locator("button", { hasText: "Python" }).click()
 
     const sourceInput = dialog.locator('input[placeholder*="github"]')
     await expect(sourceInput).toHaveValue(


### PR DESCRIPTION
## Summary

Desktop CI on `main` is failing after PR #497 (`4634c2599`) merged. That PR rebuilt the Create Workspace wizard's **Source** step around bits-ui `Tabs` (Git / Local / Image) and added an image catalog containing a "Python 3.12 Featured" entry, but did not update the e2e selectors.

bits-ui keeps all tab panels mounted, so `dialog.locator("button", { hasText: "Python" })` now matches two buttons — the Git tab's "Python" template card and the Image tab's catalog row — triggering a Playwright strict-mode violation. Two tests fail:

- `integration.e2e.ts:361` — should create Python workspace
- `workspaces.e2e.ts:73` — should advance to source step with templates

The fix scopes the template lookups to `dialog.getByRole("tabpanel")`. bits-ui marks inactive panels `hidden`, and Playwright's `getByRole` excludes hidden elements, so the locator resolves only to the active Git panel. Product code is untouched — this is purely a test-selector fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test suite for workspace creation workflows. Enhanced test reliability for Python workspace initialization and the Create Workspace Wizard by refining template selection logic to properly target active UI panels, preventing unintended element matching across tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->