### PR TITLE
chore(images-site): add ignore command for monorepo CD

### DIFF
--- a/sites/images-devsy-sh/netlify.toml
+++ b/sites/images-devsy-sh/netlify.toml
@@ -2,6 +2,8 @@
   base = "sites/images-devsy-sh/"
   publish = "dist"
   command = "npm install && npm run build"
+  # Only rebuild when files in this site's base directory change.
+  ignore = "git diff --quiet HEAD^ HEAD -- ."
 
 [[headers]]
   for = "/catalog.json"


### PR DESCRIPTION
## Summary

Scoped to **images.devsy.sh only.** Adds a Netlify `ignore` command to `sites/images-devsy-sh/netlify.toml` so that, once the site is linked to the repo for continuous deployment, it **only rebuilds when files under `sites/images-devsy-sh/` change** — unrelated monorepo commits (docs, dl, desktop, Go) won't trigger an images deploy.

- `ignore = "git diff --quiet HEAD^ HEAD -- ."` — evaluated from the site's `base` dir, so `.` scopes to `sites/images-devsy-sh/`.
- Existing `base`/`publish`/`command` are unchanged.

No other sites are touched in this PR.

### Follow-up (manual, not in this PR)
Linking the repo to the `images-devsy-sh` Netlify site is a one-time UI step (Site config → Build & deploy → Link repository; the org's GitHub App is already installed via the docs site). The current CLI-deployed production build stays live until then.