### PR TITLE
fix(devcontainer): persist source override across workspace restarts

### DIFF
--- a/cmd/workspace/up/agent.go
+++ b/cmd/workspace/up/agent.go
@@ -144,6 +144,7 @@ func (cmd *UpCmd) buildWorkspaceOptions(workspace *provider2.Workspace) provider
 	baseOptions.ID = workspace.ID
 	baseOptions.DevContainerPath = workspace.DevContainerPath
 	baseOptions.DevContainerImage = workspace.DevContainerImage
+	baseOptions.DevContainerSource = workspace.DevContainerSource
 	baseOptions.IDE = workspace.IDE.Name
 	baseOptions.IDEOptions = nil
 	baseOptions.Source = workspace.Source.String()

--- a/cmd/workspace/up/up_client.go
+++ b/cmd/workspace/up/up_client.go
@@ -108,6 +108,7 @@ func (cmd *UpCmd) resolveParams(
 		ReconfigureProvider: cmd.Reconfigure,
 		DevContainerImage:   cmd.DevContainerImage,
 		DevContainerPath:    cmd.DevContainerPath,
+		DevContainerSource:  cmd.DevContainerSource,
 		SSHConfigPath:       cmd.SSHConfigPath,
 		SSHConfigIncludePath: devsyConfig.ContextOption(
 			config.ContextOptionSSHConfigIncludePath,

--- a/pkg/devcontainer/config.go
+++ b/pkg/devcontainer/config.go
@@ -36,8 +36,12 @@ const (
 // each supported source in order and falling back to an auto-detected default
 // when none applies.
 func (r *runner) getRawConfig(options provider.CLIOptions) (*config.DevContainerConfig, error) {
-	if options.DevContainerSource != "" {
-		return r.rawConfigFromSource(options)
+	source := options.DevContainerSource
+	if source == "" {
+		source = r.workspaceConfig.Workspace.DevContainerSource
+	}
+	if source != "" {
+		return r.rawConfigFromSource(source, options)
 	}
 	if conf := r.rawConfigFromWorkspace(); conf != nil {
 		return conf, nil
@@ -169,9 +173,10 @@ func workspaceMountFolderWarning(conf *config.DevContainerConfig) string {
 }
 
 func (r *runner) rawConfigFromSource(
+	source string,
 	options provider.CLIOptions,
 ) (*config.DevContainerConfig, error) {
-	spec, err := ParseSourceSpec(options.DevContainerSource)
+	spec, err := ParseSourceSpec(source)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/devcontainer/config_test.go
+++ b/pkg/devcontainer/config_test.go
@@ -467,6 +467,41 @@ func TestGetRawConfig_SourceImageBypassesDiscovery(t *testing.T) {
 	}
 }
 
+func TestGetRawConfig_PersistedSourceImageBypassesDiscovery(t *testing.T) {
+	folder := t.TempDir()
+	seedAmbiguousProfiles(t, folder)
+	r := newRunnerAt(folder)
+	// Simulate a restart: the CLI option is absent, but the override was
+	// persisted on the workspace during the first up.
+	const image = "python"
+	r.workspaceConfig.Workspace.DevContainerSource = "image:" + image
+
+	conf, err := r.getRawConfig(provider2.CLIOptions{})
+	if err != nil {
+		t.Fatalf("getRawConfig: %v", err)
+	}
+	if conf.Image != image {
+		t.Errorf("Image = %q, want %q", conf.Image, image)
+	}
+	if len(conf.Features) != 0 {
+		t.Errorf("Features = %v, want none (project features must be ignored)", conf.Features)
+	}
+}
+
+func TestGetRawConfig_CLISourceOverridesPersisted(t *testing.T) {
+	folder := t.TempDir()
+	r := newRunnerAt(folder)
+	r.workspaceConfig.Workspace.DevContainerSource = "image:persisted"
+
+	conf, err := r.getRawConfig(provider2.CLIOptions{DevContainerSource: "image:cli"})
+	if err != nil {
+		t.Fatalf("getRawConfig: %v", err)
+	}
+	if conf.Image != "cli" {
+		t.Errorf("Image = %q, want %q (CLI option must win over persisted)", conf.Image, "cli")
+	}
+}
+
 func TestGetRawConfig_SourceNoneWithImageBypassesDiscovery(t *testing.T) {
 	folder := t.TempDir()
 	seedAmbiguousProfiles(t, folder)

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -49,6 +49,11 @@ type Workspace struct {
 	// DevContainerPath is the relative path where the devcontainer.json is located.
 	DevContainerPath string `json:"devContainerPath,omitempty"`
 
+	// DevContainerSource is the devcontainer source override (e.g. "image:<ref>"
+	// or "none") that ignores the project's devcontainer.json. It is persisted so
+	// restarts reuse the same override instead of falling back to discovery.
+	DevContainerSource string `json:"devContainerSource,omitempty"`
+
 	// DevContainerConfig holds the config for the devcontainer.json.
 	DevContainerConfig *devcontainerconfig.DevContainerConfig `json:"devContainerConfig,omitempty"`
 

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -132,7 +132,8 @@ func applyDevContainerOverrides(workspace *providerpkg.Workspace, params Resolve
 		workspace.DevContainerPath = params.DevContainerPath
 		changed = true
 	}
-	if params.DevContainerSource != "" && workspace.DevContainerSource != params.DevContainerSource {
+	if params.DevContainerSource != "" &&
+		workspace.DevContainerSource != params.DevContainerSource {
 		workspace.DevContainerSource = params.DevContainerSource
 		changed = true
 	}

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -54,6 +54,7 @@ type ResolveParams struct {
 	ReconfigureProvider  bool
 	DevContainerImage    string
 	DevContainerPath     string
+	DevContainerSource   string
 	SSHConfigPath        string
 	SSHConfigIncludePath string
 	Source               *providerpkg.WorkspaceSource
@@ -129,6 +130,10 @@ func applyDevContainerOverrides(workspace *providerpkg.Workspace, params Resolve
 	}
 	if params.DevContainerPath != "" && workspace.DevContainerPath != params.DevContainerPath {
 		workspace.DevContainerPath = params.DevContainerPath
+		changed = true
+	}
+	if params.DevContainerSource != "" && workspace.DevContainerSource != params.DevContainerSource {
+		workspace.DevContainerSource = params.DevContainerSource
 		changed = true
 	}
 

--- a/pkg/workspace/workspace_test.go
+++ b/pkg/workspace/workspace_test.go
@@ -223,3 +223,19 @@ func TestApplyDevContainerOverrides_SetsImageAndPath(t *testing.T) {
 	assert.Equal(t, testDevContainerImage, loaded.DevContainerImage)
 	assert.Equal(t, testDevContainerPath, loaded.DevContainerPath)
 }
+
+func TestApplyDevContainerOverrides_PersistsSource(t *testing.T) {
+	setupTestPathManager(t)
+
+	ws := &providerpkg.Workspace{ID: "ws-source", Context: testDefaultContext}
+	const source = "image:ghcr.io/example/image:latest"
+	err := applyDevContainerOverrides(ws, ResolveParams{DevContainerSource: source})
+	require.NoError(t, err)
+
+	assert.Equal(t, source, ws.DevContainerSource)
+
+	// The source override must survive a restart, so it has to be persisted.
+	loaded, err := providerpkg.LoadWorkspaceConfig(testDefaultContext, ws.ID)
+	require.NoError(t, err)
+	assert.Equal(t, source, loaded.DevContainerSource)
+}


### PR DESCRIPTION
## Summary

When the container image devcontainer override is selected (e.g. `--devcontainer image:<ref>`), the workspace launches correctly the first time but fails to launch after a stop/restart with:

```
devcontainer up: parsing devcontainer.json: multiple devcontainer configurations found. Detected: [claude default]
```

### Root cause

The override arrives as the transient CLI option `DevContainerSource`. On the first `up`, the agent takes the "ignore the project devcontainer, synthesize a config from just this image" branch. But `DevContainerSource` was never persisted to the workspace record (unlike `DevContainerImage`/`DevContainerPath`). On restart the desktop re-invokes `up` with only the workspace id and no `--devcontainer` flag, so the override is lost and the agent falls through to filesystem discovery, which errors on repos that contain multiple `.devcontainer/<id>/` configs.

### Fix

- Add a persisted `DevContainerSource` field to the `Workspace` struct.
- Thread it through `ResolveParams` and persist it in `applyDevContainerOverrides`.
- Re-emit it in `buildWorkspaceOptions` (proxy/daemon paths).
- Make `getRawConfig` fall back to the persisted `Workspace.DevContainerSource` when the CLI option is absent — this covers the local/docker machine-client path, which does not go through `buildWorkspaceOptions` but always receives the serialized `Workspace`. The CLI option still wins when present.

Persisting the source (rather than converting `image:<ref>` into the existing `DevContainerImage` field) preserves the "ignore the project devcontainer" semantics; `DevContainerImage` only overrides the image inside a discovered config and would still require discovery.

Added regression tests for the restart scenario, CLI-over-persisted precedence, and source persistence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dev container source overrides are now remembered across workspace restarts.
  * Command-line source selections take precedence over previously saved workspace settings.
  * Saved image-based sources can be reused without rediscovering project configuration.

* **Bug Fixes**
  * Workspace configuration now consistently preserves and applies dev container source selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->