### PR TITLE
ci(release): list Other Changes before Dependency Updates

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,8 +1,11 @@
 changelog:
   categories:
-    - title: Dependency Updates
-      labels:
-        - dependencies
     - title: Other Changes
       labels:
         - "*"
+      exclude:
+        labels:
+          - dependencies
+    - title: Dependency Updates
+      labels:
+        - dependencies


### PR DESCRIPTION
GitHub renders release-note categories in config order. The previous config listed Dependency Updates first, pushing the main project changes below a long list of Renovate PRs.

Reorders so Other Changes appears first. Since category matching is order-sensitive (first match wins), Other Changes now excludes the `dependencies` label so deps PRs still fall through to the Dependency Updates category below.