### PR TITLE
ci: pin golangci-lint and align local lint with CI diff filter

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.12.2
           only-new-issues: true
 
   can-read-secret:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,8 +54,8 @@ repos:
       - id: commitizen
         stages: [commit-msg]
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.11.4
+    rev: v2.12.2
     hooks:
       - id: golangci-lint
-        args: ["--timeout", "10m"]
+        args: ["--timeout=10m"]
       - id: golangci-lint-fmt

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,9 +9,9 @@ tasks:
     desc: lint go code using golangci-lint
     cmd: golangci-lint run ./...
 
-  cli:lint:new:
-    desc: lint go code changed since origin/main using golangci-lint
-    cmd: golangci-lint run --new-from-rev="$(git merge-base HEAD origin/main)" ./... # or use --new-from-rev=HEAD~1 for changes since last push or --new for changes since last commit
+  cli:lint:ci:
+    desc: lint as CI does (diff-filtered against origin/main); use --new-from-rev=HEAD~1 to scope to last push or omit for full lint
+    cmd: golangci-lint run --new-from-rev="$(git merge-base HEAD origin/main)" ./...
 
   cli:lint:fix:
     desc: fix lint issues using golangci-lint


### PR DESCRIPTION
## Summary

Local lint and CI lint disagreed because of two things, both addressed here:

1. **Version drift.** Pre-commit pinned `golangci-lint` to `v2.11.4`; CI used `latest` (currently resolved to `v2.12.2`). Linter rules and thresholds shift across versions, so the same code could pass one and fail the other.
2. **No single command labeled "what CI runs."** `cli:lint:new` was close, but the name didn't make the parity intent obvious.

## Changes

- **`.github/workflows/pr-ci.yml`** — pin `golangci-lint` from `latest` to `v2.12.2`. CI no longer drifts when upstream releases.
- **`.pre-commit-config.yaml`** — bump pinned version `v2.11.4 -> v2.12.2` to match CI exactly.
- **`Taskfile.yml`** — replace `cli:lint:new` with `cli:lint:ci` (clearer name, same command). Run `task cli:lint:ci` for an explicit "did I match CI?" check.

## Why no `--new-from-rev` in pre-commit

Initially attempted, but `actions/checkout@v6` defaults to a shallow fetch that doesn't include `origin/main`, so `--new-from-rev=origin/main` couldn't resolve in the precommit job and golangci-lint fell back to all-issues mode, surfacing 15 pre-existing `unparam` violations introduced by the v2.11.4→v2.12.2 detection improvements. The Taskfile target gives developers the diff-filter on demand without breaking pre-commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting tool versions and configurations across CI/CD and local development environments.
  * Refined development workflow tasks to align CI behavior with local linting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->