### PR TITLE
feat(kubernetes): platform-native agent delivery

### DIFF
--- a/pkg/agent/delivery/factory.go
+++ b/pkg/agent/delivery/factory.go
@@ -21,6 +21,7 @@ type FactoryOptions struct {
 	IsRemoteDocker  bool
 	ContainerID     string
 	ExecFunc        inject.ExecFunc //nolint:staticcheck // legacy delivery strategies require this type
+	PodExec         PodExecFunc
 }
 
 func NewAgentDelivery(opts FactoryOptions) AgentDelivery {
@@ -38,14 +39,18 @@ func NewAgentDelivery(opts FactoryOptions) AgentDelivery {
 		}
 
 	case driverType == provider.KubernetesDriver:
-		log.Debugf("using legacy shell delivery for kubernetes driver")
-		log.Warnf(
-			"legacy shell delivery is deprecated; platform-native delivery will replace this in a future release",
-		)
-		return &LegacyShellDelivery{
-			ExecFunc:    opts.ExecFunc,
-			DownloadURL: "",
+		if opts.PodExec == nil {
+			log.Debugf("kubernetes pod exec unavailable, using legacy shell delivery")
+			log.Warnf(
+				"legacy shell delivery is deprecated; platform-native delivery will replace this in a future release",
+			)
+			return &LegacyShellDelivery{
+				ExecFunc:    opts.ExecFunc,
+				DownloadURL: "",
+			}
 		}
+		log.Debugf("using kubernetes-native delivery (exec stream)")
+		return &KubernetesDelivery{Exec: opts.PodExec}
 
 	case opts.IsRemoteDocker:
 		log.Debugf("using remote docker delivery (docker cp)")

--- a/pkg/agent/delivery/factory_test.go
+++ b/pkg/agent/delivery/factory_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"testing"
 
+	"github.com/devsy-org/devsy/pkg/driver"
 	"github.com/devsy-org/devsy/pkg/provider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,7 +74,26 @@ func TestNewAgentDelivery_CustomDriver(t *testing.T) {
 	assert.Equal(t, PhasePostStart, d.Phase())
 }
 
-func TestNewAgentDelivery_KubernetesDriver(t *testing.T) {
+func TestNewAgentDelivery_KubernetesDriver_Native(t *testing.T) {
+	podExec := func(_ context.Context, _ []string, _ driver.Streams) error {
+		return nil
+	}
+
+	opts := FactoryOptions{
+		WorkspaceConfig: &provider.AgentWorkspaceInfo{
+			Agent: provider.ProviderAgentConfig{
+				Driver: provider.KubernetesDriver,
+			},
+		},
+		PodExec: podExec,
+	}
+
+	d := NewAgentDelivery(opts)
+	assert.IsType(t, &KubernetesDelivery{}, d)
+	assert.Equal(t, PhasePostStart, d.Phase())
+}
+
+func TestNewAgentDelivery_KubernetesDriver_FallsBackWhenNoPodExec(t *testing.T) {
 	execFn := func(ctx context.Context, cmd string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
 		return nil
 	}
@@ -85,6 +105,7 @@ func TestNewAgentDelivery_KubernetesDriver(t *testing.T) {
 			},
 		},
 		ExecFunc: execFn,
+		// PodExec intentionally nil → legacy fallback.
 	}
 
 	d := NewAgentDelivery(opts)

--- a/pkg/agent/delivery/factory_test.go
+++ b/pkg/agent/delivery/factory_test.go
@@ -89,7 +89,9 @@ func TestNewAgentDelivery_KubernetesDriver_Native(t *testing.T) {
 	}
 
 	d := NewAgentDelivery(opts)
-	assert.IsType(t, &KubernetesDelivery{}, d)
+	native, ok := d.(*KubernetesDelivery)
+	require.True(t, ok)
+	assert.NotNil(t, native.Exec)
 	assert.Equal(t, PhasePostStart, d.Phase())
 }
 
@@ -109,7 +111,9 @@ func TestNewAgentDelivery_KubernetesDriver_FallsBackWhenNoPodExec(t *testing.T) 
 	}
 
 	d := NewAgentDelivery(opts)
-	assert.IsType(t, &LegacyShellDelivery{}, d)
+	legacy, ok := d.(*LegacyShellDelivery)
+	require.True(t, ok)
+	assert.NotNil(t, legacy.ExecFunc)
 	assert.Equal(t, PhasePostStart, d.Phase())
 }
 

--- a/pkg/agent/delivery/kubernetes.go
+++ b/pkg/agent/delivery/kubernetes.go
@@ -1,18 +1,28 @@
 package delivery
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"strings"
 
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
-	"github.com/devsy-org/devsy/pkg/inject"
+	"github.com/devsy-org/devsy/pkg/driver"
 	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/version"
 )
 
 var _ AgentDelivery = (*KubernetesDelivery)(nil)
 
+// PodExecFunc runs argv in the workspace pod's dev container with the given streams.
+type PodExecFunc func(ctx context.Context, argv []string, streams driver.Streams) error
+
+// KubernetesDelivery streams the agent binary into the pod over the cluster's exec API.
 type KubernetesDelivery struct {
-	ExecFunc inject.ExecFunc //nolint:staticcheck // K8s exec routing requires this type
+	Exec PodExecFunc
+
+	// ExpectedVersion defaults to version.GetVersion() when empty.
+	ExpectedVersion string
 }
 
 func (d *KubernetesDelivery) Phase() DeliveryPhase {
@@ -27,8 +37,17 @@ func (d *KubernetesDelivery) DeliverPostStart(ctx context.Context, opts PostStar
 	if opts.BinarySource == nil {
 		return fmt.Errorf("binary source is required for kubernetes delivery")
 	}
-	if d.ExecFunc == nil {
+	if d.Exec == nil {
 		return fmt.Errorf("exec function is required for kubernetes delivery")
+	}
+
+	destPath := pkgconfig.ContainerDevsyHelperLocation
+
+	// Skip delivery when the in-pod binary already matches.
+	expected := d.expectedVersion()
+	if actual := d.detectVersion(ctx, destPath); actual != "" && actual == expected {
+		log.Debugf("remote agent version matches expected version %s, skipping delivery", expected)
+		return nil
 	}
 
 	binary, err := opts.BinarySource(ctx, opts.Arch)
@@ -37,21 +56,43 @@ func (d *KubernetesDelivery) DeliverPostStart(ctx context.Context, opts PostStar
 	}
 	defer func() { _ = binary.Close() }()
 
-	destPath := pkgconfig.ContainerDevsyHelperLocation
+	// Write to a temp file and atomically move it into place so a failed stream
+	// never leaves an executable stub.
 	script := fmt.Sprintf(
-		`set -e; t=$(mktemp %s.XXXXXX); cat > "$t" && chmod 755 "$t" && mv "$t" %s || { rm -f "$t"; exit 1; }`,
-		destPath,
-		destPath,
+		`set -e; d=$(dirname %s); mkdir -p "$d"; `+
+			`t=$(mktemp %s.XXXXXX); `+
+			`cat > "$t" && chmod 0755 "$t" && mv -f "$t" %s || { rm -f "$t"; exit 1; }`,
+		destPath, destPath, destPath,
 	)
 
-	if err := d.ExecFunc(ctx, script, binary, nil, nil); err != nil {
+	if err := d.Exec(ctx, []string{"sh", "-c", script}, driver.Streams{Stdin: binary}); err != nil {
 		return fmt.Errorf("write binary to container: %w", err)
 	}
 
-	log.Debugf("delivered agent binary to kubernetes container via exec")
+	log.Debugf("delivered agent binary to pod via kubernetes exec")
 	return nil
 }
 
 func (d *KubernetesDelivery) Cleanup(_ context.Context, _ string) error {
 	return nil
+}
+
+func (d *KubernetesDelivery) expectedVersion() string {
+	if d.ExpectedVersion != "" {
+		return d.ExpectedVersion
+	}
+	return version.GetVersion()
+}
+
+// detectVersion returns the agent version in the pod, or "" if absent or unprobeable.
+func (d *KubernetesDelivery) detectVersion(ctx context.Context, destPath string) string {
+	script := fmt.Sprintf(`[ -x "%s" ] && "%s" --version 2>/dev/null || true`, destPath, destPath)
+
+	var stdout bytes.Buffer
+	err := d.Exec(ctx, []string{"sh", "-c", script}, driver.Streams{Stdout: &stdout})
+	if err != nil {
+		log.Debugf("failed to detect agent version in pod: %v", err)
+		return ""
+	}
+	return strings.TrimSpace(stdout.String())
 }

--- a/pkg/agent/delivery/kubernetes_test.go
+++ b/pkg/agent/delivery/kubernetes_test.go
@@ -9,9 +9,45 @@ import (
 	"testing"
 
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const testVersion = "v1.2.3"
+
+// recordingExec records each call and replays stdouts[N] as stdout on call N.
+type recordingExec struct {
+	calls   []recordedCall
+	stdouts []string
+	err     error
+}
+
+type recordedCall struct {
+	argv  []string
+	stdin string
+}
+
+func (r *recordingExec) fn(_ context.Context, argv []string, streams driver.Streams) error {
+	call := recordedCall{argv: argv}
+	if streams.Stdin != nil {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, streams.Stdin)
+		call.stdin = buf.String()
+	}
+	idx := len(r.calls)
+	r.calls = append(r.calls, call)
+	if streams.Stdout != nil && idx < len(r.stdouts) {
+		_, _ = io.WriteString(streams.Stdout, r.stdouts[idx])
+	}
+	return r.err
+}
+
+func binarySourceFrom(data string) BinarySourceFunc {
+	return func(_ context.Context, _ string) (io.ReadCloser, error) {
+		return io.NopCloser(strings.NewReader(data)), nil
+	}
+}
 
 func TestKubernetesDelivery_Phase(t *testing.T) {
 	d := &KubernetesDelivery{}
@@ -26,17 +62,14 @@ func TestKubernetesDelivery_DeliverPreStart_ReturnsError(t *testing.T) {
 }
 
 func TestKubernetesDelivery_DeliverPostStart_RequiresBinarySource(t *testing.T) {
-	d := &KubernetesDelivery{
-		ExecFunc: func(_ context.Context, _ string, _ io.Reader, _ io.Writer, _ io.Writer) error {
-			return nil
-		},
-	}
+	exec := &recordingExec{}
+	d := &KubernetesDelivery{Exec: exec.fn}
 	err := d.DeliverPostStart(context.Background(), PostStartOptions{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "binary source is required")
 }
 
-func TestKubernetesDelivery_DeliverPostStart_RequiresExecFunc(t *testing.T) {
+func TestKubernetesDelivery_DeliverPostStart_RequiresExec(t *testing.T) {
 	d := &KubernetesDelivery{}
 	err := d.DeliverPostStart(context.Background(), PostStartOptions{
 		BinarySource: fakeBinarySource,
@@ -47,63 +80,69 @@ func TestKubernetesDelivery_DeliverPostStart_RequiresExecFunc(t *testing.T) {
 
 func TestKubernetesDelivery_DeliverPostStart_WritesBinary(t *testing.T) {
 	binaryData := "test-binary-content"
-	var capturedCmd string
-	var capturedStdin bytes.Buffer
+	// Probe returns nothing → deliver.
+	exec := &recordingExec{stdouts: []string{""}}
 
-	execFn := func(_ context.Context, cmd string, stdin io.Reader, _ io.Writer, _ io.Writer) error {
-		capturedCmd = cmd
-		if stdin != nil {
-			_, _ = io.Copy(&capturedStdin, stdin)
-		}
-		return nil
-	}
-
-	d := &KubernetesDelivery{ExecFunc: execFn}
+	d := &KubernetesDelivery{Exec: exec.fn, ExpectedVersion: testVersion}
 	err := d.DeliverPostStart(context.Background(), PostStartOptions{
-		BinarySource: func(_ context.Context, _ string) (io.ReadCloser, error) {
-			return io.NopCloser(strings.NewReader(binaryData)), nil
-		},
-		Arch: "amd64",
+		BinarySource: binarySourceFrom(binaryData),
+		Arch:         testArch,
 	})
-
 	require.NoError(t, err)
 
+	require.Len(t, exec.calls, 2)
 	destPath := pkgconfig.ContainerDevsyHelperLocation
-	assert.Contains(t, capturedCmd, "cat >")
-	assert.Contains(t, capturedCmd, destPath)
-	assert.Contains(t, capturedCmd, "chmod 755")
 
-	assert.Equal(t, binaryData, capturedStdin.String())
+	probeScript := strings.Join(exec.calls[0].argv, " ")
+	assert.Contains(t, probeScript, "--version")
+	assert.Contains(t, probeScript, destPath)
+
+	writeScript := strings.Join(exec.calls[1].argv, " ")
+	assert.Contains(t, writeScript, "mktemp")
+	assert.Contains(t, writeScript, "chmod 0755")
+	assert.Contains(t, writeScript, "mv -f")
+	assert.Contains(t, writeScript, destPath)
+	assert.Equal(t, binaryData, exec.calls[1].stdin)
+}
+
+func TestKubernetesDelivery_DeliverPostStart_SkipsWhenVersionMatches(t *testing.T) {
+	exec := &recordingExec{stdouts: []string{testVersion + "\n"}}
+
+	d := &KubernetesDelivery{Exec: exec.fn, ExpectedVersion: testVersion}
+	err := d.DeliverPostStart(context.Background(), PostStartOptions{
+		BinarySource: binarySourceFrom("should-not-be-streamed"),
+		Arch:         testArch,
+	})
+	require.NoError(t, err)
+
+	require.Len(t, exec.calls, 1, "only the version probe should run")
+	assert.Empty(t, exec.calls[0].stdin)
+}
+
+func TestKubernetesDelivery_DeliverPostStart_DeliversWhenProbeErrors(t *testing.T) {
+	// A failing probe must not abort delivery; it should still attempt the write.
+	probeErr := &recordingExec{err: fmt.Errorf("probe boom")}
+	d := &KubernetesDelivery{Exec: probeErr.fn, ExpectedVersion: testVersion}
+
+	err := d.DeliverPostStart(context.Background(), PostStartOptions{
+		BinarySource: binarySourceFrom("data"),
+		Arch:         testArch,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "write binary to container")
+	assert.Len(t, probeErr.calls, 2)
 }
 
 func TestKubernetesDelivery_DeliverPostStart_BinarySourceError(t *testing.T) {
-	execFn := func(_ context.Context, _ string, _ io.Reader, _ io.Writer, _ io.Writer) error {
-		return nil
-	}
-
-	d := &KubernetesDelivery{ExecFunc: execFn}
+	exec := &recordingExec{stdouts: []string{""}}
+	d := &KubernetesDelivery{Exec: exec.fn}
 	err := d.DeliverPostStart(context.Background(), PostStartOptions{
 		BinarySource: func(_ context.Context, _ string) (io.ReadCloser, error) {
 			return nil, fmt.Errorf("download failed")
 		},
 	})
-
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "acquire binary")
-}
-
-func TestKubernetesDelivery_DeliverPostStart_ExecError(t *testing.T) {
-	execFn := func(_ context.Context, _ string, _ io.Reader, _ io.Writer, _ io.Writer) error {
-		return fmt.Errorf("exec failed")
-	}
-
-	d := &KubernetesDelivery{ExecFunc: execFn}
-	err := d.DeliverPostStart(context.Background(), PostStartOptions{
-		BinarySource: fakeBinarySource,
-	})
-
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "write binary to container")
 }
 
 func TestKubernetesDelivery_Cleanup_IsNoOp(t *testing.T) {

--- a/pkg/agent/delivery/kubernetes_test.go
+++ b/pkg/agent/delivery/kubernetes_test.go
@@ -16,11 +16,12 @@ import (
 
 const testVersion = "v1.2.3"
 
-// recordingExec records each call and replays stdouts[N] as stdout on call N.
+// recordingExec records each call, replays stdouts[N] as stdout, and returns
+// errs[N] on call N (nil when unset).
 type recordingExec struct {
 	calls   []recordedCall
 	stdouts []string
-	err     error
+	errs    []error
 }
 
 type recordedCall struct {
@@ -40,7 +41,10 @@ func (r *recordingExec) fn(_ context.Context, argv []string, streams driver.Stre
 	if streams.Stdout != nil && idx < len(r.stdouts) {
 		_, _ = io.WriteString(streams.Stdout, r.stdouts[idx])
 	}
-	return r.err
+	if idx < len(r.errs) {
+		return r.errs[idx]
+	}
+	return nil
 }
 
 func binarySourceFrom(data string) BinarySourceFunc {
@@ -120,16 +124,18 @@ func TestKubernetesDelivery_DeliverPostStart_SkipsWhenVersionMatches(t *testing.
 }
 
 func TestKubernetesDelivery_DeliverPostStart_DeliversWhenProbeErrors(t *testing.T) {
-	// A failing probe must not abort delivery; it should still attempt the write.
-	probeErr := &recordingExec{err: fmt.Errorf("probe boom")}
+	// A failing probe must not abort delivery; the write still succeeds.
+	probeErr := &recordingExec{
+		stdouts: []string{""},
+		errs:    []error{fmt.Errorf("probe boom"), nil},
+	}
 	d := &KubernetesDelivery{Exec: probeErr.fn, ExpectedVersion: testVersion}
 
 	err := d.DeliverPostStart(context.Background(), PostStartOptions{
 		BinarySource: binarySourceFrom("data"),
 		Arch:         testArch,
 	})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "write binary to container")
+	require.NoError(t, err)
 	assert.Len(t, probeErr.calls, 2)
 }
 

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -87,13 +87,24 @@ func (r *runner) injectAgentIntoContainer(ctx context.Context, timeout time.Dura
 
 	if strategy.Phase() == delivery.PhasePostStart {
 		if err := r.deliverPostStart(ctx, strategy); err != nil {
-			log.Debugf("post-start delivery failed, falling back to legacy inject: %v", err)
+			log.Warnf("platform-native delivery failed, falling back to legacy inject: %v", err)
 			return r.legacyInject(ctx, timeout)
 		}
 		return nil
 	}
 
 	return r.legacyInject(ctx, timeout)
+}
+
+// podExecCapableDriver is implemented by the kubernetes driver, decoupling
+// delivery wiring from the driver package.
+type podExecCapableDriver interface {
+	CommandContainerArgv(
+		ctx context.Context,
+		workspaceID string,
+		argv []string,
+		streams driver.Streams,
+	) error
 }
 
 func (r *runner) newAgentDelivery() delivery.AgentDelivery {
@@ -108,6 +119,13 @@ func (r *runner) newAgentDelivery() delivery.AgentDelivery {
 
 	execFn := delivery.CommandFunc(r.Driver.CommandDevContainer, r.ID)
 
+	var podExec delivery.PodExecFunc
+	if d, ok := r.Driver.(podExecCapableDriver); ok {
+		podExec = func(ctx context.Context, argv []string, streams driver.Streams) error {
+			return d.CommandContainerArgv(ctx, r.ID, argv, streams)
+		}
+	}
+
 	return delivery.NewAgentDelivery(delivery.FactoryOptions{
 		WorkspaceConfig: r.WorkspaceConfig,
 		WorkspaceID:     r.ID,
@@ -116,7 +134,23 @@ func (r *runner) newAgentDelivery() delivery.AgentDelivery {
 		HelperImage:     r.WorkspaceConfig.Agent.Docker.HelperImage,
 		ContainerID:     r.ID,
 		ExecFunc:        execFn,
+		PodExec:         podExec,
 	})
+}
+
+// deliveryArch returns the target arch for the agent binary. The kubernetes
+// cluster arch can differ from the host, so it takes precedence when available.
+func (r *runner) deliveryArch(ctx context.Context) string {
+	arch := runtime.GOARCH
+	if r.WorkspaceConfig.Agent.Driver != provider2.KubernetesDriver {
+		return arch
+	}
+	if a, err := r.Driver.TargetArchitecture(ctx, r.ID); err == nil && a != "" {
+		return a
+	} else if err != nil {
+		log.Debugf("target architecture lookup failed, using host arch %q: %v", arch, err)
+	}
+	return arch
 }
 
 func (r *runner) deliverPostStart(ctx context.Context, strategy delivery.AgentDelivery) error {
@@ -128,7 +162,7 @@ func (r *runner) deliverPostStart(ctx context.Context, strategy delivery.AgentDe
 	err = strategy.DeliverPostStart(ctx, delivery.PostStartOptions{
 		WorkspaceID:  r.ID,
 		BinarySource: binarySource,
-		Arch:         runtime.GOARCH,
+		Arch:         r.deliveryArch(ctx),
 	})
 	if err != nil {
 		return fmt.Errorf("deliver agent (post-start): %w", err)

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -138,19 +138,22 @@ func (r *runner) newAgentDelivery() delivery.AgentDelivery {
 	})
 }
 
-// deliveryArch returns the target arch for the agent binary. The kubernetes
-// cluster arch can differ from the host, so it takes precedence when available.
-func (r *runner) deliveryArch(ctx context.Context) string {
-	arch := runtime.GOARCH
+// deliveryArch returns the target arch for the agent binary. For kubernetes the
+// cluster arch can differ from the host, so a lookup failure is surfaced rather
+// than guessing the host arch: streaming a wrong-arch binary would succeed here
+// but fail when the agent starts, after the legacy fallback can no longer run.
+func (r *runner) deliveryArch(ctx context.Context) (string, error) {
 	if r.WorkspaceConfig.Agent.Driver != provider2.KubernetesDriver {
-		return arch
+		return runtime.GOARCH, nil
 	}
-	if a, err := r.Driver.TargetArchitecture(ctx, r.ID); err == nil && a != "" {
-		return a
-	} else if err != nil {
-		log.Debugf("target architecture lookup failed, using host arch %q: %v", arch, err)
+	arch, err := r.Driver.TargetArchitecture(ctx, r.ID)
+	if err != nil {
+		return "", fmt.Errorf("resolve cluster architecture: %w", err)
 	}
-	return arch
+	if arch == "" {
+		return "", fmt.Errorf("cluster architecture is empty")
+	}
+	return arch, nil
 }
 
 func (r *runner) deliverPostStart(ctx context.Context, strategy delivery.AgentDelivery) error {
@@ -159,10 +162,15 @@ func (r *runner) deliverPostStart(ctx context.Context, strategy delivery.AgentDe
 		return fmt.Errorf("create binary source: %w", err)
 	}
 
+	arch, err := r.deliveryArch(ctx)
+	if err != nil {
+		return err
+	}
+
 	err = strategy.DeliverPostStart(ctx, delivery.PostStartOptions{
 		WorkspaceID:  r.ID,
 		BinarySource: binarySource,
-		Arch:         r.deliveryArch(ctx),
+		Arch:         arch,
 	})
 	if err != nil {
 		return fmt.Errorf("deliver agent (post-start): %w", err)

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -401,11 +401,16 @@ func (r *runner) deliverPreStart(ctx context.Context, runOptions *driver.RunOpti
 		return fmt.Errorf("create binary source: %w", err)
 	}
 
+	arch, err := r.deliveryArch(ctx)
+	if err != nil {
+		return err
+	}
+
 	return strategy.DeliverPreStart(ctx, delivery.PreStartOptions{
 		WorkspaceID:  r.ID,
 		RunOptions:   runOptions,
 		BinarySource: binarySource,
-		Arch:         r.deliveryArch(ctx),
+		Arch:         arch,
 	})
 }
 

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
-	"runtime"
 	"strings"
 	"time"
 
@@ -406,7 +405,7 @@ func (r *runner) deliverPreStart(ctx context.Context, runOptions *driver.RunOpti
 		WorkspaceID:  r.ID,
 		RunOptions:   runOptions,
 		BinarySource: binarySource,
-		Arch:         runtime.GOARCH,
+		Arch:         r.deliveryArch(ctx),
 	})
 }
 

--- a/pkg/driver/kubernetes/client.go
+++ b/pkg/driver/kubernetes/client.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -119,7 +121,7 @@ func (c *Client) Exec(ctx context.Context, options *ExecStreamOptions) error {
 			Stderr:    options.Stderr != nil,
 		}, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(c.config, "POST", execRequest.URL())
+	exec, err := newFallbackExecutor(c.config, execRequest.URL())
 	if err != nil {
 		return err
 	}
@@ -140,4 +142,20 @@ func (c *Client) Exec(ctx context.Context, options *ExecStreamOptions) error {
 	case err = <-errChan:
 		return err
 	}
+}
+
+// newFallbackExecutor prefers the WebSocket transport and falls back to SPDY,
+// which is deprecated and disabled on newer API servers.
+func newFallbackExecutor(config *rest.Config, url *url.URL) (remotecommand.Executor, error) {
+	spdyExec, err := remotecommand.NewSPDYExecutor(config, "POST", url)
+	if err != nil {
+		return nil, err
+	}
+
+	wsExec, err := remotecommand.NewWebSocketExecutor(config, "GET", url.String())
+	if err != nil {
+		return nil, err
+	}
+
+	return remotecommand.NewFallbackExecutor(wsExec, spdyExec, httpstream.IsUpgradeFailure)
 }

--- a/pkg/driver/kubernetes/driver.go
+++ b/pkg/driver/kubernetes/driver.go
@@ -184,6 +184,26 @@ func (k *KubernetesDriver) CommandDevContainer(
 	})
 }
 
+// CommandContainerArgv execs argv in the workspace pod's dev container, streaming
+// the given stdin/stdout/stderr. Unlike CommandDevContainer it takes explicit
+// argv rather than wrapping the command in sh -c.
+func (k *KubernetesDriver) CommandContainerArgv(
+	ctx context.Context,
+	workspaceID string,
+	argv []string,
+	streams driver.Streams,
+) error {
+	return k.client.Exec(ctx, &ExecStreamOptions{
+		Pod:       getID(workspaceID),
+		Namespace: k.namespace,
+		Container: DevContainerName,
+		Command:   argv,
+		Stdin:     streams.Stdin,
+		Stdout:    streams.Stdout,
+		Stderr:    streams.Stderr,
+	})
+}
+
 func (k *KubernetesDriver) GetDevContainerLogs(
 	ctx context.Context,
 	workspaceID string,

--- a/pkg/driver/types.go
+++ b/pkg/driver/types.go
@@ -56,6 +56,13 @@ type CommandParams struct {
 	Stderr      io.Writer
 }
 
+// Streams bundles the standard IO streams for an exec.
+type Streams struct {
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
 // RunOptions are the options for running a container.
 type RunOptions struct {
 	// UID is a unique identifier for this workspace


### PR DESCRIPTION
## Summary

Replaces legacy shell delivery for the kubernetes driver with a platform-native delivery, removing the deprecation warning emitted on `devsy up`:

```
debug  using legacy shell delivery for kubernetes driver
warn   legacy shell delivery is deprecated; platform-native delivery will replace this in a future release
```

`KubernetesDelivery` streams the locally-cached agent binary into the pod over the cluster's exec API — no in-container network or shell-driven download, which matters for air-gapped / egress-restricted clusters. It version-probes the existing binary for idempotency (skips re-delivery on match) and writes via an atomic temp-file `mv` so a partial stream never leaves an executable stub.

Two related fixes:
- **Cross-architecture delivery**: the agent arch is now resolved from the cluster via `TargetArchitecture` instead of the host `runtime.GOARCH`, so an arm64 host delivering to an amd64 cluster gets the right binary.
- **Transport**: the kubernetes exec now prefers WebSocket with an SPDY fallback (SPDY is deprecated and disabled on newer API servers).

Delivery is wired behind the existing `legacyInject` fallback, so a native-delivery failure self-heals rather than failing `devsy up`.

## Notes

- A `driver.Streams` struct bundles stdin/stdout/stderr for the new exec signatures.
- Follow-up (not in this PR): e2e assertion that the warning is absent and the agent reports the expected version; migrating the driver's other exec paths off SPDY-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes-based agent delivery can now use native pod exec, with automatic fallback to the legacy path when native exec isn’t available.
  * Agent delivery now skips redeploying the binary when the container already has the expected version.

* **Bug Fixes**
  * Improved Kubernetes command execution reliability by falling back from WebSocket to SPDY when needed.
  * Agent installation now better matches the target container architecture during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->