### PR TITLE
refactor(port): group splitParts results into a struct

### DIFF
--- a/pkg/port/parse.go
+++ b/pkg/port/parse.go
@@ -19,25 +19,12 @@ type Mapping struct {
 }
 
 func ParsePortSpec(port string) (Mapping, error) {
-	hostIP, hostPort, containerIP, containerPort, err := splitParts(port)
+	parts, err := splitParts(port)
 	if err != nil {
 		return Mapping{}, err
 	}
 
-	hostAddress, err := toAddress(hostIP, hostPort)
-	if err != nil {
-		return Mapping{}, fmt.Errorf("parse host address: %w", err)
-	}
-
-	containerAddress, err := toAddress(containerIP, containerPort)
-	if err != nil {
-		return Mapping{}, fmt.Errorf("parse container address: %w", err)
-	}
-
-	return Mapping{
-		Host:      hostAddress,
-		Container: containerAddress,
-	}, nil
+	return parts.toMapping()
 }
 
 func toAddress(host, port string) (Address, error) {
@@ -63,28 +50,52 @@ func toAddress(host, port string) (Address, error) {
 	}, nil
 }
 
-func splitParts(rawport string) (string, string, string, string, error) {
-	parts := strings.Split(rawport, ":")
+type parsedParts struct {
+	hostIP        string
+	hostPort      string
+	containerIP   string
+	containerPort string
+}
+
+func (p parsedParts) toMapping() (Mapping, error) {
+	hostAddress, err := toAddress(p.hostIP, p.hostPort)
+	if err != nil {
+		return Mapping{}, fmt.Errorf("parse host address: %w", err)
+	}
+
+	containerAddress, err := toAddress(p.containerIP, p.containerPort)
+	if err != nil {
+		return Mapping{}, fmt.Errorf("parse container address: %w", err)
+	}
+
+	return Mapping{
+		Host:      hostAddress,
+		Container: containerAddress,
+	}, nil
+}
+
+func splitParts(rawPort string) (parsedParts, error) {
+	parts := strings.Split(rawPort, ":")
 	n := len(parts)
-	containerport := parts[n-1]
+	containerPort := parts[n-1]
 
 	switch n {
 	case 1:
-		return "", containerport, "", containerport, nil
+		return parsedParts{hostPort: containerPort, containerPort: containerPort}, nil
 	case 2:
-		return "", parts[0], "", containerport, nil
+		return parsedParts{hostPort: parts[0], containerPort: containerPort}, nil
 	case 3:
 		// a:b:c — if middle token is non-numeric, it's a host/IP for the
 		// container side: hostPort:containerHost:containerPort.
 		// Otherwise it's hostHost:hostPort:containerPort.
 		if _, err := strconv.Atoi(parts[1]); err != nil {
-			return "", parts[0], parts[1], containerport, nil
+			return parsedParts{hostPort: parts[0], containerIP: parts[1], containerPort: containerPort}, nil
 		}
 
-		return parts[0], parts[1], "", containerport, nil
+		return parsedParts{hostIP: parts[0], hostPort: parts[1], containerPort: containerPort}, nil
 	case 4:
-		return parts[0], parts[1], parts[2], parts[3], nil
+		return parsedParts{hostIP: parts[0], hostPort: parts[1], containerIP: parts[2], containerPort: parts[3]}, nil
 	default:
-		return "", "", "", "", fmt.Errorf("unexpected port format: %s", rawport)
+		return parsedParts{}, fmt.Errorf("unexpected port format: %s", rawPort)
 	}
 }

--- a/pkg/port/parse.go
+++ b/pkg/port/parse.go
@@ -89,12 +89,21 @@ func splitParts(rawPort string) (parsedParts, error) {
 		// container side: hostPort:containerHost:containerPort.
 		// Otherwise it's hostHost:hostPort:containerPort.
 		if _, err := strconv.Atoi(parts[1]); err != nil {
-			return parsedParts{hostPort: parts[0], containerIP: parts[1], containerPort: containerPort}, nil
+			return parsedParts{
+				hostPort:      parts[0],
+				containerIP:   parts[1],
+				containerPort: containerPort,
+			}, nil
 		}
 
 		return parsedParts{hostIP: parts[0], hostPort: parts[1], containerPort: containerPort}, nil
 	case 4:
-		return parsedParts{hostIP: parts[0], hostPort: parts[1], containerIP: parts[2], containerPort: parts[3]}, nil
+		return parsedParts{
+			hostIP:        parts[0],
+			hostPort:      parts[1],
+			containerIP:   parts[2],
+			containerPort: parts[3],
+		}, nil
 	default:
 		return parsedParts{}, fmt.Errorf("unexpected port format: %s", rawPort)
 	}

--- a/pkg/port/parse_test.go
+++ b/pkg/port/parse_test.go
@@ -216,11 +216,11 @@ func TestSplitParts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			hostIP, hostPort, contIP, contPort, err := splitParts(tt.input)
+			parts, err := splitParts(tt.input)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			got := result{hostIP, hostPort, contIP, contPort}
+			got := result{parts.hostIP, parts.hostPort, parts.containerIP, parts.containerPort}
 			if got != tt.want {
 				t.Errorf("got %+v, want %+v", got, tt.want)
 			}
@@ -229,7 +229,7 @@ func TestSplitParts(t *testing.T) {
 }
 
 func TestSplitParts_Errors(t *testing.T) {
-	_, _, _, _, err := splitParts("a:b:c:d:e")
+	_, err := splitParts("a:b:c:d:e")
 	if err == nil {
 		t.Fatal("expected error for five parts")
 	}


### PR DESCRIPTION
## Summary

`splitParts` in `pkg/port/parse.go` returned four `string` values plus an `error`. Functions should not return more than three values, so this collapses the address components into an unexported `parsedParts` struct.

- `splitParts` now returns `(parsedParts, error)` instead of a five-value tuple.
- Address resolution moved onto a `parsedParts.toMapping()` method, reducing redundancy between the intermediate type and `Mapping`. `ParsePortSpec` now reads as two stages: tokenize → resolve.
- Tidied local/param naming to camelCase (`rawPort`, `containerPort`) to match the struct fields.

`go vet` is clean and all 29 package tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified port specification parsing behind the scenes while keeping existing port-handling behavior unchanged.
  * Preserved current support for 1–4 part port formats and the same validation/error messages for invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->