### PR TITLE
fix(docker): distinguish image-not-found from inspect failures

### DIFF
--- a/pkg/devcontainer/build.go
+++ b/pkg/devcontainer/build.go
@@ -367,8 +367,13 @@ func (r *runner) findPrebuildImage(
 		options.PrebuildRepositories,
 		devsyCustomizations.PrebuildRepository...)
 
+	if len(options.PrebuildRepositories) == 0 {
+		log.Debug("no prebuild repositories configured; skipping remote prebuild lookup")
+		return nil, nil
+	}
+
 	log.Debugf(
-		"Try to find prebuild image %s in repositories %s",
+		"looking for prebuild image %s in repositories %s",
 		params.prebuildHash,
 		strings.Join(options.PrebuildRepositories, ","),
 	)

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -39,7 +39,34 @@ const (
 var (
 	ErrContainerTerminal = errors.New("container in terminal state")
 	ErrContainerExited   = errors.New("container exited after start")
+	ErrImageNotFound     = errors.New("image not found")
 )
+
+var imageNotFoundMarkers = []string{
+	"no such image",
+	"no such object",
+	"image not known",
+	"manifest unknown",
+	"name unknown",
+	"repository name not known to registry",
+}
+
+func isImageNotFoundError(err error) bool {
+	msg := strings.ToLower(err.Error())
+	for _, marker := range imageNotFoundMarkers {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func classifyImageError(imageName string, err error) error {
+	if isImageNotFoundError(err) {
+		return fmt.Errorf("%s: %w", imageName, ErrImageNotFound)
+	}
+	return err
+}
 
 func (db DockerBuilder) String() string {
 	return [...]string{"", "buildx", "buildkit"}[db]
@@ -298,32 +325,42 @@ func (r *DockerHelper) InspectImage(
 ) (*config.ImageDetails, error) {
 	imageDetails := []*config.ImageDetails{}
 	err := r.Inspect(ctx, []string{imageName}, "image", &imageDetails)
-	if err != nil {
-		// try remote?
-		if !tryRemote {
-			return nil, err
+	if err == nil {
+		if len(imageDetails) == 0 {
+			return nil, fmt.Errorf("%s: %w", imageName, ErrImageNotFound)
 		}
-
-		imageConfig, _, err := image.GetImageConfig(ctx, imageName)
-		if err != nil {
-			return nil, fmt.Errorf("get image config remotely: %w", err)
-		}
-
-		return &config.ImageDetails{
-			ID: imageName,
-			Config: config.ImageDetailsConfig{
-				User:       imageConfig.Config.User,
-				Env:        imageConfig.Config.Env,
-				Labels:     imageConfig.Config.Labels,
-				Entrypoint: imageConfig.Config.Entrypoint,
-				Cmd:        imageConfig.Config.Cmd,
-			},
-		}, nil
-	} else if len(imageDetails) == 0 {
-		return nil, fmt.Errorf("cannot find image details for %s", imageName)
+		return imageDetails[0], nil
 	}
 
-	return imageDetails[0], nil
+	if !tryRemote {
+		return nil, classifyImageError(imageName, err)
+	}
+
+	return inspectImageRemote(ctx, imageName)
+}
+
+func inspectImageRemote(
+	ctx context.Context,
+	imageName string,
+) (*config.ImageDetails, error) {
+	imageConfig, _, err := image.GetImageConfig(ctx, imageName)
+	if err != nil {
+		if isImageNotFoundError(err) {
+			return nil, fmt.Errorf("%s: %w", imageName, ErrImageNotFound)
+		}
+		return nil, fmt.Errorf("get image config remotely: %w", err)
+	}
+
+	return &config.ImageDetails{
+		ID: imageName,
+		Config: config.ImageDetailsConfig{
+			User:       imageConfig.Config.User,
+			Env:        imageConfig.Config.Env,
+			Labels:     imageConfig.Config.Labels,
+			Entrypoint: imageConfig.Config.Entrypoint,
+			Cmd:        imageConfig.Config.Cmd,
+		},
+	}, nil
 }
 
 func (r *DockerHelper) InspectContainers(

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -305,7 +305,7 @@ func (r *DockerHelper) GetImageTag(ctx context.Context, imageID string) (string,
 	args = append(args, imageID)
 	out, err := r.buildCmd(ctx, args...).Output()
 	if err != nil {
-		return "", fmt.Errorf("inspect container: %w", command.WrapCommandError(out, err))
+		return "", fmt.Errorf("inspect image: %w", command.WrapCommandError(out, err))
 	}
 
 	repoTag := string(out)
@@ -394,7 +394,7 @@ func (r *DockerHelper) Inspect(
 	args = append(args, ids...)
 	out, err := r.buildCmd(ctx, args...).Output()
 	if err != nil {
-		return fmt.Errorf("inspect container: %w", command.WrapCommandError(out, err))
+		return fmt.Errorf("inspect %s: %w", inspectType, command.WrapCommandError(out, err))
 	}
 
 	err = json.Unmarshal(out, obj)

--- a/pkg/docker/helper_test.go
+++ b/pkg/docker/helper_test.go
@@ -197,6 +197,76 @@ esac
 	assert.True(t, errors.Is(err, ErrContainerTerminal), "expected terminal sentinel, got %v", err)
 }
 
+func TestIsImageNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{"docker no such image", "Error response from daemon: No such image: foo:bar", true},
+		{"podman no such object", "Error: no such object: foo", true},
+		{"nerdctl image not known", "image not known", true},
+		{"remote manifest unknown", "MANIFEST_UNKNOWN: manifest unknown", true},
+		{"registry name unknown", "NAME_UNKNOWN: name unknown", true},
+		{"registry repository not known", "repository name not known to registry", true},
+		{"daemon unreachable", "Cannot connect to the Docker daemon at the socket", false},
+		{"permission denied", "permission denied while trying to connect", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isImageNotFoundError(errors.New(tt.msg)))
+		})
+	}
+}
+
+func TestInspectImage_NotFoundReturnsSentinel(t *testing.T) {
+	tmp := t.TempDir()
+	bin := writeScript(t, tmp, "docker-fake", `#!/bin/sh
+echo 'Error response from daemon: No such image: foo:bar' >&2
+exit 1
+`)
+
+	h := &DockerHelper{DockerCommand: bin}
+	details, err := h.InspectImage(context.Background(), "foo:bar", false)
+
+	require.Error(t, err)
+	assert.Nil(t, details)
+	assert.True(t, errors.Is(err, ErrImageNotFound), "expected ErrImageNotFound, got %v", err)
+}
+
+func TestInspectImage_RealErrorNotMistakenForMiss(t *testing.T) {
+	tmp := t.TempDir()
+	bin := writeScript(t, tmp, "docker-fake", `#!/bin/sh
+echo 'Cannot connect to the Docker daemon at unix:///var/run/docker.sock' >&2
+exit 1
+`)
+
+	h := &DockerHelper{DockerCommand: bin}
+	details, err := h.InspectImage(context.Background(), "foo:bar", false)
+
+	require.Error(t, err)
+	assert.Nil(t, details)
+	assert.False(
+		t,
+		errors.Is(err, ErrImageNotFound),
+		"daemon failure must not be reported as a miss",
+	)
+}
+
+func TestInspectImage_EmptyResultReturnsSentinel(t *testing.T) {
+	tmp := t.TempDir()
+	bin := writeScript(t, tmp, "docker-fake", `#!/bin/sh
+echo '[]'
+`)
+
+	h := &DockerHelper{DockerCommand: bin}
+	details, err := h.InspectImage(context.Background(), "foo:bar", false)
+
+	require.Error(t, err)
+	assert.Nil(t, details)
+	assert.True(t, errors.Is(err, ErrImageNotFound), "empty inspect result should be a miss")
+}
+
 func TestGPUSupportEnabled_CommandFailure(t *testing.T) {
 	tmp := t.TempDir()
 	bin := writeScript(t, tmp, "bad-runtime", `#!/bin/sh

--- a/pkg/driver/docker/build.go
+++ b/pkg/driver/docker/build.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
@@ -249,7 +250,14 @@ func (r *imageResolver) tryResolve(
 
 	imageDetails, err := r.driver.Docker.InspectImage(ctx, req.imageName, false)
 	if err != nil {
-		log.Debugf("error trying to find local image %s: %v", req.imageName, err)
+		if errors.Is(err, docker.ErrImageNotFound) {
+			log.Debugf("no local image %s; building from source", req.imageName)
+		} else {
+			log.Warnf(
+				"could not inspect local image %s, building from source: %v",
+				req.imageName, err,
+			)
+		}
 		return nil, false
 	}
 

--- a/pkg/driver/docker/lifecycle.go
+++ b/pkg/driver/docker/lifecycle.go
@@ -253,19 +253,23 @@ func (d *dockerDriver) EnsureImage(
 ) error {
 	log.Infof("inspecting image: image=%s", options.Image)
 	_, err := d.Docker.InspectImage(ctx, options.Image, false)
-	if err != nil {
-		log.Infof("image not found, pulling image: image=%s", options.Image)
-		writer := log.Writer(log.LevelDebug)
-		defer func() { _ = writer.Close() }()
-
-		return d.Docker.Pull(ctx, docker.PullOptions{
-			Image:    options.Image,
-			Platform: options.Platform,
-			Stdout:   writer,
-			Stderr:   writer,
-		})
+	if err == nil {
+		return nil
 	}
-	return nil
+	if !errors.Is(err, docker.ErrImageNotFound) {
+		return fmt.Errorf("inspect image %s: %w", options.Image, err)
+	}
+
+	log.Infof("image not found, pulling image: image=%s", options.Image)
+	writer := log.Writer(log.LevelDebug)
+	defer func() { _ = writer.Close() }()
+
+	return d.Docker.Pull(ctx, docker.PullOptions{
+		Image:    options.Image,
+		Platform: options.Platform,
+		Stdout:   writer,
+		Stderr:   writer,
+	})
 }
 
 func (d *dockerDriver) startContainer(

--- a/pkg/driver/docker/lifecycle_test.go
+++ b/pkg/driver/docker/lifecycle_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/docker"
+	"github.com/devsy-org/devsy/pkg/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -54,6 +55,50 @@ func newExitedContainer() *config.ContainerDetails {
 		ID:    "c1",
 		State: config.ContainerDetailsState{Status: "exited"},
 	}
+}
+
+// fakeEnsureImageDocker emulates `docker inspect` failing with the given
+// stderr and records whether `docker pull` was invoked by touching marker.
+func fakeEnsureImageDocker(t *testing.T, inspectStderr, marker string) string {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/bin/sh
+case "$1" in
+  inspect)
+    echo '` + inspectStderr + `' >&2
+    exit 1
+    ;;
+  pull)
+    echo pulled > "` + marker + `"
+    ;;
+esac
+`
+	path := filepath.Join(dir, "docker-fake")
+	//nolint:gosec // test helper script needs exec bit
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+	return path
+}
+
+func TestEnsureImage_NotFoundPulls(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "pulled")
+	bin := fakeEnsureImageDocker(t, "Error response from daemon: No such image: x", marker)
+	d := &dockerDriver{Docker: &docker.DockerHelper{DockerCommand: bin}}
+
+	err := d.EnsureImage(context.Background(), &driver.RunOptions{Image: "x:latest"})
+
+	require.NoError(t, err)
+	assert.FileExists(t, marker, "a not-found image should trigger a pull")
+}
+
+func TestEnsureImage_RealErrorDoesNotPull(t *testing.T) {
+	marker := filepath.Join(t.TempDir(), "pulled")
+	bin := fakeEnsureImageDocker(t, "Cannot connect to the Docker daemon", marker)
+	d := &dockerDriver{Docker: &docker.DockerHelper{DockerCommand: bin}}
+
+	err := d.EnsureImage(context.Background(), &driver.RunOptions{Image: "x:latest"})
+
+	require.Error(t, err)
+	assert.NoFileExists(t, marker, "a genuine daemon failure must not trigger a pull")
 }
 
 func TestEnsureContainerRunning_AlreadyRunning(t *testing.T) {


### PR DESCRIPTION
## Summary

Devcontainer builds logged expected image cache-misses as errors — a plain `docker inspect` miss surfaced as `error trying to find local image ... exit status 1`, and the prebuild lookup logged `Try to find prebuild image ... in repositories ` with an empty repository list. Both read like failures during a successful launch.

This introduces a typed `ErrImageNotFound` sentinel so a miss is distinguishable from a genuine daemon/registry failure, and cleans up the surrounding logging and error handling.

### Core change
- **`pkg/docker/helper.go`** — `InspectImage` classifies not-found responses (docker/podman/nerdctl and registry phrasings) and returns `ErrImageNotFound`, including the empty-result case. Real failures pass through unchanged. The remote lookup is extracted into `inspectImageRemote`.
- **`pkg/driver/docker/build.go`** — `tryResolve` branches on `errors.Is(err, ErrImageNotFound)`: a miss logs at debug, a genuine inspect failure logs at warn. Behavior (fall through to build on any error) is unchanged.
- **`pkg/devcontainer/build.go`** — `findPrebuildImage` short-circuits when no prebuild repositories are configured, removing the misleading empty `in repositories` log line.

### Follow-on correctness fixes enabled by the sentinel
- **`EnsureImage`** now pulls only when the inspect reports `ErrImageNotFound`, and returns the underlying error otherwise — instead of logging "image not found" and attempting a pointless pull on a genuine daemon failure.
- **`Inspect` / `GetImageTag`** now label errors with the actual object type instead of always reporting `inspect container:` (misleading for image inspects).

The `Repository != "" || ForceBuild` guard in `tryResolve` is intentionally retained — it forces a real build so the push-during-build path is not skipped.

Tests cover the classifier (incl. registry `NAME_UNKNOWN` / `manifest unknown` phrasings), `InspectImage` miss vs. real-error behavior, and `EnsureImage` pull-vs-error branching. No functional change to build/launch behavior; this is observability and error-typing only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing Docker images across local and remote inspections.
  * Prevented image pulls when inspection fails for reasons other than a missing image.
  * Improved error messages for image and container inspection failures.
  * Skipped unnecessary remote prebuild image lookups when no repositories are configured.

* **Tests**
  * Added coverage for missing-image detection, inspection failures, and image-pull behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->