### PR TITLE
chore: add FUNDING.yml for GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [skevetter]


### PR DESCRIPTION
Adds `.github/FUNDING.yml` to enable the GitHub Sponsors button for `skevetter`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project funding information so visitors can easily support the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->