### PR TITLE
fix(docker): remap container UID when remote user comes from image metadata

### DIFF
--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -331,10 +331,6 @@ func (r *runner) finalizeComposeContainer(
 		return nil, fmt.Errorf("get image metadata from container: %w", err)
 	}
 
-	if err := r.updateContainerUserUID(ctx, parsedConfig); err != nil {
-		return nil, err
-	}
-
 	mergedConfig, err := mergeImageMetadataConfig(
 		ctx,
 		parsedConfig,
@@ -342,6 +338,11 @@ func (r *runner) finalizeComposeContainer(
 		options.ExtraDevContainerPath,
 	)
 	if err != nil {
+		return nil, err
+	}
+
+	resolvedConfig := withResolvedUser(parsedConfig.Config, mergedConfig)
+	if err := r.updateContainerUserUID(ctx, resolvedConfig); err != nil {
 		return nil, err
 	}
 
@@ -372,7 +373,7 @@ func (r *runner) finalizeComposeContainer(
 // updateContainerUserUID updates the container user's UID/GID on Docker drivers.
 func (r *runner) updateContainerUserUID(
 	ctx context.Context,
-	parsedConfig *config.SubstitutedConfig,
+	parsedConfig *config.DevContainerConfig,
 ) error {
 	dockerDriver, ok := r.Driver.(driver.DockerDriver)
 	if !ok {
@@ -383,7 +384,7 @@ func (r *runner) updateContainerUserUID(
 	if err := dockerDriver.UpdateContainerUserUID(
 		ctx,
 		r.ID,
-		parsedConfig.Config,
+		parsedConfig,
 		writer,
 	); err != nil {
 		log.Errorf("failed to update container user UID/GID: error=%v", err)

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -534,7 +534,7 @@ func (r *runner) runContainer(
 		return dockerDriver.RunDockerDevContainer(ctx, &driver.RunDockerDevContainerParams{
 			WorkspaceID:          r.ID,
 			Options:              runOptions,
-			ParsedConfig:         p.parsedConfig.Config,
+			ParsedConfig:         withResolvedUser(p.parsedConfig.Config, mergedConfig),
 			IDE:                  r.WorkspaceConfig.Workspace.IDE.Name,
 			IDEOptions:           r.WorkspaceConfig.Workspace.IDE.Options,
 			LocalWorkspaceFolder: r.LocalWorkspaceFolder,
@@ -544,6 +544,21 @@ func (r *runner) runContainer(
 
 	// build run options for regular driver
 	return r.Driver.RunDevContainer(ctx, r.ID, runOptions)
+}
+
+// withResolvedUser returns a copy of parsedConfig carrying the effective user
+// identity from the merged config. remoteUser/containerUser/updateRemoteUserUID
+// often come from image metadata rather than the raw devcontainer.json, so the
+// container UID/GID remap must see the merged values or it silently skips.
+func withResolvedUser(
+	parsedConfig *config.DevContainerConfig,
+	mergedConfig *config.MergedDevContainerConfig,
+) *config.DevContainerConfig {
+	resolved := config.CloneDevContainerConfig(parsedConfig)
+	resolved.RemoteUser = mergedConfig.RemoteUser
+	resolved.ContainerUser = mergedConfig.ContainerUser
+	resolved.UpdateRemoteUserUID = mergedConfig.UpdateRemoteUserUID
+	return resolved
 }
 
 // parseWorkspaceMount parses the substituted workspace mount, returning nil when

--- a/pkg/devcontainer/single_test.go
+++ b/pkg/devcontainer/single_test.go
@@ -91,3 +91,32 @@ func TestWorkspaceMountDestination(t *testing.T) { //nolint:funlen // table-driv
 		})
 	}
 }
+
+func TestWithResolvedUser(t *testing.T) {
+	parsed := &config.DevContainerConfig{}
+	parsed.RunArgs = []string{"--cap-add=SYS_PTRACE"}
+
+	uid := true
+	merged := &config.MergedDevContainerConfig{}
+	merged.RemoteUser = "vscode"
+	merged.ContainerUser = "node"
+	merged.UpdateRemoteUserUID = &uid
+
+	got := withResolvedUser(parsed, merged)
+
+	if got.RemoteUser != "vscode" {
+		t.Errorf("RemoteUser = %q, want vscode", got.RemoteUser)
+	}
+	if got.ContainerUser != "node" {
+		t.Errorf("ContainerUser = %q, want node", got.ContainerUser)
+	}
+	if got.UpdateRemoteUserUID == nil || !*got.UpdateRemoteUserUID {
+		t.Errorf("UpdateRemoteUserUID = %v, want true", got.UpdateRemoteUserUID)
+	}
+	if len(got.RunArgs) != 1 || got.RunArgs[0] != "--cap-add=SYS_PTRACE" {
+		t.Errorf("RunArgs not preserved: %v", got.RunArgs)
+	}
+	if parsed.RemoteUser != "" {
+		t.Error("source config must not be mutated")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a `permission denied` failure on re-`up` for git-clone workspaces whose remote user comes from image metadata (e.g. `mcr.microsoft.com/devcontainers/*` images set `remoteUser: vscode`).

The container UID/GID remap (`UpdateContainerUserUID`) gated on the **raw** `devcontainer.json`'s `remoteUser`/`containerUser`. Those fields are commonly empty because the user is defined in image metadata, not the JSON. With the raw config empty, `shouldUpdateUserUID` returned false, the remap was skipped, and the in-container workspace chown left the bind-mounted host tree owned by the container UID (1000). On the next `up`, the host agent (a different UID) could no longer read the tree, reported *"Couldn't find a devcontainer.json"*, and failed writing a default one with `permission denied`.

The fix passes the **merged** config's resolved user identity (`remoteUser`/`containerUser`/`updateRemoteUserUID`) to the remap on both the single-container and compose paths, so the container user is remapped to match the host user.

## Changes

- `withResolvedUser` helper overlays the merged user identity onto the config handed to the UID remap.
- `runContainer` (single-container) and `finalizeComposeContainer` (compose) now use it. Compose builds the merged config before the remap so the resolved user is available.

## Verification

Reproduced and fixed end-to-end on a remote `ws3-ssh` provider with `github.com/microsoft/vscode-remote-try-python`:

- Before: run 1 succeeds, run 2 fails with `permission denied` writing `.devcontainer.json`. Confirmed identical on the pre-fix commit, so this is a pre-existing bug, not a regression.
- After: container `vscode` remapped to the host UID (502), host tree owned by the host user, and runs 2 and 3 succeed with a clean git tree and no spurious default `.devcontainer.json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed container user ID/GID handling so workspace permissions now reflect the resolved image and dev container user settings.
  * Improved repo re-run behavior for setups that derive the remote user from image metadata.
* **Tests**
  * Added coverage for resolved user handling and for re-running a repository after initial setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->