### PR TITLE
fix(config): migrate legacy config.yaml after config dir move

### DIFF
--- a/pkg/config/pathmanager.go
+++ b/pkg/config/pathmanager.go
@@ -79,8 +79,6 @@ type basePathManager struct {
 	pm PathManager // self-reference wired after construction
 }
 
-// --- Config paths ---
-
 func (b *basePathManager) ConfigFilePath() (string, error) {
 	if p := os.Getenv(EnvConfig); p != "" {
 		return p, nil
@@ -98,37 +96,6 @@ func (b *basePathManager) ConfigFilePath() (string, error) {
 
 	return configPath, nil
 }
-
-func (b *basePathManager) migrateLegacyConfigFile(configPath string) error {
-	if _, err := os.Stat(configPath); err == nil || !os.IsNotExist(err) {
-		return err
-	}
-
-	dataDir, err := b.pm.DataDir()
-	if err != nil {
-		return err
-	}
-
-	legacyPath := filepath.Join(dataDir, ConfigFile)
-	if legacyPath == configPath {
-		return nil
-	}
-	if _, err := os.Stat(legacyPath); err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-
-		return err
-	}
-
-	if err := os.Rename(legacyPath, configPath); err != nil {
-		return fmt.Errorf("migrate config from %s to %s: %w", legacyPath, configPath, err)
-	}
-
-	return nil
-}
-
-// --- Data sub-paths (context-relative) ---
 
 func (b *basePathManager) ContextDir(context string) (string, error) {
 	dir, err := b.pm.DataDir()
@@ -287,8 +254,6 @@ func (b *basePathManager) LocksDir(context string) (string, error) {
 	return filepath.Join(dir, "locks"), nil
 }
 
-// --- Cache sub-paths ---
-
 func (b *basePathManager) AgentCacheDir() (string, error) {
 	dir, err := b.pm.CacheDir()
 	if err != nil {
@@ -333,8 +298,6 @@ func (b *basePathManager) SSHKeysDir() (string, error) {
 
 	return filepath.Join(dir, "keys"), nil
 }
-
-// --- Runtime sub-paths ---
 
 func (b *basePathManager) DaemonPIDFile() (string, error) {
 	dir, err := b.pm.RuntimeDir()
@@ -390,8 +353,6 @@ func (b *basePathManager) ProcessStreamsFile(name string) (string, error) {
 	return filepath.Join(dir, name+".streams"), nil
 }
 
-// --- State sub-paths ---
-
 func (b *basePathManager) LogDir() (string, error) {
 	dir, err := b.pm.StateDir()
 	if err != nil {
@@ -401,7 +362,34 @@ func (b *basePathManager) LogDir() (string, error) {
 	return filepath.Join(dir, "logs"), nil
 }
 
-// --- Singleton management ---
+func (b *basePathManager) migrateLegacyConfigFile(configPath string) error {
+	if _, err := os.Stat(configPath); err == nil || !os.IsNotExist(err) {
+		return err
+	}
+
+	dataDir, err := b.pm.DataDir()
+	if err != nil {
+		return err
+	}
+
+	legacyPath := filepath.Join(dataDir, ConfigFile)
+	if legacyPath == configPath {
+		return nil
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if err := os.Rename(legacyPath, configPath); err != nil {
+		return fmt.Errorf("migrate config from %s to %s: %w", legacyPath, configPath, err)
+	}
+
+	return nil
+}
 
 var (
 	defaultPM     PathManager

--- a/pkg/config/pathmanager.go
+++ b/pkg/config/pathmanager.go
@@ -91,7 +91,41 @@ func (b *basePathManager) ConfigFilePath() (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(dir, ConfigFile), nil
+	configPath := filepath.Join(dir, ConfigFile)
+	if err := b.migrateLegacyConfigFile(configPath); err != nil {
+		return "", err
+	}
+
+	return configPath, nil
+}
+
+func (b *basePathManager) migrateLegacyConfigFile(configPath string) error {
+	if _, err := os.Stat(configPath); err == nil || !os.IsNotExist(err) {
+		return err
+	}
+
+	dataDir, err := b.pm.DataDir()
+	if err != nil {
+		return err
+	}
+
+	legacyPath := filepath.Join(dataDir, ConfigFile)
+	if legacyPath == configPath {
+		return nil
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	if err := os.Rename(legacyPath, configPath); err != nil {
+		return fmt.Errorf("migrate config from %s to %s: %w", legacyPath, configPath, err)
+	}
+
+	return nil
 }
 
 // --- Data sub-paths (context-relative) ---

--- a/pkg/config/pathmanager_darwin_test.go
+++ b/pkg/config/pathmanager_darwin_test.go
@@ -84,7 +84,7 @@ func TestDarwinConfigFilePath_MigratesLegacyConfig(t *testing.T) {
 		t.Errorf("ConfigFilePath = %q, want %q", got, newPath)
 	}
 
-	migrated, err := os.ReadFile(newPath)
+	migrated, err := os.ReadFile(newPath) // #nosec G304 -- test-controlled temp path
 	if err != nil {
 		t.Fatalf("read migrated config: %v", err)
 	}
@@ -107,7 +107,8 @@ func TestDarwinConfigFilePath_KeepsExistingConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DataDir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dataDir, ConfigFile), []byte("legacy\n"), 0o600); err != nil {
+	legacyPath := filepath.Join(dataDir, ConfigFile)
+	if err := os.WriteFile(legacyPath, []byte("legacy\n"), 0o600); err != nil {
 		t.Fatalf("seed legacy config: %v", err)
 	}
 
@@ -124,7 +125,7 @@ func TestDarwinConfigFilePath_KeepsExistingConfig(t *testing.T) {
 		t.Fatalf("ConfigFilePath: %v", err)
 	}
 
-	got, err := os.ReadFile(newPath)
+	got, err := os.ReadFile(newPath) // #nosec G304 -- test-controlled temp path
 	if err != nil {
 		t.Fatalf("read config: %v", err)
 	}

--- a/pkg/config/pathmanager_darwin_test.go
+++ b/pkg/config/pathmanager_darwin_test.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -53,5 +54,81 @@ func TestDarwinConfigFilePath(t *testing.T) {
 	want := filepath.Join(home, ".config", RepoName, ConfigFile)
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestDarwinConfigFilePath_MigratesLegacyConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(EnvConfig, "")
+
+	pm := newTestDarwinPM()
+
+	dataDir, err := pm.DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	legacyPath := filepath.Join(dataDir, ConfigFile)
+	want := []byte("defaultContext: default\n")
+	if err := os.WriteFile(legacyPath, want, 0o600); err != nil {
+		t.Fatalf("seed legacy config: %v", err)
+	}
+
+	got, err := pm.ConfigFilePath()
+	if err != nil {
+		t.Fatalf("ConfigFilePath: %v", err)
+	}
+
+	newPath := filepath.Join(home, ".config", RepoName, ConfigFile)
+	if got != newPath {
+		t.Errorf("ConfigFilePath = %q, want %q", got, newPath)
+	}
+
+	migrated, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("read migrated config: %v", err)
+	}
+	if string(migrated) != string(want) {
+		t.Errorf("migrated contents = %q, want %q", migrated, want)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Errorf("legacy config still present at %q (err=%v)", legacyPath, err)
+	}
+}
+
+func TestDarwinConfigFilePath_KeepsExistingConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(EnvConfig, "")
+
+	pm := newTestDarwinPM()
+
+	dataDir, err := pm.DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, ConfigFile), []byte("legacy\n"), 0o600); err != nil {
+		t.Fatalf("seed legacy config: %v", err)
+	}
+
+	newPath := filepath.Join(home, ".config", RepoName, ConfigFile)
+	if err := os.MkdirAll(filepath.Dir(newPath), 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	want := []byte("current\n")
+	if err := os.WriteFile(newPath, want, 0o600); err != nil {
+		t.Fatalf("seed current config: %v", err)
+	}
+
+	if _, err := pm.ConfigFilePath(); err != nil {
+		t.Fatalf("ConfigFilePath: %v", err)
+	}
+
+	got, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("config was overwritten: got %q, want %q", got, want)
 	}
 }

--- a/pkg/config/pathmanager_linux_test.go
+++ b/pkg/config/pathmanager_linux_test.go
@@ -114,7 +114,7 @@ func TestConfigFilePathMigratesLegacyConfig(t *testing.T) {
 		t.Errorf("ConfigFilePath = %q, want %q", got, newPath)
 	}
 
-	migrated, err := os.ReadFile(newPath)
+	migrated, err := os.ReadFile(newPath) // #nosec G304 -- test-controlled temp path
 	if err != nil {
 		t.Fatalf("read migrated config: %v", err)
 	}
@@ -139,7 +139,8 @@ func TestConfigFilePathKeepsExistingConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DataDir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dataDir, ConfigFile), []byte("legacy\n"), 0o600); err != nil {
+	legacyPath := filepath.Join(dataDir, ConfigFile)
+	if err := os.WriteFile(legacyPath, []byte("legacy\n"), 0o600); err != nil {
 		t.Fatalf("seed legacy config: %v", err)
 	}
 
@@ -156,7 +157,7 @@ func TestConfigFilePathKeepsExistingConfig(t *testing.T) {
 		t.Fatalf("ConfigFilePath: %v", err)
 	}
 
-	got, err := os.ReadFile(newPath)
+	got, err := os.ReadFile(newPath) // #nosec G304 -- test-controlled temp path
 	if err != nil {
 		t.Fatalf("read config: %v", err)
 	}

--- a/pkg/config/pathmanager_linux_test.go
+++ b/pkg/config/pathmanager_linux_test.go
@@ -85,6 +85,86 @@ func TestConfigFilePathDefault(t *testing.T) {
 	}
 }
 
+func TestConfigFilePathMigratesLegacyConfig(t *testing.T) {
+	skipIfNotLinux(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(EnvConfig, "")
+
+	pm := newTestLinuxPM()
+
+	dataDir, err := pm.DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	legacyPath := filepath.Join(dataDir, ConfigFile)
+	want := []byte("defaultContext: default\n")
+	if err := os.WriteFile(legacyPath, want, 0o600); err != nil {
+		t.Fatalf("seed legacy config: %v", err)
+	}
+
+	got, err := pm.ConfigFilePath()
+	if err != nil {
+		t.Fatalf("ConfigFilePath: %v", err)
+	}
+
+	newPath := filepath.Join(home, ".config", RepoName, ConfigFile)
+	if got != newPath {
+		t.Errorf("ConfigFilePath = %q, want %q", got, newPath)
+	}
+
+	migrated, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("read migrated config: %v", err)
+	}
+	if string(migrated) != string(want) {
+		t.Errorf("migrated contents = %q, want %q", migrated, want)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Errorf("legacy config still present at %q (err=%v)", legacyPath, err)
+	}
+}
+
+func TestConfigFilePathKeepsExistingConfig(t *testing.T) {
+	skipIfNotLinux(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(EnvConfig, "")
+
+	pm := newTestLinuxPM()
+
+	dataDir, err := pm.DataDir()
+	if err != nil {
+		t.Fatalf("DataDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, ConfigFile), []byte("legacy\n"), 0o600); err != nil {
+		t.Fatalf("seed legacy config: %v", err)
+	}
+
+	newPath := filepath.Join(home, ".config", RepoName, ConfigFile)
+	if err := os.MkdirAll(filepath.Dir(newPath), 0o700); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	want := []byte("current\n")
+	if err := os.WriteFile(newPath, want, 0o600); err != nil {
+		t.Fatalf("seed current config: %v", err)
+	}
+
+	if _, err := pm.ConfigFilePath(); err != nil {
+		t.Fatalf("ConfigFilePath: %v", err)
+	}
+
+	got, err := os.ReadFile(newPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("config was overwritten: got %q, want %q", got, want)
+	}
+}
+
 func TestConfigFilePathDEVSYCONFIGOverride(t *testing.T) {
 	custom := "/custom/path/config.yaml"
 	t.Setenv(EnvConfig, custom)


### PR DESCRIPTION
## Summary

v1.4.0-beta.1 broke **every** existing workspace with `provider "docker" is not initialized`.

Root cause: PR #580 moved the unix config directory from `~/.devsy` to `~/.config/devsy` without a migration. Each provider's `Initialized` flag lives in `config.yaml` (`Contexts[ctx].Providers[...].Initialized`), which is read from `ConfigDir`. After upgrade, devsy read an empty config from the new (empty) directory — `LoadConfig` silently returns an empty config when the file is absent — so `provider.State == nil` and the check at `pkg/workspace/workspace.go` failed for all providers.

## Fix

`ConfigFilePath()` now transparently relocates a legacy `DataDir/config.yaml` (`~/.devsy/config.yaml`) into the new `ConfigDir` when the new location is empty. The operation is idempotent and self-limiting:

- Upgrading user: legacy file exists, new path empty → renamed once, carries provider/context state forward.
- Subsequent launches: file already at new path → no-op.
- Fresh install / Windows (where `ConfigDir` always differed from `DataDir`) → no-op; never clobbers an existing config.

Added migration and no-clobber tests for darwin and linux path managers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing configuration files are now automatically moved to the new standard location when first accessed.
  * If a configuration file is already present in the new location, it is left unchanged.
  * Missing legacy config files are handled gracefully without causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->