### PR TITLE
chore(lint): resolve modernize findings

### DIFF
--- a/cmd/internal/agentcontainer/setup_internal_test.go
+++ b/cmd/internal/agentcontainer/setup_internal_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func ptr(s string) *string { return &s }
-
 func TestCompressSetupInfoPreservesSubstitutedValues(t *testing.T) {
 	// Simulate post-substitution state: PATH is a real value, not a
 	// ${containerEnv:PATH} literal.
@@ -22,8 +20,8 @@ func TestCompressSetupInfoPreservesSubstitutedValues(t *testing.T) {
 		MergedConfig: &config.MergedDevContainerConfig{
 			DevContainerConfigBase: config.DevContainerConfigBase{
 				RemoteEnv: map[string]*string{
-					"PATH": ptr("/usr/local/bin:/usr/bin:/bin"),
-					"HOME": ptr("/home/testuser"),
+					"PATH": new("/usr/local/bin:/usr/bin:/bin"),
+					"HOME": new("/home/testuser"),
 				},
 			},
 		},

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -407,7 +407,7 @@ func Tunnel(ctx context.Context, opts TunnelOptions) error {
 		IsLocal:                     false,
 		RemoteAgentPath:             config.ContainerDevsyHelperLocation,
 		DownloadURL:                 config.DefaultAgentDownloadURL(),
-		PreferDownloadFromRemoteUrl: Bool(false),
+		PreferDownloadFromRemoteUrl: new(false),
 		Timeout:                     opts.Timeout,
 	}); err != nil {
 		return err

--- a/pkg/agent/delivery/legacy_shell.go
+++ b/pkg/agent/delivery/legacy_shell.go
@@ -41,7 +41,7 @@ func (d *LegacyShellDelivery) DeliverPostStart(ctx context.Context, opts PostSta
 		IsLocal:                     false,
 		RemoteAgentPath:             pkgconfig.ContainerDevsyHelperLocation,
 		DownloadURL:                 d.downloadURL(),
-		PreferDownloadFromRemoteUrl: agent.Bool(false),
+		PreferDownloadFromRemoteUrl: new(false),
 	}
 
 	if d.Timeout != nil {

--- a/pkg/agent/inject.go
+++ b/pkg/agent/inject.go
@@ -77,8 +77,9 @@ func (o *InjectOptions) ApplyDefaults() {
 	o.applyPreferDownloadDefaults()
 }
 
+//go:fix inline
 func Bool(b bool) *bool {
-	return &b
+	return new(b)
 }
 
 func (o *InjectOptions) Validate() error {
@@ -141,13 +142,13 @@ func (o *InjectOptions) applyPreferDownloadDefaults() {
 	case preferDownloadEnv != "":
 		o.applyEnvPreference(preferDownloadEnv)
 	case hasCustomAgentURL:
-		o.PreferDownloadFromRemoteUrl = Bool(true)
+		o.PreferDownloadFromRemoteUrl = new(true)
 		o.SkipVersionCheck = true
 	case version.GetVersion() == version.DevVersion:
-		o.PreferDownloadFromRemoteUrl = Bool(false)
+		o.PreferDownloadFromRemoteUrl = new(false)
 		o.SkipVersionCheck = true
 	default:
-		o.PreferDownloadFromRemoteUrl = Bool(true)
+		o.PreferDownloadFromRemoteUrl = new(true)
 	}
 }
 
@@ -157,7 +158,7 @@ func (o *InjectOptions) applyEnvPreference(preferDownloadEnv string) {
 		log.Warnf("failed to parse %s, using default", config.EnvAgentPreferDownload)
 		pref = true
 	}
-	o.PreferDownloadFromRemoteUrl = Bool(pref)
+	o.PreferDownloadFromRemoteUrl = new(pref)
 	o.SkipVersionCheck = true
 }
 

--- a/pkg/devcontainer/config/extends_test.go
+++ b/pkg/devcontainer/config/extends_test.go
@@ -830,8 +830,3 @@ func TestExtends_LocalWorkspaceFolderBasenameInPath(t *testing.T) {
 		t.Errorf("expected image 'alpine:3', got %q", cfg.Image)
 	}
 }
-
-//go:fix inline
-func strPtr(s string) *string {
-	return new(s)
-}

--- a/pkg/devcontainer/run_test.go
+++ b/pkg/devcontainer/run_test.go
@@ -149,13 +149,11 @@ func searchString(s, substr string) bool {
 	return false
 }
 
-func strPtr(s string) *string { return &s }
-
 func TestGetWorkspace_CustomWorkspaceMount(t *testing.T) {
 	customMount := "type=bind,source=/host/src,target=/custom-ws"
 	conf := &config.DevContainerConfig{
 		NonComposeBase: config.NonComposeBase{
-			WorkspaceMount: strPtr(customMount),
+			WorkspaceMount: new(customMount),
 		},
 	}
 
@@ -205,7 +203,7 @@ func TestGetWorkspace_DefaultMountWithWorkspaceFolder(t *testing.T) {
 func TestGetWorkspace_EmptyWorkspaceMount(t *testing.T) {
 	conf := &config.DevContainerConfig{
 		NonComposeBase: config.NonComposeBase{
-			WorkspaceMount: strPtr(""),
+			WorkspaceMount: new(""),
 		},
 	}
 
@@ -236,7 +234,7 @@ func TestGetWorkspace_UserConsistencyPreserved(t *testing.T) {
 	customMount := "type=bind,source=/src,target=/ws,consistency=delegated"
 	conf := &config.DevContainerConfig{
 		NonComposeBase: config.NonComposeBase{
-			WorkspaceMount: strPtr(customMount),
+			WorkspaceMount: new(customMount),
 		},
 	}
 

--- a/pkg/devcontainer/setup/lifecyclehooks_test.go
+++ b/pkg/devcontainer/setup/lifecyclehooks_test.go
@@ -275,8 +275,6 @@ func makeTestPhaseHooks() []phaseHook {
 	}
 }
 
-func ptr(s string) *string { return &s }
-
 func (s *LifecycleHookTestSuite) TestMergeRemoteEnvNilUnsetsKey() {
 	probedEnv := map[string]string{"KEEP": "yes", "DROP": "bye"}
 	remoteEnv := map[string]*string{"DROP": nil}
@@ -290,7 +288,7 @@ func (s *LifecycleHookTestSuite) TestMergeRemoteEnvNilUnsetsKey() {
 
 func (s *LifecycleHookTestSuite) TestMergeRemoteEnvNonNilOverrides() {
 	probedEnv := map[string]string{"VAR": "old"}
-	remoteEnv := map[string]*string{"VAR": ptr("new")}
+	remoteEnv := map[string]*string{"VAR": new("new")}
 
 	result := mergeRemoteEnv(remoteEnv, probedEnv, "vscode")
 

--- a/pkg/devcontainer/setup_test.go
+++ b/pkg/devcontainer/setup_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/types"
 )
 
-func boolPtr(v bool) *bool { return &v }
-
 func TestShouldChownWorkspace(t *testing.T) {
 	cases := []struct {
 		name           string
@@ -98,12 +96,12 @@ func TestResolvePullFromInsideContainer(t *testing.T) {
 	}{
 		{
 			name: "override true wins",
-			opts: provider2.CLIOptions{PullFromInsideContainerOverride: boolPtr(true)},
+			opts: provider2.CLIOptions{PullFromInsideContainerOverride: new(true)},
 			want: types.StrBool(stringTrue),
 		},
 		{
 			name: "override false wins even with git source",
-			opts: provider2.CLIOptions{PullFromInsideContainerOverride: boolPtr(false)},
+			opts: provider2.CLIOptions{PullFromInsideContainerOverride: new(false)},
 			repo: "https://github.com/example/repo",
 			want: types.StrBool(stringFalse),
 		},

--- a/pkg/dockerfile/parse.go
+++ b/pkg/dockerfile/parse.go
@@ -3,6 +3,7 @@ package dockerfile
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/devsy-org/devsy/pkg/scanner"
@@ -185,8 +186,8 @@ func (d *Dockerfile) resolveFromArgs(
 	variable string,
 	stage *BaseStage,
 ) (string, bool) {
-	for i := len(stage.Args) - 1; i >= 0; i-- {
-		arg := &stage.Args[i]
+	for _, v := range slices.Backward(stage.Args) {
+		arg := &v
 		if arg.Key != variable {
 			continue
 		}
@@ -206,8 +207,8 @@ func (d *Dockerfile) resolveFromEnvs(
 	variable string,
 	stage *BaseStage,
 ) (string, bool) {
-	for i := len(stage.Envs) - 1; i >= 0; i-- {
-		env := &stage.Envs[i]
+	for _, v := range slices.Backward(stage.Envs) {
+		env := &v
 		if env.Key != variable {
 			continue
 		}

--- a/pkg/machineid/id_darwin.go
+++ b/pkg/machineid/id_darwin.go
@@ -13,7 +13,7 @@ func ID() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("ioreg: %w", err)
 	}
-	for _, line := range strings.Split(string(out), "\n") {
+	for line := range strings.SplitSeq(string(out), "\n") {
 		if strings.Contains(line, "IOPlatformUUID") {
 			parts := strings.SplitN(line, "=", 2)
 			if len(parts) == 2 {

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -57,8 +57,8 @@ func InheritFromEnvironment(
 func assignedNames(assignments []string) map[string]bool {
 	names := make(map[string]bool, len(assignments))
 	for _, assignment := range assignments {
-		if idx := strings.Index(assignment, "="); idx != -1 {
-			names[assignment[:idx]] = true
+		if before, _, ok := strings.Cut(assignment, "="); ok {
+			names[before] = true
 		}
 	}
 	return names

--- a/pkg/ts/derp.go
+++ b/pkg/ts/derp.go
@@ -51,8 +51,8 @@ func GetEnvOrDefault(envVar, defaultVal string) string {
 
 // RemoveProtocol removes protocol from URL.
 func RemoveProtocol(hostPath string) string {
-	if idx := strings.Index(hostPath, "://"); idx != -1 {
-		return hostPath[idx+3:]
+	if _, after, ok := strings.Cut(hostPath, "://"); ok {
+		return after
 	}
 	return hostPath
 }

--- a/pkg/workspace/rename_integration_test.go
+++ b/pkg/workspace/rename_integration_test.go
@@ -56,8 +56,6 @@ func loadWorkspaceResult(
 	return result
 }
 
-func ptrStr(s string) *string { return &s }
-
 func TestUpdateWorkspaceResult_BasicRename(t *testing.T) {
 	setupTestPathManager(t)
 
@@ -73,7 +71,7 @@ func TestUpdateWorkspaceResult_BasicRename(t *testing.T) {
 		MergedConfig: &devcontainerconfig.MergedDevContainerConfig{},
 	}
 	result.MergedConfig.WorkspaceFolder = "/workspaces/my-project"
-	result.MergedConfig.WorkspaceMount = ptrStr(
+	result.MergedConfig.WorkspaceMount = new(
 		"type=bind,source=/home/user/my-project,target=/workspaces/my-project",
 	)
 
@@ -109,7 +107,7 @@ func TestUpdateWorkspaceResult_MergedConfigUpdated(t *testing.T) {
 		MergedConfig: &devcontainerconfig.MergedDevContainerConfig{},
 	}
 	result.MergedConfig.WorkspaceFolder = "/workspaces/app"
-	result.MergedConfig.WorkspaceMount = ptrStr(
+	result.MergedConfig.WorkspaceMount = new(
 		"type=bind,source=/home/dev/app,target=/workspaces/app",
 	)
 
@@ -145,7 +143,7 @@ func TestUpdateWorkspaceResult_NonDefaultWorkspaceDir(t *testing.T) {
 		MergedConfig: &devcontainerconfig.MergedDevContainerConfig{},
 	}
 	result.MergedConfig.WorkspaceFolder = "/home/coder/project"
-	result.MergedConfig.WorkspaceMount = ptrStr(
+	result.MergedConfig.WorkspaceMount = new(
 		"type=bind,source=/mnt/data/project,target=/home/coder/project",
 	)
 
@@ -187,7 +185,7 @@ func TestUpdateWorkspaceResult_NestedPath(t *testing.T) {
 		MergedConfig: &devcontainerconfig.MergedDevContainerConfig{},
 	}
 	result.MergedConfig.WorkspaceFolder = "/workspaces/org/repo"
-	result.MergedConfig.WorkspaceMount = ptrStr(
+	result.MergedConfig.WorkspaceMount = new(
 		"type=bind,source=/home/user/dev/org/repo,target=/workspaces/org/repo",
 	)
 
@@ -220,7 +218,7 @@ func TestUpdateWorkspaceResult_SameNameIdempotent(t *testing.T) {
 		MergedConfig: &devcontainerconfig.MergedDevContainerConfig{},
 	}
 	result.MergedConfig.WorkspaceFolder = "/workspaces/my-ws"
-	result.MergedConfig.WorkspaceMount = ptrStr(
+	result.MergedConfig.WorkspaceMount = new(
 		"type=bind,source=/home/user/my-ws,target=/workspaces/my-ws",
 	)
 


### PR DESCRIPTION
Resolves all 30 `modernize` linter findings reported by golangci-lint.

## Changes
Applied golangci-lint `--fix` scoped to `modernize`:
- **newexpr** – pointer-wrapper helpers and `&x` replaced with the Go 1.26 `new(expr)` form
- **slicesbackward** – manual reverse `for` loops → `slices.Backward` (`pkg/dockerfile/parse.go`, verified read-only)
- **stringscut** – `strings.Index` + slicing → `strings.Cut` (`options.go`, `derp.go`)
- **stringsseq** – `strings.Split` range → `strings.SplitSeq` (`id_darwin.go`)

Removed test helper functions (`ptr`, `strPtr`, `boolPtr`, `ptrStr`) left unused after their call sites were inlined, including a pre-existing unused `strPtr` in `extends_test.go`.

## Verification
- `modernize`: 30 → 0
- `unused`: 1 → 0
- `go build ./...` passes; all tests compile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined internal handling of configuration values, string parsing, and reverse-order processing.
  - Improved efficiency in platform-specific system identification and data processing.
  - Preserved existing behavior and public interfaces.

- **Tests**
  - Simplified test setup and pointer handling across agent, container, workspace, and environment scenarios.
  - Continued coverage of configuration merging, workspace renaming, and value round trips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->