### PR TITLE
refactor(cmd): use cobra MarkFlags for flag validation

### DIFF
--- a/cmd/config/read.go
+++ b/cmd/config/read.go
@@ -59,6 +59,8 @@ func NewReadCmd(f *flags.GlobalFlags) *cobra.Command {
 			"Include the merged configuration in the output"),
 	)
 
+	readConfigCmd.MarkFlagsOneRequired(names.WorkspaceFolder, names.ContainerID, names.IDLabel)
+
 	return readConfigCmd
 }
 
@@ -122,14 +124,6 @@ func (cmd *ReadCmd) resolve(ctx context.Context) (
 	string,
 	error,
 ) {
-	if cmd.ContainerID == "" && cmd.WorkspaceFolder == "" && len(cmd.IDLabels) == 0 {
-		return nil, "", fmt.Errorf(
-			"either %s, %s, or %s must be provided",
-			names.Flag(names.WorkspaceFolder),
-			names.Flag(names.ContainerID),
-			names.Flag(names.IDLabel),
-		)
-	}
 	if cmd.ContainerID != "" {
 		return cmd.resolveConfigFromContainer(ctx)
 	}

--- a/cmd/internal/runusercommands.go
+++ b/cmd/internal/runusercommands.go
@@ -137,6 +137,8 @@ func NewRunUserCommandsCmd(f *flags.GlobalFlags) *cobra.Command {
 		),
 	)
 
+	runCmd.MarkFlagsOneRequired(names.WorkspaceFolder, names.ContainerID)
+
 	return runCmd
 }
 
@@ -180,13 +182,6 @@ func (cmd *RunUserCommandsCmd) Run(ctx context.Context) error {
 }
 
 func (cmd *RunUserCommandsCmd) validate() error {
-	if cmd.WorkspaceFolder == "" && cmd.ContainerID == "" {
-		return fmt.Errorf(
-			"either %s or %s must be provided",
-			names.Flag(names.WorkspaceFolder),
-			names.Flag(names.ContainerID),
-		)
-	}
 	if cmd.ContainerID != "" && cmd.WorkspaceFolder == "" && cmd.Config == "" {
 		return fmt.Errorf(
 			"--config is required when --container-id is used without --workspace-folder",

--- a/cmd/internal/runusercommands_test.go
+++ b/cmd/internal/runusercommands_test.go
@@ -56,7 +56,8 @@ func TestNewRunUserCommandsCmd_RequiresWorkspaceFolderOrContainerID(t *testing.T
 	cmd.SetArgs([]string{})
 	err := cmd.Execute()
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "either --workspace-folder or --container-id must be provided")
+	assert.Contains(t, err.Error(),
+		"at least one of the flags in the group [workspace-folder container-id] is required")
 }
 
 func TestNewRunUserCommandsCmd_ContainerIDWithoutConfigFails(t *testing.T) {
@@ -296,11 +297,6 @@ func TestRunUserCommandsCmd_Validate(t *testing.T) {
 			},
 			false,
 			"",
-		},
-		{
-			"neither provided",
-			&RunUserCommandsCmd{GlobalFlags: &flags.GlobalFlags{}},
-			true, "either --workspace-folder or --container-id",
 		},
 		{
 			"container-id without config or workspace",

--- a/cmd/workspace/build.go
+++ b/cmd/workspace/build.go
@@ -120,6 +120,7 @@ func (cmd *BuildCmd) registerImageFlags(buildCmd *cobra.Command) {
 		cliflags.Bool(&cmd.Pull, names.Pull, false,
 			"Always attempt to pull a newer version of the base image when building"),
 	)
+	buildCmd.MarkFlagsMutuallyExclusive(names.Push, names.SkipPush)
 }
 
 func (cmd *BuildCmd) registerTestingFlags(buildCmd *cobra.Command) {
@@ -194,10 +195,6 @@ func (cmd *BuildCmd) prepareBuild(ctx context.Context) (*config.Config, error) {
 }
 
 func (cmd *BuildCmd) validateBuildFlags() error {
-	if cmd.PushDuringBuild && cmd.SkipPush {
-		return fmt.Errorf("cannot use %s and %s together",
-			names.Flag(names.Push), names.Flag(names.SkipPush))
-	}
 	if cmd.PushDuringBuild && cmd.Repository == "" {
 		return fmt.Errorf("%s requires %s to be specified",
 			names.Flag(names.Push), names.Flag(names.Repository))

--- a/cmd/workspace/build_test.go
+++ b/cmd/workspace/build_test.go
@@ -59,6 +59,14 @@ func TestBuildCmd_NoBuildFlagParsesValue(t *testing.T) {
 	assert.True(t, val)
 }
 
+func TestBuildCmd_PushAndSkipPushMutuallyExclusive(t *testing.T) {
+	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
+	buildCmd.SetArgs([]string{"--" + names.Push, "--" + names.SkipPush})
+	err := buildCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "none of the others can be")
+}
+
 func TestBuildCmd_NoCacheDefaultFalse(t *testing.T) {
 	buildCmd := NewBuildCmd(&flags.GlobalFlags{})
 	err := buildCmd.ParseFlags([]string{})


### PR DESCRIPTION
Replaces hand-written flag-group validation with cobra's built-in declarative helpers, so validation runs at parse time with standardized error messages.

## Changes
- **`cmd/config/read.go`** — `MarkFlagsOneRequired(WorkspaceFolder, ContainerID, IDLabel)`, removing the manual three-way check.
- **`cmd/internal/runusercommands.go`** — `MarkFlagsOneRequired(WorkspaceFolder, ContainerID)`, removing the manual check. The conditional `--config` requirement stays in `validate()` (not expressible via MarkFlags).
- **`cmd/workspace/build.go`** — `MarkFlagsMutuallyExclusive(Push, SkipPush)`, removing the manual "cannot use together" check.
- Tests updated for the new cobra error messages; added coverage for the `--push`/`--skip-push` exclusivity.

## Left as manual (intentional)
Directional dependencies (`--track-activity` requires `--stdio`, `--push` requires `--repository`) and positional-arg-based checks (`provider add`, `workspace exec`) can't be expressed with cobra's symmetric flag-group helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command-line validation for configuration reads and user commands when required input flags are missing.
  - Prevented workspace builds from accepting both `--push` and `--skip-push` simultaneously.
  - Preserved validation requiring a repository when image pushing is enabled.

- **Tests**
  - Added coverage confirming incompatible build options are rejected.
  - Updated validation expectations for missing command inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->