### PR TITLE
fix(desktop): restore Delete/Copy log button click handlers

### DIFF
--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -747,8 +747,8 @@ async function handleRenameConfirmed() {
                                     <button
                                       type="button"
                                       class="rounded p-1.5 opacity-0 transition-opacity hover:bg-muted group-hover/log:opacity-60 hover:!opacity-100"
-                                      onclick={() => copyToClipboard(logContent)}
                                       {...props}
+                                      onclick={() => copyToClipboard(logContent)}
                                     >
                                       <ClipboardCopy class="h-3.5 w-3.5" />
                                     </button>
@@ -763,8 +763,8 @@ async function handleRenameConfirmed() {
                                   <button
                                     type="button"
                                     class="rounded p-1.5 opacity-0 transition-opacity hover:bg-destructive/10 hover:text-destructive group-hover/log:opacity-60 hover:!opacity-100"
-                                    onclick={() => deleteLog(entry)}
                                     {...props}
+                                    onclick={() => deleteLog(entry)}
                                   >
                                     <Trash2 class="h-3.5 w-3.5" />
                                   </button>


### PR DESCRIPTION
## Summary

The **Delete log** button on the workspace details page did nothing when clicked. The Delete log and Copy log buttons are wrapped in a \`Tooltip.Trigger\` snippet that passes a \`props\` object containing bits-ui's own event handlers. Both buttons spread \`{...props}\` *after* their own \`onclick\`, so the tooltip's handler overrode the button's and the click was a no-op.

Reordered so \`{...props}\` is spread before \`onclick\`, matching the working pattern already used by the "copy output" button on the same page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the “Copy log” and “Delete log” actions so their click behavior works reliably from the workspace details view.
  - Improved tooltip button handling to prevent button attributes from overriding the intended action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->