### PR TITLE
feat(assets): serve provider and IDE icons from dl.devsy.sh

### DIFF
--- a/cmd/pro/login.go
+++ b/cmd/pro/login.go
@@ -362,7 +362,7 @@ func login(
 
 var fallbackProvider = `name: devsy-pro
 version: v0.0.0
-icon: https://devsy.sh/assets/devsy.svg
+icon: https://dl.devsy.sh/assets/devsy.svg
 description: Devsy Pro
 options:
   DEVSY_CONFIG:

--- a/hack/pro/provider.yaml
+++ b/hack/pro/provider.yaml
@@ -1,6 +1,6 @@
 name: devsy-pro
 version: ##VERSION##
-icon: https://devsy.sh/assets/devsy.svg
+icon: https://dl.devsy.sh/assets/devsy.svg
 description: Devsy Pro
 options:
   DEVSY_CONFIG:

--- a/pkg/config/repo.go
+++ b/pkg/config/repo.go
@@ -28,8 +28,11 @@ const (
 	// WebsiteBaseURL is the project website used for asset URLs.
 	WebsiteBaseURL = "https://" + RepoName + ".sh"
 
+	// DownloadBaseURL is the object storage host serving release artifacts and image assets.
+	DownloadBaseURL = "https://dl." + RepoName + ".sh"
+
 	// WebsiteAssetsURL is the base URL for icon/image assets.
-	WebsiteAssetsURL = WebsiteBaseURL + "/assets"
+	WebsiteAssetsURL = DownloadBaseURL + "/assets"
 
 	// AgentDownloadBaseURL is the prefix under which versioned agent binaries are published.
 	AgentDownloadBaseURL = GitHubReleasesURL + "/download/"

--- a/pkg/ide/ideparse/parse.go
+++ b/pkg/ide/ideparse/parse.go
@@ -65,7 +65,7 @@ var AllowedIDEs = []AllowedIDE{
 		Name:        config.IDECodeServer,
 		DisplayName: "code-server",
 		Options:     codeserver.Options,
-		Icon:        "https://raw.githubusercontent.com/coder/code-server/main/src/browser/media/favicon.svg",
+		Icon:        config.WebsiteAssetsURL + "/code-server.svg",
 		Group:       config.IDEGroupPrimary,
 	},
 	{
@@ -228,7 +228,8 @@ var AllowedIDEs = []AllowedIDE{
 		Name:        config.IDEBob,
 		DisplayName: "IBM Bob",
 		Options:     vscode.Options,
-		Icon:        "https://devsy.sh/assets/bob.svg",
+		Icon:        config.WebsiteAssetsURL + "/bob.svg",
+		IconDark:    config.WebsiteAssetsURL + "/bob_dark.svg",
 		Group:       config.IDEGroupPrimary,
 	},
 }

--- a/providers/docker/provider.yaml
+++ b/providers/docker/provider.yaml
@@ -1,6 +1,6 @@
 name: docker
 version: v1.0.0
-icon: https://devsy.sh/assets/docker.svg
+icon: https://dl.devsy.sh/assets/docker.svg
 home: https://github.com/devsy-org/devsy
 description: |-
   Devsy on Docker

--- a/providers/kubernetes/provider.yaml
+++ b/providers/kubernetes/provider.yaml
@@ -1,6 +1,6 @@
 name: kubernetes
 version: v1.0.0
-icon: https://devsy.sh/assets/kubernetes.svg
+icon: https://dl.devsy.sh/assets/kubernetes.svg
 home: https://github.com/devsy-org/devsy
 description: |-
   Devsy on Kubernetes

--- a/providers/podman/provider.yaml
+++ b/providers/podman/provider.yaml
@@ -1,6 +1,6 @@
 name: podman
 version: v1.0.0
-icon: https://devsy.sh/assets/podman.svg
+icon: https://dl.devsy.sh/assets/podman.svg
 home: https://github.com/devsy-org/devsy
 description: |-
   Devsy on Podman

--- a/providers/pro/provider.yaml
+++ b/providers/pro/provider.yaml
@@ -1,6 +1,6 @@
 name: devsy-pro
 version: v1.0.0
-icon: https://devsy.sh/assets/devsy.svg
+icon: https://dl.devsy.sh/assets/devsy.svg
 home: https://github.com/devsy-org/devsy
 description: Devsy Pro
 options:


### PR DESCRIPTION
## Summary

Repoints provider and IDE icon URLs to the Cloudflare R2 object storage host (`dl.devsy.sh/assets`). The previous URLs — `devsy.sh/assets/*` and `raw.githubusercontent.com/devsy-org/devsy/main/desktop/src/images/*` — both 404, so provider and IDE icons were broken.

The SVG assets have already been uploaded to R2 and resolve (`200 image/svg+xml`).

## Changes

- Add `config.DownloadBaseURL` and point `WebsiteAssetsURL` at it, fixing every IDE icon that resolved through the old dead host.
- Make the Bob IDE parse its icon via `WebsiteAssetsURL` like all other IDEs, and add its dark variant.
- Repoint built-in provider icons (docker, kubernetes, podman, pro) and the Pro fallback provider.

## Notes

The external `devsy-provider-*` repos hardcode their icon URLs in `hack/provider/main.go` and are updated separately; each needs a new release to regenerate `provider.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated provider and IDE icon links to use the dedicated asset host.
  * Improved consistency and reliability when loading Docker, Kubernetes, Podman, Dev, code-server, and Bob icons.
  * Centralized asset URL configuration for release and image assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->