### PR TITLE
ci(licenses): warn instead of fail when attribution is out of date

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -131,8 +131,6 @@ jobs:
           go-version-file: go.mod
 
       - name: Check license policy and attribution
-        env:
-          GITHUB_HEAD_REF: ${{ github.head_ref }}
         run: go run ./hack/licenses --check
 
   integration-tests-unprivileged:

--- a/hack/licenses/main.go
+++ b/hack/licenses/main.go
@@ -11,7 +11,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
-	"strings"
 )
 
 const detectorVersion = "v0.10.0"
@@ -96,33 +95,16 @@ func checkInSync(hackDir, outFile string, deps []byte) error {
 		diff.Stdout = os.Stderr
 		diff.Stderr = os.Stderr
 		_ = diff.Run()
-		const msg = "THIRD_PARTY_LICENSES.md is out of date; run 'task cli:licenses' and commit the result"
-		// Renovate bumps dependencies without regenerating the attribution
-		// file, so warn instead of failing on its branches; the file is
-		// reconciled when a maintainer runs the generator.
-		if onRenovateBranch() {
-			fmt.Fprintln(os.Stderr, "warning:", msg)
-			return nil
-		}
-		return fmt.Errorf("%s", msg)
+		// Dependency bumps (e.g. Renovate) change the attribution file without
+		// regenerating it, so warn instead of failing; the file is reconciled
+		// when a maintainer runs the generator and commits the result.
+		fmt.Fprintln(os.Stderr,
+			"warning: THIRD_PARTY_LICENSES.md is out of date; run 'task cli:licenses' and commit the result")
+		return nil
 	}
 
 	fmt.Fprintln(os.Stderr, "THIRD_PARTY_LICENSES.md is up to date.")
 	return nil
-}
-
-// onRenovateBranch reports whether the check is running against a Renovate
-// branch, using the GITHUB_HEAD_REF set on pull_request events and falling back
-// to the locally checked-out branch.
-func onRenovateBranch() bool {
-	if strings.HasPrefix(os.Getenv("GITHUB_HEAD_REF"), "renovate/") {
-		return true
-	}
-	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
-	if err != nil {
-		return false
-	}
-	return strings.HasPrefix(strings.TrimSpace(string(out)), "renovate/")
 }
 
 func repoRoot() (string, error) {

--- a/hack/licenses/main.go
+++ b/hack/licenses/main.go
@@ -95,9 +95,6 @@ func checkInSync(hackDir, outFile string, deps []byte) error {
 		diff.Stdout = os.Stderr
 		diff.Stderr = os.Stderr
 		_ = diff.Run()
-		// Dependency bumps (e.g. Renovate) change the attribution file without
-		// regenerating it, so warn instead of failing; the file is reconciled
-		// when a maintainer runs the generator and commits the result.
 		fmt.Fprintln(
 			os.Stderr,
 			"warning: THIRD_PARTY_LICENSES.md is out of date; run 'task cli:licenses' and commit the result",

--- a/hack/licenses/main.go
+++ b/hack/licenses/main.go
@@ -98,8 +98,10 @@ func checkInSync(hackDir, outFile string, deps []byte) error {
 		// Dependency bumps (e.g. Renovate) change the attribution file without
 		// regenerating it, so warn instead of failing; the file is reconciled
 		// when a maintainer runs the generator and commits the result.
-		fmt.Fprintln(os.Stderr,
-			"warning: THIRD_PARTY_LICENSES.md is out of date; run 'task cli:licenses' and commit the result")
+		fmt.Fprintln(
+			os.Stderr,
+			"warning: THIRD_PARTY_LICENSES.md is out of date; run 'task cli:licenses' and commit the result",
+		)
 		return nil
 	}
 


### PR DESCRIPTION
The third-party license check regenerates THIRD_PARTY_LICENSES.md and previously failed CI when it drifted from the committed copy. Dependency bumps (e.g. Renovate) change the dependency set without regenerating the attribution file, so the check failed on those PRs and on main after they merged.

Make the out-of-sync condition a warning that exits 0 instead of a hard failure. The diff is still printed for visibility, and a maintainer reconciles the file by running `task cli:licenses`. License *policy* violations (forbidden licenses) still fail, since those error out inside the detector before this check runs.

Also reverts the now-unnecessary `GITHUB_HEAD_REF` env var and the `onRenovateBranch` helper from the prior branch-scoped approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * License checks now give a consistent warning when generated license information is out of sync, instead of failing only in some cases.
  * The CI license verification step was simplified to run more reliably without branch-specific handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->