### PR TITLE
chore(ide): update vscode web and codeserver versions

### DIFF
--- a/pkg/ide/codeserver/codeserver.go
+++ b/pkg/ide/codeserver/codeserver.go
@@ -51,7 +51,7 @@ var Options = ide.Options{
 	VersionOption: {
 		Name:        VersionOption,
 		Description: "The version for the code-server binary (without the leading v)",
-		Default:     "4.121.0",
+		Default:     "4.129.0",
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,

--- a/pkg/ide/vscodeweb/vscodeweb.go
+++ b/pkg/ide/vscodeweb/vscodeweb.go
@@ -50,9 +50,8 @@ var Options = ide.Options{
 	},
 	VersionOption: {
 		Name: VersionOption,
-		Description: "The VS Code version for the serve-web CLI " +
-			"(a release version like 1.96.4, or 'latest')",
-		Default: "1.96.4",
+		Description: "The VS Code version for the serve-web CLI (e.g., 1.129.1 or 'latest')",
+		Default: "1.129.1",
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,

--- a/pkg/ide/vscodeweb/vscodeweb.go
+++ b/pkg/ide/vscodeweb/vscodeweb.go
@@ -49,9 +49,9 @@ var Options = ide.Options{
 		Default:     "",
 	},
 	VersionOption: {
-		Name: VersionOption,
+		Name:        VersionOption,
 		Description: "The VS Code version for the serve-web CLI (e.g., 1.129.1 or 'latest')",
-		Default: "1.129.1",
+		Default:     "1.129.1",
 	},
 	DownloadArm64Option: {
 		Name:        DownloadArm64Option,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the default Code Server version to 4.129.0.
  * Updated the default VS Code Web version to 1.129.1.
  * Improved the VS Code Web version option guidance, including support for the “latest” format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->