### PR TITLE
revert(config): restore unix ConfigDir to ~/.devsy

### DIFF
--- a/pkg/config/pathmanager_darwin.go
+++ b/pkg/config/pathmanager_darwin.go
@@ -25,7 +25,7 @@ func (d *darwinPathManager) ConfigDir() (string, error) {
 		return "", fmt.Errorf("config dir: %w", err)
 	}
 
-	return ensureDir(filepath.Join(home, ".config", RepoName))
+	return ensureDir(filepath.Join(home, "."+RepoName))
 }
 
 func (d *darwinPathManager) DataDir() (string, error) {

--- a/pkg/config/pathmanager_darwin_test.go
+++ b/pkg/config/pathmanager_darwin_test.go
@@ -14,7 +14,7 @@ func newTestDarwinPM() PathManager {
 	return pm
 }
 
-func TestDarwinConfigDir_IsUnderXDGConfig(t *testing.T) {
+func TestDarwinConfigDir_SharesDataRoot(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -25,7 +25,7 @@ func TestDarwinConfigDir_IsUnderXDGConfig(t *testing.T) {
 		t.Fatalf("ConfigDir: %v", err)
 	}
 
-	want := filepath.Join(home, ".config", RepoName)
+	want := filepath.Join(home, "."+RepoName)
 	if got != want {
 		t.Errorf("ConfigDir = %q, want %q", got, want)
 	}
@@ -34,8 +34,8 @@ func TestDarwinConfigDir_IsUnderXDGConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DataDir: %v", err)
 	}
-	if got == dataDir {
-		t.Errorf("ConfigDir and DataDir must be distinct, both = %q", got)
+	if got != dataDir {
+		t.Errorf("ConfigDir and DataDir must share the same root: config=%q data=%q", got, dataDir)
 	}
 }
 
@@ -50,7 +50,7 @@ func TestDarwinConfigFilePath(t *testing.T) {
 		t.Fatalf("ConfigFilePath: %v", err)
 	}
 
-	want := filepath.Join(home, ".config", RepoName, ConfigFile)
+	want := filepath.Join(home, "."+RepoName, ConfigFile)
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}

--- a/pkg/config/pathmanager_linux.go
+++ b/pkg/config/pathmanager_linux.go
@@ -25,7 +25,7 @@ func (l *linuxPathManager) ConfigDir() (string, error) {
 		return "", fmt.Errorf("config dir: %w", err)
 	}
 
-	return ensureDir(filepath.Join(home, ".config", RepoName))
+	return ensureDir(filepath.Join(home, "."+RepoName))
 }
 
 func (l *linuxPathManager) DataDir() (string, error) {

--- a/pkg/config/pathmanager_linux_test.go
+++ b/pkg/config/pathmanager_linux_test.go
@@ -45,7 +45,7 @@ func TestLinuxDefaults(t *testing.T) {
 		fn   func() (string, error)
 		want string
 	}{
-		{"ConfigDir", pm.ConfigDir, filepath.Join(home, ".config", RepoName)},
+		{"ConfigDir", pm.ConfigDir, filepath.Join(home, "."+RepoName)},
 		{"DataDir", pm.DataDir, filepath.Join(home, "."+RepoName)},
 		{"CacheDir", pm.CacheDir, filepath.Join(home, ".cache", RepoName)},
 		{"StateDir", pm.StateDir, filepath.Join(home, "."+RepoName, "state")},
@@ -79,7 +79,7 @@ func TestConfigFilePathDefault(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	want := filepath.Join(home, ".config", RepoName, ConfigFile)
+	want := filepath.Join(home, "."+RepoName, ConfigFile)
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

Alternative to #596. Instead of migrating config.yaml forward, this reverts the unix `ConfigDir` move introduced in #580.

#580 moved `ConfigDir` from `~/.devsy` to `~/.config/devsy` on darwin/linux, but left `DataDir`/`StateDir`/`CacheDir` in place. config.yaml holds each provider's `Initialized` flag, while the state it references (contexts, providers, workspaces) stayed under `DataDir` at `~/.devsy`. After upgrading to v1.4.0-beta.1, devsy read an empty config from the new (empty) directory and **every workspace** failed with `provider "docker" is not initialized`.

Since the split was only half-done — config.yaml separated from the data it configures, with no XDG payoff — this restores `ConfigDir` to `~/.devsy` so the two sit together again. This is a true no-op for existing users (their config.yaml never moved).

## Notes

- Keeps the `pm.pm = pm` staticcheck cleanup that #580 also bundled in.
- Windows is unaffected: `ConfigDir` (APPDATA) already differs from `DataDir` (LOCALAPPDATA) there.
- Tests updated to assert `ConfigDir == DataDir` on unix.

If the XDG split is a deliberate direction (moving all dirs under `~/.config` / `~/.local/share`), prefer the migration approach in #596 instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default configuration file locations on Linux and macOS to use a hidden folder in the user’s home directory.
  * Aligned related path checks so config and data locations now follow the same home-based root on macOS.
  * Adjusted expected config file paths in tests to match the new defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->