### PR TITLE
refactor(config): separate config dir from data dir on unix

### DIFF
--- a/pkg/config/pathmanager_darwin.go
+++ b/pkg/config/pathmanager_darwin.go
@@ -14,7 +14,7 @@ type darwinPathManager struct {
 
 func newPlatformPathManager() PathManager {
 	pm := &darwinPathManager{}
-	pm.basePathManager.pm = pm
+	pm.pm = pm
 
 	return pm
 }
@@ -25,7 +25,7 @@ func (d *darwinPathManager) ConfigDir() (string, error) {
 		return "", fmt.Errorf("config dir: %w", err)
 	}
 
-	return ensureDir(filepath.Join(home, "."+RepoName))
+	return ensureDir(filepath.Join(home, ".config", RepoName))
 }
 
 func (d *darwinPathManager) DataDir() (string, error) {

--- a/pkg/config/pathmanager_darwin_test.go
+++ b/pkg/config/pathmanager_darwin_test.go
@@ -1,0 +1,57 @@
+//go:build darwin
+
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func newTestDarwinPM() PathManager {
+	pm := &darwinPathManager{}
+	pm.pm = pm
+
+	return pm
+}
+
+func TestDarwinConfigDir_IsUnderXDGConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	pm := newTestDarwinPM()
+
+	got, err := pm.ConfigDir()
+	if err != nil {
+		t.Fatalf("ConfigDir: %v", err)
+	}
+
+	want := filepath.Join(home, ".config", RepoName)
+	if got != want {
+		t.Errorf("ConfigDir = %q, want %q", got, want)
+	}
+
+	dataDir, err := pm.DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if got == dataDir {
+		t.Errorf("ConfigDir and DataDir must be distinct, both = %q", got)
+	}
+}
+
+func TestDarwinConfigFilePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(EnvConfig, "")
+
+	pm := newTestDarwinPM()
+	got, err := pm.ConfigFilePath()
+	if err != nil {
+		t.Fatalf("ConfigFilePath: %v", err)
+	}
+
+	want := filepath.Join(home, ".config", RepoName, ConfigFile)
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}

--- a/pkg/config/pathmanager_linux.go
+++ b/pkg/config/pathmanager_linux.go
@@ -25,7 +25,7 @@ func (l *linuxPathManager) ConfigDir() (string, error) {
 		return "", fmt.Errorf("config dir: %w", err)
 	}
 
-	return ensureDir(filepath.Join(home, "."+RepoName))
+	return ensureDir(filepath.Join(home, ".config", RepoName))
 }
 
 func (l *linuxPathManager) DataDir() (string, error) {

--- a/pkg/config/pathmanager_linux_test.go
+++ b/pkg/config/pathmanager_linux_test.go
@@ -45,7 +45,7 @@ func TestLinuxDefaults(t *testing.T) {
 		fn   func() (string, error)
 		want string
 	}{
-		{"ConfigDir", pm.ConfigDir, filepath.Join(home, "."+RepoName)},
+		{"ConfigDir", pm.ConfigDir, filepath.Join(home, ".config", RepoName)},
 		{"DataDir", pm.DataDir, filepath.Join(home, "."+RepoName)},
 		{"CacheDir", pm.CacheDir, filepath.Join(home, ".cache", RepoName)},
 		{"StateDir", pm.StateDir, filepath.Join(home, "."+RepoName, "state")},
@@ -79,7 +79,7 @@ func TestConfigFilePathDefault(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	want := filepath.Join(home, "."+RepoName, ConfigFile)
+	want := filepath.Join(home, ".config", RepoName, ConfigFile)
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}

--- a/pkg/config/pathmanager_windows.go
+++ b/pkg/config/pathmanager_windows.go
@@ -14,7 +14,7 @@ type windowsPathManager struct {
 
 func newPlatformPathManager() PathManager {
 	pm := &windowsPathManager{}
-	pm.basePathManager.pm = pm
+	pm.pm = pm
 
 	return pm
 }


### PR DESCRIPTION
Unix path managers resolved ConfigDir and DataDir to the same ~/.devsy
path, so config.yaml piled into the data root alongside contexts and
bind-mount sources. Move ConfigDir to ~/.config/devsy, matching Windows'
already-distinct layout. DataDir/StateDir/CacheDir are unchanged.

Also unify the pm self-reference assignment (pm.pm = pm) across darwin
and windows to match linux and clear the staticcheck finding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized default config and config file locations on macOS and Linux to use the common `~/.config/<AppName>` path.
  * Updated Windows path initialization to ensure path resolution works correctly across platforms.
* **Tests**
  * Added and updated platform-specific tests to verify config, data, and config file paths resolve as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->