### PR TITLE
ci: exempt owner from CLA signature requirement

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -40,7 +40,7 @@ jobs:
           branch: "main"
           remote-organization-name: "devsy-org"
           remote-repository-name: "cla-signatures"
-          allowlist: "renovate[bot],dependabot[bot],*[bot]"
+          allowlist: "skevetter,renovate[bot],dependabot[bot],*[bot]"
           custom-pr-sign-comment: "I have read the CLA Document and I hereby sign the CLA"
           custom-allsigned-prcomment: >
             All contributors have signed the CLA.


### PR DESCRIPTION
## Summary

Adds repo owner `skevetter` to the CLA Assistant allowlist so the owner's pull requests are not blocked pending a CLA signature.

As owner/Licensor, the owner already holds the rights the CLA grants, so self-exemption does not create a chain-of-rights gap. Mirrors the existing bot allowlist entries.