### PR TITLE
feat(desktop): point image catalog at images.devsy.sh

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -47,8 +47,7 @@ type UpdateInfo = {
 let providerUpdateCache: Record<string, UpdateInfo> = {}
 
 const IMAGE_CATALOG_URL =
-  process.env.DEVSY_IMAGE_CATALOG_URL ??
-  "https://raw.githubusercontent.com/devsy-org/devsy/main/desktop/resources/image-catalog-seed.json"
+  process.env.DEVSY_IMAGE_CATALOG_URL ?? "https://images.devsy.sh/catalog.json"
 const IMAGE_CATALOG_TTL_MS = 24 * 60 * 60 * 1000
 
 function imageCatalogPaths(): { cachePath: string; seedPath: string } {


### PR DESCRIPTION
## Summary

Now that **images.devsy.sh** is live (PR #500, merged) and serves `catalog.json` with the required CORS headers, this repoints the desktop Create Workspace wizard's default catalog URL from the raw GitHub seed file to the hosted endpoint:

- `DEVSY_IMAGE_CATALOG_URL` override is unchanged.
- Default goes from `raw.githubusercontent.com/.../image-catalog-seed.json` → `https://images.devsy.sh/catalog.json`.
- The bundled `image-catalog-seed.json` remains the offline fallback (remote → cache → seed), so the wizard still works if the site is unreachable.

Verified live: `https://images.devsy.sh/catalog.json` returns valid JSON (version 1, 10 images) with `Access-Control-Allow-Origin: *` and `Content-Type: application/json` over HTTP/2. Main-process typecheck clean; 45 main-process tests pass (incl. the image-catalog suite).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default image catalog endpoint to use a new service URL for improved reliability when using standard configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->