### PR TITLE
fix(devcontainer): exclude synthesized devcontainer configs from git

### DIFF
--- a/pkg/devcontainer/config.go
+++ b/pkg/devcontainer/config.go
@@ -339,12 +339,13 @@ func CleanupImportedDevContainers(workspaceFolder string) error {
 func (r *runner) saveSynthesizedConfig(
 	c *config.DevContainerConfig,
 ) (*config.DevContainerConfig, error) {
-	c.Origin = path.Join(
-		filepath.ToSlash(r.localWorkspaceFolder),
-		".devcontainer."+pkgconfig.BinaryName+".json",
-	)
+	name := ".devcontainer." + pkgconfig.BinaryName + ".json"
+	c.Origin = path.Join(filepath.ToSlash(r.localWorkspaceFolder), name)
 	if err := config.SaveDevContainerJSON(c); err != nil {
 		return nil, fmt.Errorf("write synthesized devcontainer.json: %w", err)
+	}
+	if err := r.excludeFromGit(name); err != nil {
+		log.Debugf("could not add synthesized devcontainer to git exclude: %v", err)
 	}
 	return c, nil
 }
@@ -361,9 +362,13 @@ func (r *runner) getDefaultConfig(
 		defaultConfig = language.DefaultConfig(r.localWorkspaceFolder)
 	}
 
-	defaultConfig.Origin = path.Join(filepath.ToSlash(r.localWorkspaceFolder), ".devcontainer.json")
+	const name = ".devcontainer.json"
+	defaultConfig.Origin = path.Join(filepath.ToSlash(r.localWorkspaceFolder), name)
 	if err := config.SaveDevContainerJSON(defaultConfig); err != nil {
 		return nil, fmt.Errorf("write default devcontainer.json: %w", err)
+	}
+	if err := r.excludeFromGit(name); err != nil {
+		log.Debugf("could not add default devcontainer to git exclude: %v", err)
 	}
 	return defaultConfig, nil
 }

--- a/pkg/devcontainer/import_external_test.go
+++ b/pkg/devcontainer/import_external_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	pkgconfig "github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -155,6 +157,22 @@ func TestImportExternalDevContainer_AddsGitExclude(t *testing.T) {
 	exclude, err := os.ReadFile(filepath.Join(ws, ".git", "info", "exclude"))
 	require.NoError(t, err)
 	assert.Contains(t, string(exclude), importedProfileParent+"/"+importedProfileName)
+}
+
+func TestSaveSynthesizedConfig_AddsGitExclude(t *testing.T) {
+	ws := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(ws, ".git", "info"), 0o750))
+	r := &runner{localWorkspaceFolder: ws}
+
+	_, err := r.saveSynthesizedConfig(&config.DevContainerConfig{
+		ImageContainer: config.ImageContainer{Image: "alpine"},
+	})
+	require.NoError(t, err)
+
+	// #nosec G304 -- test path
+	exclude, err := os.ReadFile(filepath.Join(ws, ".git", "info", "exclude"))
+	require.NoError(t, err)
+	assert.Contains(t, string(exclude), "/.devcontainer."+pkgconfig.BinaryName+".json")
 }
 
 func TestImportExternalDevContainer_NonGitRepoSkipsExclude(t *testing.T) {


### PR DESCRIPTION
## Summary

When a devcontainer config is synthesized rather than imported from a path, the generated file was written to the workspace root but never added to `.git/info/exclude`, so it showed up as an untracked file (e.g. `.devcontainer.devsy.json` after passing an image reference).

Only the imported-path source (`importExternalDevContainer`) excluded its artifact. This adds the same `excludeFromGit` call to the two synthesizing paths:

- `saveSynthesizedConfig` — used for image sources and `--devcontainer-source none` (writes `.devcontainer.devsy.json`)
- `getDefaultConfig` — the auto-detection fallback (writes `.devcontainer.json`)

Both degrade gracefully outside a git repo and only log at debug on failure, matching the existing import path.

Adds `TestSaveSynthesizedConfig_AddsGitExclude`.