### PR TITLE
fix(desktop): fix renderer freeze while streaming workspace logs

### DIFF
--- a/desktop/src/renderer/src/lib/__mocks__/setup.ts
+++ b/desktop/src/renderer/src/lib/__mocks__/setup.ts
@@ -33,6 +33,15 @@ if (
   }
 }
 
+// jsdom doesn't implement ResizeObserver
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+
 // jsdom doesn't implement matchMedia
 if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
   Object.defineProperty(window, "matchMedia", {

--- a/desktop/src/renderer/src/lib/components/log/LogTable.svelte
+++ b/desktop/src/renderer/src/lib/components/log/LogTable.svelte
@@ -1,62 +1,118 @@
 <script lang="ts">
 import { badgeVariants } from "$lib/components/ui/badge/index.js"
-import * as Table from "$lib/components/ui/table/index.js"
 import { parseLogLine } from "$lib/utils/log-parser.js"
 
 let {
   lines,
   class: className = "",
-  maxLines = 5000,
-}: { lines: string[]; class?: string; maxLines?: number } = $props()
+  maxHeightClass = "max-h-96",
+  rowHeight = 28,
+  overscan = 12,
+  follow = false,
+}: {
+  lines: string[]
+  class?: string
+  maxHeightClass?: string
+  rowHeight?: number
+  overscan?: number
+  follow?: boolean
+} = $props()
 
-let truncated = $derived(lines.length > maxLines)
-let hiddenCount = $derived(truncated ? lines.length - maxLines : 0)
-let visibleLines = $derived(truncated ? lines.slice(lines.length - maxLines) : lines)
-let parsed = $derived(visibleLines.map(parseLogLine))
+let viewport = $state<HTMLDivElement | null>(null)
+let scrollTop = $state(0)
+let viewportHeight = $state(0)
+let pinnedToBottom = $state(true)
+
+let total = $derived(lines.length)
+let totalHeight = $derived(total * rowHeight)
+
+let startIndex = $derived(
+  Math.max(0, Math.floor(scrollTop / rowHeight) - overscan),
+)
+let endIndex = $derived(
+  Math.min(
+    total,
+    Math.ceil((scrollTop + viewportHeight) / rowHeight) + overscan,
+  ),
+)
+
+let visible = $derived(
+  lines.slice(startIndex, endIndex).map((raw, i) => ({
+    index: startIndex + i,
+    line: parseLogLine(raw),
+  })),
+)
+
+function onScroll() {
+  if (!viewport) return
+  scrollTop = viewport.scrollTop
+  const distanceFromBottom =
+    viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight
+  pinnedToBottom = distanceFromBottom <= rowHeight
+}
+
+$effect(() => {
+  if (!viewport) return
+  const observer = new ResizeObserver(() => {
+    if (viewport) viewportHeight = viewport.clientHeight
+  })
+  observer.observe(viewport)
+  viewportHeight = viewport.clientHeight
+  return () => observer.disconnect()
+})
+
+$effect(() => {
+  // Follow the tail as new lines arrive, but only while the user is at the bottom.
+  void total
+  if (follow && pinnedToBottom && viewport) {
+    viewport.scrollTop = viewport.scrollHeight
+  }
+})
 </script>
 
-<Table.Root class="w-full table-fixed {className}">
-  <Table.Header class="sticky top-0 z-10 bg-background">
-    <Table.Row>
-      <Table.Head class="w-20">Time</Table.Head>
-      <Table.Head class="w-24">Level</Table.Head>
-      <Table.Head class="max-w-0">Message</Table.Head>
-    </Table.Row>
-  </Table.Header>
-  <Table.Body>
-    {#if truncated}
-      <Table.Row>
-        <Table.Cell colspan={3} class="text-center text-xs text-muted-foreground">
-          {hiddenCount.toLocaleString()} earlier lines hidden — showing the most recent {maxLines.toLocaleString()}
-        </Table.Cell>
-      </Table.Row>
-    {/if}
-    {#each parsed as line, i (i)}
-      <Table.Row
+<div
+  bind:this={viewport}
+  onscroll={onScroll}
+  class="relative overflow-auto rounded-md border {maxHeightClass} {className}"
+>
+  <div
+    class="sticky top-0 z-10 grid grid-cols-[5rem_6rem_1fr] border-b bg-background text-start font-medium"
+    style="height: {rowHeight}px"
+  >
+    <div class="flex items-center px-2">Time</div>
+    <div class="flex items-center px-2">Level</div>
+    <div class="flex items-center px-2">Message</div>
+  </div>
+
+  <div class="relative" style="height: {totalHeight}px">
+    {#each visible as row (row.index)}
+      <div
         class={[
-          line.level === "fatal" || line.level === "error" ? "bg-destructive/5" : "",
-          line.level === "warn" ? "bg-amber-500/5" : "",
+          "absolute grid w-full grid-cols-[5rem_6rem_1fr] items-center border-b",
+          row.line.level === "fatal" || row.line.level === "error" ? "bg-destructive/5" : "",
+          row.line.level === "warn" ? "bg-amber-500/5" : "",
         ].filter(Boolean).join(" ")}
+        style="top: {row.index * rowHeight}px; height: {rowHeight}px"
       >
-        <Table.Cell class="font-mono text-xs text-muted-foreground">{line.time}</Table.Cell>
-        <Table.Cell>
-          {#if line.level}
+        <div class="truncate px-2 font-mono text-xs text-muted-foreground">{row.line.time}</div>
+        <div class="px-2">
+          {#if row.line.level}
             <span
               class={badgeVariants({
                 variant:
-                  line.level === "fatal" || line.level === "error"
+                  row.line.level === "fatal" || row.line.level === "error"
                     ? "destructive"
-                    : line.level === "warn"
+                    : row.line.level === "warn"
                       ? "outline"
                       : "secondary",
               })}
             >
-              {line.level}
+              {row.line.level}
             </span>
           {/if}
-        </Table.Cell>
-        <Table.Cell class="text-sm max-w-0 whitespace-normal break-words" title={line.message}>{line.message}</Table.Cell>
-      </Table.Row>
+        </div>
+        <div class="truncate px-2 text-sm" title={row.line.message}>{row.line.message}</div>
+      </div>
     {/each}
-  </Table.Body>
-</Table.Root>
+  </div>
+</div>

--- a/desktop/src/renderer/src/lib/components/log/LogTable.svelte
+++ b/desktop/src/renderer/src/lib/components/log/LogTable.svelte
@@ -73,20 +73,25 @@ $effect(() => {
 <div
   bind:this={viewport}
   onscroll={onScroll}
+  role="table"
+  aria-rowcount={total}
   class="relative overflow-auto rounded-md border {maxHeightClass} {className}"
 >
   <div
+    role="row"
     class="sticky top-0 z-10 grid grid-cols-[5rem_6rem_1fr] border-b bg-background text-start font-medium"
     style="height: {rowHeight}px"
   >
-    <div class="flex items-center px-2">Time</div>
-    <div class="flex items-center px-2">Level</div>
-    <div class="flex items-center px-2">Message</div>
+    <div role="columnheader" class="flex items-center px-2">Time</div>
+    <div role="columnheader" class="flex items-center px-2">Level</div>
+    <div role="columnheader" class="flex items-center px-2">Message</div>
   </div>
 
-  <div class="relative" style="height: {totalHeight}px">
+  <div role="rowgroup" class="relative" style="height: {totalHeight}px">
     {#each visible as row (row.index)}
       <div
+        role="row"
+        aria-rowindex={row.index + 1}
         class={[
           "absolute grid w-full grid-cols-[5rem_6rem_1fr] items-center border-b",
           row.line.level === "fatal" || row.line.level === "error" ? "bg-destructive/5" : "",
@@ -94,8 +99,8 @@ $effect(() => {
         ].filter(Boolean).join(" ")}
         style="top: {row.index * rowHeight}px; height: {rowHeight}px"
       >
-        <div class="truncate px-2 font-mono text-xs text-muted-foreground">{row.line.time}</div>
-        <div class="px-2">
+        <div role="cell" class="truncate px-2 font-mono text-xs text-muted-foreground">{row.line.time}</div>
+        <div role="cell" class="px-2">
           {#if row.line.level}
             <span
               class={badgeVariants({
@@ -111,7 +116,7 @@ $effect(() => {
             </span>
           {/if}
         </div>
-        <div class="truncate px-2 text-sm" title={row.line.message}>{row.line.message}</div>
+        <div role="cell" class="truncate px-2 text-sm" title={row.line.message}>{row.line.message}</div>
       </div>
     {/each}
   </div>

--- a/desktop/src/renderer/src/lib/components/log/LogTable.svelte
+++ b/desktop/src/renderer/src/lib/components/log/LogTable.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { badgeVariants } from "$lib/components/ui/badge/index.js"
 import { parseLogLine } from "$lib/utils/log-parser.js"
+import { cn } from "$lib/utils.js"
 
 let {
   lines,
@@ -75,7 +76,7 @@ $effect(() => {
   onscroll={onScroll}
   role="table"
   aria-rowcount={total}
-  class="relative overflow-auto rounded-md border {maxHeightClass} {className}"
+  class={cn("relative overflow-auto rounded-md border", maxHeightClass, className)}
 >
   <div
     role="row"

--- a/desktop/src/renderer/src/lib/components/log/LogTable.svelte
+++ b/desktop/src/renderer/src/lib/components/log/LogTable.svelte
@@ -3,10 +3,16 @@ import { badgeVariants } from "$lib/components/ui/badge/index.js"
 import * as Table from "$lib/components/ui/table/index.js"
 import { parseLogLine } from "$lib/utils/log-parser.js"
 
-let { lines, class: className = "" }: { lines: string[]; class?: string } =
-  $props()
+let {
+  lines,
+  class: className = "",
+  maxLines = 5000,
+}: { lines: string[]; class?: string; maxLines?: number } = $props()
 
-let parsed = $derived(lines.map(parseLogLine))
+let truncated = $derived(lines.length > maxLines)
+let hiddenCount = $derived(truncated ? lines.length - maxLines : 0)
+let visibleLines = $derived(truncated ? lines.slice(lines.length - maxLines) : lines)
+let parsed = $derived(visibleLines.map(parseLogLine))
 </script>
 
 <Table.Root class="w-full table-fixed {className}">
@@ -18,6 +24,13 @@ let parsed = $derived(lines.map(parseLogLine))
     </Table.Row>
   </Table.Header>
   <Table.Body>
+    {#if truncated}
+      <Table.Row>
+        <Table.Cell colspan={3} class="text-center text-xs text-muted-foreground">
+          {hiddenCount.toLocaleString()} earlier lines hidden — showing the most recent {maxLines.toLocaleString()}
+        </Table.Cell>
+      </Table.Row>
+    {/if}
     {#each parsed as line, i (i)}
       <Table.Row
         class={[

--- a/desktop/src/renderer/src/lib/components/provider/ProviderWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderWizard.svelte
@@ -529,14 +529,10 @@ function handleDone() {
                 >
                   Show logs
                 </summary>
-                <div class="max-h-48 overflow-y-auto border-t">
-                  <LogTable lines={initLines} />
-                </div>
+                <LogTable lines={initLines} maxHeightClass="max-h-48" class="border-x-0 border-b-0 rounded-none" />
               </details>
             {:else}
-              <div class="max-h-48 overflow-y-auto rounded-md border bg-muted/30">
-                <LogTable lines={initLines} />
-              </div>
+              <LogTable lines={initLines} maxHeightClass="max-h-48" follow />
             {/if}
           {:else if initRunning}
             <div class="flex items-center justify-center py-8">

--- a/desktop/src/renderer/src/lib/components/terminal/Terminal.svelte
+++ b/desktop/src/renderer/src/lib/components/terminal/Terminal.svelte
@@ -32,6 +32,8 @@ let containerEl: HTMLDivElement | undefined = $state()
 let term: Terminal | undefined
 let fitAddon: FitAddon | undefined
 let resizeObserver: ResizeObserver | undefined
+let lastCols = -1
+let lastRows = -1
 
 const darkTheme = {
   background: "#1e1e2e",
@@ -187,11 +189,13 @@ onMount(async () => {
   }
 
   resizeObserver = new ResizeObserver(() => {
-    if (fitAddon && term) {
-      fitAddon.fit()
-      term.refresh(0, term.rows - 1)
-      terminalResize(sessionId, term.cols, term.rows)
-    }
+    if (!fitAddon || !term) return
+    fitAddon.fit()
+    if (term.cols === lastCols && term.rows === lastRows) return
+    lastCols = term.cols
+    lastRows = term.rows
+    term.refresh(0, term.rows - 1)
+    terminalResize(sessionId, term.cols, term.rows)
   })
   resizeObserver.observe(containerEl)
 })

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -208,6 +208,8 @@ let launchedWorkspaceId = $state<string | null>(null)
 let confirmCancelOpen = $state(false)
 let unlisten: UnlistenFn | null = null
 let watchdog: ReturnType<typeof setTimeout> | null = null
+let pendingLines: string[] = []
+let flushHandle: number | null = null
 
 // Image platform compatibility (image source only)
 let hostPlatform = $state("")
@@ -331,6 +333,11 @@ function reset() {
   ideSearch = ""
   commandId = null
   outputLines = []
+  pendingLines = []
+  if (flushHandle !== null) {
+    cancelAnimationFrame(flushHandle)
+    flushHandle = null
+  }
   launchRunning = false
   launchError = ""
   launchSuccess = false
@@ -400,16 +407,32 @@ onMount(() => {
 onDestroy(() => {
   unlisten?.()
   clearWatchdog()
+  if (flushHandle !== null) {
+    cancelAnimationFrame(flushHandle)
+    flushHandle = null
+  }
 })
+
+function flushLines() {
+  flushHandle = null
+  if (pendingLines.length === 0) return
+  outputLines = [...outputLines, ...pendingLines]
+  pendingLines = []
+  outputEl?.scrollIntoView?.({ block: "end", behavior: "smooth" })
+}
 
 function handleProgress(progress: CommandProgress, wsId: string | undefined) {
   if (progress.message) {
-    outputLines = [...outputLines, progress.message]
-    requestAnimationFrame(() => {
-      outputEl?.scrollIntoView?.({ block: "end", behavior: "smooth" })
-    })
+    pendingLines.push(progress.message)
+    if (flushHandle === null) {
+      flushHandle = requestAnimationFrame(flushLines)
+    }
   }
   if (progress.done) {
+    if (flushHandle !== null) {
+      cancelAnimationFrame(flushHandle)
+    }
+    flushLines()
     launchRunning = false
     clearWatchdog()
     if (isCommandSuccess(progress.message)) {
@@ -430,6 +453,11 @@ async function handleLaunch() {
   launchError = ""
   launchSuccess = false
   outputLines = []
+  pendingLines = []
+  if (flushHandle !== null) {
+    cancelAnimationFrame(flushHandle)
+    flushHandle = null
+  }
   commandId = null
   launchedWorkspaceId = null
   clearWatchdog()

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -200,7 +200,6 @@ let ideSearch = $state("")
 // Launch state
 let commandId = $state<string | null>(null)
 let outputLines = $state<string[]>([])
-let outputEl = $state<HTMLDivElement | null>(null)
 let launchRunning = $state(false)
 let launchError = $state("")
 let launchSuccess = $state(false)
@@ -418,7 +417,6 @@ function flushLines() {
   if (pendingLines.length === 0) return
   outputLines = [...outputLines, ...pendingLines]
   pendingLines = []
-  outputEl?.scrollIntoView?.({ block: "end", behavior: "smooth" })
 }
 
 function handleProgress(progress: CommandProgress, wsId: string | undefined) {
@@ -1149,10 +1147,7 @@ function selectTemplate(t: { name: string; source: string }) {
                   Copy
                 </Button>
               </div>
-              <div class="max-h-80 overflow-auto rounded-md border">
-                <LogTable lines={outputLines} />
-                <div bind:this={outputEl}></div>
-              </div>
+              <LogTable lines={outputLines} maxHeightClass="max-h-80" follow />
             </div>
           {:else if launchRunning}
             <div class="flex items-center justify-center py-8">

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -415,8 +415,8 @@ onDestroy(() => {
 function flushLines() {
   flushHandle = null
   if (pendingLines.length === 0) return
-  outputLines = [...outputLines, ...pendingLines]
-  pendingLines = []
+  outputLines.push(...pendingLines)
+  pendingLines.length = 0
 }
 
 function handleProgress(progress: CommandProgress, wsId: string | undefined) {

--- a/desktop/src/renderer/src/lib/utils/log-parser.ts
+++ b/desktop/src/renderer/src/lib/utils/log-parser.ts
@@ -86,7 +86,24 @@ function tryParseInnerLog(
  *
  * ANSI codes are stripped before parsing.
  */
+const parseCache = new Map<string, ParsedLogLine>()
+const PARSE_CACHE_MAX = 10_000
+
 export function parseLogLine(raw: string): ParsedLogLine {
+  const cached = parseCache.get(raw)
+  if (cached) return cached
+
+  const result = parseLogLineUncached(raw)
+
+  if (parseCache.size >= PARSE_CACHE_MAX) {
+    const oldest = parseCache.keys().next().value
+    if (oldest !== undefined) parseCache.delete(oldest)
+  }
+  parseCache.set(raw, result)
+  return result
+}
+
+function parseLogLineUncached(raw: string): ParsedLogLine {
   const clean = stripAnsi(raw)
 
   // Zap console format (tab-separated): ISO8601\tLEVEL\tmessage\tsource.go:NNN

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -153,8 +153,8 @@ let filteredIdes = $derived(
 function flushLines() {
   flushHandle = null
   if (pendingLines.length === 0) return
-  outputLines = [...outputLines, ...pendingLines]
-  pendingLines = []
+  outputLines.push(...pendingLines)
+  pendingLines.length = 0
 }
 
 async function copyToClipboard(text: string) {

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -112,6 +112,8 @@ let operationLabel = $state("")
 let operationRunning = $state(false)
 let unlisten: UnlistenFn | null = null
 let tableEndEl = $state<HTMLDivElement | null>(null)
+let pendingLines: string[] = []
+let flushHandle: number | null = null
 
 let logEntries = $state<LogEntry[]>([])
 let selectedLog = $state<string | null>(null)
@@ -155,6 +157,14 @@ function scrollToBottom() {
   }
 }
 
+function flushLines() {
+  flushHandle = null
+  if (pendingLines.length === 0) return
+  outputLines = [...outputLines, ...pendingLines]
+  pendingLines = []
+  scrollToBottom()
+}
+
 async function copyToClipboard(text: string) {
   try {
     await navigator.clipboard.writeText(text)
@@ -169,10 +179,16 @@ onMount(async () => {
     unlisten = await onCommandProgress((progress) => {
       if (commandId && progress.commandId === commandId) {
         if (progress.message) {
-          outputLines = [...outputLines, progress.message]
-          requestAnimationFrame(scrollToBottom)
+          pendingLines.push(progress.message)
+          if (flushHandle === null) {
+            flushHandle = requestAnimationFrame(flushLines)
+          }
         }
         if (progress.done) {
+          if (flushHandle !== null) {
+            cancelAnimationFrame(flushHandle)
+          }
+          flushLines()
           operationRunning = false
           const success = isCommandSuccess(progress.message)
           if (success) {
@@ -213,6 +229,10 @@ onMount(async () => {
 
 onDestroy(() => {
   unlisten?.()
+  if (flushHandle !== null) {
+    cancelAnimationFrame(flushHandle)
+    flushHandle = null
+  }
   // Clean up SSH session if navigating away
   if (sshSessionId) {
     if (!sshExited) {
@@ -313,6 +333,11 @@ function startStreamingOp(label: string) {
   operationLabel = label
   operationRunning = true
   outputLines = []
+  pendingLines = []
+  if (flushHandle !== null) {
+    cancelAnimationFrame(flushHandle)
+    flushHandle = null
+  }
   activeTab = "logs"
 }
 

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -111,7 +111,6 @@ let commandId = $state<string | null>(null)
 let operationLabel = $state("")
 let operationRunning = $state(false)
 let unlisten: UnlistenFn | null = null
-let tableEndEl = $state<HTMLDivElement | null>(null)
 let pendingLines: string[] = []
 let flushHandle: number | null = null
 
@@ -151,18 +150,11 @@ let filteredIdes = $derived(
   ),
 )
 
-function scrollToBottom() {
-  if (tableEndEl) {
-    tableEndEl.scrollIntoView({ block: "end", behavior: "smooth" })
-  }
-}
-
 function flushLines() {
   flushHandle = null
   if (pendingLines.length === 0) return
   outputLines = [...outputLines, ...pendingLines]
   pendingLines = []
-  scrollToBottom()
 }
 
 async function copyToClipboard(text: string) {
@@ -708,18 +700,15 @@ async function handleRenameConfirmed() {
                     </Tooltip.Root>
                   </div>
                 {/if}
-                <div class="max-h-96 overflow-auto rounded-md border">
-                  {#if outputLines.length === 0}
-                    <div class="flex items-center justify-center p-4">
-                      <p class="text-sm text-muted-foreground">
-                        {operationRunning ? "Waiting for output..." : "No output yet. Run an operation to see live output."}
-                      </p>
-                    </div>
-                  {:else}
-                    <LogTable lines={outputLines} />
-                    <div bind:this={tableEndEl}></div>
-                  {/if}
-                </div>
+                {#if outputLines.length === 0}
+                  <div class="flex items-center justify-center rounded-md border p-4">
+                    <p class="text-sm text-muted-foreground">
+                      {operationRunning ? "Waiting for output..." : "No output yet. Run an operation to see live output."}
+                    </p>
+                  </div>
+                {:else}
+                  <LogTable lines={outputLines} follow />
+                {/if}
               </Accordion.Content>
             </Accordion.Item>
 
@@ -786,13 +775,11 @@ async function handleRenameConfirmed() {
                           </div>
                         </div>
                         <Accordion.Content>
-                          <div class="max-h-96 overflow-auto rounded-md border">
-                            {#if selectedLog === entry.filename}
-                              <LogTable lines={logContent.split("\n")} />
-                            {:else}
-                              <p class="p-4 text-sm text-muted-foreground">Loading...</p>
-                            {/if}
-                          </div>
+                          {#if selectedLog === entry.filename}
+                            <LogTable lines={logContent.split("\n")} />
+                          {:else}
+                            <p class="rounded-md border p-4 text-sm text-muted-foreground">Loading...</p>
+                          {/if}
                         </Accordion.Content>
                       </Accordion.Item>
                     {/each}


### PR DESCRIPTION
## Summary

Fixes a renderer freeze where the desktop window pinned the main thread at 100% CPU and became unresponsive. Reproduced during workspace creation (wizard launch tab) while the container streamed logs: the log view froze even though the underlying CLI completed the launch successfully. A representative launch produced a **3.4 MB / 12,456-line** log with individual lines up to ~13 KB.

Diagnosed via `sample` on a frozen renderer: the main thread was spinning permanently inside `v8::MicrotasksScope::PerformCheckpoint` (JIT frames, unsymbolized).

## Root cause

Three compounding costs on the log-rendering path:

1. **Per-line reactive flush** — each `CommandProgress` event did `outputLines = [...outputLines, msg]` plus a scroll `requestAnimationFrame`, so a fast stream produced one full Svelte state flush per line.
2. **Quadratic re-parse** — `LogTable` re-derived `parsed = lines.map(parseLogLine)` over the *entire* buffer on every append; each line ran several regexes + `JSON.parse`. Line N re-parsed all N−1 prior lines.
3. **Unbounded DOM** — `LogTable` rendered one table row per line, so a large log built tens of thousands of DOM nodes in one synchronous layout.

## Changes

- **`log-parser.ts`** — memoize `parseLogLine` (bounded `Map`, cap 10k). Each unique line is parsed once.
- **`WorkspaceWizard.svelte`** / **`WorkspaceDetailPage.svelte`** — coalesce incoming lines into `pendingLines` and flush once per animation frame instead of per line. Cleared on reset, new operation start, and `onDestroy`.
- **`LogTable.svelte`** — **virtualized (windowed) rendering**. The component owns its scroll viewport and renders only the rows visible in view (plus overscan) as fixed-height absolutely-positioned rows over a full-height spacer. A 12k-line log mounts a handful of DOM nodes; the full log is scrollable with no pagination and no truncation. An opt-in `follow` mode pins to the tail as lines stream, but only while the user is already at the bottom. Consumers dropped their outer scroll wrappers and manual `scrollIntoView` hooks.
- **`Terminal.svelte`** ResizeObserver guard was **split into #610** (unrelated defensive hardening).

## Verification

- `npx svelte-check` on the renderer: **0 errors** (1 pre-existing unrelated warning).
- `npx vitest run`: **243/243 tests pass**. (One main-process suite, `cli.test.ts`, fails only because deps were installed with `--ignore-scripts` so Electron's binary wasn't fetched — unrelated to these changes; CI installs normally.)

## Notes

A live symbolized profile was not captured; the O(n²) / unbounded-DOM path is strongly supported by the source audit and the exact repro (freeze while streaming a 3.4 MB log, CLI succeeds).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live logs now use a virtualized, scrollable viewer with “follow to latest” behavior.
* **Bug Fixes**
  * Live output is now batch-rendered to reduce flicker and prevent missed updates during rapid progress.
  * Log streaming cleanup now cancels any pending UI updates to avoid stale output.
  * Terminal resizing avoids redundant refresh/IPC notifications.
* **Performance Improvements**
  * Log parsing is accelerated via cached results with size limits.
* **Tests**
  * Test environments now include a safe `ResizeObserver` fallback when missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->