### PR TITLE
chore(lint): resolve gocritic findings

### DIFF
--- a/cmd/internal/agentcontainer/daemon.go
+++ b/cmd/internal/agentcontainer/daemon.go
@@ -90,7 +90,6 @@ func (cmd *DaemonCmd) Run(c *cobra.Command, args []string) error {
 	}
 
 	ctx, stop := signal.NotifyContext(c.Context(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	g, ctx := errgroup.WithContext(ctx)
 	var tasksStarted bool
@@ -136,6 +135,7 @@ func (cmd *DaemonCmd) Run(c *cobra.Command, args []string) error {
 	}
 
 	err := g.Wait()
+	stop() // Restore default signal handling before exiting.
 	if err != nil {
 		log.Errorf("daemon error: %v", err)
 		os.Exit(1)

--- a/cmd/internal/sh.go
+++ b/cmd/internal/sh.go
@@ -37,11 +37,12 @@ func NewShellCmd() *cobra.Command {
 }
 
 func (cmd *ShellCommand) Run(ctx context.Context, args []string) error {
-	if cmd.Command == "" && len(args) == 0 {
+	switch {
+	case cmd.Command == "" && len(args) == 0:
 		return nil
-	} else if cmd.Command != "" && len(args) > 0 {
+	case cmd.Command != "" && len(args) > 0:
 		return fmt.Errorf("either use -c or provide a script file")
-	} else if len(args) > 1 {
+	case len(args) > 1:
 		return fmt.Errorf("only a single script file can be used")
 	}
 

--- a/cmd/pro/start.go
+++ b/cmd/pro/start.go
@@ -872,11 +872,12 @@ func (cmd *StartCmd) runInDocker(ctx context.Context, name string) (string, erro
 	args = append(args, cmd.DockerArgs...)
 
 	// set image
-	if cmd.DockerImage != "" {
+	switch {
+	case cmd.DockerImage != "":
 		args = append(args, cmd.DockerImage)
-	} else if cmd.Version != "" {
+	case cmd.Version != "":
 		args = append(args, "ghcr.io/devsy-org/devsy-pro:"+strings.TrimPrefix(cmd.Version, "v"))
-	} else {
+	default:
 		args = append(args, "ghcr.io/devsy-org/devsy-pro:latest")
 	}
 
@@ -955,14 +956,15 @@ func (cmd *StartCmd) findLoftContainer(
 	runningContainerID := ""
 	for _, containerID := range arr {
 		containerState, err := cmd.inspectContainer(ctx, containerID)
-		if err != nil {
+		switch {
+		case err != nil:
 			return "", err
-		} else if onlyRunning && strings.ToLower(containerState.State.Status) != "running" {
+		case onlyRunning && strings.ToLower(containerState.State.Status) != "running":
 			err = cmd.removeContainer(ctx, containerID)
 			if err != nil {
 				return "", err
 			}
-		} else {
+		default:
 			runningContainerID = containerID
 		}
 	}
@@ -1772,9 +1774,10 @@ func ensureAdminPassword(
 	}
 
 	admin, err := loftClient.StorageV1().Users().Get(ctx, "admin", metav1.GetOptions{})
-	if err != nil && !kerrors.IsNotFound(err) {
+	switch {
+	case err != nil && !kerrors.IsNotFound(err):
 		return false, err
-	} else if admin == nil {
+	case admin == nil:
 		admin, err = loftClient.StorageV1().Users().Create(ctx, &storagev1.User{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "admin",
@@ -1794,7 +1797,7 @@ func ensureAdminPassword(
 		if err != nil {
 			return false, err
 		}
-	} else if admin.Spec.PasswordRef == nil || admin.Spec.PasswordRef.SecretName == "" || admin.Spec.PasswordRef.SecretNamespace == "" {
+	case admin.Spec.PasswordRef == nil || admin.Spec.PasswordRef.SecretName == "" || admin.Spec.PasswordRef.SecretNamespace == "":
 		return false, nil
 	}
 

--- a/cmd/pro/start.go
+++ b/cmd/pro/start.go
@@ -1797,9 +1797,9 @@ func ensureAdminPassword(
 		if err != nil {
 			return false, err
 		}
-	case admin.Spec.PasswordRef == nil || 
-		admin.Spec.PasswordRef.SecretName == "" ||
-		admin.Spec.PasswordRef.SecretNamespace == "":
+	case admin.Spec.PasswordRef == nil ||
+			admin.Spec.PasswordRef.SecretName == "" ||
+			admin.Spec.PasswordRef.SecretNamespace == "":
 		return false, nil
 	}
 

--- a/cmd/pro/start.go
+++ b/cmd/pro/start.go
@@ -1798,8 +1798,8 @@ func ensureAdminPassword(
 			return false, err
 		}
 	case admin.Spec.PasswordRef == nil ||
-			admin.Spec.PasswordRef.SecretName == "" ||
-			admin.Spec.PasswordRef.SecretNamespace == "":
+		admin.Spec.PasswordRef.SecretName == "" ||
+		admin.Spec.PasswordRef.SecretNamespace == "":
 		return false, nil
 	}
 

--- a/cmd/pro/start.go
+++ b/cmd/pro/start.go
@@ -1797,7 +1797,9 @@ func ensureAdminPassword(
 		if err != nil {
 			return false, err
 		}
-	case admin.Spec.PasswordRef == nil || admin.Spec.PasswordRef.SecretName == "" || admin.Spec.PasswordRef.SecretNamespace == "":
+	case admin.Spec.PasswordRef == nil || 
+		admin.Spec.PasswordRef.SecretName == "" ||
+		admin.Spec.PasswordRef.SecretNamespace == "":
 		return false, nil
 	}
 

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -13,22 +13,22 @@ func NewDefaultFramework(path string) *Framework {
 	binName := "devsy-"
 	switch runtime.GOOS {
 	case "darwin":
-		binName = binName + "darwin-"
+		binName += "darwin-"
 	case "linux":
-		binName = binName + "linux-"
+		binName += "linux-"
 	case "windows":
-		binName = binName + "windows-"
+		binName += "windows-"
 	}
 
 	switch runtime.GOARCH {
 	case "amd64":
-		binName = binName + "amd64"
+		binName += "amd64"
 	case "arm64":
-		binName = binName + "arm64"
+		binName += "arm64"
 	}
 
 	if runtime.GOOS == "windows" {
-		binName = binName + ".exe"
+		binName += ".exe"
 	}
 
 	return &Framework{DevsyBinDir: path, DevsyBinName: binName}

--- a/e2e/framework/util.go
+++ b/e2e/framework/util.go
@@ -82,21 +82,20 @@ func createTempDir(baseDir string) (string, error) {
 	var dir string
 	var err error
 
-	if os.Getenv("GITHUB_ACTIONS") == "true" {
+	switch {
+	case os.Getenv("GITHUB_ACTIONS") == "true":
 		runnerTemp := os.Getenv("RUNNER_TEMP")
 		if runnerTemp != "" {
 			dir, err = os.MkdirTemp(runnerTemp, "temp-*")
 		} else {
 			dir, err = os.MkdirTemp("", "temp-*")
 		}
-	} else if os.Getenv("ACT") == "true" {
+	case os.Getenv("ACT") == "true":
 		dir, err = os.MkdirTemp("/tmp", "temp-*")
-	} else {
-		if baseDir == "" {
-			dir, err = os.MkdirTemp("", "temp-*")
-		} else {
-			dir, err = os.MkdirTemp(baseDir, "temp-*")
-		}
+	case baseDir == "":
+		dir, err = os.MkdirTemp("", "temp-*")
+	default:
+		dir, err = os.MkdirTemp(baseDir, "temp-*")
 	}
 
 	if err != nil {

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -128,12 +128,13 @@ func ReadAgentWorkspaceInfo(
 	// check if we need to become root
 	log.Debug("checking if root privileges are required")
 	shouldExit, err := rerunAsRoot(workspaceInfo)
-	if err != nil {
+	switch {
+	case err != nil:
 		return false, nil, fmt.Errorf("rerun as root: %w", err)
-	} else if shouldExit {
+	case shouldExit:
 		log.Debug("rerunning as root, exiting current process")
 		return true, nil, nil
-	} else if workspaceInfo == nil {
+	case workspaceInfo == nil:
 		log.Debug("no workspace info available and not rerunning as root")
 		return false, nil, ErrFindAgentHomeDir
 	}

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/devsy-org/api/pkg/devsy"
@@ -40,13 +41,13 @@ func RunServicesServer(
 	workspace *provider2.Workspace,
 	options ...Option,
 ) error {
-	opts := append(options, []Option{
+	options = append(options,
 		WithForwarder(forwarder),
 		WithAllowGitCredentials(allowGitCredentials),
 		WithAllowDockerCredentials(allowDockerCredentials),
 		WithWorkspace(workspace),
-	}...)
-	tunnelServ := New(opts...)
+	)
+	tunnelServ := New(options...)
 
 	return tunnelServ.Run(ctx, reader, writer)
 }
@@ -59,12 +60,12 @@ func RunUpServer(
 	workspace *provider2.Workspace,
 	options ...Option,
 ) (*config.Result, error) {
-	opts := append(options, []Option{
+	options = append(options,
 		WithWorkspace(workspace),
 		WithAllowGitCredentials(allowGitCredentials),
 		WithAllowDockerCredentials(allowDockerCredentials),
-	}...)
-	tunnelServ := New(opts...)
+	)
+	tunnelServ := New(options...)
 
 	return tunnelServ.RunWithResult(ctx, reader, writer)
 }
@@ -77,13 +78,13 @@ func RunSetupServer(
 	mounts []*config.Mount,
 	options ...Option,
 ) (*config.Result, error) {
-	opts := append(options, []Option{
+	options = append(options,
 		WithMounts(mounts),
 		WithAllowGitCredentials(allowGitCredentials),
 		WithAllowDockerCredentials(allowDockerCredentials),
 		WithAllowKubeConfig(true),
-	}...)
-	tunnelServ := New(opts...)
+	)
+	tunnelServ := New(options...)
 	tunnelServ.allowPlatformOptions = true
 
 	return tunnelServ.RunWithResult(ctx, reader, writer)
@@ -267,9 +268,9 @@ func (t *tunnelServer) GitCredentials(
 	}
 
 	if t.platformOptions != nil && t.platformOptions.Enabled {
-		gitHttpCredentials := append(
+		gitHttpCredentials := slices.Concat(
 			t.platformOptions.UserCredentials.GitHttp,
-			t.platformOptions.ProjectCredentials.GitHttp...)
+			t.platformOptions.ProjectCredentials.GitHttp)
 		if len(gitHttpCredentials) > 0 {
 			if len(gitHttpCredentials) == 1 {
 				credentials.Username = gitHttpCredentials[0].User

--- a/pkg/client/clientimplementation/daemonclient/client.go
+++ b/pkg/client/clientimplementation/daemonclient/client.go
@@ -159,15 +159,16 @@ func (c *client) CheckWorkspaceReachable(ctx context.Context) error {
 			}
 		}
 
-		if getWorkspaceErr != nil {
+		switch {
+		case getWorkspaceErr != nil:
 			return fmt.Errorf("couldn't get workspace: %w", getWorkspaceErr)
-		} else if instance.Status.Phase != storagev1.InstanceReady {
+		case instance.Status.Phase != storagev1.InstanceReady:
 			return fmt.Errorf(
 				"workspace is %q, run `devsy workspace up %s` to start it again",
 				instance.Status.Phase,
 				c.workspace.ID,
 			)
-		} else if instance.Status.LastWorkspaceStatus != storagev1.WorkspaceStatusRunning {
+		case instance.Status.LastWorkspaceStatus != storagev1.WorkspaceStatusRunning:
 			return fmt.Errorf(
 				"workspace is %q, run `devsy workspace up %s` to start it again",
 				instance.Status.LastWorkspaceStatus,

--- a/pkg/client/clientimplementation/daemonclient/delete.go
+++ b/pkg/client/clientimplementation/daemonclient/delete.go
@@ -112,11 +112,12 @@ func (c *client) Delete(ctx context.Context, opt clientpkg.DeleteOptions) error 
 				ManagementV1().
 				DevsyWorkspaceInstances(workspace.Namespace).
 				Get(ctx, workspace.Name, metav1.GetOptions{})
-			if kerrors.IsNotFound(err) {
+			switch {
+			case kerrors.IsNotFound(err):
 				return true, nil
-			} else if err != nil {
+			case err != nil:
 				return false, fmt.Errorf("error getting workspace: %w", err)
-			} else if workspaceInstance.DeletionTimestamp == nil {
+			case workspaceInstance.DeletionTimestamp == nil:
 				// this can occur if the workspace is already deleted and was recreated
 				return true, nil
 			}

--- a/pkg/client/clientimplementation/daemonclient/up.go
+++ b/pkg/client/clientimplementation/daemonclient/up.go
@@ -148,11 +148,12 @@ func waitTaskDone(
 		}, builders.ParameterCodec).
 		Do(ctx).
 		Into(tasks)
-	if err != nil {
+	switch {
+	case err != nil:
 		return nil, fmt.Errorf("error getting up result: %w", err)
-	} else if len(tasks.Tasks) == 0 || tasks.Tasks[0].Result == nil {
+	case len(tasks.Tasks) == 0 || tasks.Tasks[0].Result == nil:
 		return nil, fmt.Errorf("up result not found")
-	} else if len(tasks.Tasks) > 1 {
+	case len(tasks.Tasks) > 1:
 		return nil, fmt.Errorf("multiple up results found")
 	}
 

--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -96,15 +96,15 @@ type DevContainerConfigBase struct {
 	// The path of the workspace folder inside the container.
 	WorkspaceFolder string `json:"workspaceFolder,omitempty"`
 
-	// DEPRECATED: Use 'customizations/vscode/settings' instead
+	// Deprecated: Use 'customizations/vscode/settings' instead
 	// Machine specific settings that should be copied into the container. These are only copied when connecting to the container for the first time, rebuilding the container then triggers it again.
 	Settings map[string]any `json:"settings,omitempty"`
 
-	// DEPRECATED: Use 'customizations/vscode/extensions' instead
+	// Deprecated: Use 'customizations/vscode/extensions' instead
 	// An array of extensions that should be installed into the container.
 	Extensions []string `json:"extensions,omitempty"`
 
-	// DEPRECATED: Use 'customizations/vscode/devPort' instead
+	// Deprecated: Use 'customizations/vscode/devPort' instead
 	// The port VS Code can use to connect to its backend.
 	DevPort int `json:"devPort,omitempty"`
 

--- a/pkg/devcontainer/prebuild.go
+++ b/pkg/devcontainer/prebuild.go
@@ -42,11 +42,12 @@ func (r *runner) Build(ctx context.Context, options provider.BuildOptions) (stri
 
 	// prebuild already exists
 	var prebuildImage string
-	if options.Repository != "" {
+	switch {
+	case options.Repository != "":
 		prebuildImage = options.Repository + ":" + buildInfo.PrebuildHash
-	} else if prebuildRepo != "" {
+	case prebuildRepo != "":
 		prebuildImage = prebuildRepo + ":" + buildInfo.PrebuildHash
-	} else {
+	default:
 		prebuildImage = build.GetImageName(r.localWorkspaceFolder, buildInfo.PrebuildHash)
 	}
 

--- a/pkg/driver/kubernetes/run.go
+++ b/pkg/driver/kubernetes/run.go
@@ -111,16 +111,17 @@ func (k *KubernetesDriver) runContainer(
 	if k.options.WorkspaceVolumeMount != "" {
 		// Ensure workspace volume mount option is parent or same dir as workspace mount
 		rel, err := filepath.Rel(k.options.WorkspaceVolumeMount, mount.Target)
-		if err != nil {
+		switch {
+		case err != nil:
 			log.Warnf("Relative filepath: %v", err)
-		} else if strings.HasPrefix(rel, "..") {
+		case strings.HasPrefix(rel, ".."):
 			log.Warnf(
 				"Workspace volume mount needs to be the same as the workspace mount or a parent, skipping option. "+
 					"WorkspaceVolumeMount: %s, MountTarget: %s",
 				k.options.WorkspaceVolumeMount,
 				mount.Target,
 			)
-		} else {
+		default:
 			mount.Target = k.options.WorkspaceVolumeMount
 			log.Debugf("Using workspace volume mount: %s", k.options.WorkspaceVolumeMount)
 		}

--- a/pkg/ide/ideparse/parse.go
+++ b/pkg/ide/ideparse/parse.go
@@ -242,11 +242,12 @@ func RefreshIDEOptions(
 ) (*provider.Workspace, error) {
 	ide = strings.ToLower(ide)
 	if ide == "" {
-		if workspace.IDE.Name != "" {
+		switch {
+		case workspace.IDE.Name != "":
 			ide = workspace.IDE.Name
-		} else if devsyConfig.Current().DefaultIDE != "" {
+		case devsyConfig.Current().DefaultIDE != "":
 			ide = devsyConfig.Current().DefaultIDE
-		} else {
+		default:
 			ide = detect()
 		}
 	}

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -319,11 +319,12 @@ func readLine(reader io.Reader) (string, error) {
 	str := ""
 	for {
 		n, err := reader.Read(buf)
-		if err != nil {
+		switch {
+		case err != nil:
 			return "", err
-		} else if n == 0 {
+		case n == 0:
 			continue
-		} else if buf[0] == '\n' {
+		case buf[0] == '\n':
 			return str, nil
 		}
 

--- a/pkg/options/resolver/resolve.go
+++ b/pkg/options/resolver/resolve.go
@@ -100,13 +100,14 @@ func (r *Resolver) resolveOption(
 	}
 
 	// resolve option
-	if userValueOk {
+	switch {
+	case userValueOk:
 		resolvedOptionValues[optionName] = config.OptionValue{
 			Value:        userValue,
 			Children:     beforeValue.Children,
 			UserProvided: true,
 		}
-	} else if option.Default != "" {
+	case option.Default != "":
 		resolvedOptionValues[optionName] = config.OptionValue{
 			Children: beforeValue.Children,
 			Value: ResolveDefaultValue(
@@ -114,7 +115,7 @@ func (r *Resolver) resolveOption(
 				combine(resolvedOptionValues, r.extraValues),
 			),
 		}
-	} else if option.Command != "" {
+	case option.Command != "":
 		optionValue, err := resolveFromCommand(ctx, option, resolvedOptionValues, r.extraValues)
 		if err != nil {
 			return err
@@ -122,12 +123,12 @@ func (r *Resolver) resolveOption(
 
 		optionValue.Children = beforeValue.Children
 		resolvedOptionValues[optionName] = optionValue
-	} else if len(option.Enum) == 1 {
+	case len(option.Enum) == 1:
 		resolvedOptionValues[optionName] = config.OptionValue{
 			Children: beforeValue.Children,
 			Value:    option.Enum[0].Value,
 		}
-	} else {
+	default:
 		resolvedOptionValues[optionName] = config.OptionValue{
 			Children: beforeValue.Children,
 		}

--- a/pkg/platform/deploy.go
+++ b/pkg/platform/deploy.go
@@ -62,14 +62,15 @@ func WaitForPodReady(
 			loftPod := &pods.Items[0]
 			found := false
 			for _, containerStatus := range loftPod.Status.ContainerStatuses {
-				if containerStatus.State.Running != nil && containerStatus.Ready {
+				switch {
+				case containerStatus.State.Running != nil && containerStatus.Ready:
 					if containerStatus.Name == "manager" {
 						found = true
 					}
 
 					continue
-				} else if containerStatus.State.Terminated != nil ||
-					(containerStatus.State.Waiting != nil && CriticalStatus[containerStatus.State.Waiting.Reason]) {
+				case containerStatus.State.Terminated != nil ||
+					(containerStatus.State.Waiting != nil && CriticalStatus[containerStatus.State.Waiting.Reason]):
 					reason := ""
 					message := ""
 					if containerStatus.State.Terminated != nil {
@@ -116,21 +117,22 @@ func WaitForPodReady(
 						message,
 						reason,
 					)
-				} else if containerStatus.State.Waiting != nil && time.Now().After(now.Add(time.Second*10)) {
-					if containerStatus.State.Waiting.Message != "" {
+				case containerStatus.State.Waiting != nil && time.Now().After(now.Add(time.Second*10)):
+					switch {
+					case containerStatus.State.Waiting.Message != "":
 						log.Infof(
 							"Keep waiting, %s container is still starting up: %s (%s)",
 							pkgconfig.ProductNamePro,
 							containerStatus.State.Waiting.Message,
 							containerStatus.State.Waiting.Reason,
 						)
-					} else if containerStatus.State.Waiting.Reason != "" {
+					case containerStatus.State.Waiting.Reason != "":
 						log.Infof(
 							"Keep waiting, %s container is still starting up: %s",
 							pkgconfig.ProductNamePro,
 							containerStatus.State.Waiting.Reason,
 						)
-					} else {
+					default:
 						log.Infof(
 							"Keep waiting, %s container is still starting up",
 							pkgconfig.ProductNamePro,

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -331,21 +331,23 @@ type BuildOptions struct {
 }
 
 func (w WorkspaceSource) String() string {
-	if w.GitRepository != "" {
-		if w.GitPRReference != "" {
+	switch {
+	case w.GitRepository != "":
+		switch {
+		case w.GitPRReference != "":
 			return WorkspaceSourceGit + w.GitRepository + "@" + w.GitPRReference
-		} else if w.GitBranch != "" {
+		case w.GitBranch != "":
 			return WorkspaceSourceGit + w.GitRepository + "@" + w.GitBranch
-		} else if w.GitCommit != "" {
+		case w.GitCommit != "":
 			return WorkspaceSourceGit + w.GitRepository + git.CommitDelimiter + w.GitCommit
 		}
 
 		return WorkspaceSourceGit + w.GitRepository
-	} else if w.LocalFolder != "" {
+	case w.LocalFolder != "":
 		return WorkspaceSourceLocal + w.LocalFolder
-	} else if w.Image != "" {
+	case w.Image != "":
 		return WorkspaceSourceImage + w.Image
-	} else if w.Container != "" {
+	case w.Container != "":
 		return WorkspaceSourceContainer + w.Container
 	}
 
@@ -353,21 +355,23 @@ func (w WorkspaceSource) String() string {
 }
 
 func (w WorkspaceSource) Type() string {
-	if w.GitRepository != "" {
-		if w.GitPRReference != "" {
+	switch {
+	case w.GitRepository != "":
+		switch {
+		case w.GitPRReference != "":
 			return WorkspaceSourceGit + "pr"
-		} else if w.GitBranch != "" {
+		case w.GitBranch != "":
 			return WorkspaceSourceGit + "branch"
-		} else if w.GitCommit != "" {
+		case w.GitCommit != "":
 			return WorkspaceSourceGit + "commit"
 		}
 
 		return WorkspaceSourceGit
-	} else if w.LocalFolder != "" {
+	case w.LocalFolder != "":
 		return WorkspaceSourceLocal
-	} else if w.Image != "" {
+	case w.Image != "":
 		return WorkspaceSourceImage
-	} else if w.Container != "" {
+	case w.Container != "":
 		return WorkspaceSourceContainer
 	}
 

--- a/pkg/ssh/config.go
+++ b/pkg/ssh/config.go
@@ -433,13 +433,14 @@ func transformHostSection(path, host string, transform func(line string) string)
 	endMarker := MarkerEndPrefix + host
 	for configScanner.Scan() {
 		text := configScanner.Text()
-		if strings.HasPrefix(text, startMarker) {
+		switch {
+		case strings.HasPrefix(text, startMarker):
 			inSection = true
-		} else if strings.HasPrefix(text, endMarker) {
+		case strings.HasPrefix(text, endMarker):
 			inSection = false
-		} else if !inSection {
+		case !inSection:
 			newLines = append(newLines, text)
-		} else if inSection {
+		case inSection:
 			text = transform(text)
 			if text != "" {
 				newLines = append(newLines, text)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -176,46 +176,45 @@ func (e *OptionEnumArray) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return err
 	}
-	switch obj := jsonObj.(type) {
-	case []any:
-		if len(obj) == 0 {
-			*e = OptionEnumArray{}
-			return nil
-		}
-		ret := make([]OptionEnum, 0, len(obj))
-		switch obj[0].(type) {
-		case string:
-			for _, v := range obj {
-				if s, ok := v.(string); ok {
-					ret = append(ret, OptionEnum{Value: s})
-				}
-			}
-		case map[string]any:
-			for _, v := range obj {
-				m, ok := v.(map[string]any)
-				if !ok {
-					return ErrUnsupportedType
-				}
-				value := ""
-				if s, ok := m["value"].(string); ok {
-					value = s
-				}
-				displayName := ""
-				if s, ok := m["displayName"].(string); ok {
-					displayName = s
-				}
-				ret = append(ret, OptionEnum{
-					Value:       value,
-					DisplayName: displayName,
-				})
-			}
-		default:
-			return ErrUnsupportedType
-		}
-
-		*e = OptionEnumArray(ret)
+	obj, ok := jsonObj.([]any)
+	if !ok {
+		return ErrUnsupportedType
+	}
+	if len(obj) == 0 {
+		*e = OptionEnumArray{}
 		return nil
 	}
+	ret := make([]OptionEnum, 0, len(obj))
+	switch obj[0].(type) {
+	case string:
+		for _, v := range obj {
+			if s, ok := v.(string); ok {
+				ret = append(ret, OptionEnum{Value: s})
+			}
+		}
+	case map[string]any:
+		for _, v := range obj {
+			m, ok := v.(map[string]any)
+			if !ok {
+				return ErrUnsupportedType
+			}
+			value := ""
+			if s, ok := m["value"].(string); ok {
+				value = s
+			}
+			displayName := ""
+			if s, ok := m["displayName"].(string); ok {
+				displayName = s
+			}
+			ret = append(ret, OptionEnum{
+				Value:       value,
+				DisplayName: displayName,
+			})
+		}
+	default:
+		return ErrUnsupportedType
+	}
 
-	return ErrUnsupportedType
+	*e = OptionEnumArray(ret)
+	return nil
 }

--- a/pkg/workspace/list.go
+++ b/pkg/workspace/list.go
@@ -218,16 +218,17 @@ func listProWorkspacesForProvider(
 		instances []managementv1.DevsyWorkspaceInstance
 		err       error
 	)
-	if providerConfig.IsProxyProvider() {
+	switch {
+	case providerConfig.IsProxyProvider():
 		instances, err = listInstancesProxyProvider(
 			ctx,
 			devsyConfig,
 			provider,
 			providerConfig,
 		)
-	} else if providerConfig.IsDaemonProvider() {
+	case providerConfig.IsDaemonProvider():
 		instances, err = listInstancesDaemonProvider(ctx, provider, owner)
-	} else {
+	default:
 		return nil, fmt.Errorf("cannot list pro workspaces with provider %s", provider)
 	}
 	if err != nil {

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -142,11 +142,12 @@ func getWorkspaceClient(
 	workspace *providerpkg.Workspace,
 	machine *providerpkg.Machine,
 ) (client.BaseWorkspaceClient, error) {
-	if provider.IsProxyProvider() {
+	switch {
+	case provider.IsProxyProvider():
 		return clientimplementation.NewProxyClient(devsyConfig, provider, workspace)
-	} else if provider.IsDaemonProvider() {
+	case provider.IsDaemonProvider():
 		return daemonclient.New(devsyConfig, provider, workspace)
-	} else {
+	default:
 		return clientimplementation.NewWorkspaceClient(
 			devsyConfig,
 			provider,
@@ -383,7 +384,8 @@ func createWorkspace(
 
 	// create a new machine
 	var machineConfig *providerpkg.Machine
-	if provider.Config.IsMachineProvider() && workspace.Machine.ID == "" {
+	switch {
+	case provider.Config.IsMachineProvider() && workspace.Machine.ID == "":
 		// create a new machine
 		if provider.State != nil && provider.State.SingleMachine {
 			workspace.Machine.ID = SingleMachineName(devsyConfig, provider.Config.Name)
@@ -459,7 +461,7 @@ func createWorkspace(
 				return nil, nil, nil, fmt.Errorf("load machine config: %w", err)
 			}
 		}
-	} else if provider.Config.IsProxyProvider() || provider.Config.IsDaemonProvider() {
+	case provider.Config.IsProxyProvider() || provider.Config.IsDaemonProvider():
 		// We'll do have to do a bit of mumbo jumbo here because the pro process can't communicate with us directly.
 		// It needs os i/o to render the form in CLI mode so we can't go with our typical setup.
 		// Instead we first save the config, tell the provider where it lives, it updates it,
@@ -486,7 +488,7 @@ func createWorkspace(
 		if err != nil {
 			return nil, nil, nil, err
 		}
-	} else {
+	default:
 		// save workspace config
 		err = providerpkg.SaveWorkspaceConfig(workspace)
 		if err != nil {

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -142,12 +142,11 @@ func getWorkspaceClient(
 	workspace *providerpkg.Workspace,
 	machine *providerpkg.Machine,
 ) (client.BaseWorkspaceClient, error) {
-	switch {
-	case provider.IsProxyProvider():
+	if provider.IsProxyProvider() {
 		return clientimplementation.NewProxyClient(devsyConfig, provider, workspace)
-	case provider.IsDaemonProvider():
+	} else if provider.IsDaemonProvider() {
 		return daemonclient.New(devsyConfig, provider, workspace)
-	default:
+	} else {
 		return clientimplementation.NewWorkspaceClient(
 			devsyConfig,
 			provider,
@@ -384,8 +383,7 @@ func createWorkspace(
 
 	// create a new machine
 	var machineConfig *providerpkg.Machine
-	switch {
-	case provider.Config.IsMachineProvider() && workspace.Machine.ID == "":
+	if provider.Config.IsMachineProvider() && workspace.Machine.ID == "" {
 		// create a new machine
 		if provider.State != nil && provider.State.SingleMachine {
 			workspace.Machine.ID = SingleMachineName(devsyConfig, provider.Config.Name)
@@ -461,7 +459,7 @@ func createWorkspace(
 				return nil, nil, nil, fmt.Errorf("load machine config: %w", err)
 			}
 		}
-	case provider.Config.IsProxyProvider() || provider.Config.IsDaemonProvider():
+	} else if provider.Config.IsProxyProvider() || provider.Config.IsDaemonProvider() {
 		// We'll do have to do a bit of mumbo jumbo here because the pro process can't communicate with us directly.
 		// It needs os i/o to render the form in CLI mode so we can't go with our typical setup.
 		// Instead we first save the config, tell the provider where it lives, it updates it,
@@ -488,7 +486,7 @@ func createWorkspace(
 		if err != nil {
 			return nil, nil, nil, err
 		}
-	default:
+	} else {
 		// save workspace config
 		err = providerpkg.SaveWorkspaceConfig(workspace)
 		if err != nil {


### PR DESCRIPTION
Resolves all 39 `gocritic` linter findings reported by golangci-lint.

## Changes by check
- **ifElseChain** (26) – rewrote `if / else if` chains to `switch` statements
- **assignOp** (6) – `x = x + y` → `x += y` (`e2e/framework/framework.go`)
- **appendAssign** (4) – `pkg/agent/tunnelserver/tunnelserver.go`:
  - variadic `opts := append(options, …)` now assigns back to `options`
  - `append(UserCredentials.GitHttp, ProjectCredentials.GitHttp…)` → `slices.Concat(…)` to avoid mutating the shared `UserCredentials` backing array
- **deprecatedComment** (3) – `DEPRECATED:` → canonical `Deprecated:` casing
- **exitAfterDefer** (1) – `cmd/internal/agentcontainer/daemon.go`: `defer stop()` never ran before `os.Exit`; now calls `stop()` explicitly before exiting
- **singleCaseSwitch** (1) – single-case type switch rewritten as a type assertion (`pkg/types/types.go`)

## Verification
- `gocritic`: 39 → 0
- Also cleared 3 `staticcheck` and 1 `modernize` finding that flagged the same chains
- `go build ./...` passes; affected-package tests pass (389)
- `golangci-lint fmt` reports no diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process shutdown behavior so signal handling is restored before the daemon exits.
  * Workspace source types now report an explicit unknown type when no recognized source is configured.
  * Invalid option-enum JSON values now return a clear unsupported-type error.

* **Refactor**
  * Simplified branching across workspace management, container startup, deployment monitoring, IDE selection, option resolution, and related workflows without changing expected behavior.

* **Documentation**
  * Clarified deprecation wording for dev container settings and extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->