### PR TITLE
ci: use org fork of CLA action and central signature store

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,15 +27,19 @@ jobs:
         with:
           app-id: ${{ secrets.DEVSY_GITHUB_APP_ID }}
           private-key: ${{ secrets.DEVSY_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }},cla-signatures
 
       - uses: devsy-org/cla-assistant-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
-          path-to-signatures: "signatures/cla.json"
+          path-to-signatures: "signatures/${{ github.event.repository.name }}/cla.json"
           path-to-document: "https://github.com/${{ github.repository }}/blob/main/.github/CLA.md"
-          branch: "cla-signatures"
+          branch: "main"
+          remote-organization-name: "devsy-org"
+          remote-repository-name: "cla-signatures"
           allowlist: "renovate[bot],dependabot[bot],*[bot]"
           custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
           custom-allsigned-prcomment: >

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,7 +28,7 @@ jobs:
           app-id: ${{ secrets.DEVSY_GITHUB_APP_ID }}
           private-key: ${{ secrets.DEVSY_GITHUB_APP_PRIVATE_KEY }}
 
-      - uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+      - uses: devsy-org/cla-assistant-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           PERSONAL_ACCESS_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Two related CLA-infrastructure changes, prerequisites for rolling CLA enforcement out across all devsy-org repos:

1. **Fork the archived action.** Repoint from `contributor-assistant/github-action` (archived/read-only) to `devsy-org/cla-assistant-action`, our fork at the identical `v2.6.1` SHA. We now control updates.
2. **Central signature store.** Write signatures to `devsy-org/cla-signatures` (a per-repo path: `signatures/<repo>/cla.json`) instead of a local `cla-signatures` branch. Contributors sign **once for all devsy-org repos**, and signatures live in one auditable, private repo.

The app token is scoped to both the current repo and `cla-signatures` so it can commit to the remote store.
