### PR TITLE
fix(docker): disable SELinux label for containers on enforcing hosts

### DIFF
--- a/pkg/driver/docker/runargs.go
+++ b/pkg/driver/docker/runargs.go
@@ -50,6 +50,7 @@ func (d *dockerDriver) buildRunArgs(
 		b.addPrivileged,
 		b.addPodmanArgs,
 		b.addCapabilities,
+		b.addSELinux,
 		b.addMounts,
 		b.addIDEMount,
 		b.addLabels,
@@ -106,6 +107,11 @@ func (b *runArgsBuilder) addPodmanArgs() error {
 
 func (b *runArgsBuilder) addCapabilities() error {
 	b.args = b.driver.addCapabilityArgs(b.args, b.params.Options)
+	return nil
+}
+
+func (b *runArgsBuilder) addSELinux() error {
+	b.args = b.driver.addSELinuxArgs(b.args, b.params.Options)
 	return nil
 }
 

--- a/pkg/driver/docker/selinux.go
+++ b/pkg/driver/docker/selinux.go
@@ -1,0 +1,47 @@
+package docker
+
+import (
+	"os"
+	"strings"
+
+	"github.com/devsy-org/devsy/pkg/driver"
+)
+
+// selinuxLabelDisable is the security-opt value that turns off the container's
+// SELinux label.
+const selinuxLabelDisable = "label=disable"
+
+// selinuxEnforcePath is a var so tests can override it.
+var selinuxEnforcePath = "/sys/fs/selinux/enforce"
+
+// addSELinuxArgs disables the container's SELinux label on enforcing hosts.
+// Without it, the agent's exec into the confined container is denied
+// ("fork/exec /bin/bash: permission denied"). A user-set label opt wins.
+func (d *dockerDriver) addSELinuxArgs(args []string, options *driver.RunOptions) []string {
+	return append(args, selinuxLabelDisableArgs(options.SecurityOpt, selinuxEnforcing())...)
+}
+
+func selinuxLabelDisableArgs(securityOpts []string, enforcing bool) []string {
+	if !enforcing || userSetsSELinuxLabel(securityOpts) {
+		return nil
+	}
+	return []string{"--security-opt", selinuxLabelDisable}
+}
+
+func userSetsSELinuxLabel(securityOpts []string) bool {
+	for _, opt := range securityOpts {
+		opt = strings.TrimSpace(opt)
+		if opt == "label" || strings.HasPrefix(opt, "label=") || strings.HasPrefix(opt, "label:") {
+			return true
+		}
+	}
+	return false
+}
+
+func selinuxEnforcing() bool {
+	data, err := os.ReadFile(selinuxEnforcePath)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == "1"
+}

--- a/pkg/driver/docker/selinux_test.go
+++ b/pkg/driver/docker/selinux_test.go
@@ -1,0 +1,123 @@
+package docker
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestSELinuxLabelDisableArgs(t *testing.T) {
+	labelDisable := []string{testSecurityOptFlag, selinuxLabelDisable}
+
+	cases := []struct {
+		name         string
+		securityOpts []string
+		enforcing    bool
+		want         []string
+	}{
+		{
+			name:      "enforcing adds label=disable",
+			enforcing: true,
+			want:      labelDisable,
+		},
+		{
+			name:      "not enforcing is a no-op",
+			enforcing: false,
+			want:      nil,
+		},
+		{
+			name:         "not enforcing with user opts is still a no-op",
+			securityOpts: []string{testSeccompUnconfined},
+			enforcing:    false,
+			want:         nil,
+		},
+		{
+			name:         "user label opt is respected",
+			securityOpts: []string{"label=type:container_t"},
+			enforcing:    true,
+			want:         nil,
+		},
+		{
+			name:         "unrelated security opt still adds label=disable",
+			securityOpts: []string{testSeccompUnconfined},
+			enforcing:    true,
+			want:         labelDisable,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := selinuxLabelDisableArgs(tc.securityOpts, tc.enforcing)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSELinuxEnforcing(t *testing.T) {
+	orig := selinuxEnforcePath
+	t.Cleanup(func() { selinuxEnforcePath = orig })
+
+	write := func(t *testing.T, content string) string {
+		t.Helper()
+		p := filepath.Join(t.TempDir(), "enforce")
+		if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "enforcing", content: "1\n", want: true},
+		{name: "permissive", content: "0\n", want: false},
+		{name: "no trailing newline", content: "1", want: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			selinuxEnforcePath = write(t, tc.content)
+			if got := selinuxEnforcing(); got != tc.want {
+				t.Fatalf("selinuxEnforcing() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("missing file means not enforcing", func(t *testing.T) {
+		selinuxEnforcePath = filepath.Join(t.TempDir(), "does-not-exist")
+		if selinuxEnforcing() {
+			t.Fatal("expected false when SELinux file is absent")
+		}
+	})
+}
+
+func TestUserSetsSELinuxLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		opts []string
+		want bool
+	}{
+		{name: "nil", opts: nil, want: false},
+		{name: "label=disable", opts: []string{selinuxLabelDisable}, want: true},
+		{name: "label with spaces", opts: []string{" label=type:foo "}, want: true},
+		{name: "label colon separator", opts: []string{"label:disable"}, want: true},
+		{name: "bare label", opts: []string{"label"}, want: true},
+		{name: "unrelated prefix not matched", opts: []string{"labelfoo=bar"}, want: false},
+		{
+			name: "other opts",
+			opts: []string{testSeccompUnconfined, "no-new-privileges"},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := userSetsSELinuxLabel(tc.opts); got != tc.want {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

On SELinux-enforcing hosts (Fedora, RHEL, CentOS) a devsy workspace container runs in a confined SELinux domain (e.g. `container_t`). devsy injects its agent binary into the container and execs the user's shell as the workspace user, and under an enforcing policy that nested exec is denied — surfacing as:

```
start command: fork/exec /bin/bash: permission denied
```

This is a blocked SELinux **domain transition**, so it frequently logs **no AVC**, which makes it look mysterious (the container starts fine; only the in-container exec fails). Every OCI runtime devsy drives — Docker, Podman, and nerdctl/containerd — labels containers by default on such hosts, so the failure is a property of the **host policy**, not of a specific runtime.

## Change

Add `--security-opt label=disable` to the container run args when the host SELinux policy is enforcing, wired as a new `addSELinux` step in the run-args builder.

- **No-op on non-enforcing hosts** (Ubuntu, Docker Desktop, permissive mode) — gated on `/sys/fs/selinux/enforce == "1"`, missing file fails safe.
- **Respects user intent** — skipped if the user already set a `label` security-opt via `devcontainer.json` `securityOpt`.
- **Runtime-independent** — applies to docker/podman/nerdctl alike, since all label containers on enforcing hosts.

The workload still runs in its own namespaces; disabling only the SELinux **label** does not remove namespace/cgroup isolation. On VM-backed providers (e.g. the Lima provider) the VM itself remains the isolation boundary.

## How it was found / validated

Reproduced end-to-end on a real SELinux-enforcing Fedora VM running rootful Podman:

- **Enforcing, no fix** → `fork/exec /bin/bash: permission denied`, no AVC in audit log.
- **Enforcing + `--security-opt label=disable`** → workspace connects and runs commands. ✅
- **SELinux permissive + fresh container** → also works, confirming the mechanism is SELinux domain transition (not a plain file permission). ✅

## Notes / scope

- Included docker (not just podman) deliberately: the mechanism and fix are identical, so keying on host policy avoids leaving the same bug unfixed for docker-on-Fedora/RHEL.
- The podman path is validated on a real Fedora VM; the docker/nerdctl-on-SELinux paths share the same code path and unit tests but were not separately booted on Fedora.
- Unit tests cover the enforcing/non-enforcing matrix, user-label precedence, `enforce` file parsing (with/without newline, missing file), and the label-key matcher.

Draft: opening for review of the approach before finalizing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker runs now automatically disable SELinux labeling when SELinux is enforcing and no custom label option is provided.
  * Existing user-configured SELinux label settings are preserved.

* **Tests**
  * Added coverage for SELinux enforcement detection and security-option handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->