### PR TITLE
feat: workspace source clarity & image platform compatibility

### DIFF
--- a/cmd/helper/get_image_platforms.go
+++ b/cmd/helper/get_image_platforms.go
@@ -1,0 +1,50 @@
+package helper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/devsy-org/devsy/pkg/image"
+	"github.com/spf13/cobra"
+)
+
+type GetImagePlatformsCommand struct {
+	*flags.GlobalFlags
+}
+
+// NewGetImagePlatformsCmd creates a new command.
+func NewGetImagePlatformsCmd(flags *flags.GlobalFlags) *cobra.Command {
+	cmd := &GetImagePlatformsCommand{
+		GlobalFlags: flags,
+	}
+	shellCmd := &cobra.Command{
+		Use:   "get-image-platforms [image-name]",
+		Short: "List the os/arch platforms an image supports",
+		RunE: func(cobraCmd *cobra.Command, args []string) error {
+			return cmd.Run(cobraCmd.Context(), args)
+		},
+	}
+
+	return shellCmd
+}
+
+func (cmd *GetImagePlatformsCommand) Run(ctx context.Context, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("image name is missing")
+	}
+
+	platforms, err := image.GetImagePlatforms(ctx, args[0])
+	if err != nil {
+		return err
+	}
+	out, err := json.Marshal(map[string][]string{"platforms": platforms})
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(out)) //nolint:forbidigo // helper prints to stdout
+
+	return nil
+}

--- a/cmd/helper/helper.go
+++ b/cmd/helper/helper.go
@@ -35,6 +35,7 @@ func NewHelperCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	helperCmd.AddCommand(NewFleetServerCmd(globalFlags))
 	helperCmd.AddCommand(NewDockerCredentialsHelperCmd(globalFlags))
 	helperCmd.AddCommand(NewGetImageCmd(globalFlags))
+	helperCmd.AddCommand(NewGetImagePlatformsCmd(globalFlags))
 	helperCmd.AddCommand(NewBrowserTunnelCmd(globalFlags))
 	return helperCmd
 }

--- a/cmd/workspace/up/up_flags.go
+++ b/cmd/workspace/up/up_flags.go
@@ -236,6 +236,10 @@ func (cmd *UpCmd) registerWorkspaceFlags(upCmd *cobra.Command) {
 		StringArrayVar(&cmd.Mounts, "mount", []string{},
 			"Additional mount to add to the container (format: type=bind,source=/host/path,target=/container/path). "+
 				"Can be specified multiple times")
+	upCmd.Flags().
+		StringVar(&cmd.RunPlatform, "platform", "",
+			"Run the container under a specific platform via emulation (e.g. linux/amd64). "+
+				"Empty uses the host's native platform")
 }
 
 func (cmd *UpCmd) registerTestingFlags(upCmd *cobra.Command) {

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -29,10 +29,6 @@ import { type ProviderEntry, parseProviderEntries } from "./watcher.js"
 
 const execFileAsync = promisify(execFile)
 
-function dockerOs(nodePlatform: NodeJS.Platform): string {
-  return nodePlatform === "win32" ? "windows" : nodePlatform
-}
-
 function dockerArch(nodeArch: string): string {
   if (nodeArch === "x64") return "amd64"
   if (nodeArch === "arm") return "arm"
@@ -1016,7 +1012,10 @@ export function registerIpcHandlers(deps: IpcDependencies): {
   })
 
   ipcMain.handle("get_host_platform", () => {
-    return `${dockerOs(process.platform)}/${dockerArch(process.arch)}`
+    // Devcontainers always target Linux: Docker Desktop/Podman run containers
+    // in a Linux VM, so the host process OS (darwin/win32) is never the
+    // container target. Only the architecture varies by host.
+    return `linux/${dockerArch(process.arch)}`
   })
 
   ipcMain.handle(

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -29,6 +29,16 @@ import { type ProviderEntry, parseProviderEntries } from "./watcher.js"
 
 const execFileAsync = promisify(execFile)
 
+function dockerOs(nodePlatform: NodeJS.Platform): string {
+  return nodePlatform === "win32" ? "windows" : nodePlatform
+}
+
+function dockerArch(nodeArch: string): string {
+  if (nodeArch === "x64") return "amd64"
+  if (nodeArch === "arm") return "arm"
+  return nodeArch
+}
+
 // Cache for provider update checks. Seeded on launch and refreshed every 6 hours.
 type UpdateInfo = {
   current: string
@@ -1003,6 +1013,10 @@ export function registerIpcHandlers(deps: IpcDependencies): {
 
   ipcMain.handle("get_app_version", () => {
     return app.getVersion()
+  })
+
+  ipcMain.handle("get_host_platform", () => {
+    return `${dockerOs(process.platform)}/${dockerArch(process.arch)}`
   })
 
   ipcMain.handle(

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -523,6 +523,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         workspaceFolder?: string
         devcontainerPath?: string
         prebuildRepository?: string
+        platform?: string
       },
     ) => {
       trackEvent("workspace_create", { provider: args.provider })
@@ -537,6 +538,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         cliArgs.push("--devcontainer-path", args.devcontainerPath)
       if (args.prebuildRepository)
         cliArgs.push("--prebuild-repository", args.prebuildRepository)
+      if (args.platform) cliArgs.push("--platform", args.platform)
 
       const wsId = args.workspaceId ?? args.source
       const cmdId = crypto.randomUUID()

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -1003,6 +1003,18 @@ export function registerIpcHandlers(deps: IpcDependencies): {
     return app.getVersion()
   })
 
+  ipcMain.handle(
+    "image_inspect_platforms",
+    async (_event, args: { ref: string }) => {
+      const result = await cli.run<{ platforms: string[] }>([
+        "helper",
+        "get-image-platforms",
+        args.ref,
+      ])
+      return result.platforms
+    },
+  )
+
   ipcMain.handle("get_auto_download", () => {
     return getAutoDownloadEnabled()
   })

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.platform.test.ts
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.platform.test.ts
@@ -151,6 +151,36 @@ describe("WorkspaceWizard platform compatibility", () => {
     unmount()
   })
 
+  it("falls back to the first offered platform when amd64 is not available", async () => {
+    getImagePlatforms.mockResolvedValue(["linux/s390x"])
+    const { getByText, unmount } = render(WorkspaceWizard, {
+      props: { open: true },
+    })
+    await flushAsync()
+    await gotoReviewWithImage(getByText, "ubuntu:22.04")
+
+    await waitFor(() =>
+      expect(getByText(/no build for your machine/i)).toBeTruthy(),
+    )
+
+    // The emulation offer names the only platform the image provides.
+    expect(getByText(/Run under emulation \(linux\/s390x\)/i)).toBeTruthy()
+
+    const checkbox = document.querySelector(
+      'input[type="checkbox"]',
+    ) as HTMLInputElement
+    await fireEvent.click(checkbox)
+    await flushAsync()
+
+    await fireEvent.click(getLaunch())
+    await flushAsync()
+
+    expect(workspaceUp).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: "linux/s390x" }),
+    )
+    unmount()
+  })
+
   it("does not warn for a multi-arch image on an arm64 host", async () => {
     getImagePlatforms.mockResolvedValue(["linux/amd64", "linux/arm64"])
     const { getByText, queryByText, unmount } = render(WorkspaceWizard, {

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.platform.test.ts
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.platform.test.ts
@@ -1,0 +1,190 @@
+import { tick } from "svelte"
+import { render, fireEvent, cleanup, waitFor } from "@testing-library/svelte"
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest"
+import type { Provider } from "$lib/types/index.js"
+
+const getImagePlatforms = vi.fn()
+const getHostPlatform = vi.fn().mockResolvedValue("linux/arm64")
+const workspaceUp = vi.fn().mockResolvedValue("cmd-1")
+
+vi.mock("$lib/ipc/commands.js", () => ({
+  getImagePlatforms: (...args: unknown[]) => getImagePlatforms(...args),
+  getHostPlatform: (...args: unknown[]) => getHostPlatform(...args),
+  workspaceUp: (...args: unknown[]) => workspaceUp(...args),
+  openDirectoryDialog: vi.fn(),
+}))
+vi.mock("$lib/ipc/events.js", () => ({
+  onCommandProgress: vi.fn().mockResolvedValue(() => {}),
+}))
+
+vi.mock("$lib/stores/imageCatalog.js", async () => {
+  const { writable } = await import("svelte/store")
+  const actual = await vi.importActual<
+    typeof import("$lib/stores/imageCatalog.js")
+  >("$lib/stores/imageCatalog.js")
+  return {
+    imageCatalog: writable({ images: [], categories: [], loading: false }),
+    loadImageCatalog: vi.fn(),
+    filterImages: actual.filterImages,
+    isImageCompatible: actual.isImageCompatible,
+  }
+})
+
+vi.mock("$lib/stores/providers.js", async () => {
+  const { writable } = await import("svelte/store")
+  return { providers: writable<Provider[]>([]) }
+})
+vi.mock("$lib/stores/workspaces.js", async () => {
+  const { writable } = await import("svelte/store")
+  return { workspaces: writable<{ id: string }[]>([]) }
+})
+vi.mock("$lib/stores/toasts.js", () => ({
+  toasts: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}))
+vi.mock("$lib/router.js", () => ({
+  goto: vi.fn(),
+  push: vi.fn(),
+  replace: vi.fn(),
+  router: {},
+  location: { subscribe: () => () => {} },
+}))
+
+import { providers } from "$lib/stores/providers.js"
+import { workspaces } from "$lib/stores/workspaces.js"
+import WorkspaceWizard from "./WorkspaceWizard.svelte"
+
+function makeProvider(name: string, initialized = true): Provider {
+  return { name, version: "0.1.0", state: { initialized } }
+}
+
+async function flushAsync() {
+  await new Promise((r) => setTimeout(r, 30))
+  await tick()
+  await tick()
+}
+
+function getActiveContinue(): HTMLButtonElement {
+  return Array.from(document.querySelectorAll("button")).find(
+    (b) =>
+      b.textContent?.trim() === "Continue" &&
+      !(b as HTMLButtonElement).disabled,
+  ) as HTMLButtonElement
+}
+
+function getLaunch(): HTMLButtonElement {
+  return Array.from(document.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === "Launch",
+  ) as HTMLButtonElement
+}
+
+// Drive the wizard from the provider step to the review step with a custom
+// image reference, which is the only path that exercises the platform check.
+async function gotoReviewWithImage(
+  getByText: (t: string) => HTMLElement,
+  imageRef: string,
+) {
+  // provider step
+  await fireEvent.click(getByText("docker"))
+  await flushAsync()
+  await fireEvent.click(getActiveContinue())
+  await flushAsync()
+
+  // source step: switch to the Image tab and enter a custom ref
+  await fireEvent.click(getByText("Image"))
+  await flushAsync()
+  const customImageInput = document.querySelector(
+    'input[placeholder*="registry/image:tag"]',
+  ) as HTMLInputElement
+  await fireEvent.input(customImageInput, { target: { value: imageRef } })
+  await flushAsync()
+  await fireEvent.click(getActiveContinue())
+  await flushAsync()
+
+  // ide step
+  await fireEvent.click(getActiveContinue())
+  await flushAsync()
+}
+
+describe("WorkspaceWizard platform compatibility", () => {
+  beforeEach(() => {
+    workspaceUp.mockClear()
+    getImagePlatforms.mockReset()
+    getHostPlatform.mockReset().mockResolvedValue("linux/arm64")
+    workspaceUp.mockResolvedValue("cmd-1")
+    providers.set([makeProvider("docker")])
+    workspaces.set([])
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    document.body.innerHTML = ""
+  })
+
+  it("warns and offers emulation for an amd64-only image on an arm64 host", async () => {
+    getImagePlatforms.mockResolvedValue(["linux/amd64"])
+    const { getByText, unmount } = render(WorkspaceWizard, {
+      props: { open: true },
+    })
+    await flushAsync()
+    await gotoReviewWithImage(getByText, "ubuntu:22.04")
+
+    // Warning renders once the (mocked) platform lookup resolves.
+    await waitFor(() =>
+      expect(getByText(/no build for your machine/i)).toBeTruthy(),
+    )
+
+    const checkbox = document.querySelector(
+      'input[type="checkbox"]',
+    ) as HTMLInputElement
+    expect(checkbox).toBeTruthy()
+
+    await fireEvent.click(checkbox)
+    await flushAsync()
+
+    await fireEvent.click(getLaunch())
+    await flushAsync()
+
+    expect(workspaceUp).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: "linux/amd64" }),
+    )
+    unmount()
+  })
+
+  it("does not warn for a multi-arch image on an arm64 host", async () => {
+    getImagePlatforms.mockResolvedValue(["linux/amd64", "linux/arm64"])
+    const { getByText, queryByText, unmount } = render(WorkspaceWizard, {
+      props: { open: true },
+    })
+    await flushAsync()
+    await gotoReviewWithImage(getByText, "ubuntu:22.04")
+
+    // Give the lookup a chance to resolve, then assert nothing surfaced.
+    await flushAsync()
+    expect(queryByText(/no build for your machine/i)).toBeNull()
+    expect(document.querySelector('input[type="checkbox"]')).toBeNull()
+    unmount()
+  })
+
+  it("stays silent and still launches when the platform lookup rejects", async () => {
+    getImagePlatforms.mockRejectedValue(new Error("registry unreachable"))
+    const { getByText, queryByText, unmount } = render(WorkspaceWizard, {
+      props: { open: true },
+    })
+    await flushAsync()
+    await gotoReviewWithImage(getByText, "ubuntu:22.04")
+
+    await flushAsync()
+    expect(queryByText(/no build for your machine/i)).toBeNull()
+    expect(document.querySelector('input[type="checkbox"]')).toBeNull()
+
+    await fireEvent.click(getLaunch())
+    await flushAsync()
+
+    expect(workspaceUp).toHaveBeenCalled()
+    expect(workspaceUp).toHaveBeenCalledWith(
+      expect.objectContaining({ platform: undefined }),
+    )
+    unmount()
+  })
+})

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -362,7 +362,13 @@ $effect(() => {
 
 onMount(() => {
   // Listener is registered at handleLaunch time (race-safe pattern).
-  void getHostPlatform().then((p) => (hostPlatform = p))
+  void getHostPlatform()
+    .then((p) => (hostPlatform = p))
+    .catch((err) => {
+      // Advisory only: leaving hostPlatform empty hides the compat check
+      // rather than blocking launch. Log so a real defect isn't masked.
+      console.warn("Host platform lookup failed:", err)
+    })
 })
 
 onDestroy(() => {

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -25,7 +25,12 @@ import ImagePicker from "$lib/components/workspace/ImagePicker.svelte"
 import ConfirmDialog from "$lib/components/layout/ConfirmDialog.svelte"
 import LogTable from "$lib/components/log/LogTable.svelte"
 import { uniqueNamesGenerator, adjectives, animals } from "unique-names-generator"
-import { workspaceUp, openDirectoryDialog } from "$lib/ipc/commands.js"
+import {
+  workspaceUp,
+  openDirectoryDialog,
+  getHostPlatform,
+  getImagePlatforms,
+} from "$lib/ipc/commands.js"
 import { buildWorkspaceSource } from "$lib/utils/workspace-source.js"
 import type {
   WorkspaceSourceType,
@@ -35,6 +40,7 @@ import { onCommandProgress } from "$lib/ipc/events.js"
 import type { CommandProgress } from "$lib/types/index.js"
 import { providers } from "$lib/stores/providers.js"
 import { workspaces } from "$lib/stores/workspaces.js"
+import { isImageCompatible } from "$lib/stores/imageCatalog.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
 import { isCommandSuccess, stripAnsi } from "$lib/utils/log-parser.js"
@@ -201,6 +207,13 @@ let confirmCancelOpen = $state(false)
 let unlisten: UnlistenFn | null = null
 let watchdog: ReturnType<typeof setTimeout> | null = null
 
+// Image platform compatibility (image source only)
+let hostPlatform = $state("")
+let imagePlatforms = $state<string[]>([])
+let checkedRef = $state("")
+let compatLoading = $state(false)
+let emulationEnabled = $state(false)
+
 let initializedProviders = $derived(
   $providers.filter((p) => p.state?.initialized === true),
 )
@@ -233,6 +246,19 @@ let nameConflict = $derived(
     $workspaces.some(
       (ws) => ws.id.toLowerCase() === resolvedId.toLowerCase(),
     ),
+)
+
+let imageIncompatible = $derived(
+  sourceType === "image" &&
+    hostPlatform !== "" &&
+    imagePlatforms.length > 0 &&
+    !isImageCompatible(imagePlatforms, hostPlatform),
+)
+
+// Prefer linux/amd64 if the image offers it; otherwise the first listed
+// platform. This is what we run under emulation.
+let emulationTarget = $derived(
+  imagePlatforms.includes("linux/amd64") ? "linux/amd64" : imagePlatforms[0] ?? "",
 )
 
 let stepStates = $derived.by(() => {
@@ -301,8 +327,36 @@ $effect(() => {
   }
 })
 
+$effect(() => {
+  if (
+    currentStep === "review" &&
+    sourceType === "image" &&
+    imageRef.trim() &&
+    imageRef.trim() !== checkedRef &&
+    !compatLoading
+  ) {
+    const ref = imageRef.trim()
+    checkedRef = ref
+    compatLoading = true
+    imagePlatforms = []
+    emulationEnabled = false
+    getImagePlatforms(ref)
+      .then((p) => {
+        imagePlatforms = p
+      })
+      .catch(() => {
+        // Advisory only: a failed lookup never blocks launch.
+        imagePlatforms = []
+      })
+      .finally(() => {
+        compatLoading = false
+      })
+  }
+})
+
 onMount(() => {
   // Listener is registered at handleLaunch time (race-safe pattern).
+  void getHostPlatform().then((p) => (hostPlatform = p))
 })
 
 onDestroy(() => {
@@ -368,6 +422,10 @@ async function handleLaunch() {
       workspaceFolder: workspaceFolder.trim() || undefined,
       devcontainerPath: assembled.devcontainerPath,
       prebuildRepository: assembled.prebuildRepository,
+      platform:
+        imageIncompatible && emulationEnabled && emulationTarget
+          ? emulationTarget
+          : undefined,
       debug: true,
     })
 
@@ -912,6 +970,35 @@ function selectTemplate(t: { name: string; source: string }) {
               <span class="font-medium truncate font-mono">{resolvedId}</span>
             </div>
           </div>
+
+          {#if sourceType === "image" && compatLoading}
+            <p class="text-sm text-muted-foreground">Checking image compatibility…</p>
+          {/if}
+
+          {#if imageIncompatible}
+            <Alert.Root>
+              <TriangleAlert class="h-4 w-4 text-amber-600" />
+              <Alert.Description class="text-amber-700 dark:text-amber-400">
+                This image has no build for your machine ({hostPlatform}) and will
+                fail to start unless you run it under emulation below.
+              </Alert.Description>
+            </Alert.Root>
+
+            <label class="flex items-start gap-2 text-sm">
+              <input
+                type="checkbox"
+                class="mt-0.5"
+                checked={emulationEnabled}
+                onchange={(e) => (emulationEnabled = e.currentTarget.checked)}
+              />
+              <span>
+                <span class="font-medium">Run under emulation ({emulationTarget})</span>
+                <span class="block text-xs text-muted-foreground">
+                  Runs an {emulationTarget} image on your machine via emulation. Works, but noticeably slower.
+                </span>
+              </span>
+            </label>
+          {/if}
 
           <div class="flex justify-between gap-2 pt-2">
             <Button variant="outline" onclick={() => goToStep("ide")}>Back</Button>

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -532,31 +532,40 @@ function selectTemplate(t: { name: string; source: string }) {
 
         {#if isGit}
           <div class="space-y-1.5">
-            <Label class="text-sm">Subfolder</Label>
+            <Label class="text-sm">Project subfolder</Label>
             <Input
-              placeholder="path/within/repo (optional)"
+              placeholder="packages/api"
               value={subPath}
               oninput={(e) => (subPath = e.currentTarget.value)}
             />
+            <p class="text-xs text-muted-foreground">
+              The folder inside the repo that holds your project. Leave blank to use the repo root.
+            </p>
           </div>
         {/if}
 
         <div class="space-y-1.5">
-          <Label class="text-sm">Workspace Folder</Label>
+          <Label class="text-sm">Open folder in container</Label>
           <Input
-            placeholder="path opened inside the container (optional)"
+            placeholder="/workspaces/app"
             value={workspaceFolder}
             oninput={(e) => (workspaceFolder = e.currentTarget.value)}
           />
+          <p class="text-xs text-muted-foreground">
+            The folder your editor opens once the container is running. Leave blank to use the default.
+          </p>
         </div>
 
         <div class="space-y-1.5">
-          <Label class="text-sm">devcontainer.json path</Label>
+          <Label class="text-sm">Dev container config</Label>
           <Input
-            placeholder=".devcontainer/devcontainer.json (optional)"
+            placeholder=".devcontainer/devcontainer.json"
             value={devcontainerPath}
             oninput={(e) => (devcontainerPath = e.currentTarget.value)}
           />
+          <p class="text-xs text-muted-foreground">
+            Path to the devcontainer.json to build from. Leave blank to auto-detect.
+          </p>
         </div>
 
         <div class="space-y-1.5">
@@ -867,13 +876,13 @@ function selectTemplate(t: { name: string; source: string }) {
             {/if}
             {#if sourceType === "git" && subPath.trim()}
               <div class="flex justify-between gap-3">
-                <span class="text-muted-foreground">Subfolder</span>
+                <span class="text-muted-foreground">Project subfolder</span>
                 <span class="font-medium truncate">{subPath}</span>
               </div>
             {/if}
             {#if assembled.devcontainerPath}
               <div class="flex justify-between gap-3">
-                <span class="text-muted-foreground">devcontainer.json</span>
+                <span class="text-muted-foreground">Dev container config</span>
                 <span class="font-medium truncate">{assembled.devcontainerPath}</span>
               </div>
             {/if}
@@ -885,7 +894,7 @@ function selectTemplate(t: { name: string; source: string }) {
             {/if}
             {#if workspaceFolder}
               <div class="flex justify-between gap-3">
-                <span class="text-muted-foreground">Workspace Folder</span>
+                <span class="text-muted-foreground">Open folder in container</span>
                 <span class="font-medium truncate">{workspaceFolder}</span>
               </div>
             {/if}

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -480,7 +480,12 @@ function continueFromReview() {
 function selectTemplate(t: { name: string; source: string }) {
   repoUrl = t.source
   if (!workspaceName) {
-    workspaceName = uniquifyName(t.name.toLowerCase().replace(/[^a-z0-9]/g, "-"))
+    workspaceName = uniquifyName(
+      t.name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, ""),
+    )
   }
 }
 </script>

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -348,8 +348,10 @@ $effect(() => {
       .then((p) => {
         imagePlatforms = p
       })
-      .catch(() => {
-        // Advisory only: a failed lookup never blocks launch.
+      .catch((err) => {
+        // Advisory only: a failed lookup never blocks launch. Log so a genuine
+        // renderer defect isn't silently masked as "image compatible".
+        console.warn(`Image platform lookup failed for ${ref}:`, err)
         imagePlatforms = []
       })
       .finally(() => {

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -316,6 +316,10 @@ function reset() {
   launchSuccess = false
   launchedWorkspaceId = null
   confirmCancelOpen = false
+  checkedRef = ""
+  imagePlatforms = []
+  compatLoading = false
+  emulationEnabled = false
   clearWatchdog()
   unlisten?.()
   unlisten = null

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.test.ts
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.test.ts
@@ -9,6 +9,8 @@ const onCommandProgress = vi.fn()
 vi.mock("$lib/ipc/commands.js", () => ({
   workspaceUp: (...args: unknown[]) => workspaceUp(...args),
   openDirectoryDialog: vi.fn(),
+  getHostPlatform: vi.fn().mockResolvedValue("linux/arm64"),
+  getImagePlatforms: vi.fn().mockResolvedValue(["linux/amd64", "linux/arm64"]),
 }))
 
 vi.mock("$lib/stores/imageCatalog.js", async () => {
@@ -24,6 +26,7 @@ vi.mock("$lib/stores/imageCatalog.js", async () => {
     }),
     loadImageCatalog: vi.fn(),
     filterImages: actual.filterImages,
+    isImageCompatible: actual.isImageCompatible,
   }
 })
 
@@ -453,11 +456,11 @@ describe("WorkspaceWizard", () => {
     await flushAsync()
 
     const subPathInput = document.querySelector(
-      'input[placeholder*="path/within/repo"]',
+      'input[placeholder*="packages/api"]',
     ) as HTMLInputElement
     await fireEvent.input(subPathInput, { target: { value: "pkg/api" } })
     const wsFolderInput = document.querySelector(
-      'input[placeholder*="opened inside the container"]',
+      'input[placeholder="/workspaces/app"]',
     ) as HTMLInputElement
     await fireEvent.input(wsFolderInput, { target: { value: "/workspaces/app" } })
     const devcontainerInput = document.querySelector(
@@ -515,7 +518,7 @@ describe("WorkspaceWizard", () => {
     await fireEvent.click(advancedToggle)
     await flushAsync()
     const wsFolderInput = document.querySelector(
-      'input[placeholder*="opened inside the container"]',
+      'input[placeholder="/workspaces/app"]',
     ) as HTMLInputElement
     await fireEvent.input(wsFolderInput, { target: { value: "/workspaces/app" } })
     await flushAsync()

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -29,6 +29,7 @@ export async function workspaceUp(params: {
   workspaceFolder?: string
   devcontainerPath?: string
   prebuildRepository?: string
+  platform?: string
 }): Promise<string> {
   return invoke<string>("workspace_up", params)
 }
@@ -169,6 +170,11 @@ export async function imageCatalogGet(): Promise<LoadCatalogResult> {
 
 export async function imageCatalogRefresh(): Promise<LoadCatalogResult> {
   return invoke<LoadCatalogResult>("image_catalog_refresh")
+}
+
+/** Supported `os/arch` platforms for an image ref, via the registry manifest. */
+export async function getImagePlatforms(ref: string): Promise<string[]> {
+  return invoke<string[]>("image_inspect_platforms", { ref })
 }
 
 // Machine commands

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -172,6 +172,11 @@ export async function imageCatalogRefresh(): Promise<LoadCatalogResult> {
   return invoke<LoadCatalogResult>("image_catalog_refresh")
 }
 
+/** Host container platform as `os/arch` (e.g. "linux/arm64"). */
+export async function getHostPlatform(): Promise<string> {
+  return invoke<string>("get_host_platform")
+}
+
 /** Supported `os/arch` platforms for an image ref, via the registry manifest. */
 export async function getImagePlatforms(ref: string): Promise<string[]> {
   return invoke<string[]>("image_inspect_platforms", { ref })

--- a/desktop/src/renderer/src/lib/ipc/mock.ts
+++ b/desktop/src/renderer/src/lib/ipc/mock.ts
@@ -269,6 +269,8 @@ const COMMANDS: Record<string, Handler> = {
   terminal_close: () => undefined,
   terminal_list: () => [],
 
+  image_inspect_platforms: () => ["linux/amd64", "linux/arm64"],
+
   // Release channel
   get_release_channel: () => "stable",
   set_release_channel: () => undefined,

--- a/desktop/src/renderer/src/lib/ipc/mock.ts
+++ b/desktop/src/renderer/src/lib/ipc/mock.ts
@@ -269,6 +269,8 @@ const COMMANDS: Record<string, Handler> = {
   terminal_close: () => undefined,
   terminal_list: () => [],
 
+  get_host_platform: () => "linux/amd64",
+
   image_inspect_platforms: () => ["linux/amd64", "linux/arm64"],
 
   // Release channel

--- a/desktop/src/renderer/src/lib/stores/imageCatalog.test.ts
+++ b/desktop/src/renderer/src/lib/stores/imageCatalog.test.ts
@@ -11,6 +11,7 @@ import {
   loadImageCatalog,
   resetImageCatalogStore,
   filterImages,
+  isImageCompatible,
 } from "./imageCatalog.js"
 import { imageCatalogGet } from "$lib/ipc/commands.js"
 import type { CatalogImage } from "$lib/types/index.js"
@@ -82,5 +83,17 @@ describe("imageCatalog store", () => {
   it("filterImages: category filter", () => {
     const out = filterImages(IMAGES, "", "tools")
     expect(out.map((i) => i.id)).toEqual(["tf"])
+  })
+
+  it("isImageCompatible: empty list means compatible", () => {
+    expect(isImageCompatible([], "linux/arm64")).toBe(true)
+  })
+
+  it("isImageCompatible: matching platform is compatible", () => {
+    expect(isImageCompatible(["linux/amd64"], "linux/amd64")).toBe(true)
+  })
+
+  it("isImageCompatible: missing host platform is incompatible", () => {
+    expect(isImageCompatible(["linux/amd64"], "linux/arm64")).toBe(false)
   })
 })

--- a/desktop/src/renderer/src/lib/stores/imageCatalog.ts
+++ b/desktop/src/renderer/src/lib/stores/imageCatalog.ts
@@ -66,6 +66,18 @@ export function resetImageCatalogStore(): void {
   internal.set(initial)
 }
 
+/**
+ * Returns false when a non-empty platform list excludes the host's platform.
+ * An empty list is treated as compatible (multi-arch / unknown).
+ */
+export function isImageCompatible(
+  platforms: string[],
+  hostPlatform: string,
+): boolean {
+  if (platforms.length === 0) return true
+  return platforms.includes(hostPlatform)
+}
+
 export function filterImages(
   images: CatalogImage[],
   search: string,

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -614,6 +614,7 @@ func (r *runner) getRunOptions(
 		Userns:         substitutionContext.Userns,
 		UidMap:         substitutionContext.UidMap,
 		GidMap:         substitutionContext.GidMap,
+		Platform:       r.WorkspaceConfig.CLIOptions.RunPlatform,
 	}, nil
 }
 

--- a/pkg/driver/docker/docker.go
+++ b/pkg/driver/docker/docker.go
@@ -519,6 +519,7 @@ func (d *dockerDriver) buildRunArgs(
 		addLabels().
 		addGPU().
 		addRunArgs().
+		addRunPlatform().
 		addDetached().
 		addEntrypoint().
 		addImage()
@@ -596,6 +597,19 @@ func (b *runArgsBuilder) addGPU() *runArgsBuilder {
 
 func (b *runArgsBuilder) addRunArgs() *runArgsBuilder {
 	b.args = append(b.args, b.params.ParsedConfig.RunArgs...)
+	return b
+}
+
+func (b *runArgsBuilder) addRunPlatform() *runArgsBuilder {
+	if b.params.Options.Platform == "" {
+		return b
+	}
+	for _, a := range b.params.ParsedConfig.RunArgs {
+		if a == "--platform" || strings.HasPrefix(a, "--platform=") {
+			return b // explicit config wins; avoid duplicate/conflict.
+		}
+	}
+	b.args = append(b.args, "--platform="+b.params.Options.Platform)
 	return b
 }
 

--- a/pkg/driver/docker/docker_test.go
+++ b/pkg/driver/docker/docker_test.go
@@ -18,6 +18,7 @@ const (
 	testUpdateUIDDefaultOn  = "on"
 	testOSLinux             = "linux"
 	testRemoteUser          = "vscode"
+	testRunArg              = "run"
 )
 
 type DockerDriverTestSuite struct {
@@ -266,7 +267,7 @@ func (s *DockerDriverTestSuite) TestStripMountConsistency() {
 
 func (s *DockerDriverTestSuite) TestAddRunPlatform_SetAppendsFlag() {
 	b := &runArgsBuilder{
-		args:   []string{"run"},
+		args:   []string{testRunArg},
 		driver: s.driver,
 		params: &driver.RunDockerDevContainerParams{
 			Options:      &driver.RunOptions{Platform: "linux/amd64"},
@@ -279,7 +280,7 @@ func (s *DockerDriverTestSuite) TestAddRunPlatform_SetAppendsFlag() {
 
 func (s *DockerDriverTestSuite) TestAddRunPlatform_EmptyNoFlag() {
 	b := &runArgsBuilder{
-		args:   []string{"run"},
+		args:   []string{testRunArg},
 		driver: s.driver,
 		params: &driver.RunDockerDevContainerParams{
 			Options:      &driver.RunOptions{Platform: ""},
@@ -294,7 +295,7 @@ func (s *DockerDriverTestSuite) TestAddRunPlatform_EmptyNoFlag() {
 
 func (s *DockerDriverTestSuite) TestAddRunPlatform_ExplicitInConfigNotDuplicated() {
 	b := &runArgsBuilder{
-		args:   []string{"run"},
+		args:   []string{testRunArg},
 		driver: s.driver,
 		params: &driver.RunDockerDevContainerParams{
 			Options: &driver.RunOptions{Platform: "linux/amd64"},

--- a/pkg/driver/docker/docker_test.go
+++ b/pkg/driver/docker/docker_test.go
@@ -263,3 +263,54 @@ func (s *DockerDriverTestSuite) TestStripMountConsistency() {
 		s.Equal(tt.want, stripMountConsistency(tt.input))
 	}
 }
+
+func (s *DockerDriverTestSuite) TestAddRunPlatform_SetAppendsFlag() {
+	b := &runArgsBuilder{
+		args:   []string{"run"},
+		driver: s.driver,
+		params: &driver.RunDockerDevContainerParams{
+			Options:      &driver.RunOptions{Platform: "linux/amd64"},
+			ParsedConfig: &config.DevContainerConfig{},
+		},
+	}
+	b.addRunPlatform()
+	s.Contains(b.args, "--platform=linux/amd64")
+}
+
+func (s *DockerDriverTestSuite) TestAddRunPlatform_EmptyNoFlag() {
+	b := &runArgsBuilder{
+		args:   []string{"run"},
+		driver: s.driver,
+		params: &driver.RunDockerDevContainerParams{
+			Options:      &driver.RunOptions{Platform: ""},
+			ParsedConfig: &config.DevContainerConfig{},
+		},
+	}
+	b.addRunPlatform()
+	for _, a := range b.args {
+		s.NotContains(a, "--platform")
+	}
+}
+
+func (s *DockerDriverTestSuite) TestAddRunPlatform_ExplicitInConfigNotDuplicated() {
+	b := &runArgsBuilder{
+		args:   []string{"run"},
+		driver: s.driver,
+		params: &driver.RunDockerDevContainerParams{
+			Options: &driver.RunOptions{Platform: "linux/amd64"},
+			ParsedConfig: &config.DevContainerConfig{
+				NonComposeBase: config.NonComposeBase{
+					RunArgs: []string{"--platform", "linux/arm64"},
+				},
+			},
+		},
+	}
+	b.addRunPlatform()
+	count := 0
+	for _, a := range b.args {
+		if a == "--platform=linux/amd64" {
+			count++
+		}
+	}
+	s.Equal(0, count, "should not auto-add when config already sets --platform")
+}

--- a/pkg/driver/types.go
+++ b/pkg/driver/types.go
@@ -103,4 +103,8 @@ type RunOptions struct {
 
 	// GidMap are GID mappings for user namespace
 	GidMap []string `json:"gidMap,omitempty"`
+
+	// Platform is the target platform (os/arch) to run the container under,
+	// e.g. "linux/amd64". Empty means use the host's native platform.
+	Platform string `json:"platform,omitempty"`
 }

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -13,6 +13,11 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
+const (
+	osLinux   = "linux"
+	osUnknown = "unknown"
+)
+
 var (
 	dockerTagRegexp  = regexp.MustCompile(`^[\w][\w.-]*$`)
 	DockerTagMaxSize = 128
@@ -50,7 +55,7 @@ func GetImageForArch(ctx context.Context, image, arch string) (v1.Image, error) 
 
 	remoteOptions := []remote.Option{
 		remote.WithAuthFromKeychain(keychain),
-		remote.WithPlatform(v1.Platform{Architecture: arch, OS: "linux"}),
+		remote.WithPlatform(v1.Platform{Architecture: arch, OS: osLinux}),
 	}
 
 	img, err := remote.Image(ref, remoteOptions...)
@@ -124,7 +129,7 @@ func platformsFromManifests(manifests []v1.Descriptor) []string {
 	for _, m := range manifests {
 		p := m.Platform
 		if p == nil || p.OS == "" || p.Architecture == "" ||
-			p.OS == "unknown" || p.Architecture == "unknown" {
+			p.OS == osUnknown || p.Architecture == osUnknown {
 			continue
 		}
 		key := p.OS + "/" + p.Architecture

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -165,7 +165,7 @@ func GetImagePlatforms(ctx context.Context, image string) ([]string, error) {
 	// Not an index — fall back to single-image config OS/Arch.
 	configFile, _, cErr := GetImageConfig(ctx, image)
 	if cErr != nil {
-		return nil, fmt.Errorf("retrieve image %s: %w", image, SanitizeRegistryError(err))
+		return nil, fmt.Errorf("retrieve image %s: %w", image, SanitizeRegistryError(cErr))
 	}
 	if configFile.OS == "" || configFile.Architecture == "" {
 		return []string{}, nil

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -163,6 +163,7 @@ func GetImagePlatforms(ctx context.Context, image string) ([]string, error) {
 	}
 
 	// Not an index — fall back to single-image config OS/Arch.
+	log.Debugf("Image %q is not an index (%v); falling back to single-image config", image, err)
 	configFile, _, cErr := GetImageConfig(ctx, image)
 	if cErr != nil {
 		return nil, fmt.Errorf("retrieve image %s: %w", image, SanitizeRegistryError(cErr))

--- a/pkg/image/image.go
+++ b/pkg/image/image.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"regexp"
+	"sort"
 
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -113,6 +114,63 @@ func GetImageConfig(
 	}
 
 	return configFile, img, nil
+}
+
+// platformsFromManifests collects unique "os/arch" strings from manifest
+// descriptors, skipping nil and unknown/attestation entries.
+func platformsFromManifests(manifests []v1.Descriptor) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, m := range manifests {
+		p := m.Platform
+		if p == nil || p.OS == "" || p.Architecture == "" ||
+			p.OS == "unknown" || p.Architecture == "unknown" {
+			continue
+		}
+		key := p.OS + "/" + p.Architecture
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, key)
+	}
+	return out
+}
+
+// GetImagePlatforms returns the "os/arch" platforms a remote image reference
+// supports. Multi-arch indexes return every entry; single-image manifests fall
+// back to the config file's OS/Architecture.
+func GetImagePlatforms(ctx context.Context, image string) ([]string, error) {
+	ref, err := name.ParseReference(image)
+	if err != nil {
+		return nil, err
+	}
+
+	keychain, err := GetKeychain(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("create authentication keychain: %w", err)
+	}
+
+	idx, err := remote.Index(ref, remote.WithAuthFromKeychain(keychain))
+	if err == nil {
+		manifest, mErr := idx.IndexManifest()
+		if mErr != nil {
+			return nil, fmt.Errorf("read image index %s: %w", image, mErr)
+		}
+		platforms := platformsFromManifests(manifest.Manifests)
+		sort.Strings(platforms)
+		return platforms, nil
+	}
+
+	// Not an index — fall back to single-image config OS/Arch.
+	configFile, _, cErr := GetImageConfig(ctx, image)
+	if cErr != nil {
+		return nil, fmt.Errorf("retrieve image %s: %w", image, SanitizeRegistryError(err))
+	}
+	if configFile.OS == "" || configFile.Architecture == "" {
+		return []string{}, nil
+	}
+	return []string{configFile.OS + "/" + configFile.Architecture}, nil
 }
 
 func ValidateTags(tags []string) error {

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -1,0 +1,29 @@
+package image
+
+import (
+	"sort"
+	"testing"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+func TestPlatformsFromIndex_FiltersUnknownAndDedupes(t *testing.T) {
+	manifests := []v1.Descriptor{
+		{Platform: &v1.Platform{OS: "linux", Architecture: "amd64"}},
+		{Platform: &v1.Platform{OS: "linux", Architecture: "arm64"}},
+		{Platform: &v1.Platform{OS: "linux", Architecture: "amd64"}}, // dup
+		{Platform: &v1.Platform{OS: "unknown", Architecture: "unknown"}},
+		{Platform: nil},
+	}
+	got := platformsFromManifests(manifests)
+	sort.Strings(got)
+	want := []string{"linux/amd64", "linux/arm64"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -7,7 +7,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
-func TestPlatformsFromIndex_FiltersUnknownAndDedupes(t *testing.T) {
+func TestPlatformsFromManifests_FiltersUnknownAndDedupes(t *testing.T) {
 	manifests := []v1.Descriptor{
 		{Platform: &v1.Platform{OS: "linux", Architecture: "amd64"}},
 		{Platform: &v1.Platform{OS: "linux", Architecture: "arm64"}},

--- a/pkg/image/image_test.go
+++ b/pkg/image/image_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestPlatformsFromManifests_FiltersUnknownAndDedupes(t *testing.T) {
 	manifests := []v1.Descriptor{
-		{Platform: &v1.Platform{OS: "linux", Architecture: "amd64"}},
-		{Platform: &v1.Platform{OS: "linux", Architecture: "arm64"}},
-		{Platform: &v1.Platform{OS: "linux", Architecture: "amd64"}}, // dup
-		{Platform: &v1.Platform{OS: "unknown", Architecture: "unknown"}},
+		{Platform: &v1.Platform{OS: osLinux, Architecture: "amd64"}},
+		{Platform: &v1.Platform{OS: osLinux, Architecture: "arm64"}},
+		{Platform: &v1.Platform{OS: osLinux, Architecture: "amd64"}}, // dup
+		{Platform: &v1.Platform{OS: osUnknown, Architecture: osUnknown}},
 		{Platform: nil},
 	}
 	got := platformsFromManifests(manifests)

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -241,6 +241,7 @@ type CLIOptions struct {
 	IDLabels                    []string          `json:"idLabels,omitempty"`
 	GPUAvailability             string            `json:"gpuAvailability,omitempty"`
 	WorkspaceMountConsistency   string            `json:"workspaceMountConsistency,omitempty"`
+	RunPlatform                 string            `json:"runPlatform,omitempty"`
 	Mounts                      []string          `json:"mounts,omitempty"`
 	UpdateRemoteUserUIDDefault  string            `json:"updateRemoteUserUIDDefault,omitempty"`
 	ContainerDataFolder         string            `json:"containerDataFolder,omitempty"`


### PR DESCRIPTION
## Summary

- **Clearer source field copy**: relabels the three advanced source fields (Subfolder, Git ref, Prebuild repository) in the desktop Create Workspace wizard with accurate labels, placeholders, and helper text.
- **Live image platform check**: adds `image.GetImagePlatforms` (registry manifest inspection via go-containerregistry), exposed through a hidden `devsy helper get-image-platforms` command and the `image_inspect_platforms` desktop IPC. On the wizard review step, an image with no build for the host architecture surfaces an amber warning (image-source only).
- **Emulation toggle**: a review-step checkbox threads a new `workspace up --platform` flag end-to-end (`CLIOptions.RunPlatform` → `RunOptions.Platform` → `docker run --platform=`), letting an incompatible image run under emulation. Falls back to the first offered platform when `linux/amd64` is unavailable.
- A failed platform lookup is advisory only and never blocks launch; the swallowed error is now logged on both the Go fallback path and the renderer catch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform selection when launching workspaces to specify target architecture
  * Added automatic detection of compatible platforms for container images
  * Added compatibility warnings with emulation option when an image isn't optimized for your system architecture

<!-- end of auto-generated comment: release notes by coderabbit.ai -->