### PR TITLE
fix(config): setup DEVSY_HOME / --home in PathManager

### DIFF
--- a/pkg/config/pathmanager.go
+++ b/pkg/config/pathmanager.go
@@ -22,6 +22,19 @@ func ensureDir(path string) (string, error) {
 	return path, nil
 }
 
+// homeOverrideDir roots sub beneath DEVSY_HOME when set, returning ok=false so
+// callers fall through to the OS-native default when it is unset.
+func homeOverrideDir(sub ...string) (string, bool, error) {
+	home := os.Getenv(EnvHome)
+	if home == "" {
+		return "", false, nil
+	}
+
+	dir, err := ensureDir(filepath.Join(append([]string{home}, sub...)...))
+
+	return dir, true, err
+}
+
 // PathManager centralises all filesystem path computation for the Devsy CLI.
 // Per-OS implementations supply the five top-level directory methods; every
 // sub-path is derived from those by the shared basePathManager.

--- a/pkg/config/pathmanager_darwin.go
+++ b/pkg/config/pathmanager_darwin.go
@@ -20,6 +20,10 @@ func newPlatformPathManager() PathManager {
 }
 
 func (d *darwinPathManager) ConfigDir() (string, error) {
+	if dir, ok, err := homeOverrideDir(); ok {
+		return dir, err
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("config dir: %w", err)
@@ -29,6 +33,10 @@ func (d *darwinPathManager) ConfigDir() (string, error) {
 }
 
 func (d *darwinPathManager) DataDir() (string, error) {
+	if dir, ok, err := homeOverrideDir(); ok {
+		return dir, err
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("data dir: %w", err)
@@ -38,6 +46,10 @@ func (d *darwinPathManager) DataDir() (string, error) {
 }
 
 func (d *darwinPathManager) CacheDir() (string, error) {
+	if dir, ok, err := homeOverrideDir("cache"); ok {
+		return dir, err
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cache dir: %w", err)
@@ -47,6 +59,10 @@ func (d *darwinPathManager) CacheDir() (string, error) {
 }
 
 func (d *darwinPathManager) StateDir() (string, error) {
+	if dir, ok, err := homeOverrideDir("state"); ok {
+		return dir, err
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("state dir: %w", err)
@@ -57,6 +73,10 @@ func (d *darwinPathManager) StateDir() (string, error) {
 
 // RuntimeDir returns a directory for runtime state, such as sockets and PID files.
 func (d *darwinPathManager) RuntimeDir() (string, error) {
+	if dir, ok, err := homeOverrideDir("run"); ok {
+		return dir, err
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("runtime dir: %w", err)

--- a/pkg/config/pathmanager_linux.go
+++ b/pkg/config/pathmanager_linux.go
@@ -20,6 +20,10 @@ func newPlatformPathManager() PathManager {
 }
 
 func (l *linuxPathManager) ConfigDir() (string, error) {
+	if dir, ok, err := homeOverrideDir(); ok {
+		return dir, err
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("config dir: %w", err)
@@ -29,6 +33,10 @@ func (l *linuxPathManager) ConfigDir() (string, error) {
 }
 
 func (l *linuxPathManager) DataDir() (string, error) {
+	if dir, ok, err := homeOverrideDir(); ok {
+		return dir, err
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("data dir: %w", err)
@@ -38,6 +46,10 @@ func (l *linuxPathManager) DataDir() (string, error) {
 }
 
 func (l *linuxPathManager) CacheDir() (string, error) {
+	if dir, ok, err := homeOverrideDir("cache"); ok {
+		return dir, err
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cache dir: %w", err)
@@ -47,6 +59,10 @@ func (l *linuxPathManager) CacheDir() (string, error) {
 }
 
 func (l *linuxPathManager) StateDir() (string, error) {
+	if dir, ok, err := homeOverrideDir("state"); ok {
+		return dir, err
+	}
+
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("state dir: %w", err)
@@ -56,6 +72,10 @@ func (l *linuxPathManager) StateDir() (string, error) {
 }
 
 func (l *linuxPathManager) RuntimeDir() (string, error) {
+	if dir, ok, err := homeOverrideDir("run"); ok {
+		return dir, err
+	}
+
 	return ensureDir(filepath.Join(os.TempDir(), fmt.Sprintf("%s-%d", RepoName, os.Getuid())))
 }
 

--- a/pkg/config/pathmanager_test.go
+++ b/pkg/config/pathmanager_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -44,6 +45,55 @@ func TestResetPathManager(t *testing.T) {
 
 	if pm1 == pm2 {
 		t.Error("ResetPathManager did not clear the singleton — same instance returned")
+	}
+}
+
+func TestDevsyHomeOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(EnvHome, home)
+
+	pm := NewPathManager()
+
+	tests := []struct {
+		name string
+		fn   func() (string, error)
+		want string
+	}{
+		{"ConfigDir", pm.ConfigDir, home},
+		{"DataDir", pm.DataDir, home},
+		{"CacheDir", pm.CacheDir, filepath.Join(home, "cache")},
+		{"StateDir", pm.StateDir, filepath.Join(home, "state")},
+		{"RuntimeDir", pm.RuntimeDir, filepath.Join(home, "run")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.fn()
+			if err != nil {
+				t.Fatalf("%s: unexpected error: %v", tt.name, err)
+			}
+			if got != tt.want {
+				t.Errorf("%s = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDevsyHomeOverrideConfigFilePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(EnvHome, home)
+	t.Setenv(EnvConfig, "")
+
+	pm := NewPathManager()
+
+	got, err := pm.ConfigFilePath()
+	if err != nil {
+		t.Fatalf("ConfigFilePath: %v", err)
+	}
+
+	want := filepath.Join(home, ConfigFile)
+	if got != want {
+		t.Errorf("ConfigFilePath = %q, want %q", got, want)
 	}
 }
 

--- a/pkg/config/pathmanager_windows.go
+++ b/pkg/config/pathmanager_windows.go
@@ -20,6 +20,10 @@ func newPlatformPathManager() PathManager {
 }
 
 func (w *windowsPathManager) ConfigDir() (string, error) {
+	if dir, ok, err := homeOverrideDir(); ok {
+		return dir, err
+	}
+
 	appData := os.Getenv("APPDATA")
 	if appData == "" {
 		return "", fmt.Errorf("config dir: APPDATA environment variable is not set")
@@ -29,6 +33,10 @@ func (w *windowsPathManager) ConfigDir() (string, error) {
 }
 
 func (w *windowsPathManager) DataDir() (string, error) {
+	if dir, ok, err := homeOverrideDir(); ok {
+		return dir, err
+	}
+
 	localAppData := os.Getenv("LOCALAPPDATA")
 	if localAppData == "" {
 		return "", fmt.Errorf("data dir: LOCALAPPDATA environment variable is not set")
@@ -38,6 +46,10 @@ func (w *windowsPathManager) DataDir() (string, error) {
 }
 
 func (w *windowsPathManager) CacheDir() (string, error) {
+	if dir, ok, err := homeOverrideDir("cache"); ok {
+		return dir, err
+	}
+
 	localAppData := os.Getenv("LOCALAPPDATA")
 	if localAppData == "" {
 		return "", fmt.Errorf("cache dir: LOCALAPPDATA environment variable is not set")
@@ -47,6 +59,10 @@ func (w *windowsPathManager) CacheDir() (string, error) {
 }
 
 func (w *windowsPathManager) StateDir() (string, error) {
+	if dir, ok, err := homeOverrideDir("state"); ok {
+		return dir, err
+	}
+
 	localAppData := os.Getenv("LOCALAPPDATA")
 	if localAppData == "" {
 		return "", fmt.Errorf("state dir: LOCALAPPDATA environment variable is not set")
@@ -56,6 +72,10 @@ func (w *windowsPathManager) StateDir() (string, error) {
 }
 
 func (w *windowsPathManager) RuntimeDir() (string, error) {
+	if dir, ok, err := homeOverrideDir("run"); ok {
+		return dir, err
+	}
+
 	return ensureDir(filepath.Join(os.TempDir(), RepoName))
 }
 


### PR DESCRIPTION
## Summary

`--home` and `\$DEVSY_HOME` had no effect — provider/workspace data always resolved under `~/.devsy` (issue #672).

The PathManager refactor (#74) moved path computation into per-OS implementations whose `ConfigDir`/`DataDir`/`CacheDir`/`StateDir`/`RuntimeDir` methods call `os.UserHomeDir()` and never consult `DEVSY_HOME`. The original `GetConfigDir()` honored the override by returning it directly as the `.devsy` root; that behavior was lost.

This adds a shared `homeOverrideDir` helper and routes the five top-level dir methods on each OS through it: when `DEVSY_HOME` is set, config/data root at it and cache/state/run sit beneath it; otherwise the OS-native default applies.

Fixes #672.

## Verification

- `devsy --home /tmp/x/.devsy provider add docker` now creates `/tmp/x/.devsy` with the provider config, independent of `~/.devsy`.
- Added `TestDevsyHomeOverride` / `TestDevsyHomeOverrideConfigFilePath`.
- `go test ./pkg/config/...` (26 pass) and `./cmd/... ./pkg/provider/... ./pkg/agent/...` (590 pass).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the application home directory with the `EnvHome` environment variable.
  * Configuration, data, cache, state, runtime, and configuration-file paths now resolve under the specified directory across macOS, Linux, and Windows.
  * Required subdirectories are created automatically when an override is used.

* **Bug Fixes**
  * Ensured custom home-directory settings are consistently honored across all supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->