### PR TITLE
chore: consolidate contact email to dev@devsy.sh

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,7 +11,7 @@ Change Date:          May 19, 2046
 Change License:       Apache License, Version 2.0
 
 For information about alternative licensing arrangements for the Licensed Work,
-please contact licensing@devsy.org.
+please contact dev@devsy.sh.
 
 Notice
 


### PR DESCRIPTION
Updates stale and scattered contact addresses to the single canonical contact, dev@devsy.sh:

- LICENSE: licensing@devsy.org -> dev@devsy.sh (the devsy.org domain is incorrect)
- SECURITY.md: security@devsy.sh and the legacy security@loft.sh -> dev@devsy.sh