### PR TITLE
fix(podman): chown workspace for non-root remoteUser on macOS/Windows

### DIFF
--- a/e2e/tests/up/provider_podman.go
+++ b/e2e/tests/up/provider_podman.go
@@ -48,13 +48,10 @@ var _ = ginkgo.Describe(
 					ginkgo.SpecTimeout(framework.TimeoutShort()),
 				)
 
-				// Regression: rootless podman bind-mounts the host workspace
-				// folder as root-owned inside the container. A non-root
-				// remoteUser could not chdir into it, so the in-container SSH
-				// server's `fork/exec /usr/bin/bash` failed with "permission
-				// denied" and `devsy ssh` (and VS Code Remote-SSH) broke. The
-				// agent must chown the workspace to the remote user even though
-				// podman runs through the docker driver.
+				// Regression: rootless podman bind-mounts the workspace folder
+				// root-owned, so a non-root remoteUser couldn't chdir into it
+				// and the in-container SSH server failed with "fork/exec
+				// /usr/bin/bash: permission denied".
 				ginkgo.It(
 					"should ssh into a workspace with a non-root remoteUser",
 					func(ctx context.Context) {
@@ -68,19 +65,13 @@ var _ = ginkgo.Describe(
 						err = f.DevsyUp(ctx, tempDir)
 						framework.ExpectNoError(err)
 
-						// A non-PTY command exec is exactly the path that failed:
-						// it runs `bash -c <cmd>` with the workspace folder as the
-						// working directory, as the non-root remote user.
 						whoami, err := f.DevsySSH(ctx, tempDir, "whoami")
 						framework.ExpectNoError(err)
 						gomega.Expect(strings.TrimSpace(whoami)).To(gomega.Equal("devsyuser"))
 
-						// The workspace folder must be owned by the remote user.
-						// This is the actual fix: without the chown the folder
-						// stays root-owned (rootless podman bind mount), and the
-						// remote user cannot enter it. Asserting ownership rather
-						// than mere chdir success avoids a false pass when the
-						// bind source happens to be world-searchable.
+						// Assert ownership, not just chdir success: a
+						// world-searchable bind source would let chdir pass even
+						// without the chown.
 						owner, err := f.DevsySSH(ctx, tempDir, `stat -c %U "$PWD"`)
 						framework.ExpectNoError(err)
 						gomega.Expect(strings.TrimSpace(owner)).To(gomega.Equal("devsyuser"),

--- a/e2e/tests/up/provider_podman.go
+++ b/e2e/tests/up/provider_podman.go
@@ -47,6 +47,47 @@ var _ = ginkgo.Describe(
 					},
 					ginkgo.SpecTimeout(framework.TimeoutShort()),
 				)
+
+				// Regression: rootless podman bind-mounts the host workspace
+				// folder as root-owned inside the container. A non-root
+				// remoteUser could not chdir into it, so the in-container SSH
+				// server's `fork/exec /usr/bin/bash` failed with "permission
+				// denied" and `devsy ssh` (and VS Code Remote-SSH) broke. The
+				// agent must chown the workspace to the remote user even though
+				// podman runs through the docker driver.
+				ginkgo.It(
+					"should ssh into a workspace with a non-root remoteUser",
+					func(ctx context.Context) {
+						tempDir, err := setupWorkspace(
+							"tests/up/testdata/docker-nonroot-user",
+							initialDir,
+							f,
+						)
+						framework.ExpectNoError(err)
+
+						err = f.DevsyUp(ctx, tempDir)
+						framework.ExpectNoError(err)
+
+						// A non-PTY command exec is exactly the path that failed:
+						// it runs `bash -c <cmd>` with the workspace folder as the
+						// working directory, as the non-root remote user.
+						whoami, err := f.DevsySSH(ctx, tempDir, "whoami")
+						framework.ExpectNoError(err)
+						gomega.Expect(strings.TrimSpace(whoami)).To(gomega.Equal("devsyuser"))
+
+						// The workspace folder must be owned by the remote user.
+						// This is the actual fix: without the chown the folder
+						// stays root-owned (rootless podman bind mount), and the
+						// remote user cannot enter it. Asserting ownership rather
+						// than mere chdir success avoids a false pass when the
+						// bind source happens to be world-searchable.
+						owner, err := f.DevsySSH(ctx, tempDir, `stat -c %U "$PWD"`)
+						framework.ExpectNoError(err)
+						gomega.Expect(strings.TrimSpace(owner)).To(gomega.Equal("devsyuser"),
+							"workspace folder should be chowned to the remote user")
+					},
+					ginkgo.SpecTimeout(framework.TimeoutLong()),
+				)
 			})
 
 			ginkgo.Context("build", func() {

--- a/e2e/tests/up/testdata/docker-nonroot-user/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-nonroot-user/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "name": "Non-root user",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "remoteUser": "devsyuser"
+}

--- a/e2e/tests/up/testdata/docker-nonroot-user/Dockerfile
+++ b/e2e/tests/up/testdata/docker-nonroot-user/Dockerfile
@@ -1,7 +1,4 @@
 FROM ghcr.io/devsy-org/test-images/base:ubuntu
 
-# Create a non-root user. This is the configuration that exposes the podman
-# bind-mount ownership bug: rootless podman surfaces the host workspace bind
-# mount as root-owned inside the container, so a non-root remote user cannot
-# chdir into the workspace folder unless the agent chowns it during setup.
+# Non-root user, used as remoteUser to exercise the podman workspace-chown path.
 RUN useradd --create-home --shell /bin/bash devsyuser

--- a/e2e/tests/up/testdata/docker-nonroot-user/Dockerfile
+++ b/e2e/tests/up/testdata/docker-nonroot-user/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/devsy-org/test-images/base:ubuntu
+
+# Create a non-root user. This is the configuration that exposes the podman
+# bind-mount ownership bug: rootless podman surfaces the host workspace bind
+# mount as root-owned inside the container, so a non-root remote user cannot
+# chdir into the workspace folder unless the agent chowns it during setup.
+RUN useradd --create-home --shell /bin/bash devsyuser

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -350,7 +350,7 @@ func mountSetConsistency(mount, value string) string {
 }
 
 func needsDefaultConsistency() bool {
-	return runtime.GOOS != "linux"
+	return runtime.GOOS != goosLinux
 }
 
 func getWorkspace(

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -342,14 +342,9 @@ func (r *runner) addChownFlag(args *[]string, isDockerDriver bool) {
 }
 
 // shouldChownWorkspace reports whether the agent should chown the workspace
-// folder to the remote user during setup.
-//
-// Docker Desktop presents macOS/Windows bind mounts already owned by the
-// container user, so the chown is only needed on Linux there. Podman is the
-// exception: its `podman machine` bind mounts surface host files as root-owned
-// inside the container, so a non-root remote user can't enter the workspace
-// folder without it — hence chown for podman on any host OS. The chown writes
-// through to the host inode (cf. loft-sh/devpod#1879).
+// folder to the remote user during setup. Podman needs it on any host OS:
+// its `podman machine` bind mounts are root-owned inside the container, so a
+// non-root remote user can't enter the workspace folder otherwise.
 func shouldChownWorkspace(goos string, isDockerDriver, isPodman bool) bool {
 	return goos == goosLinux || !isDockerDriver || isPodman
 }

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -341,28 +341,21 @@ func (r *runner) addChownFlag(args *[]string, isDockerDriver bool) {
 	}
 }
 
-// shouldChownWorkspace decides whether the agent should chown the workspace
+// shouldChownWorkspace reports whether the agent should chown the workspace
 // folder to the remote user during setup.
 //
-// Docker Desktop's macOS/Windows file sharing already presents bind mounts
-// owned by the container user, so a chown is unnecessary there; the flag is
-// therefore only added on Linux hosts for the docker driver. Podman is the
-// exception: even though it runs through the docker driver, its `podman
-// machine` bind mounts surface host files as root-owned inside the container,
-// so a non-root remote user cannot enter the workspace folder unless we chown
-// it. Request the chown for podman regardless of host OS.
-//
-// Note: the chown writes through the bind mount to the host inode, so it also
-// changes ownership of the host-side workspace contents (cf. loft-sh/devpod
-// #1879). The agent only chowns when a non-root remote user is resolved, so
-// root-user containers are unaffected.
+// Docker Desktop presents macOS/Windows bind mounts already owned by the
+// container user, so the chown is only needed on Linux there. Podman is the
+// exception: its `podman machine` bind mounts surface host files as root-owned
+// inside the container, so a non-root remote user can't enter the workspace
+// folder without it — hence chown for podman on any host OS. The chown writes
+// through to the host inode (cf. loft-sh/devpod#1879).
 func shouldChownWorkspace(goos string, isDockerDriver, isPodman bool) bool {
 	return goos == goosLinux || !isDockerDriver || isPodman
 }
 
-// isPodmanRuntime reports whether the workspace's docker driver is backed by
-// the Podman runtime, as configured by the built-in podman provider
-// (agent.docker.runtime: podman).
+// isPodmanRuntime reports whether the docker driver is backed by the Podman
+// runtime (agent.docker.runtime: podman).
 func (r *runner) isPodmanRuntime() bool {
 	return strings.EqualFold(r.WorkspaceConfig.Agent.Docker.Runtime, string(docker.RuntimePodman))
 }

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -20,6 +20,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/crane"
 	"github.com/devsy-org/devsy/pkg/devcontainer/sshtunnel"
+	"github.com/devsy-org/devsy/pkg/docker"
 	"github.com/devsy-org/devsy/pkg/driver"
 	"github.com/devsy-org/devsy/pkg/ide"
 	"github.com/devsy-org/devsy/pkg/log"
@@ -331,9 +332,35 @@ func (r *runner) addSetupFlags(args *[]string) {
 }
 
 func (r *runner) addChownFlag(args *[]string, isDockerDriver bool) {
-	if runtime.GOOS == "linux" || !isDockerDriver {
+	if shouldChownWorkspace(runtime.GOOS, isDockerDriver, r.isPodmanRuntime()) {
 		*args = append(*args, "--chown-workspace")
 	}
+}
+
+// shouldChownWorkspace decides whether the agent should chown the workspace
+// folder to the remote user during setup.
+//
+// Docker Desktop's macOS/Windows file sharing already presents bind mounts
+// owned by the container user, so a chown is unnecessary there; the flag is
+// therefore only added on Linux hosts for the docker driver. Podman is the
+// exception: even though it runs through the docker driver, its `podman
+// machine` bind mounts surface host files as root-owned inside the container,
+// so a non-root remote user cannot enter the workspace folder unless we chown
+// it. Request the chown for podman regardless of host OS.
+//
+// Note: the chown writes through the bind mount to the host inode, so it also
+// changes ownership of the host-side workspace contents (cf. loft-sh/devpod
+// #1879). The agent only chowns when a non-root remote user is resolved, so
+// root-user containers are unaffected.
+func shouldChownWorkspace(goos string, isDockerDriver, isPodman bool) bool {
+	return goos == "linux" || !isDockerDriver || isPodman
+}
+
+// isPodmanRuntime reports whether the workspace's docker driver is backed by
+// the Podman runtime, as configured by the built-in podman provider
+// (agent.docker.runtime: podman).
+func (r *runner) isPodmanRuntime() bool {
+	return strings.EqualFold(r.WorkspaceConfig.Agent.Docker.Runtime, string(docker.RuntimePodman))
 }
 
 func (r *runner) addDriverFlags(args *[]string, isDockerDriver bool) {

--- a/pkg/devcontainer/setup.go
+++ b/pkg/devcontainer/setup.go
@@ -32,6 +32,10 @@ const (
 	stringTrue        = "true"
 	stringFalse       = "false"
 	containerRootUser = "root"
+
+	goosLinux   = "linux"
+	goosDarwin  = "darwin"
+	goosWindows = "windows"
 )
 
 // resolvePullFromInsideContainer: explicit override > crane+git > "".
@@ -353,7 +357,7 @@ func (r *runner) addChownFlag(args *[]string, isDockerDriver bool) {
 // #1879). The agent only chowns when a non-root remote user is resolved, so
 // root-user containers are unaffected.
 func shouldChownWorkspace(goos string, isDockerDriver, isPodman bool) bool {
-	return goos == "linux" || !isDockerDriver || isPodman
+	return goos == goosLinux || !isDockerDriver || isPodman
 }
 
 // isPodmanRuntime reports whether the workspace's docker driver is backed by

--- a/pkg/devcontainer/setup_test.go
+++ b/pkg/devcontainer/setup_test.go
@@ -36,11 +36,8 @@ func TestShouldChownWorkspace(t *testing.T) {
 			goos: goosWindows, isDockerDriver: true, isPodman: false, want: false,
 		},
 		{
-			// Regression: rootless podman on macOS bind-mounts host files as
-			// root-owned, so a non-root remote user cannot enter the workspace
-			// folder without the chown. Previously skipped because podman uses
-			// the docker driver, producing "fork/exec /usr/bin/bash:
-			// permission denied" on the in-container chdir.
+			// Regression: previously skipped because podman uses the docker
+			// driver, breaking non-root remoteUser on macOS/Windows.
 			name: "podman on macOS chowns despite docker driver",
 			goos: goosDarwin, isDockerDriver: true, isPodman: true, want: true,
 		},

--- a/pkg/devcontainer/setup_test.go
+++ b/pkg/devcontainer/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/docker"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
 )
@@ -20,19 +21,19 @@ func TestShouldChownWorkspace(t *testing.T) {
 	}{
 		{
 			name: "linux docker host always chowns",
-			goos: "linux", isDockerDriver: true, isPodman: false, want: true,
+			goos: goosLinux, isDockerDriver: true, isPodman: false, want: true,
 		},
 		{
 			name: "non-docker driver always chowns (stream mounts)",
-			goos: "darwin", isDockerDriver: false, isPodman: false, want: true,
+			goos: goosDarwin, isDockerDriver: false, isPodman: false, want: true,
 		},
 		{
 			name: "docker desktop on macOS skips chown",
-			goos: "darwin", isDockerDriver: true, isPodman: false, want: false,
+			goos: goosDarwin, isDockerDriver: true, isPodman: false, want: false,
 		},
 		{
 			name: "docker desktop on windows skips chown",
-			goos: "windows", isDockerDriver: true, isPodman: false, want: false,
+			goos: goosWindows, isDockerDriver: true, isPodman: false, want: false,
 		},
 		{
 			// Regression: rootless podman on macOS bind-mounts host files as
@@ -41,15 +42,15 @@ func TestShouldChownWorkspace(t *testing.T) {
 			// the docker driver, producing "fork/exec /usr/bin/bash:
 			// permission denied" on the in-container chdir.
 			name: "podman on macOS chowns despite docker driver",
-			goos: "darwin", isDockerDriver: true, isPodman: true, want: true,
+			goos: goosDarwin, isDockerDriver: true, isPodman: true, want: true,
 		},
 		{
 			name: "podman on windows chowns despite docker driver",
-			goos: "windows", isDockerDriver: true, isPodman: true, want: true,
+			goos: goosWindows, isDockerDriver: true, isPodman: true, want: true,
 		},
 		{
 			name: "podman on linux chowns",
-			goos: "linux", isDockerDriver: true, isPodman: true, want: true,
+			goos: goosLinux, isDockerDriver: true, isPodman: true, want: true,
 		},
 	}
 	for _, c := range cases {
@@ -69,11 +70,11 @@ func TestRunnerIsPodmanRuntime(t *testing.T) {
 		runtime string
 		want    bool
 	}{
-		{name: "podman", runtime: "podman", want: true},
+		{name: "podman", runtime: string(docker.RuntimePodman), want: true},
 		{name: "podman mixed case", runtime: "Podman", want: true},
-		{name: "docker", runtime: "docker", want: false},
+		{name: "docker runtime", runtime: string(docker.RuntimeDocker), want: false},
 		{name: "empty defaults to non-podman", runtime: "", want: false},
-		{name: "nerdctl", runtime: "nerdctl", want: false},
+		{name: "nerdctl", runtime: string(docker.RuntimeNerdctl), want: false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/devcontainer/setup_test.go
+++ b/pkg/devcontainer/setup_test.go
@@ -10,6 +10,87 @@ import (
 
 func boolPtr(v bool) *bool { return &v }
 
+func TestShouldChownWorkspace(t *testing.T) {
+	cases := []struct {
+		name           string
+		goos           string
+		isDockerDriver bool
+		isPodman       bool
+		want           bool
+	}{
+		{
+			name: "linux docker host always chowns",
+			goos: "linux", isDockerDriver: true, isPodman: false, want: true,
+		},
+		{
+			name: "non-docker driver always chowns (stream mounts)",
+			goos: "darwin", isDockerDriver: false, isPodman: false, want: true,
+		},
+		{
+			name: "docker desktop on macOS skips chown",
+			goos: "darwin", isDockerDriver: true, isPodman: false, want: false,
+		},
+		{
+			name: "docker desktop on windows skips chown",
+			goos: "windows", isDockerDriver: true, isPodman: false, want: false,
+		},
+		{
+			// Regression: rootless podman on macOS bind-mounts host files as
+			// root-owned, so a non-root remote user cannot enter the workspace
+			// folder without the chown. Previously skipped because podman uses
+			// the docker driver, producing "fork/exec /usr/bin/bash:
+			// permission denied" on the in-container chdir.
+			name: "podman on macOS chowns despite docker driver",
+			goos: "darwin", isDockerDriver: true, isPodman: true, want: true,
+		},
+		{
+			name: "podman on windows chowns despite docker driver",
+			goos: "windows", isDockerDriver: true, isPodman: true, want: true,
+		},
+		{
+			name: "podman on linux chowns",
+			goos: "linux", isDockerDriver: true, isPodman: true, want: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := shouldChownWorkspace(c.goos, c.isDockerDriver, c.isPodman)
+			if got != c.want {
+				t.Errorf("shouldChownWorkspace(%q, %v, %v) = %v, want %v",
+					c.goos, c.isDockerDriver, c.isPodman, got, c.want)
+			}
+		})
+	}
+}
+
+func TestRunnerIsPodmanRuntime(t *testing.T) {
+	cases := []struct {
+		name    string
+		runtime string
+		want    bool
+	}{
+		{name: "podman", runtime: "podman", want: true},
+		{name: "podman mixed case", runtime: "Podman", want: true},
+		{name: "docker", runtime: "docker", want: false},
+		{name: "empty defaults to non-podman", runtime: "", want: false},
+		{name: "nerdctl", runtime: "nerdctl", want: false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := &runner{
+				WorkspaceConfig: &provider2.AgentWorkspaceInfo{
+					Agent: provider2.ProviderAgentConfig{
+						Docker: provider2.ProviderDockerDriverConfig{Runtime: c.runtime},
+					},
+				},
+			}
+			if got := r.isPodmanRuntime(); got != c.want {
+				t.Errorf("isPodmanRuntime() with runtime=%q = %v, want %v", c.runtime, got, c.want)
+			}
+		})
+	}
+}
+
 func TestResolvePullFromInsideContainer(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

Podman workspaces with a non-root `remoteUser` failed to open from VS Code Remote-SSH on macOS/Windows hosts, with:

```
start command: fork/exec /usr/bin/bash: permission denied
```

The container launched fine and devsy's own terminal worked, but VS Code (and `devsy workspace ssh`) could not start a shell.

## Root cause

Rootless `podman machine` surfaces the host workspace bind mount as **root-owned** (`root:root 0750`) inside the container. Go's `os/exec` performs `chdir(cmd.Dir)` in the forked child *before* `execve`; the non-root remote user cannot enter the workspace folder, so the `chdir` returns `EACCES` — which Go reports against the shell path, producing the misleading "fork/exec /usr/bin/bash: permission denied".

`addChownFlag` gated `--chown-workspace` on `runtime.GOOS == "linux" || !isDockerDriver`. Podman runs through the docker driver, so on a macOS/Windows host **neither** clause held and the workspace was never chowned to the remote user. The fix extends the condition to also chown for the Podman runtime regardless of host OS.

devsy's own terminal was unaffected because the podman provider runs commands through the in-process emulated shell (`devsy internal sh`), which never execs a real `/usr/bin/bash`.

## Spec alignment

The Dev Container spec scopes UID/GID syncing to *"an optional task for Linux (only)"* whose purpose is *"to avoid permission problems with bind mounts,"* and explicitly lets implementations handle the case themselves when the engine does not translate automatically. This fix serves that exact goal for rootless Podman on macOS, where the reference CLI's Linux-only UID-remap mechanism does not apply. The chown writes through the bind mount to the host inode (cf. loft-sh/devpod#1879); it is scoped to non-root remote users, so root-user containers are unaffected.

## Tests

- **Unit**: `shouldChownWorkspace` and `isPodmanRuntime` table tests.
- **E2E**: new rootless-podman spec with a non-root `remoteUser` fixture (`docker-nonroot-user`) asserting the workspace folder is owned by the remote user. Validated end-to-end against real rootless Podman (fails without the fix, passes with it).

## Operational note

The `chownWorkspace` setup step is guarded by a one-time marker file, so **existing broken workspaces need a Recreate** (or a fresh workspace) to pick up the chown. New workspaces work immediately.

## UI

No UI changes required — the desktop's `workspace_up` IPC handler shells out to the same `workspace up` CLI path, so this fix applies once the bundled CLI binary is built from this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace ownership handling for rootless Podman so files and folders are assigned to the expected user.
  * Fixed container setup behavior for non-root dev containers, helping `remoteUser` sessions start with the correct identity.
  * Refined mount consistency and platform checks to behave more reliably across Linux, macOS, and Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->