### PR TITLE
ci(release): categorize Renovate deps in generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Dependency Updates
+      labels:
+        - dependencies
+      authors:
+        - renovate[bot]
+        - dependabot[bot]
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,9 +3,6 @@ changelog:
     - title: Dependency Updates
       labels:
         - dependencies
-      authors:
-        - renovate[bot]
-        - dependabot[bot]
     - title: Other Changes
       labels:
         - "*"

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "automergeType": "pr",
   "automergeStrategy": "squash",
   "extends": ["config:best-practices", "helpers:pinGitHubActionDigests"],
+  "labels": ["dependencies"],
   "pre-commit": {
     "enabled": true
   },


### PR DESCRIPTION
Adds `.github/release.yml` to control GitHub's auto-generated release notes.

Renovate (and Dependabot) PRs are now grouped under a dedicated **Dependency Updates** category instead of mixing into the main changelog. All other PRs fall under **Other Changes**. Author-based matching is used since the Renovate config does not apply labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added release/changelog categories to better organize future notes.
  * Changes are now grouped into “Dependency Updates” and “Other Changes” for clearer release summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->