### PR TITLE
ci: add CLA assistant workflow and agreement

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,84 @@
+# Devsy Contributor License Agreement
+
+Thank you for your interest in contributing to Devsy (the "Project"), maintained
+by Devsy (the "Licensor"). This Contributor License Agreement ("Agreement")
+documents the rights granted by contributors to the Licensor. By signing this
+Agreement, you accept and agree to the following terms for your past, present,
+and future Contributions submitted to the Project.
+
+## 1. Definitions
+
+"You" (or "Your") means the individual or legal entity making a Contribution.
+
+"Contribution" means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to the Project for inclusion in, or documentation of, any of the products
+owned or managed by the Licensor (the "Work"). "Submitted" means any form of
+electronic, verbal, or written communication sent to the Licensor or its
+representatives, including but not limited to pull requests, issues, and patches.
+
+## 2. Grant of Copyright License
+
+Subject to the terms of this Agreement, You grant to the Licensor and to
+recipients of software distributed by the Licensor a perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable copyright license to reproduce,
+prepare derivative works of, publicly display, publicly perform, sublicense,
+and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms of this Agreement, You grant to the Licensor and to
+recipients of software distributed by the Licensor a perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import, and
+otherwise transfer the Work, where such license applies only to those patent
+claims licensable by You that are necessarily infringed by Your Contribution(s)
+alone or by combination of Your Contribution(s) with the Work to which such
+Contribution(s) was submitted.
+
+## 4. Right to Relicense (Including Under Proprietary Terms)
+
+You acknowledge and agree that the Licensor may license, sublicense, and
+distribute Your Contributions, and any derivative works thereof, **under any
+license terms the Licensor chooses, including open-source, source-available,
+and proprietary (closed-source) licenses**, and that the Licensor may change
+the license terms applicable to the Work and Your Contributions at any time and
+for any future version. You understand that the Project is currently distributed
+under the Business Source License 1.1 and that the Licensor offers commercial
+licenses, and that the rights granted in this Agreement permit the Licensor to
+continue and change such arrangements without further notice to or consent from
+You. This grant survives and is not limited by the license under which the
+Project is distributed at the time of Your Contribution.
+
+## 5. Ownership Retained
+
+You retain ownership of the copyright in Your Contributions. This Agreement is a
+license grant, not an assignment of copyright. The rights You grant here are
+irrevocable and may not be withdrawn.
+
+## 6. Your Representations
+
+You represent that:
+
+- You are legally entitled to grant the above licenses.
+- Each of Your Contributions is Your original creation, or You have the
+  necessary rights to submit it under the terms of this Agreement.
+- If Your employer has rights to intellectual property You create, You have
+  received permission to make the Contributions on behalf of that employer, or
+  Your employer has waived such rights for Your Contributions to the Project.
+- Your Contributions do not, to the best of Your knowledge, violate any
+  third-party rights.
+
+## 7. Disclaimer
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. Your Contributions are provided "AS IS",
+without warranty of any kind, to the extent permitted by applicable law.
+
+## 8. Agreement
+
+By submitting a Contribution to the Project and signing this Agreement (for
+example, by commenting on a pull request with the agreed signing statement, or
+through the Project's automated CLA tooling), You accept and agree to the terms
+of this Agreement for Your past, present, and future Contributions to the
+Project.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,8 +41,7 @@ jobs:
           custom-allsigned-prcomment: >
             All contributors have signed the CLA.
           custom-notsigned-prcomment: >
-            Thank you for your contribution. Before we can merge it, we need you
-            to agree to our [Contributor License Agreement](https://github.com/${{ github.repository }}/blob/main/.github/CLA.md).
-            Please read it carefully — it grants Devsy the right to relicense your
-            contribution, including under proprietary terms. If you agree, post a
-            comment on this pull request with exactly the following text:
+            Thank you for your contribution. Before we can merge it, please read
+            our [Contributor License Agreement](https://github.com/${{ github.repository }}/blob/main/.github/CLA.md).
+            If you agree, post a comment on this pull request with exactly the
+            following text:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,10 +22,16 @@ jobs:
          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) ||
       github.event_name == 'pull_request_target'
     steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.DEVSY_GITHUB_APP_ID }}
+          private-key: ${{ secrets.DEVSY_GITHUB_APP_PRIVATE_KEY }}
+
       - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/${{ github.repository }}/blob/main/.github/CLA.md"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,42 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: Check Contributor License Agreement
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'issue_comment' &&
+        (github.event.comment.body == 'recheck' ||
+         github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA')) ||
+      github.event_name == 'pull_request_target'
+    steps:
+      - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
+        with:
+          path-to-signatures: "signatures/cla.json"
+          path-to-document: "https://github.com/${{ github.repository }}/blob/main/.github/CLA.md"
+          branch: "cla-signatures"
+          allowlist: "renovate[bot],dependabot[bot],*[bot]"
+          custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
+          custom-allsigned-prcomment: >
+            All contributors have signed the CLA.
+          custom-notsigned-prcomment: >
+            Thank you for your contribution. Before we can merge it, we need you
+            to agree to our [Contributor License Agreement](https://github.com/${{ github.repository }}/blob/main/.github/CLA.md).
+            Please read it carefully — it grants Devsy the right to relicense your
+            contribution, including under proprietary terms. If you agree, post a
+            comment on this pull request with exactly the following text:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,17 @@
 
 Thank you for your interest in contributing to Devsy! This guide will help you get started with development.
 
+## Contributor License Agreement
+
+Before your first contribution can be merged, you must sign the [Contributor
+License Agreement](./.github/CLA.md). When you open a pull request, a bot will
+check your signing status and, if needed, comment with instructions. You sign by
+posting a comment on the pull request with the exact text the bot provides.
+
+The CLA lets you keep copyright in your contributions while granting Devsy a
+perpetual, irrevocable license to use and **relicense** them, including under
+proprietary terms. Please read it before contributing.
+
 ## Development Setup
 
 ### Prerequisites

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,10 +9,6 @@ License Agreement](./.github/CLA.md). When you open a pull request, a bot will
 check your signing status and, if needed, comment with instructions. You sign by
 posting a comment on the pull request with the exact text the bot provides.
 
-The CLA lets you keep copyright in your contributions while granting Devsy a
-perpetual, irrevocable license to use and **relicense** them, including under
-proprietary terms. Please read it before contributing.
-
 ## Development Setup
 
 ### Prerequisites


### PR DESCRIPTION
Adds a Contributor License Agreement and a self-hosted CLA Assistant workflow that requires contributors to sign before their PRs can be merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clear contributor guidance about signing the Contributor License Agreement before first contributions are merged.
  * Included the full agreement text covering contribution terms, ownership, and licensing conditions.

* **Chores**
  * Added automated checks to help verify CLA status on pull requests and comments.
  * Updated PR messaging to show whether required signatures are complete or still pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->