### PR TITLE
fix(desktop): scope Node.js template e2e selector to active tab panel

### DIFF
--- a/desktop/e2e/integration.e2e.ts
+++ b/desktop/e2e/integration.e2e.ts
@@ -232,8 +232,13 @@ test.describe
       await dialog.locator("button", { hasText: "docker" }).first().click()
       await dialog.getByRole("button", { name: /^continue$/i }).click()
 
-      // Step 2 — Source: click Node.js template
-      await dialog.locator("button", { hasText: "Node.js" }).click()
+      // Step 2 — Source: click Node.js template. Scope to the active tab panel
+      // (Git) so the template button doesn't collide with the Image catalog's
+      // "Node.js 20" card, which is also present in the DOM.
+      await dialog
+        .getByRole("tabpanel")
+        .locator("button", { hasText: "Node.js" })
+        .click()
       const sourceInput = dialog.locator('input[placeholder*="github"]')
       await expect(sourceInput).toHaveValue(
         "https://github.com/microsoft/vscode-remote-try-node",


### PR DESCRIPTION
## Summary

The `integration.e2e.ts` "should create Node.js workspace" test intermittently failed on Windows with a Playwright strict-mode violation:

```
locator('[role="dialog"]')…locator('button').filter({ hasText: 'Node.js' }) resolved to 2 elements
  1) Node.js template card (Git tab)
  2) "Node.js 20 Featured" image-catalog card (Image tab)
```

Both tab panels stay in the DOM, so the unscoped `hasText: "Node.js"` selector matched both whenever the async image catalog finished loading before the click — a race, which is why the same commit both passed and failed.

Fix: scope the locator to the active `tabpanel`, matching the pattern already used by the sibling Python-template flow in the same file and by `workspaces.e2e.ts`.

Pre-existing flake, unrelated to the change that surfaced it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved the Node.js workspace creation end-to-end test to target the correct “Node.js” source template more precisely.
  * Reduced the chance of selecting the wrong template during the workspace setup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->