### PR TITLE
fix(desktop): guard terminal ResizeObserver against feedback loop

### DIFF
--- a/desktop/src/renderer/src/lib/components/terminal/Terminal.svelte
+++ b/desktop/src/renderer/src/lib/components/terminal/Terminal.svelte
@@ -32,6 +32,8 @@ let containerEl: HTMLDivElement | undefined = $state()
 let term: Terminal | undefined
 let fitAddon: FitAddon | undefined
 let resizeObserver: ResizeObserver | undefined
+let lastCols = -1
+let lastRows = -1
 
 const darkTheme = {
   background: "#1e1e2e",
@@ -187,11 +189,13 @@ onMount(async () => {
   }
 
   resizeObserver = new ResizeObserver(() => {
-    if (fitAddon && term) {
-      fitAddon.fit()
-      term.refresh(0, term.rows - 1)
-      terminalResize(sessionId, term.cols, term.rows)
-    }
+    if (!fitAddon || !term) return
+    fitAddon.fit()
+    if (term.cols === lastCols && term.rows === lastRows) return
+    lastCols = term.cols
+    lastRows = term.rows
+    term.refresh(0, term.rows - 1)
+    terminalResize(sessionId, term.cols, term.rows)
   })
   resizeObserver.observe(containerEl)
 })


### PR DESCRIPTION
## Summary

Defensive hardening for the terminal `ResizeObserver`. The callback previously called `fitAddon.fit()`, `term.refresh()`, and the `terminalResize` IPC unconditionally on every fire. Because `fit()` mutates the terminal's dimensions, it can re-fire the observer — the classic ResizeObserver feedback loop that can recompute every frame under an oscillating layout and sustain high CPU.

Track the last propagated `cols`/`rows` and early-return when the grid size is unchanged. `fit()` still runs so layout stays correct, but `refresh()`/IPC only fire on a genuine size change.

## Notes

Split out of #609 (renderer freeze while streaming logs). This change is unrelated to that freeze and is purely preventive — no confirmed reproduction of a ResizeObserver loop.