### PR TITLE
fix(delivery): cleanup build files for mounted volume

### DIFF
--- a/pkg/agent/delivery/local_docker_test.go
+++ b/pkg/agent/delivery/local_docker_test.go
@@ -453,8 +453,6 @@ func TestLocalDockerDelivery_SeedExcludesBuildInternal(t *testing.T) {
 func TestLocalDockerDelivery_Seed_CopyAndCleanupFailureJoined(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Fresh volume (inspect fails), copy fails, and cleanup (volume rm) also
-	// fails: both errors must surface rather than be swallowed.
 	scriptPath := filepath.Join(tmpDir, "fake-docker.sh")
 	script := "#!/bin/sh\n" +
 		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"inspect\" ]; then exit 1; fi\n" +

--- a/pkg/agent/delivery/local_docker_test.go
+++ b/pkg/agent/delivery/local_docker_test.go
@@ -450,37 +450,6 @@ func TestLocalDockerDelivery_SeedExcludesBuildInternal(t *testing.T) {
 	assert.Contains(t, string(logged), ".devsy-internal")
 }
 
-func TestLocalDockerDelivery_Seed_LegacySentinelNotReseeded(t *testing.T) {
-	tmpDir := t.TempDir()
-	logPath := filepath.Join(tmpDir, "run.log")
-
-	// Managed volume with no seeded label but the legacy sentinel present:
-	// inspect reports managed=true, seeded empty; the sentinel probe (run sh -c
-	// "[ -e ... ]") succeeds. Seeding must be skipped, so no copy runs.
-	scriptPath := filepath.Join(tmpDir, "fake-docker.sh")
-	script := "#!/bin/sh\n" +
-		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"--format\" ]; then\n" +
-		"  echo 'true,'; exit 0\n" +
-		"fi\n" +
-		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"inspect\" ]; then exit 0; fi\n" +
-		"if [ \"$1\" = \"run\" ]; then echo \"$@\" >> \"" + logPath + "\"; exit 0; fi\n" +
-		"exit 0\n"
-	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
-	// #nosec G302 -- test script must be executable
-	require.NoError(t, os.Chmod(scriptPath, 0o755))
-
-	d := &LocalDockerDelivery{DockerCommand: scriptPath}
-	err := d.SeedWorkspaceVolume(context.Background(), WorkspaceSeedOptions{
-		WorkspaceID: testSeedWorkspaceID,
-		VolumeName:  testSeedVolumeName,
-		SourceDir:   testSeedSourceDir,
-	})
-	require.NoError(t, err)
-
-	logged, _ := os.ReadFile(logPath) //nolint:gosec // test reads a temp file we control
-	assert.NotContains(t, string(logged), "/source", "copy must not run for a legacy-seeded volume")
-}
-
 func TestLocalDockerDelivery_Seed_CopyAndCleanupFailureJoined(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/pkg/agent/delivery/local_docker_test.go
+++ b/pkg/agent/delivery/local_docker_test.go
@@ -420,8 +420,6 @@ func TestLocalDockerDelivery_SeedExcludesBuildInternal(t *testing.T) {
 	tmpDir := t.TempDir()
 	logPath := filepath.Join(tmpDir, "run.log")
 
-	// Fake docker records the `run` invocation so the test can assert the copy
-	// command excludes devsy's build-internal folder.
 	scriptPath := filepath.Join(tmpDir, "fake-docker.sh")
 	script := "#!/bin/sh\n" +
 		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"inspect\" ]; then exit 1; fi\n" +

--- a/pkg/agent/delivery/local_docker_test.go
+++ b/pkg/agent/delivery/local_docker_test.go
@@ -16,6 +16,12 @@ import (
 
 const testArch = "amd64"
 
+const (
+	testSeedWorkspaceID = "ws1"
+	testSeedVolumeName  = "ws1-workspace"
+	testSeedSourceDir   = "/local/src"
+)
+
 func TestLocalDockerDelivery_Phase(t *testing.T) {
 	d := &LocalDockerDelivery{}
 	assert.Equal(t, PhasePreStart, d.Phase())
@@ -432,9 +438,9 @@ func TestLocalDockerDelivery_SeedExcludesBuildInternal(t *testing.T) {
 
 	d := &LocalDockerDelivery{DockerCommand: scriptPath}
 	err := d.SeedWorkspaceVolume(context.Background(), WorkspaceSeedOptions{
-		WorkspaceID: "ws1",
-		VolumeName:  "ws1-workspace",
-		SourceDir:   "/local/src",
+		WorkspaceID: testSeedWorkspaceID,
+		VolumeName:  testSeedVolumeName,
+		SourceDir:   testSeedSourceDir,
 	})
 	require.NoError(t, err)
 
@@ -442,4 +448,62 @@ func TestLocalDockerDelivery_SeedExcludesBuildInternal(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, string(logged), "--exclude")
 	assert.Contains(t, string(logged), ".devsy-internal")
+}
+
+func TestLocalDockerDelivery_Seed_LegacySentinelNotReseeded(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "run.log")
+
+	// Managed volume with no seeded label but the legacy sentinel present:
+	// inspect reports managed=true, seeded empty; the sentinel probe (run sh -c
+	// "[ -e ... ]") succeeds. Seeding must be skipped, so no copy runs.
+	scriptPath := filepath.Join(tmpDir, "fake-docker.sh")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"inspect\" ] && [ \"$3\" = \"--format\" ]; then\n" +
+		"  echo 'true,'; exit 0\n" +
+		"fi\n" +
+		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"inspect\" ]; then exit 0; fi\n" +
+		"if [ \"$1\" = \"run\" ]; then echo \"$@\" >> \"" + logPath + "\"; exit 0; fi\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+	// #nosec G302 -- test script must be executable
+	require.NoError(t, os.Chmod(scriptPath, 0o755))
+
+	d := &LocalDockerDelivery{DockerCommand: scriptPath}
+	err := d.SeedWorkspaceVolume(context.Background(), WorkspaceSeedOptions{
+		WorkspaceID: testSeedWorkspaceID,
+		VolumeName:  testSeedVolumeName,
+		SourceDir:   testSeedSourceDir,
+	})
+	require.NoError(t, err)
+
+	logged, _ := os.ReadFile(logPath) //nolint:gosec // test reads a temp file we control
+	assert.NotContains(t, string(logged), "/source", "copy must not run for a legacy-seeded volume")
+}
+
+func TestLocalDockerDelivery_Seed_CopyAndCleanupFailureJoined(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Fresh volume (inspect fails), copy fails, and cleanup (volume rm) also
+	// fails: both errors must surface rather than be swallowed.
+	scriptPath := filepath.Join(tmpDir, "fake-docker.sh")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"inspect\" ]; then exit 1; fi\n" +
+		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"create\" ]; then exit 0; fi\n" +
+		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"rm\" ]; then echo 'rm boom' 1>&2; exit 1; fi\n" +
+		"if [ \"$1\" = \"run\" ]; then echo 'copy boom' 1>&2; exit 1; fi\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+	// #nosec G302 -- test script must be executable
+	require.NoError(t, os.Chmod(scriptPath, 0o755))
+
+	d := &LocalDockerDelivery{DockerCommand: scriptPath}
+	err := d.SeedWorkspaceVolume(context.Background(), WorkspaceSeedOptions{
+		WorkspaceID: testSeedWorkspaceID,
+		VolumeName:  testSeedVolumeName,
+		SourceDir:   testSeedSourceDir,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "seed workspace volume")
+	assert.Contains(t, err.Error(), "remove partial volume")
 }

--- a/pkg/agent/delivery/local_docker_test.go
+++ b/pkg/agent/delivery/local_docker_test.go
@@ -415,3 +415,33 @@ func TestLocalDockerDelivery_Cleanup_RemovesManagedVolumes(t *testing.T) {
 	assert.Contains(t, removed, "devsy-agent-ws1")
 	assert.Contains(t, removed, "ws1-workspace")
 }
+
+func TestLocalDockerDelivery_SeedExcludesBuildInternal(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "run.log")
+
+	// Fake docker records the `run` invocation so the test can assert the copy
+	// command excludes devsy's build-internal folder.
+	scriptPath := filepath.Join(tmpDir, "fake-docker.sh")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"inspect\" ]; then exit 1; fi\n" +
+		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"create\" ]; then exit 0; fi\n" +
+		"if [ \"$1\" = \"run\" ]; then echo \"$@\" >> \"" + logPath + "\"; exit 0; fi\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+	// #nosec G302 -- test script must be executable
+	require.NoError(t, os.Chmod(scriptPath, 0o755))
+
+	d := &LocalDockerDelivery{DockerCommand: scriptPath}
+	err := d.SeedWorkspaceVolume(context.Background(), WorkspaceSeedOptions{
+		WorkspaceID: "ws1",
+		VolumeName:  "ws1-workspace",
+		SourceDir:   "/local/src",
+	})
+	require.NoError(t, err)
+
+	logged, err := os.ReadFile(logPath) //nolint:gosec // test reads a temp file we control
+	require.NoError(t, err)
+	assert.Contains(t, string(logged), "--exclude")
+	assert.Contains(t, string(logged), ".devsy-internal")
+}

--- a/pkg/agent/delivery/workspace_seed.go
+++ b/pkg/agent/delivery/workspace_seed.go
@@ -52,8 +52,6 @@ func (d *LocalDockerDelivery) SeedWorkspaceVolume(
 		return nil
 	}
 
-	// Seeded state is a label, not a file: the volume mounts at the workspace
-	// folder, so a marker file at its root would show up as untracked content.
 	labels := pkgconfig.DockerVolumeLabels(opts.WorkspaceID, pkgconfig.VolumeRoleWorkspace)
 	labels[pkgconfig.DockerSeededLabel] = pkgconfig.LabelValueTrue
 	if err := d.createVolume(ctx, opts.VolumeName, labels); err != nil {
@@ -61,8 +59,6 @@ func (d *LocalDockerDelivery) SeedWorkspaceVolume(
 	}
 
 	if err := d.copyDirIntoVolume(ctx, opts.SourceDir, opts.VolumeName); err != nil {
-		// Remove the volume so its seeded label does not persist for an empty
-		// volume; the next up re-creates and re-seeds.
 		if rmErr := d.removeVolume(ctx, opts.VolumeName); rmErr != nil {
 			log.Debugf("failed to remove volume after seed failure: %v", rmErr)
 		}
@@ -112,8 +108,6 @@ func (d *LocalDockerDelivery) prepareSeedTarget(
 	return true, nil
 }
 
-// volumeSeedState reports whether the volume is devsy-managed and whether it
-// has already been seeded, both read from the volume's labels.
 func (d *LocalDockerDelivery) volumeSeedState(
 	ctx context.Context,
 	name string,
@@ -141,8 +135,7 @@ func (d *LocalDockerDelivery) volumeExists(ctx context.Context, name string) boo
 }
 
 // copyDirIntoVolume copies sourceDir into the volume root via a throwaway
-// helper container, excluding devsy's build artifacts so they never surface as
-// untracked files in the seeded workspace tree.
+// helper container, excluding devsy's build artifacts.
 func (d *LocalDockerDelivery) copyDirIntoVolume(
 	ctx context.Context,
 	sourceDir, volumeName string,

--- a/pkg/agent/delivery/workspace_seed.go
+++ b/pkg/agent/delivery/workspace_seed.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/log"
 )
 
@@ -148,17 +149,21 @@ func (d *LocalDockerDelivery) copyDirIntoVolume(
 	ctx context.Context,
 	sourceDir, volumeName string,
 ) error {
-	// Preserve attributes (-p), recurse into everything, and drop devsy's
-	// build-internal folder wherever it appears in the tree.
-	script := "cd /source && tar -c" +
-		" --exclude='" + pkgconfig.ConfigDirName + "-internal'" +
-		" . | tar -x -C /target"
+	// tar preserves attributes and recurses; excluding devsy's build artifacts
+	// keeps its scaffolding out of the seeded workspace tree. As a safety net —
+	// build cleanup should already have removed them before seeding runs.
+	var script strings.Builder
+	script.WriteString("cd /source && tar -c")
+	for _, artifact := range config.BuildArtifactExcludes() {
+		script.WriteString(" --exclude='" + artifact + "'")
+	}
+	script.WriteString(" . | tar -x -C /target")
 	args := []string{
 		cmdRun, flagRM,
 		"-v", sourceDir + ":/source:ro",
 		"-v", volumeName + ":/target",
 		d.helperImageName(),
-		"sh", "-c", script,
+		"sh", "-c", script.String(),
 	}
 	out, err := d.cmd(ctx, args...).CombinedOutput()
 	if err != nil {

--- a/pkg/agent/delivery/workspace_seed.go
+++ b/pkg/agent/delivery/workspace_seed.go
@@ -11,11 +11,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 )
 
-// legacySeededSentinel is the pre-label marker file older devsy versions wrote
-// into a seeded volume. Retained only to recognize volumes seeded before the
-// seeded label existed.
-const legacySeededSentinel = ".devsy-seeded"
-
 // WorkspaceSeedOptions describes a request to seed a named workspace volume
 // from a local source directory.
 type WorkspaceSeedOptions struct {
@@ -138,28 +133,7 @@ func (d *LocalDockerDelivery) volumeSeedState(
 		return false, false, fmt.Errorf("inspect volume %s: %s: %w", name, string(out), err)
 	}
 	managedStr, seededStr, _ := strings.Cut(strings.TrimSpace(string(out)), ",")
-	managed = managedStr == pkgconfig.LabelValueTrue
-	seeded = seededStr == pkgconfig.LabelValueTrue
-
-	// Volumes seeded by older versions predate the seeded label and are only
-	// marked by a sentinel file; treat that as seeded so they are not
-	// re-seeded over user changes.
-	if managed && !seeded && d.volumeHasLegacySentinel(ctx, name) {
-		seeded = true
-	}
-	return managed, seeded, nil
-}
-
-// volumeHasLegacySentinel reports whether the pre-label seeded marker file is
-// present in the volume.
-func (d *LocalDockerDelivery) volumeHasLegacySentinel(ctx context.Context, name string) bool {
-	args := []string{
-		cmdRun, flagRM,
-		"-v", name + ":/target:ro",
-		d.helperImageName(),
-		"sh", "-c", "[ -e /target/" + legacySeededSentinel + " ]",
-	}
-	return d.cmd(ctx, args...).Run() == nil
+	return managedStr == pkgconfig.LabelValueTrue, seededStr == pkgconfig.LabelValueTrue, nil
 }
 
 func (d *LocalDockerDelivery) volumeExists(ctx context.Context, name string) bool {

--- a/pkg/agent/delivery/workspace_seed.go
+++ b/pkg/agent/delivery/workspace_seed.go
@@ -60,9 +60,6 @@ func (d *LocalDockerDelivery) SeedWorkspaceVolume(
 	}
 
 	if err := d.copyDirIntoVolume(ctx, opts.SourceDir, opts.VolumeName); err != nil {
-		// The volume is now labeled seeded but holds partial contents. Removing
-		// it lets the next up re-seed; if removal also fails, surface both so a
-		// partial volume is never silently treated as complete.
 		if rmErr := d.removeVolume(ctx, opts.VolumeName); rmErr != nil {
 			return errors.Join(
 				fmt.Errorf("seed workspace volume: %w", err),
@@ -141,8 +138,6 @@ func (d *LocalDockerDelivery) volumeExists(ctx context.Context, name string) boo
 	return err == nil
 }
 
-// copyDirIntoVolume copies sourceDir into the volume root via a throwaway
-// helper container, excluding devsy's build artifacts.
 func (d *LocalDockerDelivery) copyDirIntoVolume(
 	ctx context.Context,
 	sourceDir, volumeName string,

--- a/pkg/agent/delivery/workspace_seed.go
+++ b/pkg/agent/delivery/workspace_seed.go
@@ -51,19 +51,24 @@ func (d *LocalDockerDelivery) SeedWorkspaceVolume(
 		return nil
 	}
 
+	// The seeded state is recorded as a volume label rather than a file so
+	// nothing is written into the workspace tree (the volume is mounted at the
+	// workspace folder, so a file at its root would appear as untracked content).
 	labels := pkgconfig.DockerVolumeLabels(opts.WorkspaceID, pkgconfig.VolumeRoleWorkspace)
+	labels[pkgconfig.DockerSeededLabel] = pkgconfig.LabelValueTrue
 	if err := d.createVolume(ctx, opts.VolumeName, labels); err != nil {
 		return fmt.Errorf("create workspace volume: %w", err)
 	}
 
 	if err := d.copyDirIntoVolume(ctx, opts.SourceDir, opts.VolumeName); err != nil {
-		// Leave the volume in place but unseeded so a retry re-copies.
+		// Remove the volume so its seeded label does not persist for an empty
+		// volume; the next up then re-creates and re-seeds cleanly.
+		if rmErr := d.removeVolume(ctx, opts.VolumeName); rmErr != nil {
+			log.Debugf("failed to remove volume after seed failure: %v", rmErr)
+		}
 		return fmt.Errorf("seed workspace volume: %w", err)
 	}
 
-	if err := d.markVolumeSeeded(ctx, opts.VolumeName); err != nil {
-		log.Debugf("failed to mark volume %s seeded: %v", opts.VolumeName, err)
-	}
 	log.Infof("seeded workspace volume %s from %s", opts.VolumeName, opts.SourceDir)
 	return nil
 }
@@ -107,10 +112,8 @@ func (d *LocalDockerDelivery) prepareSeedTarget(
 	return true, nil
 }
 
-// volumeSeedState reports whether the volume is devsy-managed (from its label)
-// and whether it has already been seeded (from a sentinel file written inside
-// the volume after a successful copy). Docker cannot add labels to an existing
-// volume, so seeded state is tracked with the sentinel rather than a label.
+// volumeSeedState reports whether the volume is devsy-managed and whether it
+// has already been seeded, both read from the volume's labels.
 func (d *LocalDockerDelivery) volumeSeedState(
 	ctx context.Context,
 	name string,
@@ -121,26 +124,15 @@ func (d *LocalDockerDelivery) volumeSeedState(
 
 	out, err := d.cmd(ctx,
 		"volume", "inspect",
-		"--format", "{{index .Labels \""+pkgconfig.DockerManagedLabel+"\"}}",
+		"--format", "{{index .Labels \""+pkgconfig.DockerManagedLabel+"\"}},"+
+			"{{index .Labels \""+pkgconfig.DockerSeededLabel+"\"}}",
 		name,
 	).CombinedOutput()
 	if err != nil {
 		return false, false, fmt.Errorf("inspect volume %s: %s: %w", name, string(out), err)
 	}
-	managed = strings.TrimSpace(string(out)) == "true"
-
-	return managed, d.volumeSeeded(ctx, name), nil
-}
-
-// volumeSeeded reports whether the seeded sentinel file exists in the volume.
-func (d *LocalDockerDelivery) volumeSeeded(ctx context.Context, name string) bool {
-	args := []string{
-		cmdRun, flagRM,
-		"-v", name + ":/target:ro",
-		d.helperImageName(),
-		"sh", "-c", "[ -e /target/" + seededSentinel + " ]",
-	}
-	return d.cmd(ctx, args...).Run() == nil
+	managedStr, seededStr, _ := strings.Cut(strings.TrimSpace(string(out)), ",")
+	return managedStr == pkgconfig.LabelValueTrue, seededStr == pkgconfig.LabelValueTrue, nil
 }
 
 func (d *LocalDockerDelivery) volumeExists(ctx context.Context, name string) bool {
@@ -149,17 +141,24 @@ func (d *LocalDockerDelivery) volumeExists(ctx context.Context, name string) boo
 }
 
 // copyDirIntoVolume copies the contents of sourceDir into the volume root using
-// a throwaway helper container. The source is bind-mounted read-only.
+// a throwaway helper container. The source is bind-mounted read-only. devsy's
+// own transient build artifacts are excluded so they do not appear as untracked
+// files in the seeded workspace tree.
 func (d *LocalDockerDelivery) copyDirIntoVolume(
 	ctx context.Context,
 	sourceDir, volumeName string,
 ) error {
+	// Preserve attributes (-p), recurse into everything, and drop devsy's
+	// build-internal folder wherever it appears in the tree.
+	script := "cd /source && tar -c" +
+		" --exclude='" + pkgconfig.ConfigDirName + "-internal'" +
+		" . | tar -x -C /target"
 	args := []string{
 		cmdRun, flagRM,
 		"-v", sourceDir + ":/source:ro",
 		"-v", volumeName + ":/target",
 		d.helperImageName(),
-		"sh", "-c", "cp -a /source/. /target/",
+		"sh", "-c", script,
 	}
 	out, err := d.cmd(ctx, args...).CombinedOutput()
 	if err != nil {
@@ -167,22 +166,3 @@ func (d *LocalDockerDelivery) copyDirIntoVolume(
 	}
 	return nil
 }
-
-// markVolumeSeeded records that the volume has been populated by writing a
-// sentinel file inside it. Docker cannot add labels to an existing volume, so
-// the sentinel is the source of truth for seeded state.
-func (d *LocalDockerDelivery) markVolumeSeeded(ctx context.Context, volumeName string) error {
-	args := []string{
-		cmdRun, flagRM,
-		"-v", volumeName + ":/target",
-		d.helperImageName(),
-		"sh", "-c", "touch /target/" + seededSentinel,
-	}
-	out, err := d.cmd(ctx, args...).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%s: %w", string(out), err)
-	}
-	return nil
-}
-
-const seededSentinel = ".devsy-seeded"

--- a/pkg/agent/delivery/workspace_seed.go
+++ b/pkg/agent/delivery/workspace_seed.go
@@ -52,9 +52,8 @@ func (d *LocalDockerDelivery) SeedWorkspaceVolume(
 		return nil
 	}
 
-	// The seeded state is recorded as a volume label rather than a file so
-	// nothing is written into the workspace tree (the volume is mounted at the
-	// workspace folder, so a file at its root would appear as untracked content).
+	// Seeded state is a label, not a file: the volume mounts at the workspace
+	// folder, so a marker file at its root would show up as untracked content.
 	labels := pkgconfig.DockerVolumeLabels(opts.WorkspaceID, pkgconfig.VolumeRoleWorkspace)
 	labels[pkgconfig.DockerSeededLabel] = pkgconfig.LabelValueTrue
 	if err := d.createVolume(ctx, opts.VolumeName, labels); err != nil {
@@ -63,7 +62,7 @@ func (d *LocalDockerDelivery) SeedWorkspaceVolume(
 
 	if err := d.copyDirIntoVolume(ctx, opts.SourceDir, opts.VolumeName); err != nil {
 		// Remove the volume so its seeded label does not persist for an empty
-		// volume; the next up then re-creates and re-seeds cleanly.
+		// volume; the next up re-creates and re-seeds.
 		if rmErr := d.removeVolume(ctx, opts.VolumeName); rmErr != nil {
 			log.Debugf("failed to remove volume after seed failure: %v", rmErr)
 		}
@@ -141,17 +140,13 @@ func (d *LocalDockerDelivery) volumeExists(ctx context.Context, name string) boo
 	return err == nil
 }
 
-// copyDirIntoVolume copies the contents of sourceDir into the volume root using
-// a throwaway helper container. The source is bind-mounted read-only. devsy's
-// own transient build artifacts are excluded so they do not appear as untracked
-// files in the seeded workspace tree.
+// copyDirIntoVolume copies sourceDir into the volume root via a throwaway
+// helper container, excluding devsy's build artifacts so they never surface as
+// untracked files in the seeded workspace tree.
 func (d *LocalDockerDelivery) copyDirIntoVolume(
 	ctx context.Context,
 	sourceDir, volumeName string,
 ) error {
-	// tar preserves attributes and recurses; excluding devsy's build artifacts
-	// keeps its scaffolding out of the seeded workspace tree. As a safety net —
-	// build cleanup should already have removed them before seeding runs.
 	var script strings.Builder
 	script.WriteString("cd /source && tar -c")
 	for _, artifact := range config.BuildArtifactExcludes() {

--- a/pkg/agent/delivery/workspace_seed.go
+++ b/pkg/agent/delivery/workspace_seed.go
@@ -2,6 +2,7 @@ package delivery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,11 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/log"
 )
+
+// legacySeededSentinel is the pre-label marker file older devsy versions wrote
+// into a seeded volume. Retained only to recognize volumes seeded before the
+// seeded label existed.
+const legacySeededSentinel = ".devsy-seeded"
 
 // WorkspaceSeedOptions describes a request to seed a named workspace volume
 // from a local source directory.
@@ -59,8 +65,14 @@ func (d *LocalDockerDelivery) SeedWorkspaceVolume(
 	}
 
 	if err := d.copyDirIntoVolume(ctx, opts.SourceDir, opts.VolumeName); err != nil {
+		// The volume is now labeled seeded but holds partial contents. Removing
+		// it lets the next up re-seed; if removal also fails, surface both so a
+		// partial volume is never silently treated as complete.
 		if rmErr := d.removeVolume(ctx, opts.VolumeName); rmErr != nil {
-			log.Debugf("failed to remove volume after seed failure: %v", rmErr)
+			return errors.Join(
+				fmt.Errorf("seed workspace volume: %w", err),
+				fmt.Errorf("remove partial volume %s: %w", opts.VolumeName, rmErr),
+			)
 		}
 		return fmt.Errorf("seed workspace volume: %w", err)
 	}
@@ -126,7 +138,28 @@ func (d *LocalDockerDelivery) volumeSeedState(
 		return false, false, fmt.Errorf("inspect volume %s: %s: %w", name, string(out), err)
 	}
 	managedStr, seededStr, _ := strings.Cut(strings.TrimSpace(string(out)), ",")
-	return managedStr == pkgconfig.LabelValueTrue, seededStr == pkgconfig.LabelValueTrue, nil
+	managed = managedStr == pkgconfig.LabelValueTrue
+	seeded = seededStr == pkgconfig.LabelValueTrue
+
+	// Volumes seeded by older versions predate the seeded label and are only
+	// marked by a sentinel file; treat that as seeded so they are not
+	// re-seeded over user changes.
+	if managed && !seeded && d.volumeHasLegacySentinel(ctx, name) {
+		seeded = true
+	}
+	return managed, seeded, nil
+}
+
+// volumeHasLegacySentinel reports whether the pre-label seeded marker file is
+// present in the volume.
+func (d *LocalDockerDelivery) volumeHasLegacySentinel(ctx context.Context, name string) bool {
+	args := []string{
+		cmdRun, flagRM,
+		"-v", name + ":/target:ro",
+		d.helperImageName(),
+		"sh", "-c", "[ -e /target/" + legacySeededSentinel + " ]",
+	}
+	return d.cmd(ctx, args...).Run() == nil
 }
 
 func (d *LocalDockerDelivery) volumeExists(ctx context.Context, name string) bool {

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -453,6 +453,9 @@ func (t *tunnelServer) StreamWorkspace(
 		}
 	}
 
+	// Keep transient build artifacts out of the workspace tree we ship remote.
+	excludes = append(excludes, config.BuildArtifactExcludes()...)
+
 	buf := bufio.NewWriterSize(NewStreamWriter(stream), 10*1024)
 	err = extract.WriteTarExclude(buf, t.workspace.Source.LocalFolder, false, excludes)
 	if err != nil {
@@ -496,6 +499,9 @@ func (t *tunnelServer) StreamMount(
 			}
 		}
 	}
+
+	// Keep transient build artifacts out of the mount tree we ship remote.
+	excludes = append(excludes, config.BuildArtifactExcludes()...)
 
 	buf := bufio.NewWriterSize(NewStreamWriter(stream), 10*1024)
 	err := extract.WriteTarExclude(buf, mount.Source, false, excludes)

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -453,7 +453,6 @@ func (t *tunnelServer) StreamWorkspace(
 		}
 	}
 
-	// Keep transient build artifacts out of the workspace tree we ship remote.
 	excludes = append(excludes, config.BuildArtifactExcludes()...)
 
 	buf := bufio.NewWriterSize(NewStreamWriter(stream), 10*1024)
@@ -500,7 +499,6 @@ func (t *tunnelServer) StreamMount(
 		}
 	}
 
-	// Keep transient build artifacts out of the mount tree we ship remote.
 	excludes = append(excludes, config.BuildArtifactExcludes()...)
 
 	buf := bufio.NewWriterSize(NewStreamWriter(stream), 10*1024)

--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -43,15 +43,6 @@ func (r *runner) build(
 		return nil, err
 	}
 
-	// Remove artifacts eagerly so they are gone before any later step copies
-	// the workspace tree (e.g. volume seeding); the deferred cleanup in Up
-	// covers the error paths above. Dockerless builds are the exception: the
-	// image is built later inside the container, so their artifacts must
-	// survive and are cleaned up by the dockerless flow itself.
-	if buildInfo.Dockerless == nil {
-		config.RemoveBuildArtifacts(config.GetContextPath(parsedConfig.Config))
-	}
-
 	// Add extra devcontainer config if provided
 	if options.ExtraDevContainerPath != "" {
 		if buildInfo.ImageMetadata == nil {

--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -43,6 +43,14 @@ func (r *runner) build(
 		return nil, err
 	}
 
+	// The build has consumed the on-disk artifacts (feature scaffolding,
+	// generated Dockerfiles), so remove them eagerly here rather than relying
+	// solely on the deferred cleanup in Up. This ensures they are gone before
+	// any later step that copies the workspace tree (e.g. volume seeding), so
+	// devsy's scaffolding never leaks into the workspace. The deferred cleanup
+	// remains as a safety net for the error paths above.
+	config.RemoveBuildArtifacts(config.GetContextPath(parsedConfig.Config))
+
 	// Add extra devcontainer config if provided
 	if options.ExtraDevContainerPath != "" {
 		if buildInfo.ImageMetadata == nil {
@@ -672,8 +680,7 @@ func getContainerContextAndDockerfile(
 }
 
 func cleanupBuildInformation(c *config.DevContainerConfig) {
-	contextPath := config.GetContextPath(c)
-	_ = os.RemoveAll(filepath.Join(contextPath, config.DevsyContextFeatureFolder))
+	config.RemoveBuildArtifacts(config.GetContextPath(c))
 }
 
 func featureSecretOpts(options provider.BuildOptions) *feature.SecretOptions {

--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -45,8 +45,12 @@ func (r *runner) build(
 
 	// Remove artifacts eagerly so they are gone before any later step copies
 	// the workspace tree (e.g. volume seeding); the deferred cleanup in Up
-	// covers the error paths above.
-	config.RemoveBuildArtifacts(config.GetContextPath(parsedConfig.Config))
+	// covers the error paths above. Dockerless builds are the exception: the
+	// image is built later inside the container, so their artifacts must
+	// survive and are cleaned up by the dockerless flow itself.
+	if buildInfo.Dockerless == nil {
+		config.RemoveBuildArtifacts(config.GetContextPath(parsedConfig.Config))
+	}
 
 	// Add extra devcontainer config if provided
 	if options.ExtraDevContainerPath != "" {

--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -43,12 +43,9 @@ func (r *runner) build(
 		return nil, err
 	}
 
-	// The build has consumed the on-disk artifacts (feature scaffolding,
-	// generated Dockerfiles), so remove them eagerly here rather than relying
-	// solely on the deferred cleanup in Up. This ensures they are gone before
-	// any later step that copies the workspace tree (e.g. volume seeding), so
-	// devsy's scaffolding never leaks into the workspace. The deferred cleanup
-	// remains as a safety net for the error paths above.
+	// Remove artifacts eagerly so they are gone before any later step copies
+	// the workspace tree (e.g. volume seeding); the deferred cleanup in Up
+	// covers the error paths above.
 	config.RemoveBuildArtifacts(config.GetContextPath(parsedConfig.Config))
 
 	// Add extra devcontainer config if provided

--- a/pkg/devcontainer/config/artifacts.go
+++ b/pkg/devcontainer/config/artifacts.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/devsy-org/devsy/pkg/log"
 )
 
 var buildArtifactNames = []string{
@@ -18,6 +20,9 @@ func BuildArtifactExcludes() []string {
 // RemoveBuildArtifacts deletes devsy's build artifacts from contextPath.
 func RemoveBuildArtifacts(contextPath string) {
 	for _, name := range buildArtifactNames {
-		_ = os.RemoveAll(filepath.Join(contextPath, name))
+		path := filepath.Join(contextPath, name)
+		if err := os.RemoveAll(path); err != nil {
+			log.Debugf("failed to remove build artifact %s: %v", path, err)
+		}
 	}
 }

--- a/pkg/devcontainer/config/artifacts.go
+++ b/pkg/devcontainer/config/artifacts.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// buildArtifactNames are the workspace-relative names devsy writes into the
+// build context for its own bookkeeping (feature scaffolding, generated
+// Dockerfiles, etc.). They are transient build-time artifacts, never workspace
+// content, and never needed at runtime.
+//
+// This is the single source of truth: anything that copies, hashes, or cleans
+// the workspace/build-context tree must consult these helpers rather than
+// hard-coding names, so a new artifact only needs to be added here.
+var buildArtifactNames = []string{
+	DevsyContextFeatureFolder,
+}
+
+// BuildArtifactExcludes returns the artifact names to exclude when copying or
+// hashing a tree (e.g. workspace-volume seeding, prebuild-hash computation).
+// Names are relative to the tree root; callers apply them per their own
+// matching syntax (tar --exclude, dockerignore, etc.).
+func BuildArtifactExcludes() []string {
+	return append([]string(nil), buildArtifactNames...)
+}
+
+// RemoveBuildArtifacts deletes devsy's build artifacts from contextPath. It is
+// best-effort and safe to call when they are absent.
+func RemoveBuildArtifacts(contextPath string) {
+	for _, name := range buildArtifactNames {
+		_ = os.RemoveAll(filepath.Join(contextPath, name))
+	}
+}

--- a/pkg/devcontainer/config/artifacts.go
+++ b/pkg/devcontainer/config/artifacts.go
@@ -11,13 +11,10 @@ var buildArtifactNames = []string{
 	DevsyContextFeatureFolder,
 }
 
-// BuildArtifactExcludes returns the build artifact names to exclude when
-// copying, streaming, or hashing a workspace tree.
 func BuildArtifactExcludes() []string {
 	return append([]string(nil), buildArtifactNames...)
 }
 
-// RemoveBuildArtifacts deletes devsy's build artifacts from contextPath.
 func RemoveBuildArtifacts(contextPath string) {
 	for _, name := range buildArtifactNames {
 		path := filepath.Join(contextPath, name)

--- a/pkg/devcontainer/config/artifacts.go
+++ b/pkg/devcontainer/config/artifacts.go
@@ -5,25 +5,17 @@ import (
 	"path/filepath"
 )
 
-// buildArtifactNames is the single source of truth for the transient files
-// devsy writes into the build context.
-//
-// Invariant: any operation that copies, streams, or hashes a workspace tree
-// must exclude these via BuildArtifactExcludes. That exclusion — not the
-// best-effort RemoveBuildArtifacts cleanup — is what keeps artifacts out of a
-// user's workspace, so correctness never depends on cleanup timing.
 var buildArtifactNames = []string{
 	DevsyContextFeatureFolder,
 }
 
-// BuildArtifactExcludes returns the artifact names, relative to the tree root,
-// for callers to exclude when copying, streaming, or hashing the tree.
+// BuildArtifactExcludes returns the build artifact names to exclude when
+// copying, streaming, or hashing a workspace tree.
 func BuildArtifactExcludes() []string {
 	return append([]string(nil), buildArtifactNames...)
 }
 
 // RemoveBuildArtifacts deletes devsy's build artifacts from contextPath.
-// Best-effort tidiness only; see the invariant on buildArtifactNames.
 func RemoveBuildArtifacts(contextPath string) {
 	for _, name := range buildArtifactNames {
 		_ = os.RemoveAll(filepath.Join(contextPath, name))

--- a/pkg/devcontainer/config/artifacts.go
+++ b/pkg/devcontainer/config/artifacts.go
@@ -6,20 +6,24 @@ import (
 )
 
 // buildArtifactNames is the single source of truth for the transient files
-// devsy writes into the build context. Consumers that copy, hash, or clean the
-// tree consult the helpers below rather than hard-coding names.
+// devsy writes into the build context.
+//
+// Invariant: any operation that copies, streams, or hashes a workspace tree
+// must exclude these via BuildArtifactExcludes. That exclusion — not the
+// best-effort RemoveBuildArtifacts cleanup — is what keeps artifacts out of a
+// user's workspace, so correctness never depends on cleanup timing.
 var buildArtifactNames = []string{
 	DevsyContextFeatureFolder,
 }
 
 // BuildArtifactExcludes returns the artifact names, relative to the tree root,
-// for callers to exclude when copying or hashing (tar, dockerignore, etc.).
+// for callers to exclude when copying, streaming, or hashing the tree.
 func BuildArtifactExcludes() []string {
 	return append([]string(nil), buildArtifactNames...)
 }
 
 // RemoveBuildArtifacts deletes devsy's build artifacts from contextPath.
-// Best-effort and safe to call when they are absent.
+// Best-effort tidiness only; see the invariant on buildArtifactNames.
 func RemoveBuildArtifacts(contextPath string) {
 	for _, name := range buildArtifactNames {
 		_ = os.RemoveAll(filepath.Join(contextPath, name))

--- a/pkg/devcontainer/config/artifacts.go
+++ b/pkg/devcontainer/config/artifacts.go
@@ -5,28 +5,21 @@ import (
 	"path/filepath"
 )
 
-// buildArtifactNames are the workspace-relative names devsy writes into the
-// build context for its own bookkeeping (feature scaffolding, generated
-// Dockerfiles, etc.). They are transient build-time artifacts, never workspace
-// content, and never needed at runtime.
-//
-// This is the single source of truth: anything that copies, hashes, or cleans
-// the workspace/build-context tree must consult these helpers rather than
-// hard-coding names, so a new artifact only needs to be added here.
+// buildArtifactNames is the single source of truth for the transient files
+// devsy writes into the build context. Consumers that copy, hash, or clean the
+// tree consult the helpers below rather than hard-coding names.
 var buildArtifactNames = []string{
 	DevsyContextFeatureFolder,
 }
 
-// BuildArtifactExcludes returns the artifact names to exclude when copying or
-// hashing a tree (e.g. workspace-volume seeding, prebuild-hash computation).
-// Names are relative to the tree root; callers apply them per their own
-// matching syntax (tar --exclude, dockerignore, etc.).
+// BuildArtifactExcludes returns the artifact names, relative to the tree root,
+// for callers to exclude when copying or hashing (tar, dockerignore, etc.).
 func BuildArtifactExcludes() []string {
 	return append([]string(nil), buildArtifactNames...)
 }
 
-// RemoveBuildArtifacts deletes devsy's build artifacts from contextPath. It is
-// best-effort and safe to call when they are absent.
+// RemoveBuildArtifacts deletes devsy's build artifacts from contextPath.
+// Best-effort and safe to call when they are absent.
 func RemoveBuildArtifacts(contextPath string) {
 	for _, name := range buildArtifactNames {
 		_ = os.RemoveAll(filepath.Join(contextPath, name))

--- a/pkg/devcontainer/config/artifacts_test.go
+++ b/pkg/devcontainer/config/artifacts_test.go
@@ -15,7 +15,6 @@ func TestBuildArtifactExcludesIncludesFeatureFolder(t *testing.T) {
 }
 
 func TestBuildArtifactExcludesReturnsCopy(t *testing.T) {
-	// Mutating the returned slice must not affect the source of truth.
 	got := BuildArtifactExcludes()
 	if len(got) == 0 {
 		t.Fatal("expected at least one artifact")
@@ -33,7 +32,6 @@ func TestRemoveBuildArtifacts(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(artifactDir, "0"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	// A real workspace file that must survive.
 	keep := filepath.Join(contextPath, "keep.txt")
 	// #nosec G306 -- test fixture
 	if err := os.WriteFile(keep, []byte("x"), 0o644); err != nil {
@@ -51,6 +49,5 @@ func TestRemoveBuildArtifacts(t *testing.T) {
 }
 
 func TestRemoveBuildArtifactsAbsentIsNoError(t *testing.T) {
-	// Safe to call when nothing exists.
 	RemoveBuildArtifacts(t.TempDir())
 }

--- a/pkg/devcontainer/config/artifacts_test.go
+++ b/pkg/devcontainer/config/artifacts_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestBuildArtifactExcludesIncludesFeatureFolder(t *testing.T) {
+	got := BuildArtifactExcludes()
+	if !slices.Contains(got, DevsyContextFeatureFolder) {
+		t.Errorf("expected %q in excludes, got %v", DevsyContextFeatureFolder, got)
+	}
+}
+
+func TestBuildArtifactExcludesReturnsCopy(t *testing.T) {
+	// Mutating the returned slice must not affect the source of truth.
+	got := BuildArtifactExcludes()
+	if len(got) == 0 {
+		t.Fatal("expected at least one artifact")
+	}
+	got[0] = "mutated"
+	if BuildArtifactExcludes()[0] == "mutated" {
+		t.Error("BuildArtifactExcludes must return a defensive copy")
+	}
+}
+
+func TestRemoveBuildArtifacts(t *testing.T) {
+	contextPath := t.TempDir()
+	artifactDir := filepath.Join(contextPath, DevsyContextFeatureFolder)
+	// #nosec G301 -- test fixture
+	if err := os.MkdirAll(filepath.Join(artifactDir, "0"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A real workspace file that must survive.
+	keep := filepath.Join(contextPath, "keep.txt")
+	// #nosec G306 -- test fixture
+	if err := os.WriteFile(keep, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	RemoveBuildArtifacts(contextPath)
+
+	if _, err := os.Stat(artifactDir); !os.IsNotExist(err) {
+		t.Errorf("expected artifact dir removed, stat err = %v", err)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Errorf("workspace file should survive, got %v", err)
+	}
+}
+
+func TestRemoveBuildArtifactsAbsentIsNoError(t *testing.T) {
+	// Safe to call when nothing exists.
+	RemoveBuildArtifacts(t.TempDir())
+}

--- a/pkg/devcontainer/config/prebuild.go
+++ b/pkg/devcontainer/config/prebuild.go
@@ -42,7 +42,11 @@ func CalculatePrebuildHash(params PrebuildHashParams) (string, error) {
 		log.Debugf("failed to read .dockerignore: %v", err)
 		return "", fmt.Errorf("failed to read dockerignore: %w", err)
 	}
-	excludes = append(excludes, DevsyContextFeatureFolder+"/")
+	// devsy's own build artifacts are recreated per build, so exclude them from
+	// the prebuild hash to keep the cache key stable.
+	for _, artifact := range BuildArtifactExcludes() {
+		excludes = append(excludes, artifact+"/")
+	}
 
 	var includes []string
 	if params.BuildInfo != nil && params.BuildInfo.Dockerfile != nil {

--- a/pkg/devcontainer/config/prebuild.go
+++ b/pkg/devcontainer/config/prebuild.go
@@ -42,7 +42,6 @@ func CalculatePrebuildHash(params PrebuildHashParams) (string, error) {
 		log.Debugf("failed to read .dockerignore: %v", err)
 		return "", fmt.Errorf("failed to read dockerignore: %w", err)
 	}
-	// Artifacts are recreated per build; exclude them to keep the hash stable.
 	for _, artifact := range BuildArtifactExcludes() {
 		excludes = append(excludes, artifact+"/")
 	}

--- a/pkg/devcontainer/config/prebuild.go
+++ b/pkg/devcontainer/config/prebuild.go
@@ -42,8 +42,7 @@ func CalculatePrebuildHash(params PrebuildHashParams) (string, error) {
 		log.Debugf("failed to read .dockerignore: %v", err)
 		return "", fmt.Errorf("failed to read dockerignore: %w", err)
 	}
-	// devsy's own build artifacts are recreated per build, so exclude them from
-	// the prebuild hash to keep the cache key stable.
+	// Artifacts are recreated per build; exclude them to keep the hash stable.
 	for _, artifact := range BuildArtifactExcludes() {
 		excludes = append(excludes, artifact+"/")
 	}

--- a/pkg/devcontainer/prebuild.go
+++ b/pkg/devcontainer/prebuild.go
@@ -25,8 +25,6 @@ func (r *runner) Build(ctx context.Context, options provider.BuildOptions) (stri
 
 	prebuildRepo := getPrebuildRepository(substitutedConfig)
 
-	// Tidy up transient build artifacts once the build completes; correctness
-	// relies on the exclude at copy time, not on this cleanup.
 	defer config.RemoveBuildArtifacts(config.GetContextPath(substitutedConfig.Config))
 
 	// check if we need to build container

--- a/pkg/devcontainer/prebuild.go
+++ b/pkg/devcontainer/prebuild.go
@@ -25,7 +25,8 @@ func (r *runner) Build(ctx context.Context, options provider.BuildOptions) (stri
 
 	prebuildRepo := getPrebuildRepository(substitutedConfig)
 
-	// remove build information (safety net; build() also cleans up eagerly)
+	// Tidy up transient build artifacts once the build completes; correctness
+	// relies on the exclude at copy time, not on this cleanup.
 	defer config.RemoveBuildArtifacts(config.GetContextPath(substitutedConfig.Config))
 
 	// check if we need to build container

--- a/pkg/devcontainer/prebuild.go
+++ b/pkg/devcontainer/prebuild.go
@@ -3,8 +3,6 @@ package devcontainer
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/build"
@@ -27,11 +25,8 @@ func (r *runner) Build(ctx context.Context, options provider.BuildOptions) (stri
 
 	prebuildRepo := getPrebuildRepository(substitutedConfig)
 
-	// remove build information
-	defer func() {
-		contextPath := config.GetContextPath(substitutedConfig.Config)
-		_ = os.RemoveAll(filepath.Join(contextPath, config.DevsyContextFeatureFolder))
-	}()
+	// remove build information (safety net; build() also cleans up eagerly)
+	defer config.RemoveBuildArtifacts(config.GetContextPath(substitutedConfig.Config))
 
 	// check if we need to build container
 	buildInfo, err := r.build(ctx, substitutedConfig, substitutionContext, options)


### PR DESCRIPTION
## Summary

Follow-up fix for the workspace-volume seeding added in #605. On a seeded workspace, `git status` showed devsy artifacts as uncommitted/untracked content:

```
new file:   .devcontainer/skevetter/Dockerfile
...
Untracked files:
    .devcontainer/skevetter/.devsy-internal/
    .devsy-seeded
```

The workspace volume is mounted at the workspace folder, so the volume root **is** the git working tree. Two seed artifacts leaked into it:

- **`.devsy-seeded`** — the seed marker was written as a file at the volume root. It is now tracked as an `sh.devsy.seeded` **volume label** instead (set at volume creation). The volume is removed on copy failure so the label never persists for an empty volume, preserving idempotent re-seed behavior.
- **`.devsy-internal/`** — devsy's transient Dockerfile-build folder was captured by the `cp -a` seed (the build runs before the seed and its cleanup is deferred). The copy now uses `tar` with `--exclude` for that folder, preserving attributes/permissions.

## Verification
Verified on an SSH provider with a Dockerfile-based devcontainer:
- Seeded workspace tree contains only project content — no `.devsy-seeded`, no `.devsy-internal`.
- `.git`, file contents, and executable bits preserved.
- Label-based idempotency still skips re-seeding on subsequent ups (in-volume edits persist).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace seeding and content streaming now skip build artifacts, helping keep synced and uploaded content cleaner.
* **Bug Fixes**
  * Seeded workspace volumes are now tracked more reliably, and failed seeding attempts clean up the volume for a fresh retry.
  * Build cleanup now removes build-related artifacts more thoroughly, reducing leftover files between runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->