### PR TITLE
fix(release): isolate macOS dmg arch per matrix entry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,8 @@ jobs:
 
       # macOS-only because .app is a directory bundle the CLI can read
       # directly. AppImage / deb / rpm / NSIS would need archive extractors.
+      # electron-builder emits arm64 under release/mac-arm64/ and x64 under
+      # release/mac/; pick the directory that matches the matrix arch.
       - name: verify packaged macOS app embedded CLI arch
         if: runner.os == 'macOS'
         shell: bash
@@ -203,9 +205,13 @@ jobs:
           MATRIX_GO_ARCH: ${{ matrix.go-arch }}
         run: |
           set -euo pipefail
-          app=$(find desktop/release -maxdepth 2 -type d -name 'Devsy.app' | head -n1)
-          if [ -z "$app" ]; then
-            echo "::error::no Devsy.app bundle found under desktop/release/"
+          case "$MATRIX_GO_ARCH" in
+            arm64) app=desktop/release/mac-arm64/Devsy.app ;;
+            amd64) app=desktop/release/mac/Devsy.app ;;
+            *) echo "::error::unsupported matrix arch: $MATRIX_GO_ARCH"; exit 1 ;;
+          esac
+          if [ ! -d "$app" ]; then
+            echo "::error::Devsy.app bundle missing for $MATRIX_GO_ARCH at $app"
             ls -la desktop/release || true
             exit 1
           fi

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -22,15 +22,12 @@ mac:
   category: public.app-category.developer-tools
   icon: resources/icon.icns
   artifactName: Devsy_${os}_${arch}.${ext}
+  # Architecture is selected by the CLI flag (--arm64 / --x64) at the
+  # invocation in .github/workflows/release.yml so each matrix entry
+  # produces exactly one .dmg + .zip pair for its arch.
   target:
-    - target: dmg
-      arch:
-        - x64
-        - arm64
-    - target: zip
-      arch:
-        - x64
-        - arm64
+    - dmg
+    - zip
   hardenedRuntime: true
   gatekeeperAssess: false
   entitlements: build/entitlements.mac.plist


### PR DESCRIPTION
## Summary

`v1.10.0-beta.30` shipped both `Devsy_mac_arm64.dmg` and `Devsy_mac_x64.dmg` with the same x86_64 binary embedded — same code, different codesigns. Verified by `file` + `sha256sum` against the published assets.

Two distinct bugs combined to produce this:

### 1. electron-builder's YAML arch list is additive, not filtered by CLI

`desktop/electron-builder.yml` listed `arch: [x64, arm64]` under each mac target. Verified against electron-builder source ([targetFactory.ts](https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/src/targets/targetFactory.ts#L43-L73)):

- `--mac --arm64` puts `{Arch.arm64: []}` in the CLI-derived `raw` map (empty target names array).
- The early-exit at `computeArchToTargetNamesMap` (re: [issue #1355](https://github.com/electron-userland/electron-builder/issues/1355)) only fires when CLI specifies a target *type* (e.g. `--mac dmg`); empty arrays don't trigger it.
- The function then iterates `platformOptions.target` (the YAML) and `addValue`s every `(target, arch)` pair from the YAML's `arch:` list to the result.

Net: `--arm64` plus `arch: [x64, arm64]` builds **both** arches. Verified by the failure log from `v1.10.0-beta.30`'s release run, which shows the macos-arm64 job building both `release/Devsy_mac_arm64.dmg` and `release/Devsy_mac_x64.dmg`. Both macos-arm64 and macos-x64 matrix entries did this in parallel and uploaded with `overwrite_files: true`. Whichever job uploaded last won the race — both its dmgs carried that job's `resources/bin/devsy` regardless of the dmg's name.

### 2. The post-package verifier picked the wrong .app bundle

The verifier did `find desktop/release -maxdepth 2 -type d -name 'Devsy.app' | head -n1` to locate the bundle. electron-builder produces:

- `release/mac-arm64/Devsy.app` (arm64)
- `release/mac/Devsy.app` (x64)

`find … | head -n1` returns `mac/` first alphabetically, so the macos-arm64 job verified the *x64* bundle. Because that bundle had been populated earlier in the same job with arm64 bytes (before electron-builder's second build pass overwrote them), the verify step got a green light against arm64 inside the bundle whose name says x64.

## Fix

Two changes:

- `desktop/electron-builder.yml`: drop `arch:` lists under each mac target. With no `arch:` configured, electron-builder falls back to `defaultArchs = Array.from(raw.keys())` — i.e. exactly what the CLI flag specified. Each matrix entry produces one dmg + zip pair for its arch.
- `.github/workflows/release.yml` post-package verifier: replace `find | head` with explicit `case` on `MATRIX_GO_ARCH` mapping arm64 → `release/mac-arm64/Devsy.app`, amd64 → `release/mac/Devsy.app`. Reads the right bundle deterministically.

## Validation

End-to-end validation requires a real release run. Local checks:

- Both YAML files parse.
- All pre-commit hooks (yaml lint, actionlint, secret scan) pass.
- The `release_artifacts verify` Go tool itself is unchanged.

The next pre-release tag should produce dmgs where each arch's dmg embeds the matching binary, and the post-package verify step will fail loudly if not.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS app verification process with deterministic bundle detection and explicit error messages for better build reliability.
  * Streamlined macOS build configuration to improve consistency and maintainability across different system architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->