### PR TITLE
fix(tunnel): surface agent command failure instead of masking it

### DIFF
--- a/pkg/tunnel/connerror.go
+++ b/pkg/tunnel/connerror.go
@@ -38,6 +38,9 @@ func IsEOF(err error) bool {
 
 func ClassifyTunnelErrors(tunnelErr, handlerErr error) error {
 	if handlerErr == nil {
+		if ClassifyError(tunnelErr) == ErrorPermanent {
+			return fmt.Errorf("agent command: %w", tunnelErr)
+		}
 		return nil
 	}
 	if IsEOF(handlerErr) {

--- a/pkg/tunnel/connerror_test.go
+++ b/pkg/tunnel/connerror_test.go
@@ -72,7 +72,10 @@ func TestClassifyTunnelErrors(t *testing.T) {
 		wantNil    bool
 		wantSubstr string
 	}{
-		{"handler nil", tunnelErr, nil, true, ""},
+		{"handler nil, no tunnel err", nil, nil, true, ""},
+		{"handler nil, permanent tunnel err", tunnelErr, nil, false, "agent command: dial failed"},
+		{"handler nil, shutdown tunnel err", context.Canceled, nil, true, ""},
+		{"handler nil, EOF tunnel err", io.EOF, nil, true, ""},
 		{"handler EOF with tunnel err", tunnelErr, io.EOF, false, "connect to server: dial failed"},
 		{"handler EOF no tunnel err", nil, io.EOF, true, ""},
 		{"handler non-EOF", nil, handlerNonEOF, false, "tunnel to container: handler broke"},


### PR DESCRIPTION
## Summary

Fixes a misleading error surfaced during `workspace up`: when the in-container agent failed a stage *after* sending its result over the tunnel (e.g. a failed `git clone`), the CLI reported

```
start workspace: save workspace result: workspace <id> no longer exists
```

instead of the real cause. The "no longer exists" message is a downstream symptom — the agent's failure-cleanup had already removed the workspace directory, and `up` then tripped over the missing directory while saving the result.

## Root cause

`ClassifyTunnelErrors` discarded the tunnel (agent command) error whenever the handler side completed cleanly:

```go
if handlerErr == nil {
    return nil   // agent command error thrown away
}
```

In the SSH/local path (docker/podman), the agent sends its result over gRPC and then may fail a later stage. The handler (result receiver) sees a clean completion, so `handlerErr == nil` and the agent's real exit error (`tunnelErr`) was dropped. `ExecuteCommand` then returned `(result, nil)`, `up` proceeded to `SaveWorkspaceResult`, found the directory already removed by the agent's cleanup, and reported the misleading message.

## Fix

Surface a **permanent** tunnel error when the handler returns nil, reusing the existing `ClassifyError` so normal shutdown/EOF completions still resolve to `nil`:

```go
if handlerErr == nil {
    if ClassifyError(tunnelErr) == ErrorPermanent {
        return fmt.Errorf("agent command: %w", tunnelErr)
    }
    return nil
}
```

## Before / after

Reproduced on a real Fedora host with rootless podman by cloning an unresolvable repo:

- **Before:** `start workspace: save workspace result: workspace notfound-devsy-sh no longer exists`
- **After:** `start workspace: tunnel to container: agent command: run agent command failed: exit status 128 ...`

## Notes

- The proxy path already surfaced the agent error correctly; only the SSH/local path had the masking bug.
- Two cosmetic issues remain on this error path and are intentionally left for follow-up: the agent's generic "Command failed with exit code N" line is captured into the message tail (rather than the causal line), and the failure-cleanup path emits a secondary credential-helper warning. The primary confusion — the wrong root cause — is resolved here.
