### PR TITLE
fix(kubernetes): surface pull-secret credential errors

### DIFF
--- a/pkg/driver/kubernetes/pullsecrets.go
+++ b/pkg/driver/kubernetes/pullsecrets.go
@@ -24,9 +24,12 @@ func (k *KubernetesDriver) EnsurePullSecret(
 	}
 
 	dockerCredentials, err := dockercredentials.GetAuthConfig(host)
-	if err != nil || dockerCredentials == nil || dockerCredentials.Username == "" ||
+	if err != nil {
+		return false, fmt.Errorf("retrieve credentials for %s: %w", host, err)
+	}
+	if dockerCredentials == nil || dockerCredentials.Username == "" ||
 		dockerCredentials.Secret == "" {
-		log.Debugf("Couldn't retrieve credentials for registry: %s", host)
+		log.Debugf("no credentials configured for registry %s; pulling anonymously", host)
 		return false, nil
 	}
 


### PR DESCRIPTION
`EnsurePullSecret` collapsed a genuine `GetAuthConfig` error into the same branch as "no credentials present" — swallowing it with a `nil` return and a misleading `Couldn't retrieve credentials` debug line.

For a public image, empty credentials are expected and the anonymous-pull fallback is correct. But when the lookup genuinely errored (e.g. unreadable docker config or a failing credential helper) on a private registry, the pod was created without an `imagePullSecret` and the failure only resurfaced later as an opaque `ImagePullBackOff` instead of a clear error up front.

This separates the two cases:
- a real `GetAuthConfig` error is now wrapped and returned (propagated by the caller in `run.go`)
- the empty-credentials case keeps the benign anonymous-pull fallback, with a clearer debug message

Behavior for the common public-image path is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when registry credential retrieval fails.
  * Clarified handling of missing credentials, allowing anonymous image pulls to proceed as before.
  * Updated diagnostic messaging for anonymous pull scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->