### PR TITLE
fix(feature): interpolate documentation URL and feature id in wrapper script

### DIFF
--- a/pkg/devcontainer/feature/features.go
+++ b/pkg/devcontainer/feature/features.go
@@ -44,7 +44,7 @@ func GetFeatureInstallWrapperScript(
 	warningHeader := ""
 	if feature.Deprecated {
 		warningHeader += `(!) WARNING: Using the deprecated Feature ` +
-			`"${escapeQuotesForShell(feature.id)}". This Feature will no longer receive any further updates/support.\n`
+			`"` + id + `". This Feature will no longer receive any further updates/support.\n`
 	}
 
 	echoWarning := ""
@@ -55,7 +55,7 @@ func GetFeatureInstallWrapperScript(
 	errorMessage := `ERROR: Feature "` + name + `" (` + id + `) failed to install!`
 	troubleshootingMessage := ""
 	if documentation != "" {
-		troubleshootingMessage = ` Look at the documentation at ${documentation} for help troubleshooting this error.`
+		troubleshootingMessage = ` Look at the documentation at ` + documentation + ` for help troubleshooting this error.`
 	}
 
 	return `#!/bin/sh


### PR DESCRIPTION
## Summary

The feature install wrapper script (`pkg/devcontainer/feature/features.go`) contained two JS template-literal expressions left over from the upstream TypeScript devcontainers CLI. They were pasted verbatim into Go raw strings and never interpolated, so they printed literally.

- `${documentation}` in the troubleshooting message printed literally instead of the feature's documentation URL. Users saw:
  > `Look at the documentation at ${documentation} for help troubleshooting this error.`
- `${escapeQuotesForShell(feature.id)}` in the deprecation warning printed a literal JS function call instead of the feature id.

Both are replaced with Go string concatenation of the already-escaped `documentation` / `id` values, matching how the other fields (e.g. `Documentation :`) are already handled.

This is a cosmetic message fix; it does not change install behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected feature installation messages so deprecated-feature warnings and troubleshooting guidance display properly.
  * Improved generated installation scripts by ensuring escaped values are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->