### PR TITLE
feat(provider): allow templated agent.driver value

### DIFF
--- a/pkg/provider/parse.go
+++ b/pkg/provider/parse.go
@@ -228,6 +228,13 @@ func validateStandardProvider(config *ProviderConfig) error {
 }
 
 func validateAgentDriver(config *ProviderConfig) error {
+	// A templated driver (e.g. ${SOME_OPTION}) is resolved at runtime from the
+	// provider options, so its concrete value cannot be validated here. Defer
+	// validation to driver creation, which rejects unknown resolved values.
+	if isTemplatedValue(config.Agent.Driver) {
+		return nil
+	}
+
 	if config.Agent.Driver != "" && config.Agent.Driver != CustomDriver &&
 		config.Agent.Driver != DockerDriver &&
 		config.Agent.Driver != KubernetesDriver {
@@ -239,6 +246,12 @@ func validateAgentDriver(config *ProviderConfig) error {
 	}
 
 	return nil
+}
+
+// isTemplatedValue reports whether a provider config value references an option
+// variable (e.g. ${MY_OPTION} or $MY_OPTION) that is substituted at runtime.
+func isTemplatedValue(value string) bool {
+	return strings.Contains(value, "$")
 }
 
 func validateCustomDriver(config *ProviderConfig) error {

--- a/pkg/provider/parse.go
+++ b/pkg/provider/parse.go
@@ -14,17 +14,18 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var ProviderNameRegEx = regexp.MustCompile(`[^a-z0-9\-]+`)
-
-var optionNameRegEx = regexp.MustCompile(`[^A-Z0-9_]+`)
-
-var allowedTypes = []string{
-	"string",
-	"multiline",
-	"duration",
-	"number",
-	"boolean",
-}
+var (
+	ProviderNameRegEx   = regexp.MustCompile(`[^a-z0-9\-]+`)
+	optionNameRegEx     = regexp.MustCompile(`[^A-Z0-9_]+`)
+	templatedValueRegex = regexp.MustCompile(`\$\{?[A-Za-z_][A-Za-z0-9_]*\}?`)
+	allowedTypes        = []string{
+		"string",
+		"multiline",
+		"duration",
+		"number",
+		"boolean",
+	}
+)
 
 func ParseProvider(reader io.Reader) (*ProviderConfig, error) {
 	payload, err := io.ReadAll(reader)
@@ -228,10 +229,7 @@ func validateStandardProvider(config *ProviderConfig) error {
 }
 
 func validateAgentDriver(config *ProviderConfig) error {
-	// A templated driver (e.g. ${SOME_OPTION}) is resolved at runtime from the
-	// provider options, so its concrete value cannot be validated here. Defer
-	// validation to driver creation, which rejects unknown resolved values.
-	if isTemplatedValue(config.Agent.Driver) {
+	if templatedValueRegex.MatchString(config.Agent.Driver) {
 		return nil
 	}
 
@@ -246,12 +244,6 @@ func validateAgentDriver(config *ProviderConfig) error {
 	}
 
 	return nil
-}
-
-// isTemplatedValue reports whether a provider config value references an option
-// variable (e.g. ${MY_OPTION} or $MY_OPTION) that is substituted at runtime.
-func isTemplatedValue(value string) bool {
-	return strings.Contains(value, "$")
 }
 
 func validateCustomDriver(config *ProviderConfig) error {

--- a/pkg/provider/parse_driver_test.go
+++ b/pkg/provider/parse_driver_test.go
@@ -1,0 +1,44 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateAgentDriver_Templated(t *testing.T) {
+	base := `name: aws
+version: v1.0.0
+agent:
+  path: x
+  driver: %s
+exec:
+  command: echo hi
+  create: echo hi
+  delete: echo hi
+`
+
+	cases := []struct {
+		name    string
+		driver  string
+		wantErr bool
+	}{
+		{name: "empty", driver: "", wantErr: false},
+		{name: "docker literal", driver: DockerDriver, wantErr: false},
+		{name: "kubernetes literal", driver: KubernetesDriver, wantErr: false},
+		{name: "templated braces", driver: "${AWS_DEPLOYMENT_MODE}", wantErr: false},
+		{name: "templated bare", driver: "$AWS_DEPLOYMENT_MODE", wantErr: false},
+		{name: "invalid literal", driver: "podman", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseProvider(strings.NewReader(strings.Replace(base, "%s", tc.driver, 1)))
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for driver %q, got nil", tc.driver)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for driver %q: %v", tc.driver, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Permit `agent.driver` in a provider manifest to contain a template variable (e.g. `${AWS_DEPLOYMENT_MODE}`) so a single provider can select the devcontainer driver from a provider option at deploy time.

Today `validateAgentDriver` rejects any `agent.driver` that isn't a literal `docker`/`kubernetes`/`custom`/empty at **parse time** — before option substitution — which makes it impossible to ship one manifest that toggles between drivers. This relaxes parse-time validation for templated values only; the concrete value is still validated at driver creation (`drivercreate.NewDriver` already errors on unknown drivers). Literal values remain strictly validated.

## Motivation

Enables the AWS provider to offer a single configurable `AWS_DEPLOYMENT_MODE` (docker | kubernetes) option instead of shipping two separate manifests — devsy loads one provider per repo.

## Changes

- `pkg/provider/parse.go`: `validateAgentDriver` returns early when the driver is a templated value (`isTemplatedValue`); literal validation unchanged.
- `pkg/provider/parse_driver_test.go`: table test covering empty, literal docker/kubernetes, templated `${...}`/`$BARE`, and invalid-literal cases.

## Test

`go test ./pkg/provider/` — new `TestValidateAgentDriver_Templated` passes; existing provider tests unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation so templated agent driver values are no longer rejected too early.
  * Allowed driver settings using variable-style placeholders to pass initial validation, while still checking concrete values as expected.
  * Added test coverage for empty, valid, templated, and invalid driver inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->