### PR TITLE
fix(flatpak): launch Electron via zypak-wrapper

### DIFF
--- a/desktop/flatpak/devsy-wrapper
+++ b/desktop/flatpak/devsy-wrapper
@@ -15,4 +15,4 @@ if [ -f "/.flatpak-info" ]; then
     fi
 fi
 
-exec /app/devsy/devsy-desktop "$@"
+exec zypak-wrapper /app/devsy/devsy-desktop "$@"


### PR DESCRIPTION
## Summary

Fixes the Flatpak launch failure reported in #607:

> \`[FATAL:setuid_sandbox_host.cc(163)] The SUID sandbox helper binary was found, but is not configured correctly. ... You need to make sure that /app/devsy/chrome-sandbox is owned by root and has mode 4755.\`

The launch wrapper exec'd the Electron binary directly, bypassing **Zypak**. Chromium then fell back to its setuid \`chrome-sandbox\` helper, which requires \`root:root\` ownership and mode \`4755\` — impossible inside an unprivileged Flatpak sandbox where setuid bits are stripped, so Chromium aborts.

The manifest already declares \`base: org.electronjs.Electron2.BaseApp\`, which bundles Zypak; the wrapper just wasn't using it. Launching via \`zypak-wrapper\` routes Chromium's sandbox through Flatpak's \`bwrap\` instead of the setuid helper.

## Change

\`desktop/flatpak/devsy-wrapper\`:
\`\`\`diff
-exec /app/devsy/devsy-desktop "\$@"
+exec zypak-wrapper /app/devsy/devsy-desktop "\$@"
\`\`\`

Fixes #607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the desktop app starts in packaged builds, helping it launch more reliably in sandboxed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->