### PR TITLE
feat(sites): add landing page for devsy.sh root

### DIFF
--- a/sites/docs-devsy-sh/public/_redirects
+++ b/sites/docs-devsy-sh/public/_redirects
@@ -1,3 +1,2 @@
 # Home Routes
-/                                               /docs/what-is-devsy                   301!
 /docs                                           /docs/what-is-devsy                   301!

--- a/sites/docs-devsy-sh/public/index.html
+++ b/sites/docs-devsy-sh/public/index.html
@@ -1,0 +1,961 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      Devsy — Standardized development workspaces, engineering at scale
+    </title>
+    <meta
+      name="description"
+      content="Devsy gives teams standardized workspaces that cut hardware cost, shorten onboarding, and raise developer productivity. Deploy across Docker, Kubernetes, cloud providers, and SSH hosts."
+    />
+    <link
+      rel="icon"
+      href="/docs/media/devsy-favicon.svg"
+      type="image/svg+xml"
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Devsy" />
+    <meta property="og:title" content="Devsy — Engineering at scale" />
+    <meta
+      property="og:description"
+      content="Standardized, reproducible development workspaces that run anywhere: local, cloud, Kubernetes, or remote SSH."
+    />
+    <meta property="og:url" content="https://www.devsy.sh/" />
+    <meta property="og:image" content="https://www.devsy.sh/docs/media/devsy.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Devsy — Engineering at scale" />
+    <meta
+      name="twitter:description"
+      content="Standardized, reproducible development workspaces that run anywhere: local, cloud, Kubernetes, or remote SSH."
+    />
+    <meta
+      name="twitter:image"
+      content="https://www.devsy.sh/docs/media/devsy.png"
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --purple: #7c5cff;
+        --purple-dark: #6244e6;
+        --purple-light: #a78bfa;
+        --ink: #0b0b14;
+        --slate: #545469;
+        --line: #e7e7f0;
+        --bg-soft: #f7f7fc;
+        --radius: 14px;
+        --max: 1120px;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html {
+        scroll-behavior: smooth;
+      }
+
+      body {
+        margin: 0;
+        font-family: Inter, "Helvetica Neue", Arial, sans-serif;
+        color: var(--ink);
+        background: #fff;
+        line-height: 1.6;
+        -webkit-font-smoothing: antialiased;
+      }
+
+      a {
+        color: inherit;
+        text-decoration: none;
+      }
+
+      .wrap {
+        max-width: var(--max);
+        margin: 0 auto;
+        padding: 0 24px;
+      }
+
+      /* ---------- Buttons ---------- */
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        padding: 13px 24px;
+        border-radius: 10px;
+        font-weight: 600;
+        font-size: 15px;
+        border: 1px solid transparent;
+        transition:
+          transform 0.15s ease,
+          box-shadow 0.2s ease,
+          background 0.2s ease,
+          border-color 0.2s ease;
+        cursor: pointer;
+      }
+
+      .btn-primary {
+        background: var(--purple);
+        color: #fff;
+        box-shadow: 0 8px 24px rgba(124, 92, 255, 0.32);
+      }
+
+      .btn-primary:hover {
+        background: var(--purple-dark);
+        transform: translateY(-1px);
+        box-shadow: 0 12px 30px rgba(124, 92, 255, 0.42);
+      }
+
+      .btn-ghost {
+        background: #fff;
+        border-color: var(--line);
+        color: var(--ink);
+      }
+
+      .btn-ghost:hover {
+        border-color: var(--purple-light);
+        transform: translateY(-1px);
+      }
+
+      /* ---------- Header ---------- */
+      header {
+        position: sticky;
+        top: 0;
+        z-index: 50;
+        background: rgba(255, 255, 255, 0.82);
+        backdrop-filter: saturate(180%) blur(12px);
+        border-bottom: 1px solid var(--line);
+      }
+
+      .nav {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        height: 68px;
+      }
+
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-weight: 700;
+        font-size: 22px;
+        letter-spacing: -0.02em;
+      }
+
+      .brand svg {
+        display: block;
+      }
+
+      .nav-links {
+        display: flex;
+        align-items: center;
+        gap: 30px;
+        font-size: 15px;
+        font-weight: 500;
+        color: var(--slate);
+      }
+
+      .nav-links a:hover {
+        color: var(--ink);
+      }
+
+      .nav-cta {
+        display: flex;
+        align-items: center;
+        gap: 14px;
+      }
+
+      @media (max-width: 820px) {
+        .nav-links {
+          display: none;
+        }
+      }
+
+      /* ---------- Hero ---------- */
+      .hero {
+        position: relative;
+        overflow: hidden;
+        padding: 92px 0 80px;
+        text-align: center;
+        background:
+          radial-gradient(
+            60% 120% at 50% -10%,
+            rgba(124, 92, 255, 0.14),
+            rgba(124, 92, 255, 0) 60%
+          ),
+          #fff;
+      }
+
+      h1 {
+        font-size: clamp(38px, 6vw, 62px);
+        line-height: 1.05;
+        letter-spacing: -0.03em;
+        font-weight: 800;
+        margin: 0 auto 22px;
+        max-width: 900px;
+      }
+
+      h1 .grad {
+        background: linear-gradient(120deg, var(--purple), var(--purple-light));
+        -webkit-background-clip: text;
+        background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+
+      .hero-sub {
+        font-size: clamp(18px, 2.4vw, 24px);
+        font-weight: 600;
+        letter-spacing: -0.015em;
+        color: var(--ink);
+        margin: 0 auto 18px;
+      }
+
+      .lede {
+        font-size: clamp(17px, 2.2vw, 21px);
+        color: var(--slate);
+        max-width: 660px;
+        margin: 0 auto 34px;
+      }
+
+      .hero-cta {
+        display: flex;
+        gap: 14px;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+
+      .hero-media {
+        margin: 56px auto 0;
+        max-width: 940px;
+        border-radius: 18px;
+        border: 1px solid var(--line);
+        box-shadow: 0 30px 80px -30px rgba(11, 11, 20, 0.28);
+        overflow: hidden;
+        background: #fff;
+      }
+
+      .hero-media img {
+        display: block;
+        width: 100%;
+        height: auto;
+      }
+
+      /* ---------- Section shells ---------- */
+      section {
+        padding: 88px 0;
+      }
+
+      .section-head {
+        text-align: center;
+        max-width: 640px;
+        margin: 0 auto 56px;
+      }
+
+      .section-head h2 {
+        font-size: clamp(28px, 4vw, 40px);
+        letter-spacing: -0.025em;
+        font-weight: 800;
+        margin: 0 0 14px;
+      }
+
+      .section-head p {
+        color: var(--slate);
+        font-size: 18px;
+        margin: 0;
+      }
+
+      .kicker {
+        text-transform: uppercase;
+        letter-spacing: 0.14em;
+        font-size: 12.5px;
+        font-weight: 700;
+        color: var(--purple);
+        margin-bottom: 12px;
+      }
+
+      /* ---------- Features grid ---------- */
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 22px;
+      }
+
+      @media (max-width: 900px) {
+        .grid {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .card {
+        border: 1px solid var(--line);
+        border-radius: var(--radius);
+        padding: 28px;
+        background: #fff;
+        transition:
+          transform 0.18s ease,
+          box-shadow 0.2s ease,
+          border-color 0.2s ease;
+      }
+
+      .card:hover {
+        transform: translateY(-3px);
+        border-color: var(--purple-light);
+        box-shadow: 0 18px 40px -24px rgba(124, 92, 255, 0.5);
+      }
+
+      .card .ico {
+        width: 44px;
+        height: 44px;
+        border-radius: 11px;
+        display: grid;
+        place-items: center;
+        background: rgba(124, 92, 255, 0.1);
+        color: var(--purple);
+        margin-bottom: 18px;
+      }
+
+      .card h3 {
+        margin: 0 0 8px;
+        font-size: 18px;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+      }
+
+      .card p {
+        margin: 0;
+        color: var(--slate);
+        font-size: 15px;
+      }
+
+      /* ---------- Anywhere band ---------- */
+      .band {
+        background: var(--bg-soft);
+        border-top: 1px solid var(--line);
+        border-bottom: 1px solid var(--line);
+      }
+
+      .targets {
+        display: grid;
+        grid-template-columns: repeat(4, 1fr);
+        gap: 16px;
+      }
+
+      @media (max-width: 760px) {
+        .targets {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+
+      .target {
+        background: #fff;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 24px 20px;
+        text-align: center;
+        transition:
+          transform 0.18s ease,
+          border-color 0.2s ease;
+      }
+
+      .target:hover {
+        transform: translateY(-3px);
+        border-color: var(--purple-light);
+      }
+
+      .target .ico {
+        width: 40px;
+        height: 40px;
+        margin: 0 auto 14px;
+        border-radius: 10px;
+        display: grid;
+        place-items: center;
+        background: rgba(124, 92, 255, 0.1);
+        color: var(--purple);
+      }
+
+      .target strong {
+        display: block;
+        font-size: 16px;
+        margin-bottom: 4px;
+      }
+
+      .target > span {
+        font-size: 13.5px;
+        color: var(--slate);
+      }
+
+      /* ---------- How it works ---------- */
+      .steps {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 26px;
+        counter-reset: step;
+      }
+
+      @media (max-width: 900px) {
+        .steps {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .step {
+        position: relative;
+        padding-top: 8px;
+      }
+
+      /* Connector line between step badges (desktop only) */
+      .step:not(:last-child)::before {
+        content: "";
+        position: absolute;
+        top: 28px;
+        left: 52px;
+        right: -26px;
+        height: 2px;
+        background: linear-gradient(
+          90deg,
+          var(--purple-light),
+          var(--line)
+        );
+        z-index: 0;
+      }
+
+      @media (max-width: 900px) {
+        .step:not(:last-child)::before {
+          display: none;
+        }
+      }
+
+      .step .num {
+        position: relative;
+        z-index: 1;
+        width: 40px;
+        height: 40px;
+        border-radius: 11px;
+        display: grid;
+        place-items: center;
+        font-weight: 800;
+        color: #fff;
+        background: linear-gradient(140deg, var(--purple), var(--purple-light));
+        margin-bottom: 16px;
+      }
+
+      .step h3 {
+        margin: 0 0 6px;
+        font-size: 18px;
+        letter-spacing: -0.01em;
+      }
+
+      .step p {
+        margin: 0;
+        color: var(--slate);
+        font-size: 15px;
+      }
+
+      /* ---------- CTA ---------- */
+      .cta {
+        text-align: center;
+        background: linear-gradient(150deg, #14122b, #241a4d 60%, #2c1c66);
+        border-radius: 24px;
+        padding: 64px 32px;
+        color: #fff;
+        margin: 0 auto;
+      }
+
+      .cta h2 {
+        font-size: clamp(28px, 4vw, 42px);
+        letter-spacing: -0.025em;
+        margin: 0 0 14px;
+        font-weight: 800;
+      }
+
+      .cta p {
+        color: rgba(255, 255, 255, 0.75);
+        font-size: 18px;
+        max-width: 560px;
+        margin: 0 auto 30px;
+      }
+
+      .cta .btn-ghost {
+        background: transparent;
+        border-color: rgba(255, 255, 255, 0.28);
+        color: #fff;
+      }
+
+      .cta .btn-ghost:hover {
+        border-color: #fff;
+      }
+
+      /* ---------- Footer ---------- */
+      footer {
+        border-top: 1px solid var(--line);
+        padding: 48px 0;
+        color: var(--slate);
+        font-size: 14.5px;
+      }
+
+      .foot {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 24px;
+        flex-wrap: wrap;
+      }
+
+      .foot-links {
+        display: flex;
+        gap: 26px;
+        flex-wrap: wrap;
+      }
+
+      .foot-links a:hover {
+        color: var(--ink);
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="wrap nav">
+        <a class="brand" href="/" aria-label="Devsy home">
+          <svg
+            width="30"
+            height="30"
+            viewBox="0 0 1024 1024"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <rect
+              x="0"
+              y="0"
+              width="1024"
+              height="1024"
+              rx="200"
+              ry="200"
+              fill="#7C5CFF"
+            />
+            <rect x="778" y="144" width="56" height="736" rx="12" fill="#fff" />
+            <rect x="778" y="496" width="24" height="192" fill="#fff" />
+            <circle
+              cx="506"
+              cy="592"
+              r="288"
+              fill="none"
+              stroke="#fff"
+              stroke-width="56"
+            />
+          </svg>
+          devsy
+        </a>
+        <nav class="nav-links">
+          <a href="#features">Features</a>
+          <a href="#anywhere">Deploy anywhere</a>
+          <a href="#how">How it works</a>
+          <a href="/docs/what-is-devsy">Docs</a>
+        </nav>
+        <div class="nav-cta">
+          <a
+            class="nav-links"
+            href="https://github.com/devsy-org/devsy"
+            style="display: inline-flex"
+            aria-label="GitHub"
+            >GitHub</a
+          >
+          <a class="btn btn-primary" href="/docs/getting-started/install"
+            >Get Started</a
+          >
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <!-- HERO -->
+      <section class="hero">
+        <div class="wrap">
+          <h1>
+            Ship from <span class="grad">day zero</span>.
+          </h1>
+          <p class="hero-sub">Standardized workspaces, engineering at scale.</p>
+          <p class="lede">
+            Devsy gives every engineer the same environment. Cut hardware cost,
+            shorten onboarding, and raise developer productivity. Deploy across
+            Docker, Kubernetes, cloud providers, and SSH hosts.
+          </p>
+          <div class="hero-cta">
+            <a class="btn btn-primary" href="/docs/getting-started/install"
+              >Get Started</a
+            >
+            <a class="btn btn-ghost" href="/docs/what-is-devsy"
+              >Read the docs</a
+            >
+          </div>
+          <div class="hero-media">
+            <img
+              src="/docs/media/devsy-flow.gif"
+              alt="Devsy launching and connecting to a workspace"
+              loading="lazy"
+            />
+          </div>
+        </div>
+      </section>
+
+      <!-- FEATURES -->
+      <section id="features">
+        <div class="wrap">
+          <div class="section-head">
+            <div class="kicker">Why Devsy</div>
+            <h2>One environment definition. Every backend.</h2>
+            <p>
+              Define a workspace once in <code>devcontainer.json</code>. Give
+              your whole team the same toolchain, with no lock-in and no drift.
+            </p>
+          </div>
+          <div class="grid">
+            <div class="card">
+              <div class="ico" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M4 7V5a2 2 0 0 1 2-2h2M4 17v2a2 2 0 0 0 2 2h2M20 7V5a2 2 0 0 0-2-2h-2M20 17v2a2 2 0 0 1-2 2h-2"
+                  />
+                  <rect x="8" y="8" width="8" height="8" rx="1" />
+                </svg>
+              </div>
+              <h3>Standardized environments</h3>
+              <p>
+                Every engineer gets the same dependencies, config, and Git and
+                Docker credentials. New hires ship from day zero instead of
+                losing days to setup.
+              </p>
+            </div>
+            <div class="card">
+              <div class="ico" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect x="4" y="4" width="16" height="16" rx="2" />
+                  <rect x="9" y="9" width="6" height="6" />
+                  <path
+                    d="M9 1v3M15 1v3M9 20v3M15 20v3M20 9h3M20 14h3M1 9h3M1 14h3"
+                  />
+                </svg>
+              </div>
+              <h3>Hardware on demand</h3>
+              <p>
+                Provision cloud machines with the CPU, memory, and GPU your
+                workload needs, up to the largest instances your cloud offers.
+                Move a workspace from a laptop to a multi-GPU box without
+                changing your config.
+              </p>
+            </div>
+            <div class="card">
+              <div class="ico" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M12 1v22M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"
+                  />
+                </svg>
+              </div>
+              <h3>Cost efficiency</h3>
+              <p>
+                Run on infrastructure you already pay for. Prebuilds and
+                inactivity-based auto-shutdown mean you spend only on capacity
+                in use.
+              </p>
+            </div>
+            <div class="card">
+              <div class="ico" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M18 6 6 18M8 6h10v10" />
+                </svg>
+              </div>
+              <h3>No vendor lock-in</h3>
+              <p>
+                Local, cloud, Kubernetes, or remote SSH. Switch a workspace's
+                provider with a single command. Your definition stays the same.
+              </p>
+            </div>
+            <div class="card">
+              <div class="ico" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect x="2" y="3" width="20" height="14" rx="2" />
+                  <path d="M8 21h8M12 17v4" />
+                </svg>
+              </div>
+              <h3>IDE support</h3>
+              <p>
+                Use the IDE you already know: VS Code, Cursor, Zed, the full
+                JetBrains suite, and more.
+              </p>
+            </div>
+            <div class="card">
+              <div class="ico" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M12 2v4M12 18v4M4.9 4.9l2.8 2.8M16.3 16.3l2.8 2.8M2 12h4M18 12h4M4.9 19.1l2.8-2.8M16.3 7.7l2.8-2.8"
+                  />
+                </svg>
+              </div>
+              <h3>Extensible</h3>
+              <p>
+                If a provider doesn't exist for your platform, build your own
+                with a small provider spec.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- DEPLOY ANYWHERE -->
+      <section id="anywhere" class="band">
+        <div class="wrap">
+          <div class="section-head">
+            <div class="kicker">Deploy anywhere</div>
+            <h2>Workspaces run where your work does</h2>
+            <p>
+              Built on the open Devcontainer standard, so workspaces stay
+              portable and repeatable across every provider backend.
+            </p>
+          </div>
+          <div class="targets">
+            <div class="target">
+              <div class="ico" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M13.983 11.078h2.119a.186.186 0 00.186-.185V9.006a.186.186 0 00-.186-.186h-2.119a.185.185 0 00-.185.185v1.888c0 .102.083.185.185.185m-2.954-5.43h2.118a.186.186 0 00.186-.186V3.574a.186.186 0 00-.186-.185h-2.118a.185.185 0 00-.185.185v1.888c0 .102.082.185.185.185m0 2.716h2.118a.187.187 0 00.186-.186V6.29a.186.186 0 00-.186-.185h-2.118a.185.185 0 00-.185.185v1.887c0 .102.082.185.185.186m-2.93 0h2.12a.186.186 0 00.184-.186V6.29a.185.185 0 00-.185-.185H8.1a.185.185 0 00-.185.185v1.887c0 .102.083.185.185.186m-2.964 0h2.119a.186.186 0 00.185-.186V6.29a.185.185 0 00-.185-.185H5.136a.186.186 0 00-.186.185v1.887c0 .102.084.185.186.186m5.893 2.715h2.118a.186.186 0 00.186-.185V9.006a.186.186 0 00-.186-.186h-2.118a.185.185 0 00-.185.185v1.888c0 .102.082.185.185.185m-2.93 0h2.12a.185.185 0 00.184-.185V9.006a.185.185 0 00-.184-.186h-2.12a.185.185 0 00-.184.185v1.888c0 .102.083.185.185.185m-2.964 0h2.119a.185.185 0 00.185-.185V9.006a.185.185 0 00-.184-.186h-2.12a.186.186 0 00-.186.186v1.887c0 .102.084.185.186.185m-2.92 0h2.12a.185.185 0 00.184-.185V9.006a.185.185 0 00-.184-.186h-2.12a.185.185 0 00-.184.185v1.888c0 .102.082.185.185.185M23.763 9.89c-.065-.051-.672-.51-1.954-.51-.338.001-.676.03-1.01.087-.248-1.7-1.653-2.53-1.716-2.566l-.344-.199-.226.327c-.284.438-.49.922-.612 1.43-.23.97-.09 1.882.403 2.661-.595.332-1.55.413-1.744.42H.751a.751.751 0 00-.75.748 11.376 11.376 0 00.692 4.062c.545 1.428 1.355 2.48 2.41 3.124 1.18.723 3.1 1.137 5.275 1.137.983.003 1.963-.086 2.93-.266a12.248 12.248 0 003.823-1.389c.98-.567 1.86-1.288 2.61-2.136 1.252-1.418 1.998-2.997 2.553-4.4h.221c1.372 0 2.215-.549 2.68-1.009.309-.293.55-.65.707-1.046l.098-.288Z"
+                  />
+                </svg>
+              </div>
+              <strong>Docker</strong><span>Local containers on any laptop</span>
+            </div>
+            <div class="target">
+              <div class="ico" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M10.204 14.35l.007.01-.999 2.413a5.171 5.171 0 0 1-2.075-2.597l2.578-.437.004.005a.44.44 0 0 1 .484.606zm-.833-2.129a.44.44 0 0 0 .173-.756l.002-.011L7.585 9.7a5.143 5.143 0 0 0-.73 3.255l2.514-.725.002-.009zm1.145-1.98a.44.44 0 0 0 .699-.337l.01-.005.15-2.62a5.144 5.144 0 0 0-3.01 1.442l2.147 1.523.004-.002zm.76 2.75l.723.349.722-.347.18-.78-.5-.623h-.804l-.5.623.179.779zm1.5-3.095a.44.44 0 0 0 .7.336l.008.003 2.134-1.513a5.188 5.188 0 0 0-2.992-1.442l.148 2.615.002.001zm10.876 5.97l-5.773 7.181a1.6 1.6 0 0 1-1.248.594l-9.261.003a1.6 1.6 0 0 1-1.247-.596l-5.776-7.18a1.583 1.583 0 0 1-.307-1.34L2.1 5.573c.108-.47.425-.864.863-1.073L11.305.513a1.606 1.606 0 0 1 1.385 0l8.345 3.985c.438.209.755.604.863 1.073l2.062 8.955c.108.47-.005.963-.308 1.34zm-3.289-2.057c-.042-.01-.103-.026-.145-.034-.174-.033-.315-.025-.479-.038-.35-.037-.638-.067-.895-.148-.105-.04-.18-.165-.216-.216l-.201-.059a6.45 6.45 0 0 0-.105-2.332 6.465 6.465 0 0 0-.936-2.163c.052-.047.15-.133.177-.159.008-.09.001-.183.094-.282.197-.185.444-.338.743-.522.142-.084.273-.137.415-.242.032-.024.076-.062.11-.089.24-.191.295-.52.123-.736-.172-.216-.506-.236-.745-.045-.034.027-.08.062-.111.088-.134.116-.217.23-.33.35-.246.25-.45.458-.673.609-.097.056-.239.037-.303.033l-.19.135a6.545 6.545 0 0 0-4.146-2.003l-.012-.223c-.065-.062-.143-.115-.163-.25-.022-.268.015-.557.057-.905.023-.163.061-.298.068-.475.001-.04-.001-.099-.001-.142 0-.306-.224-.555-.5-.555-.275 0-.499.249-.499.555l.001.014c0 .041-.002.092 0 .128.006.177.044.312.067.475.042.348.078.637.056.906a.545.545 0 0 1-.162.258l-.012.211a6.424 6.424 0 0 0-4.166 2.003 8.373 8.373 0 0 1-.18-.128c-.09.012-.18.04-.297-.029-.223-.15-.427-.358-.673-.608-.113-.12-.195-.234-.329-.349-.03-.026-.077-.062-.111-.088a.594.594 0 0 0-.348-.132.481.481 0 0 0-.398.176c-.172.216-.117.546.123.737l.007.005.104.083c.142.105.272.159.414.242.299.185.546.338.743.522.076.082.09.226.1.288l.16.143a6.462 6.462 0 0 0-1.02 4.506l-.208.06c-.055.072-.133.184-.215.217-.257.081-.546.11-.895.147-.164.014-.305.006-.48.039-.037.007-.09.02-.133.03l-.004.002-.007.002c-.295.071-.484.342-.423.608.061.267.349.429.645.365l.007-.001.01-.003.129-.029c.17-.046.294-.113.448-.172.33-.118.604-.217.87-.256.112-.009.23.069.288.101l.217-.037a6.5 6.5 0 0 0 2.88 3.596l-.09.218c.033.084.069.199.044.282-.097.252-.263.517-.452.813-.091.136-.185.242-.268.399-.02.037-.045.095-.064.134-.128.275-.034.591.213.71.248.12.556-.007.69-.282v-.002c.02-.039.046-.09.062-.127.07-.162.094-.301.144-.458.132-.332.205-.68.387-.897.05-.06.13-.082.215-.105l.113-.205a6.453 6.453 0 0 0 4.609.012l.106.192c.086.028.18.042.256.155.136.232.229.507.342.84.05.156.074.295.145.457.016.037.043.09.062.129.133.276.442.402.69.282.247-.118.341-.435.213-.71-.02-.039-.045-.096-.065-.134-.083-.156-.177-.261-.268-.398-.19-.296-.346-.541-.443-.793-.04-.13.007-.21.038-.294-.018-.022-.059-.144-.083-.202a6.499 6.499 0 0 0 2.88-3.622c.064.01.176.03.213.038.075-.05.144-.114.28-.104.266.039.54.138.87.256.154.06.277.128.448.173.036.01.088.019.13.028l.009.003.007.001c.297.064.584-.098.645-.365.06-.266-.128-.537-.423-.608zM16.4 9.701l-1.95 1.746v.005a.44.44 0 0 0 .173.757l.003.01 2.526.728a5.199 5.199 0 0 0-.108-1.674A5.208 5.208 0 0 0 16.4 9.7zm-4.013 5.325a.437.437 0 0 0-.404-.232.44.44 0 0 0-.372.233h-.002l-1.268 2.292a5.164 5.164 0 0 0 3.326.003l-1.27-2.296h-.01zm1.888-1.293a.44.44 0 0 0-.27.036.44.44 0 0 0-.214.572l-.003.004 1.01 2.438a5.15 5.15 0 0 0 2.081-2.615l-2.6-.44-.004.005z"
+                  />
+                </svg>
+              </div>
+              <strong>Kubernetes</strong><span>Scale across your cluster</span>
+            </div>
+            <div class="target">
+              <div class="ico" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z" />
+                </svg>
+              </div>
+              <strong>Cloud providers</strong
+              ><span>On-demand machines of any size</span>
+            </div>
+            <div class="target">
+              <div class="ico" aria-hidden="true">
+                <svg
+                  width="22"
+                  height="22"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path d="m7 11 2-2-2-2" />
+                  <path d="M11 13h4" />
+                  <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+                </svg>
+              </div>
+              <strong>SSH remote hosts</strong><span>Any reachable server</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- HOW IT WORKS -->
+      <section id="how">
+        <div class="wrap">
+          <div class="section-head">
+            <div class="kicker">How it works</div>
+            <h2>From definition to running workspace</h2>
+            <p>
+              Devsy connects each developer's local IDE to the infrastructure
+              where work runs.
+            </p>
+          </div>
+          <div class="steps">
+            <div class="step">
+              <div class="num">1</div>
+              <h3>Define once</h3>
+              <p>
+                Commit a <code>devcontainer.json</code> alongside your source.
+                It describes the tools and dependencies your whole team shares.
+              </p>
+            </div>
+            <div class="step">
+              <div class="num">2</div>
+              <h3>Pick a provider</h3>
+              <p>
+                Choose Docker, Kubernetes, a cloud machine, or an SSH host.
+                Providers provision the container for you.
+              </p>
+            </div>
+            <div class="step">
+              <div class="num">3</div>
+              <h3>Connect and build</h3>
+              <p>
+                Your local IDE attaches to the workspace. The experience is the
+                same from laptop to cloud, prototype to production.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- CTA -->
+      <section>
+        <div class="wrap">
+          <div class="cta">
+            <h2>Scale your engineering, not your setup.</h2>
+            <p>
+              Get Devsy as a desktop app or a command-line tool and launch your
+              first standardized workspace now.
+            </p>
+            <div class="hero-cta">
+              <a class="btn btn-primary" href="/docs/getting-started/install"
+                >Download &amp; install</a
+              >
+              <a class="btn btn-ghost" href="https://github.com/devsy-org/devsy"
+                >View on GitHub</a
+              >
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="wrap foot">
+        <a
+          class="brand"
+          href="/"
+          style="font-size: 18px"
+          aria-label="Devsy home"
+        >
+          <svg
+            width="24"
+            height="24"
+            viewBox="0 0 1024 1024"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <rect
+              x="0"
+              y="0"
+              width="1024"
+              height="1024"
+              rx="200"
+              ry="200"
+              fill="#7C5CFF"
+            />
+            <rect x="778" y="144" width="56" height="736" rx="12" fill="#fff" />
+            <rect x="778" y="496" width="24" height="192" fill="#fff" />
+            <circle
+              cx="506"
+              cy="592"
+              r="288"
+              fill="none"
+              stroke="#fff"
+              stroke-width="56"
+            />
+          </svg>
+          devsy
+        </a>
+        <nav class="foot-links">
+          <a href="/docs/what-is-devsy">Documentation</a>
+          <a href="/docs/getting-started/install">Install</a>
+          <a href="https://github.com/devsy-org/devsy">GitHub</a>
+        </nav>
+        <span>© <span id="year">2026</span> Devsy, Inc.</span>
+      </div>
+    </footer>
+
+    <script>
+      document.getElementById("year").textContent = new Date().getFullYear();
+    </script>
+  </body>
+</html>

--- a/sites/docs-devsy-sh/public/index.html
+++ b/sites/docs-devsy-sh/public/index.html
@@ -165,15 +165,34 @@
         color: var(--ink);
       }
 
+      .nav-link-single {
+        font-size: 15px;
+        font-weight: 500;
+        color: var(--slate);
+      }
+
+      .nav-link-single:hover {
+        color: var(--ink);
+      }
+
       .nav-cta {
         display: flex;
         align-items: center;
         gap: 14px;
       }
 
+      /* Docs link surfaced in nav-cta only on mobile, where nav-links hides */
+      .nav-docs-mobile {
+        display: none;
+      }
+
       @media (max-width: 820px) {
         .nav-links {
           display: none;
+        }
+
+        .nav-docs-mobile {
+          display: inline-flex;
         }
       }
 
@@ -558,10 +577,12 @@
           <a href="/docs/what-is-devsy">Docs</a>
         </nav>
         <div class="nav-cta">
+          <a class="nav-link-single nav-docs-mobile" href="/docs/what-is-devsy"
+            >Docs</a
+          >
           <a
-            class="nav-links"
+            class="nav-link-single"
             href="https://github.com/devsy-org/devsy"
-            style="display: inline-flex"
             aria-label="GitHub"
             >GitHub</a
           >


### PR DESCRIPTION
## Summary

Adds a self-contained static landing page served at the `www.devsy.sh/` root, and removes the redirect that previously sent the root straight to `/docs/what-is-devsy`. The page is deployed by the existing docs Netlify build, which copies `public/*` to the site root.

- **`sites/docs-devsy-sh/public/index.html`** — new landing page. Single file, inline CSS, no framework or build step. Reuses the docs brand (primary `#7C5CFF`, Inter, the ring logo mark) and the Devcontainer-standard messaging.
- **`sites/docs-devsy-sh/public/_redirects`** — drop the `/ → /docs/what-is-devsy` rule so the root serves the new page. `/docs → /docs/what-is-devsy` is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new public landing page with updated navigation, feature highlights, setup guidance, and clear calls to action.
  * Included responsive styling and a polished footer for a more consistent browsing experience.

* **Bug Fixes**
  * Updated site routing so the root path no longer redirects automatically; the `/docs` route still points to the documentation landing page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->