### PR TITLE
feat(desktop): surface single-machine (reuse machine) in provider UI

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -279,12 +279,18 @@ export function registerIpcHandlers(deps: IpcDependencies): {
 
   ipcMain.handle(
     "provider_add",
-    async (_event, args: { name: string; source?: string }) => {
+    async (
+      _event,
+      args: { name: string; source?: string; singleMachine?: boolean },
+    ) => {
       trackEvent("provider_add")
       const src = args.source ?? args.name
       const cliArgs = ["provider", "add", src, "--use=false"]
       if (args.source) {
         cliArgs.push("--name", args.name)
+      }
+      if (args.singleMachine) {
+        cliArgs.push("--single-machine")
       }
       await cli.runRaw(cliArgs)
     },
@@ -366,6 +372,19 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         cliArgs.push("-o", opt)
       }
       await cli.runRaw(cliArgs)
+    },
+  )
+
+  ipcMain.handle(
+    "provider_set_single_machine",
+    async (_event, args: { name: string; enabled: boolean }) => {
+      await cli.runRaw([
+        "provider",
+        "set",
+        args.name,
+        "--skip-init",
+        `--single-machine=${args.enabled}`,
+      ])
     },
   )
 

--- a/desktop/src/main/watcher.ts
+++ b/desktop/src/main/watcher.ts
@@ -29,7 +29,7 @@ export interface ProviderEntry {
     options?: Record<string, unknown>
     optionGroups?: unknown[]
   }
-  state?: { initialized?: boolean }
+  state?: { initialized?: boolean; singleMachine?: boolean }
   default?: boolean
 }
 
@@ -45,7 +45,7 @@ export function parseProviderEntries(raw: Record<string, ProviderEntry>) {
     isDefault: entry.default ?? false,
     state: {
       initialized: entry.state?.initialized ?? false,
-      singleMachine: false,
+      singleMachine: entry.state?.singleMachine ?? false,
     },
   }))
 }

--- a/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
@@ -4,6 +4,7 @@ import { Star } from "@lucide/svelte"
 import { Button } from "$lib/components/ui/button/index.js"
 import { Input } from "$lib/components/ui/input/index.js"
 import { Label } from "$lib/components/ui/label/index.js"
+import { Switch } from "$lib/components/ui/switch/index.js"
 import { Separator } from "$lib/components/ui/separator/index.js"
 import * as Select from "$lib/components/ui/select/index.js"
 import * as Alert from "$lib/components/ui/alert/index.js"
@@ -23,6 +24,7 @@ import {
   providerList,
   providerOptions,
   providerSetOptions,
+  providerSetSingleMachine,
   providerRename,
   providerSetVersion,
 } from "$lib/ipc/commands.js"
@@ -152,6 +154,23 @@ async function handleSetDefault() {
     toasts.success(`Set ${provider.name} as default provider`)
   } catch (err) {
     toasts.error(`Failed to set default: ${extractErrorMessage(err)}`)
+  }
+}
+
+let togglingSingleMachine = $state(false)
+
+async function handleToggleSingleMachine(enabled: boolean) {
+  togglingSingleMachine = true
+  try {
+    await providerSetSingleMachine(provider.name, enabled)
+    providers.set(await providerList())
+    toasts.success(
+      enabled ? "Reuse machine enabled" : "Reuse machine disabled",
+    )
+  } catch (err) {
+    toasts.error(`Failed to update reuse machine: ${extractErrorMessage(err)}`)
+  } finally {
+    togglingSingleMachine = false
   }
 }
 
@@ -374,6 +393,20 @@ async function handleSaveOptions() {
         <Button variant="outline" size="sm" onclick={handleUpdate}>Update</Button>
       </ButtonGroup.Root>
       <Button variant="destructive" size="sm" onclick={() => (confirmDeleteOpen = true)}>Delete</Button>
+    </div>
+
+    <div class="flex items-center justify-between gap-4 px-6">
+      <div class="space-y-0.5">
+        <Label>Reuse machine</Label>
+        <p class="text-sm text-muted-foreground">
+          Run all workspaces on a single shared machine instead of one per workspace.
+        </p>
+      </div>
+      <Switch
+        checked={provider.state?.singleMachine ?? false}
+        onCheckedChange={handleToggleSingleMachine}
+        disabled={togglingSingleMachine}
+      />
     </div>
 
     {#if $providerVersions.updates[provider.name]?.updateAvailable === true}

--- a/desktop/src/renderer/src/lib/components/provider/ProviderWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderWizard.svelte
@@ -5,6 +5,7 @@ import { Check, Circle, AlertCircle, Loader2 } from "@lucide/svelte"
 import { Button } from "$lib/components/ui/button/index.js"
 import { Input } from "$lib/components/ui/input/index.js"
 import { Label } from "$lib/components/ui/label/index.js"
+import { Switch } from "$lib/components/ui/switch/index.js"
 import * as Select from "$lib/components/ui/select/index.js"
 import * as Dialog from "$lib/components/ui/dialog/index.js"
 import * as Alert from "$lib/components/ui/alert/index.js"
@@ -70,6 +71,7 @@ let error = $state("")
 // Step 1 state
 let source = $state("")
 let customName = $state("")
+let singleMachine = $state(false)
 let adding = $state(false)
 
 // Step 2 state
@@ -129,6 +131,7 @@ function reset() {
   error = ""
   source = ""
   customName = ""
+  singleMachine = false
   adding = false
   providerName = ""
   options = {}
@@ -197,7 +200,7 @@ async function handleSelect() {
   error = ""
   adding = true
   try {
-    await providerAdd(name, name !== src ? src : undefined)
+    await providerAdd(name, name !== src ? src : undefined, singleMachine)
     providerName = name
   } catch (err) {
     const msg = extractErrorMessage(err)
@@ -409,6 +412,19 @@ function handleDone() {
                 placeholder="Defaults to source name"
                 value={customName}
                 oninput={(e) => { customName = e.currentTarget.value; error = "" }}
+                disabled={adding}
+              />
+            </div>
+            <div class="flex items-center justify-between gap-4">
+              <div class="space-y-0.5">
+                <Label>Reuse machine</Label>
+                <p class="text-sm text-muted-foreground">
+                  Run all workspaces on a single shared machine instead of one per workspace.
+                </p>
+              </div>
+              <Switch
+                checked={singleMachine}
+                onCheckedChange={(v) => { singleMachine = v }}
                 disabled={adding}
               />
             </div>

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -92,8 +92,16 @@ export async function providerList(): Promise<Provider[]> {
 export async function providerAdd(
   name: string,
   source?: string,
+  singleMachine?: boolean,
 ): Promise<void> {
-  return invoke("provider_add", { name, source })
+  return invoke("provider_add", { name, source, singleMachine })
+}
+
+export async function providerSetSingleMachine(
+  name: string,
+  enabled: boolean,
+): Promise<void> {
+  return invoke("provider_set_single_machine", { name, enabled })
 }
 
 export async function providerDelete(name: string): Promise<void> {


### PR DESCRIPTION
## Summary

Surfaces the existing `--single-machine` ("reuse machine") capability in the Desktop UI. The Go CLI already supports `--single-machine` on `provider add`/`init`/`set` and reports `state.singleMachine` in `provider list`, but the desktop never wired it up (upstream DevPod had a toggle this fork dropped).

## Changes

- **`main/watcher.ts`** — read the real `singleMachine` from `provider list` output instead of hardcoding `false`, so the UI reflects actual state.
- **`main/ipc.ts`** — thread `--single-machine` into the `provider_add` handler; add a `provider_set_single_machine` handler (`provider set <name> --skip-init --single-machine=<bool>`) for editing existing providers.
- **`renderer/.../ipc/commands.ts`** — extend `providerAdd` with an optional `singleMachine` arg; add `providerSetSingleMachine(name, enabled)`.
- **`ProviderWizard.svelte`** — "Reuse machine" toggle in the add flow's select step.
- **`ProviderSheet.svelte`** — "Reuse machine" toggle for existing providers, refreshing provider state after the change.

Users can now enable reuse-machine at add time or flip it later on a provider's sheet. This applies to all machine providers (aws/gcloud/azure/lima/…), since single-machine is core.

## Validation

- Renderer `svelte-check`: 0 errors / 0 warnings
- Main-process `tsc --noEmit`: clean
- `electron-vite build`: succeeds

Not yet exercised by clicking the toggle in a live Electron session (needs a GUI run). Opening as draft for review of the approach.
