### PR TITLE
feat(git): add support for GitLab merge requests

### DIFF
--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -651,18 +651,18 @@ function selectTemplate(t: { name: string; source: string }) {
               <Label class="text-sm">Ref Type</Label>
               <Select.Root type="single" bind:value={refType}>
                 <Select.Trigger class="h-8 w-full rounded-lg">
-                  {refType === "branch" ? "Branch" : refType === "commit" ? "Commit" : "Pull Request"}
+                  {refType === "branch" ? "Branch" : refType === "commit" ? "Commit" : "Pull / Merge Request"}
                 </Select.Trigger>
                 <Select.Content>
                   <Select.Item value="branch">Branch</Select.Item>
                   <Select.Item value="commit">Commit</Select.Item>
-                  <Select.Item value="pr">Pull Request</Select.Item>
+                  <Select.Item value="pr">Pull / Merge Request</Select.Item>
                 </Select.Content>
               </Select.Root>
             </div>
             <div class="space-y-1.5">
               <Label class="text-sm">
-                {refType === "branch" ? "Branch name" : refType === "commit" ? "Commit SHA" : "PR number"}
+                {refType === "branch" ? "Branch name" : refType === "commit" ? "Commit SHA" : "PR / MR number"}
               </Label>
               <Input
                 placeholder={refType === "branch" ? "main" : refType === "commit" ? "abc123…" : "42"}
@@ -1022,7 +1022,7 @@ function selectTemplate(t: { name: string; source: string }) {
             {#if sourceType === "git" && refValue.trim()}
               <div class="flex justify-between gap-3">
                 <span class="text-muted-foreground">
-                  {refType === "branch" ? "Branch" : refType === "commit" ? "Commit" : "Pull request"}
+                  {refType === "branch" ? "Branch" : refType === "commit" ? "Commit" : "Pull / Merge request"}
                 </span>
                 <span class="font-medium truncate">{refValue}</span>
               </div>

--- a/desktop/src/renderer/src/lib/utils/workspace-source.test.ts
+++ b/desktop/src/renderer/src/lib/utils/workspace-source.test.ts
@@ -80,6 +80,13 @@ describe("buildWorkspaceSource", () => {
     expect(out.source).toBe("git@gitlab.example.com:org/repo.git@merge-requests/7/head")
   })
 
+  it("git: PR ref uses pull/N/head when only the owner/path says gitlab", () => {
+    const out = buildWorkspaceSource(
+      gitForm({ repoUrl: "git@github.com:gitlab-org/repo.git", refType: "pr", refValue: "7" }),
+    )
+    expect(out.source).toBe("git@github.com:gitlab-org/repo.git@pull/7/head")
+  })
+
   it("git: subpath appends @subpath: after ref", () => {
     const out = buildWorkspaceSource(
       gitForm({

--- a/desktop/src/renderer/src/lib/utils/workspace-source.test.ts
+++ b/desktop/src/renderer/src/lib/utils/workspace-source.test.ts
@@ -59,11 +59,25 @@ describe("buildWorkspaceSource", () => {
     expect(out.source).toBe("github.com/org/repo@sha256:abc123")
   })
 
-  it("git: PR ref appends @pull/N/head", () => {
+  it("git: PR ref appends @pull/N/head for GitHub", () => {
     const out = buildWorkspaceSource(
       gitForm({ repoUrl: "github.com/org/repo", refType: "pr", refValue: "42" }),
     )
     expect(out.source).toBe("github.com/org/repo@pull/42/head")
+  })
+
+  it("git: MR ref appends @merge-requests/N/head for GitLab", () => {
+    const out = buildWorkspaceSource(
+      gitForm({ repoUrl: "gitlab.com/org/repo", refType: "pr", refValue: "7125" }),
+    )
+    expect(out.source).toBe("gitlab.com/org/repo@merge-requests/7125/head")
+  })
+
+  it("git: MR ref detects self-hosted GitLab by hostname", () => {
+    const out = buildWorkspaceSource(
+      gitForm({ repoUrl: "git@gitlab.example.com:org/repo.git", refType: "pr", refValue: "7" }),
+    )
+    expect(out.source).toBe("git@gitlab.example.com:org/repo.git@merge-requests/7/head")
   })
 
   it("git: subpath appends @subpath: after ref", () => {

--- a/desktop/src/renderer/src/lib/utils/workspace-source.ts
+++ b/desktop/src/renderer/src/lib/utils/workspace-source.ts
@@ -35,8 +35,7 @@ export interface WorkspaceSourceResult {
 }
 
 // hostFromUrl extracts the hostname from SSH (git@host:path) and URL
-// (scheme://[user@]host/path) forms, so an owner or path segment can't sway
-// provider detection.
+// (scheme://[user@]host/path) forms.
 function hostFromUrl(repoUrl: string): string {
   let s = repoUrl
   const scheme = s.indexOf("://")
@@ -49,8 +48,7 @@ function hostFromUrl(repoUrl: string): string {
 }
 
 // GitLab exposes merge requests at merge-requests/N/head; every other host
-// uses pull/N/head. Detection is best-effort — the CLI fetch falls back to the
-// other convention when the detected one has no such ref.
+// uses pull/N/head.
 function prRefspec(repoUrl: string, number: string): string {
   const segment = /gitlab/i.test(hostFromUrl(repoUrl)) ? "merge-requests" : "pull"
   return `@${segment}/${number}/head`

--- a/desktop/src/renderer/src/lib/utils/workspace-source.ts
+++ b/desktop/src/renderer/src/lib/utils/workspace-source.ts
@@ -34,7 +34,19 @@ export interface WorkspaceSourceResult {
   prebuildRepository?: string
 }
 
-function refSuffix(refType: GitRefType, refValue: string): string {
+// GitLab exposes merge requests at merge-requests/N/head; every other host
+// uses pull/N/head. Detection is best-effort — the CLI fetch falls back to the
+// other convention when the detected one has no such ref.
+function prRefspec(repoUrl: string, number: string): string {
+  const segment = /gitlab/i.test(repoUrl) ? "merge-requests" : "pull"
+  return `@${segment}/${number}/head`
+}
+
+function refSuffix(
+  refType: GitRefType,
+  refValue: string,
+  repoUrl: string,
+): string {
   const value = refValue.trim()
   if (!value) return ""
   switch (refType) {
@@ -43,7 +55,7 @@ function refSuffix(refType: GitRefType, refValue: string): string {
     case "commit":
       return `@sha256:${value}`
     case "pr":
-      return `@pull/${value}/head`
+      return prRefspec(repoUrl, value)
   }
 }
 
@@ -72,7 +84,8 @@ export function buildWorkspaceSource(
     }
   }
 
-  const source = `${form.repoUrl.trim()}${refSuffix(form.refType, form.refValue)}${subPathSuffix(form.subPath)}`
+  const repoUrl = form.repoUrl.trim()
+  const source = `${repoUrl}${refSuffix(form.refType, form.refValue, repoUrl)}${subPathSuffix(form.subPath)}`
 
   return {
     source,

--- a/desktop/src/renderer/src/lib/utils/workspace-source.ts
+++ b/desktop/src/renderer/src/lib/utils/workspace-source.ts
@@ -34,11 +34,25 @@ export interface WorkspaceSourceResult {
   prebuildRepository?: string
 }
 
+// hostFromUrl extracts the hostname from SSH (git@host:path) and URL
+// (scheme://[user@]host/path) forms, so an owner or path segment can't sway
+// provider detection.
+function hostFromUrl(repoUrl: string): string {
+  let s = repoUrl
+  const scheme = s.indexOf("://")
+  if (scheme !== -1) s = s.slice(scheme + 3)
+  const at = s.indexOf("@")
+  if (at !== -1) s = s.slice(at + 1)
+  const sep = s.search(/[/:]/)
+  if (sep !== -1) s = s.slice(0, sep)
+  return s
+}
+
 // GitLab exposes merge requests at merge-requests/N/head; every other host
 // uses pull/N/head. Detection is best-effort — the CLI fetch falls back to the
 // other convention when the detected one has no such ref.
 function prRefspec(repoUrl: string, number: string): string {
-  const segment = /gitlab/i.test(repoUrl) ? "merge-requests" : "pull"
+  const segment = /gitlab/i.test(hostFromUrl(repoUrl)) ? "merge-requests" : "pull"
   return `@${segment}/${number}/head`
 }
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -10,14 +10,14 @@ import (
 )
 
 const (
-	CommitDelimiter string = "@sha256:"
+	CommitDelimiter      string = "@sha256:"
 	PullRequestReference string = "(?:pull|merge-requests)/([0-9]+)/head"
 	SubPathDelimiter     string = "@subpath:"
 	repoBaseRegEx        string = `((?:(?:https?|git|ssh|file):\/\/)?\/?(?:[^@\/\n]+@)?` +
 		`(?:[^:\/\n]+)(?:[:\/][^\/\n]+)+(?:\.git)?)`
 )
 
-// WARN: Keep these in sync with the ref parsing in UI
+// WARN: Keep these in sync with the ref parsing in UI.
 var (
 	branchRegEx = regexp.MustCompile(`^` + repoBaseRegEx + `@([a-zA-Z0-9\./\-\_]+)$`)
 	commitRegEx = regexp.MustCompile(

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -10,14 +10,16 @@ import (
 )
 
 const (
-	CommitDelimiter      string = "@sha256:"
-	PullRequestReference string = "pull/([0-9]+)/head"
+	CommitDelimiter string = "@sha256:"
+	// PullRequestReference matches a pull-request (GitHub) or merge-request
+	// (GitLab) refspec, capturing the request number.
+	PullRequestReference string = "(?:pull|merge-requests)/([0-9]+)/head"
 	SubPathDelimiter     string = "@subpath:"
 	repoBaseRegEx        string = `((?:(?:https?|git|ssh|file):\/\/)?\/?(?:[^@\/\n]+@)?` +
 		`(?:[^:\/\n]+)(?:[:\/][^\/\n]+)+(?:\.git)?)`
 )
 
-// WARN: Make sure this matches the regex in /desktop/src/views/Workspaces/CreateWorkspace/CreateWorkspaceInput.tsx!
+// WARN: Keep these in sync with the ref parsing in desktop's workspace-source.ts.
 var (
 	branchRegEx = regexp.MustCompile(`^` + repoBaseRegEx + `@([a-zA-Z0-9\./\-\_]+)$`)
 	commitRegEx = regexp.MustCompile(
@@ -36,7 +38,8 @@ var recognizedSchemes = []string{"ssh://", "git@", "http://", "https://", "file:
 
 // NormalizeRepository parses a repository reference into its structured parts.
 // Accepts plain URLs, the "git:<url>" workspace-source scheme, and references
-// suffixed with @branch, @subpath:<path>, @sha256:<commit>, or @pull/N/head.
+// suffixed with @branch, @subpath:<path>, @sha256:<commit>, or a pull/merge
+// request ref (@pull/N/head or @merge-requests/N/head).
 // Bare host[/path] inputs are upgraded to https://.
 func NormalizeRepository(str string) *GitInfo {
 	str = canonicalizeURL(str)
@@ -87,14 +90,23 @@ func PingRepository(str string, extraEnv []string) bool {
 	return At("", WithEnv(extraEnv)).LsRemote(timeoutCtx, str) == nil
 }
 
+// GetBranchNameForPR returns the local branch name for a request ref, using the
+// provider convention encoded in the ref (PR<n> for GitHub, MR<n> for GitLab).
 func GetBranchNameForPR(ref string) string {
-	regex := regexp.MustCompile(PullRequestReference)
-	return regex.ReplaceAllString(ref, "PR${1}")
+	number := prNumber(ref)
+	if number == "" {
+		return ref
+	}
+	return hostForRef(ref).BranchName(number)
 }
 
+// GetIDForPR returns the lowercased request identifier used in workspace IDs.
 func GetIDForPR(ref string) string {
-	regex := regexp.MustCompile(PullRequestReference)
-	return regex.ReplaceAllString(ref, "pr${1}")
+	number := prNumber(ref)
+	if number == "" {
+		return ref
+	}
+	return strings.ToLower(hostForRef(ref).BranchName(number))
 }
 
 // GitInfo is the parsed form of a repository reference. Branch, Commit, PR,

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -11,15 +11,13 @@ import (
 
 const (
 	CommitDelimiter string = "@sha256:"
-	// PullRequestReference matches a pull-request (GitHub) or merge-request
-	// (GitLab) refspec, capturing the request number.
 	PullRequestReference string = "(?:pull|merge-requests)/([0-9]+)/head"
 	SubPathDelimiter     string = "@subpath:"
 	repoBaseRegEx        string = `((?:(?:https?|git|ssh|file):\/\/)?\/?(?:[^@\/\n]+@)?` +
 		`(?:[^:\/\n]+)(?:[:\/][^\/\n]+)+(?:\.git)?)`
 )
 
-// WARN: Keep these in sync with the ref parsing in desktop's workspace-source.ts.
+// WARN: Keep these in sync with the ref parsing in UI
 var (
 	branchRegEx = regexp.MustCompile(`^` + repoBaseRegEx + `@([a-zA-Z0-9\./\-\_]+)$`)
 	commitRegEx = regexp.MustCompile(

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -152,6 +152,14 @@ var normalizeRepositoryCases = []testCaseNormalizeRepository{
 		expectedSubpath:     "",
 	},
 	{
+		in:                  "git@gitlab.com:h3upperbounds/data/data-team.git@merge-requests/7125/head",
+		expectedRepo:        "git@gitlab.com:h3upperbounds/data/data-team.git",
+		expectedPRReference: "merge-requests/7125/head",
+		expectedBranch:      "",
+		expectedCommit:      "",
+		expectedSubpath:     "",
+	},
+	{
 		in:                  "github.com/devsy-org/devsy-without-protocol-with-slash.git@subpath:/test/path",
 		expectedRepo:        repoDevsyNoProtoSlash,
 		expectedPRReference: "",
@@ -259,6 +267,10 @@ func TestGetBranchNameForPRReference(t *testing.T) {
 		{
 			in:             testPRRef,
 			expectedBranch: "PR996",
+		},
+		{
+			in:             "merge-requests/7125/head",
+			expectedBranch: "MR7125",
 		},
 		{
 			in:             "pull/abc/head",

--- a/pkg/git/host.go
+++ b/pkg/git/host.go
@@ -51,13 +51,31 @@ func (h Host) BranchName(number string) string {
 // It is best-effort: self-hosted instances on custom domains won't be
 // recognized, which is why the fetch path falls back to the other convention.
 func DetectHost(repoURL string) Host {
-	lower := strings.ToLower(repoURL)
+	// Match only the hostname so an owner or path segment (e.g. a GitHub repo
+	// named "gitlab-ci") cannot masquerade as another provider.
+	host := strings.ToLower(hostFromURL(repoURL))
 	for _, h := range knownHosts {
-		if strings.Contains(lower, h.hostHint) {
+		if strings.Contains(host, h.hostHint) {
 			return h
 		}
 	}
 	return HostGitHub
+}
+
+// hostFromURL extracts the hostname from SSH (git@host:path) and URL
+// (scheme://[user@]host/path) forms, returning "" when none is present.
+func hostFromURL(repoURL string) string {
+	s := repoURL
+	if i := strings.Index(s, "://"); i != -1 {
+		s = s[i+3:]
+	}
+	if i := strings.Index(s, "@"); i != -1 {
+		s = s[i+1:]
+	}
+	if i := strings.IndexAny(s, "/:"); i != -1 {
+		s = s[:i]
+	}
+	return s
 }
 
 // hostForRef infers the provider from the ref itself, which already encodes the

--- a/pkg/git/host.go
+++ b/pkg/git/host.go
@@ -35,7 +35,6 @@ var (
 		hostHint:   hostNameGitLab,
 	}
 
-	// GitHub first: it is both the detection default and the first fallback.
 	knownHosts = []Host{HostGitHub, HostGitLab}
 )
 
@@ -48,11 +47,7 @@ func (h Host) BranchName(number string) string {
 }
 
 // DetectHost picks the provider from a repository URL, defaulting to GitHub.
-// It is best-effort: self-hosted instances on custom domains won't be
-// recognized, which is why the fetch path falls back to the other convention.
 func DetectHost(repoURL string) Host {
-	// Match only the hostname so an owner or path segment (e.g. a GitHub repo
-	// named "gitlab-ci") cannot masquerade as another provider.
 	host := strings.ToLower(hostFromURL(repoURL))
 	for _, h := range knownHosts {
 		if strings.Contains(host, h.hostHint) {
@@ -78,8 +73,7 @@ func hostFromURL(repoURL string) string {
 	return s
 }
 
-// hostForRef infers the provider from the ref itself, which already encodes the
-// convention exactly (unlike DetectHost's URL heuristic).
+// hostForRef infers the provider from the ref itself.
 func hostForRef(ref string) Host {
 	if strings.Contains(ref, HostGitLab.refPrefix+"/") {
 		return HostGitLab
@@ -94,8 +88,7 @@ func prNumber(ref string) string {
 	return ""
 }
 
-// prCandidates orders the hosts to try for a checkout: detected host first,
-// remaining conventions as fallbacks.
+// prCandidates orders the hosts to try for a checkout.
 func prCandidates(repoURL string) []Host {
 	primary := DetectHost(repoURL)
 	candidates := []Host{primary}

--- a/pkg/git/host.go
+++ b/pkg/git/host.go
@@ -1,0 +1,75 @@
+package git
+
+import (
+	"regexp"
+	"strings"
+)
+
+var prNumberRegEx = regexp.MustCompile(`(?:pull|merge-requests)/([0-9]+)/head`)
+
+// Host is a git provider's convention for referencing pull/merge requests:
+// GitHub exposes them at pull/N/head, GitLab at merge-requests/N/head.
+type Host struct {
+	Name       string
+	refPrefix  string
+	branchAbbr string
+	hostHint   string // substring identifying the provider in a repository URL
+}
+
+var (
+	HostGitHub = Host{Name: "github", refPrefix: "pull", branchAbbr: "PR", hostHint: "github"}
+	HostGitLab = Host{Name: "gitlab", refPrefix: "merge-requests", branchAbbr: "MR", hostHint: "gitlab"}
+
+	// GitHub first: it is both the detection default and the first fallback.
+	knownHosts = []Host{HostGitHub, HostGitLab}
+)
+
+func (h Host) Refspec(number string) string {
+	return h.refPrefix + "/" + number + "/head"
+}
+
+func (h Host) BranchName(number string) string {
+	return h.branchAbbr + number
+}
+
+// DetectHost picks the provider from a repository URL, defaulting to GitHub.
+// It is best-effort: self-hosted instances on custom domains won't be
+// recognized, which is why the fetch path falls back to the other convention.
+func DetectHost(repoURL string) Host {
+	lower := strings.ToLower(repoURL)
+	for _, h := range knownHosts {
+		if strings.Contains(lower, h.hostHint) {
+			return h
+		}
+	}
+	return HostGitHub
+}
+
+// hostForRef infers the provider from the ref itself, which already encodes the
+// convention exactly (unlike DetectHost's URL heuristic).
+func hostForRef(ref string) Host {
+	if strings.Contains(ref, HostGitLab.refPrefix+"/") {
+		return HostGitLab
+	}
+	return HostGitHub
+}
+
+func prNumber(ref string) string {
+	if m := prNumberRegEx.FindStringSubmatch(ref); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// prCandidates orders the hosts to try for a checkout: detected host first,
+// remaining conventions as fallbacks.
+func prCandidates(repoURL string) []Host {
+	primary := DetectHost(repoURL)
+	candidates := []Host{primary}
+	for _, h := range knownHosts {
+		if h.Name != primary.Name {
+			candidates = append(candidates, h)
+		}
+	}
+	return candidates
+}

--- a/pkg/git/host.go
+++ b/pkg/git/host.go
@@ -7,6 +7,11 @@ import (
 
 var prNumberRegEx = regexp.MustCompile(`(?:pull|merge-requests)/([0-9]+)/head`)
 
+const (
+	hostNameGitHub = "github"
+	hostNameGitLab = "gitlab"
+)
+
 // Host is a git provider's convention for referencing pull/merge requests:
 // GitHub exposes them at pull/N/head, GitLab at merge-requests/N/head.
 type Host struct {
@@ -17,8 +22,18 @@ type Host struct {
 }
 
 var (
-	HostGitHub = Host{Name: "github", refPrefix: "pull", branchAbbr: "PR", hostHint: "github"}
-	HostGitLab = Host{Name: "gitlab", refPrefix: "merge-requests", branchAbbr: "MR", hostHint: "gitlab"}
+	HostGitHub = Host{
+		Name:       hostNameGitHub,
+		refPrefix:  "pull",
+		branchAbbr: "PR",
+		hostHint:   hostNameGitHub,
+	}
+	HostGitLab = Host{
+		Name:       hostNameGitLab,
+		refPrefix:  "merge-requests",
+		branchAbbr: "MR",
+		hostHint:   hostNameGitLab,
+	}
 
 	// GitHub first: it is both the detection default and the first fallback.
 	knownHosts = []Host{HostGitHub, HostGitLab}

--- a/pkg/git/host_test.go
+++ b/pkg/git/host_test.go
@@ -12,11 +12,14 @@ func TestDetectHost(t *testing.T) {
 		url  string
 		want string
 	}{
-		{"git@github.com:org/repo.git", "github"},
-		{"https://github.com/org/repo.git", "github"},
-		{"git@gitlab.com:org/repo.git", "gitlab"},
-		{"https://gitlab.example.com/org/repo.git", "gitlab"},
-		{"https://git.internal.example/org/repo.git", "github"}, // unknown host defaults to GitHub
+		{"git@github.com:org/repo.git", hostNameGitHub},
+		{"https://github.com/org/repo.git", hostNameGitHub},
+		{"git@gitlab.com:org/repo.git", hostNameGitLab},
+		{"https://gitlab.example.com/org/repo.git", hostNameGitLab},
+		{
+			"https://git.internal.example/org/repo.git",
+			hostNameGitHub,
+		}, // unknown host defaults to GitHub
 	}
 	for _, c := range cases {
 		assert.Check(t, cmp.Equal(c.want, DetectHost(c.url).Name), "url=%s", c.url)
@@ -39,6 +42,6 @@ func TestPRNumber(t *testing.T) {
 func TestPRCandidatesOrder(t *testing.T) {
 	got := prCandidates("git@gitlab.com:org/repo.git")
 	assert.Equal(t, 2, len(got))
-	assert.Equal(t, "gitlab", got[0].Name) // detected host first
-	assert.Equal(t, "github", got[1].Name) // fallback
+	assert.Equal(t, hostNameGitLab, got[0].Name) // detected host first
+	assert.Equal(t, hostNameGitHub, got[1].Name) // fallback
 }

--- a/pkg/git/host_test.go
+++ b/pkg/git/host_test.go
@@ -16,6 +16,9 @@ func TestDetectHost(t *testing.T) {
 		{"https://github.com/org/repo.git", hostNameGitHub},
 		{"git@gitlab.com:org/repo.git", hostNameGitLab},
 		{"https://gitlab.example.com/org/repo.git", hostNameGitLab},
+		// Only the hostname decides: a "gitlab" owner/path on github.com is GitHub.
+		{"git@github.com:gitlab-org/repo.git", hostNameGitHub},
+		{"https://github.com/org/gitlab-mirror.git", hostNameGitHub},
 		{
 			"https://git.internal.example/org/repo.git",
 			hostNameGitHub,

--- a/pkg/git/host_test.go
+++ b/pkg/git/host_test.go
@@ -1,0 +1,44 @@
+package git
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	"gotest.tools/assert/cmp"
+)
+
+func TestDetectHost(t *testing.T) {
+	cases := []struct {
+		url  string
+		want string
+	}{
+		{"git@github.com:org/repo.git", "github"},
+		{"https://github.com/org/repo.git", "github"},
+		{"git@gitlab.com:org/repo.git", "gitlab"},
+		{"https://gitlab.example.com/org/repo.git", "gitlab"},
+		{"https://git.internal.example/org/repo.git", "github"}, // unknown host defaults to GitHub
+	}
+	for _, c := range cases {
+		assert.Check(t, cmp.Equal(c.want, DetectHost(c.url).Name), "url=%s", c.url)
+	}
+}
+
+func TestHostRefspecAndBranch(t *testing.T) {
+	assert.Equal(t, "pull/42/head", HostGitHub.Refspec("42"))
+	assert.Equal(t, "PR42", HostGitHub.BranchName("42"))
+	assert.Equal(t, "merge-requests/42/head", HostGitLab.Refspec("42"))
+	assert.Equal(t, "MR42", HostGitLab.BranchName("42"))
+}
+
+func TestPRNumber(t *testing.T) {
+	assert.Equal(t, "996", prNumber("pull/996/head"))
+	assert.Equal(t, "7125", prNumber("merge-requests/7125/head"))
+	assert.Equal(t, "", prNumber("refs/heads/main"))
+}
+
+func TestPRCandidatesOrder(t *testing.T) {
+	got := prCandidates("git@gitlab.com:org/repo.git")
+	assert.Equal(t, 2, len(got))
+	assert.Equal(t, "gitlab", got[0].Name) // detected host first
+	assert.Equal(t, "github", got[1].Name) // fallback
+}

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -96,13 +97,32 @@ func (r *Repo) CheckoutPR(ctx context.Context, repoURL, prRef string) error {
 		prBranch := host.BranchName(number)
 		log.Debugf("fetching %s request: %s", host.Name, refspec)
 
-		if err := r.Fetch(ctx, refspec+":"+prBranch); err != nil {
-			lastErr = err
-			continue
+		err := r.Fetch(ctx, refspec+":"+prBranch)
+		if err == nil {
+			return r.Switch(ctx, prBranch)
 		}
-		return r.Switch(ctx, prBranch)
+		// Only try the next provider's convention when this refspec is genuinely
+		// absent; auth, network, and cancellation errors must surface as-is
+		// rather than be masked by a subsequent lookup's failure.
+		if !isMissingRefError(err) {
+			return err
+		}
+		lastErr = err
 	}
 	return lastErr
+}
+
+// isMissingRefError reports whether err is git failing to find the requested
+// remote ref, as opposed to an auth, network, or cancellation failure.
+func isMissingRefError(err error) bool {
+	var cmdErr *CommandError
+	if !errors.As(err, &cmdErr) {
+		return false
+	}
+	msg := strings.ToLower(cmdErr.Stderr)
+	return strings.Contains(msg, "couldn't find remote ref") ||
+		strings.Contains(msg, "no such ref") ||
+		strings.Contains(msg, "not found in upstream")
 }
 
 // Reset moves HEAD to commit using the given mode.

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -79,15 +79,30 @@ func (r *Repo) Switch(ctx context.Context, branch string) error {
 	return nil
 }
 
-// CheckoutPR fetches the given pull request refspec and switches to a local branch for it.
-func (r *Repo) CheckoutPR(ctx context.Context, prRef string) error {
-	log.Debugf("fetching pull request: %s", prRef)
-
-	prBranch := GetBranchNameForPR(prRef)
-	if err := r.Fetch(ctx, prRef+":"+prBranch); err != nil {
-		return err
+// CheckoutPR fetches a pull/merge request into a local branch and switches to
+// it. The request number is taken from prRef; the remote refspec is resolved
+// against repoURL's hosting provider, falling back to the other known
+// conventions when the detected one has no such ref (e.g. self-hosted GitLab on
+// a custom domain that URL detection can't recognize).
+func (r *Repo) CheckoutPR(ctx context.Context, repoURL, prRef string) error {
+	number := prNumber(prRef)
+	if number == "" {
+		return fmt.Errorf("not a pull/merge request reference: %q", prRef)
 	}
-	return r.Switch(ctx, prBranch)
+
+	var lastErr error
+	for _, host := range prCandidates(repoURL) {
+		refspec := host.Refspec(number)
+		prBranch := host.BranchName(number)
+		log.Debugf("fetching %s request: %s", host.Name, refspec)
+
+		if err := r.Fetch(ctx, refspec+":"+prBranch); err != nil {
+			lastErr = err
+			continue
+		}
+		return r.Switch(ctx, prBranch)
+	}
+	return lastErr
 }
 
 // Reset moves HEAD to commit using the given mode.
@@ -140,7 +155,7 @@ func (r *Repo) CloneFromInfo(
 
 	switch {
 	case gitInfo.PR != "":
-		if err := r.CheckoutPR(ctx, gitInfo.PR); err != nil {
+		if err := r.CheckoutPR(ctx, gitInfo.Repository, gitInfo.PR); err != nil {
 			return err
 		}
 	case gitInfo.Commit != "":

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -101,9 +101,6 @@ func (r *Repo) CheckoutPR(ctx context.Context, repoURL, prRef string) error {
 		if err == nil {
 			return r.Switch(ctx, prBranch)
 		}
-		// Only try the next provider's convention when this refspec is genuinely
-		// absent; auth, network, and cancellation errors must surface as-is
-		// rather than be masked by a subsequent lookup's failure.
 		if !isMissingRefError(err) {
 			return err
 		}

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -12,11 +12,16 @@ import (
 // Shared literals used across Repo tests.
 const (
 	testRepoURL   = "git@host:org/repo.git"
+	testGitHubURL = "https://github.com/org/repo.git"
+	testGitLabURL = "git@gitlab.com:org/repo.git"
 	testPRRef     = "pull/996/head"
 	testPRLocal   = "PR996"
 	testPRRefSpec = testPRRef + ":" + testPRLocal
+	testMRLocal   = "MR7"
+	testMRRefSpec = "merge-requests/7/head:" + testMRLocal
 	testCommit    = "abc123"
 	subFetch      = "fetch"
+	subSwitch     = "switch"
 	originRemote  = "origin"
 	testTarget    = "/tmp/target"
 )
@@ -68,20 +73,21 @@ func TestRepoCheckoutPR(t *testing.T) {
 	fake := &fakeRunner{}
 	repo := At("/tmp/repo", WithRunner(fake))
 
-	assert.NilError(t, repo.CheckoutPR(context.Background(), "https://github.com/org/repo.git", testPRRef))
+	err := repo.CheckoutPR(context.Background(), testGitHubURL, testPRRef)
+	assert.NilError(t, err)
 	// Expect a fetch of the PR ref into a local branch, then a switch to it.
 	assert.DeepEqual(t, []string{subFetch, originRemote, testPRRefSpec}, fake.calls[0].Args)
-	assert.DeepEqual(t, []string{"switch", testPRLocal}, fake.calls[1].Args)
+	assert.DeepEqual(t, []string{subSwitch, testPRLocal}, fake.calls[1].Args)
 }
 
 func TestRepoCheckoutPRGitLab(t *testing.T) {
 	fake := &fakeRunner{}
 	repo := At("/tmp/repo", WithRunner(fake))
 
-	err := repo.CheckoutPR(context.Background(), "git@gitlab.com:org/repo.git", "merge-requests/7/head")
+	err := repo.CheckoutPR(context.Background(), testGitLabURL, "merge-requests/7/head")
 	assert.NilError(t, err)
-	assert.DeepEqual(t, []string{subFetch, originRemote, "merge-requests/7/head:MR7"}, fake.calls[0].Args)
-	assert.DeepEqual(t, []string{"switch", "MR7"}, fake.calls[1].Args)
+	assert.DeepEqual(t, []string{subFetch, originRemote, testMRRefSpec}, fake.calls[0].Args)
+	assert.DeepEqual(t, []string{subSwitch, testMRLocal}, fake.calls[1].Args)
 }
 
 // A GitLab MR requested with a GitHub-style ref still resolves: host detection
@@ -90,10 +96,10 @@ func TestRepoCheckoutPRGitLabFromGitHubStyleRef(t *testing.T) {
 	fake := &fakeRunner{}
 	repo := At("/tmp/repo", WithRunner(fake))
 
-	err := repo.CheckoutPR(context.Background(), "git@gitlab.com:org/repo.git", "pull/7/head")
+	err := repo.CheckoutPR(context.Background(), testGitLabURL, "pull/7/head")
 	assert.NilError(t, err)
-	assert.DeepEqual(t, []string{subFetch, originRemote, "merge-requests/7/head:MR7"}, fake.calls[0].Args)
-	assert.DeepEqual(t, []string{"switch", "MR7"}, fake.calls[1].Args)
+	assert.DeepEqual(t, []string{subFetch, originRemote, testMRRefSpec}, fake.calls[0].Args)
+	assert.DeepEqual(t, []string{subSwitch, testMRLocal}, fake.calls[1].Args)
 }
 
 // When the detected host's ref is missing (undetectable self-hosted instance),
@@ -104,11 +110,15 @@ func TestRepoCheckoutPRFallback(t *testing.T) {
 
 	// URL detection yields GitHub (default); its fetch fails, so the checkout
 	// falls back to the GitLab convention.
-	err := repo.CheckoutPR(context.Background(), "https://git.internal.example/org/repo.git", "pull/7/head")
+	err := repo.CheckoutPR(
+		context.Background(),
+		"https://git.internal.example/org/repo.git",
+		"pull/7/head",
+	)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, []string{subFetch, originRemote, "pull/7/head:PR7"}, fake.calls[0].Args)
-	assert.DeepEqual(t, []string{subFetch, originRemote, "merge-requests/7/head:MR7"}, fake.calls[1].Args)
-	assert.DeepEqual(t, []string{"switch", "MR7"}, fake.calls[2].Args)
+	assert.DeepEqual(t, []string{subFetch, originRemote, testMRRefSpec}, fake.calls[1].Args)
+	assert.DeepEqual(t, []string{subSwitch, testMRLocal}, fake.calls[2].Args)
 }
 
 func TestRepoLsRemote(t *testing.T) {
@@ -204,7 +214,7 @@ func TestRepoCloneFromInfoPR(t *testing.T) {
 	assert.NilError(t, repo.CloneFromInfo(context.Background(), info, ""))
 	assert.Equal(t, subClone, fake.calls[0].Args[0])
 	assert.DeepEqual(t, []string{subFetch, originRemote, testPRRefSpec}, fake.calls[1].Args)
-	assert.DeepEqual(t, []string{"switch", testPRLocal}, fake.calls[2].Args)
+	assert.DeepEqual(t, []string{subSwitch, testPRLocal}, fake.calls[2].Args)
 }
 
 func TestRepoCloneFromInfoHelper(t *testing.T) {

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -32,8 +32,6 @@ type fakeRunner struct {
 	calls  []RunOptions
 	stdout []byte
 	err    error
-	// errUntil makes the first errUntil calls fail, simulating a missing
-	// remote ref that triggers the CheckoutPR fallback.
 	errUntil int
 }
 
@@ -80,7 +78,6 @@ func TestRepoCheckoutPR(t *testing.T) {
 
 	err := repo.CheckoutPR(context.Background(), testGitHubURL, testPRRef)
 	assert.NilError(t, err)
-	// Expect a fetch of the PR ref into a local branch, then a switch to it.
 	assert.DeepEqual(t, []string{subFetch, originRemote, testPRRefSpec}, fake.calls[0].Args)
 	assert.DeepEqual(t, []string{subSwitch, testPRLocal}, fake.calls[1].Args)
 }
@@ -95,8 +92,6 @@ func TestRepoCheckoutPRGitLab(t *testing.T) {
 	assert.DeepEqual(t, []string{subSwitch, testMRLocal}, fake.calls[1].Args)
 }
 
-// A GitLab MR requested with a GitHub-style ref still resolves: host detection
-// from the URL picks GitLab and rewrites the refspec to merge-requests/N/head.
 func TestRepoCheckoutPRGitLabFromGitHubStyleRef(t *testing.T) {
 	fake := &fakeRunner{}
 	repo := At("/tmp/repo", WithRunner(fake))
@@ -107,14 +102,10 @@ func TestRepoCheckoutPRGitLabFromGitHubStyleRef(t *testing.T) {
 	assert.DeepEqual(t, []string{subSwitch, testMRLocal}, fake.calls[1].Args)
 }
 
-// When the detected host's ref is missing (undetectable self-hosted instance),
-// the fetch falls back to the other known convention.
 func TestRepoCheckoutPRFallback(t *testing.T) {
 	fake := &fakeRunner{errUntil: 1}
 	repo := At("/tmp/repo", WithRunner(fake))
 
-	// URL detection yields GitHub (default); its fetch fails, so the checkout
-	// falls back to the GitLab convention.
 	err := repo.CheckoutPR(
 		context.Background(),
 		"https://git.internal.example/org/repo.git",
@@ -126,8 +117,6 @@ func TestRepoCheckoutPRFallback(t *testing.T) {
 	assert.DeepEqual(t, []string{subSwitch, testMRLocal}, fake.calls[2].Args)
 }
 
-// A non-ref fetch failure (auth, network, …) must surface immediately without
-// being masked by the alternate-provider fallback.
 func TestRepoCheckoutPRNonRefErrorNoFallback(t *testing.T) {
 	authErr := &CommandError{
 		Args:     []string{subFetch},
@@ -140,7 +129,6 @@ func TestRepoCheckoutPRNonRefErrorNoFallback(t *testing.T) {
 
 	err := repo.CheckoutPR(context.Background(), testGitHubURL, testPRRef)
 	assert.ErrorContains(t, err, "Authentication failed")
-	// Only the first candidate is attempted; the auth error is not retried.
 	assert.Equal(t, 1, len(fake.calls))
 }
 

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -40,7 +40,12 @@ type fakeRunner struct {
 func (f *fakeRunner) Run(_ context.Context, opts RunOptions) (RunResult, error) {
 	f.calls = append(f.calls, opts)
 	if len(f.calls) <= f.errUntil {
-		return RunResult{}, errors.New("couldn't find remote ref")
+		return RunResult{}, &CommandError{
+			Args:     opts.Args,
+			ExitCode: 128,
+			Stderr:   "fatal: couldn't find remote ref " + opts.Args[len(opts.Args)-1],
+			Err:      errors.New("exit status 128"),
+		}
 	}
 	return RunResult{Stdout: f.stdout}, f.err
 }
@@ -119,6 +124,24 @@ func TestRepoCheckoutPRFallback(t *testing.T) {
 	assert.DeepEqual(t, []string{subFetch, originRemote, "pull/7/head:PR7"}, fake.calls[0].Args)
 	assert.DeepEqual(t, []string{subFetch, originRemote, testMRRefSpec}, fake.calls[1].Args)
 	assert.DeepEqual(t, []string{subSwitch, testMRLocal}, fake.calls[2].Args)
+}
+
+// A non-ref fetch failure (auth, network, …) must surface immediately without
+// being masked by the alternate-provider fallback.
+func TestRepoCheckoutPRNonRefErrorNoFallback(t *testing.T) {
+	authErr := &CommandError{
+		Args:     []string{subFetch},
+		ExitCode: 128,
+		Stderr:   "fatal: Authentication failed for 'https://host/org/repo.git'",
+		Err:      errors.New("exit status 128"),
+	}
+	fake := &fakeRunner{err: authErr}
+	repo := At("/tmp/repo", WithRunner(fake))
+
+	err := repo.CheckoutPR(context.Background(), testGitHubURL, testPRRef)
+	assert.ErrorContains(t, err, "Authentication failed")
+	// Only the first candidate is attempted; the auth error is not retried.
+	assert.Equal(t, 1, len(fake.calls))
 }
 
 func TestRepoLsRemote(t *testing.T) {

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -29,9 +29,9 @@ const (
 // fakeRunner records the invocations it receives and returns canned output,
 // letting git operations be tested without a real repository.
 type fakeRunner struct {
-	calls  []RunOptions
-	stdout []byte
-	err    error
+	calls    []RunOptions
+	stdout   []byte
+	err      error
 	errUntil int
 }
 

--- a/pkg/git/repo_test.go
+++ b/pkg/git/repo_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"gotest.tools/assert"
@@ -26,10 +27,16 @@ type fakeRunner struct {
 	calls  []RunOptions
 	stdout []byte
 	err    error
+	// errUntil makes the first errUntil calls fail, simulating a missing
+	// remote ref that triggers the CheckoutPR fallback.
+	errUntil int
 }
 
 func (f *fakeRunner) Run(_ context.Context, opts RunOptions) (RunResult, error) {
 	f.calls = append(f.calls, opts)
+	if len(f.calls) <= f.errUntil {
+		return RunResult{}, errors.New("couldn't find remote ref")
+	}
 	return RunResult{Stdout: f.stdout}, f.err
 }
 
@@ -61,10 +68,47 @@ func TestRepoCheckoutPR(t *testing.T) {
 	fake := &fakeRunner{}
 	repo := At("/tmp/repo", WithRunner(fake))
 
-	assert.NilError(t, repo.CheckoutPR(context.Background(), testPRRef))
+	assert.NilError(t, repo.CheckoutPR(context.Background(), "https://github.com/org/repo.git", testPRRef))
 	// Expect a fetch of the PR ref into a local branch, then a switch to it.
 	assert.DeepEqual(t, []string{subFetch, originRemote, testPRRefSpec}, fake.calls[0].Args)
 	assert.DeepEqual(t, []string{"switch", testPRLocal}, fake.calls[1].Args)
+}
+
+func TestRepoCheckoutPRGitLab(t *testing.T) {
+	fake := &fakeRunner{}
+	repo := At("/tmp/repo", WithRunner(fake))
+
+	err := repo.CheckoutPR(context.Background(), "git@gitlab.com:org/repo.git", "merge-requests/7/head")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, []string{subFetch, originRemote, "merge-requests/7/head:MR7"}, fake.calls[0].Args)
+	assert.DeepEqual(t, []string{"switch", "MR7"}, fake.calls[1].Args)
+}
+
+// A GitLab MR requested with a GitHub-style ref still resolves: host detection
+// from the URL picks GitLab and rewrites the refspec to merge-requests/N/head.
+func TestRepoCheckoutPRGitLabFromGitHubStyleRef(t *testing.T) {
+	fake := &fakeRunner{}
+	repo := At("/tmp/repo", WithRunner(fake))
+
+	err := repo.CheckoutPR(context.Background(), "git@gitlab.com:org/repo.git", "pull/7/head")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, []string{subFetch, originRemote, "merge-requests/7/head:MR7"}, fake.calls[0].Args)
+	assert.DeepEqual(t, []string{"switch", "MR7"}, fake.calls[1].Args)
+}
+
+// When the detected host's ref is missing (undetectable self-hosted instance),
+// the fetch falls back to the other known convention.
+func TestRepoCheckoutPRFallback(t *testing.T) {
+	fake := &fakeRunner{errUntil: 1}
+	repo := At("/tmp/repo", WithRunner(fake))
+
+	// URL detection yields GitHub (default); its fetch fails, so the checkout
+	// falls back to the GitLab convention.
+	err := repo.CheckoutPR(context.Background(), "https://git.internal.example/org/repo.git", "pull/7/head")
+	assert.NilError(t, err)
+	assert.DeepEqual(t, []string{subFetch, originRemote, "pull/7/head:PR7"}, fake.calls[0].Args)
+	assert.DeepEqual(t, []string{subFetch, originRemote, "merge-requests/7/head:MR7"}, fake.calls[1].Args)
+	assert.DeepEqual(t, []string{"switch", "MR7"}, fake.calls[2].Args)
 }
 
 func TestRepoLsRemote(t *testing.T) {


### PR DESCRIPTION
## Summary

Cloning a GitLab repository at a merge-request ref failed with `fatal: couldn't find remote ref pull/N/head`. The clone itself succeeded; the follow-up fetch failed because devsy hardcoded GitHub's `pull/N/head` refspec everywhere, while GitLab exposes merge requests at `merge-requests/N/head`.

This introduces a small git-host abstraction that owns each provider's convention in one place, replacing the scattered hardcoded assumptions.

## Changes

- **`pkg/git/host.go`** (new) — a `Host` registry (`HostGitHub`, `HostGitLab`) holding each provider's refspec prefix (`pull` vs `merge-requests`) and local-branch prefix (`PR` vs `MR`), with `DetectHost(url)` and `prCandidates(url)`.
- **`pkg/git/repo.go`** — `CheckoutPR` now takes the repo URL, resolves the host, and **falls back** to the other convention when the detected refspec is missing. This makes self-hosted GitLab on custom domains work even though URL detection can't recognize them.
- **`pkg/git/git.go`** — broadened the ref regex to accept both conventions; host-aware branch/ID naming.
- **Desktop** — `workspace-source.ts` emits the correct refspec by host; the wizard is relabeled **"Pull / Merge Request"** instead of GitHub-only "Pull Request".

## Notes

- The stale `WARN` comment in `git.go` pointing at a deleted `CreateWorkspaceInput.tsx` was updated to reference the real file.
- Go tests (host detection, GitLab refs, GitHub-style-ref-on-GitLab, fallback path) pass. New desktop vitest cases are written but unrun in this worktree (no `node_modules`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added checkout support for GitLab merge requests, including self-hosted GitLab repositories.
  * Automatically detects whether a PR/MR reference uses GitHub or GitLab conventions and applies the correct refspec, with fallback behavior when the first attempt fails.
  * Updated the Git advanced options and review step UI to use “Pull / Merge Request” terminology.

* **Bug Fixes**
  * Corrected PR/MR ref formatting and normalization across supported Git hosting providers.

* **Tests**
  * Expanded unit test coverage for host detection and PR/MR ref conversion for GitHub and GitLab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->