### PR TITLE
fix(desktop): respect Debug Mode setting in Create Workspace wizard

### DIFF
--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -41,6 +41,7 @@ import type { CommandProgress } from "$lib/types/index.js"
 import { providers } from "$lib/stores/providers.js"
 import { workspaces } from "$lib/stores/workspaces.js"
 import { isImageCompatible } from "$lib/stores/imageCatalog.js"
+import { loadLocalOptions } from "$lib/stores/settings.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
 import { isCommandSuccess, stripAnsi } from "$lib/utils/log-parser.js"
@@ -462,7 +463,7 @@ async function handleLaunch() {
         imageIncompatible && emulationEnabled && emulationTarget
           ? emulationTarget
           : undefined,
-      debug: true,
+      debug: loadLocalOptions().debugFlag,
     })
 
     commandId = cmdId


### PR DESCRIPTION
## Summary
- Create Workspace wizard hardcoded `debug: true` when calling `workspaceUp`, so the **Debug Mode** toggle in Settings (`debugFlag` in `devsy-local-options`) was never read — debug-level CLI logs streamed into the launch panel regardless of the user's preference.
- Wizard now reads `loadLocalOptions().debugFlag`, matching the pattern already used in `WorkspaceDetailPage.svelte` for start/rebuild/reset flows.

## Flow
`SettingsPage` toggles `debugFlag` → localStorage → wizard reads it → `workspace_up` IPC → main process appends `--debug` → CLI `log.Init` keeps level at `Info` (or `Debug` when on).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace wizard now respects local debug settings instead of forcing debug mode enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->