### PR TITLE
chore: update license wording

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -15,6 +15,10 @@ please contact licensing@devsy.org.
 
 Notice
 
+The Business Source License (this document, or the "License") is not an
+Open Source license. However, the Licensed Work will eventually be made
+available under an Open Source License, as stated in this License.
+
 Business Source License 1.1
 
 Terms
@@ -23,7 +27,9 @@ The Licensor hereby grants you the right to copy, modify, create derivative
 works, redistribute, and make non-production use of the Licensed Work. The
 Licensor may make an Additional Use Grant, above, permitting limited production use.
 
-Effective on the Change Date, the Licensor hereby grants you rights under
+Effective on the Change Date, or the fourth anniversary of the first publicly
+available distribution of a specific version of the Licensed Work under this
+License, whichever comes first, the Licensor hereby grants you rights under
 the terms of the Change License, and the rights granted in the paragraph
 above terminate.
 


### PR DESCRIPTION
Restores the two pieces of the canonical MariaDB BSL 1.1 template that were trimmed from the Notice and conversion clause:

- Adds the standard "is not an Open Source license" notice statement.
- Adds the springing fallback so the Change License also takes effect on the fourth anniversary of a version's first public distribution, whichever is earlier.

No change to Licensor, Licensed Work, Additional Use Grant, Change Date, or Change License (Apache 2.0). This makes the license match the official template verbatim except for the filled-in Parameters.