### PR TITLE
fix(telemetry): improve analytics count

### DIFF
--- a/desktop/src/main/analytics.ts
+++ b/desktop/src/main/analytics.ts
@@ -55,6 +55,8 @@ export function initAnalytics(): void {
     host: POSTHOG_HOST,
     flushAt: 20,
     flushInterval: 30_000,
+    disableGeoip: false,
+    isServer: false,
   })
 }
 

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"os"
 	"strings"
 
 	"github.com/devsy-org/devsy/pkg/agent/delivery"
@@ -15,6 +16,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/devcontainer/metadata"
 	"github.com/devsy-org/devsy/pkg/driver"
 	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/telemetry/distinctid"
 )
 
 var dockerlessImage = "ghcr.io/devsy-org/dockerless:0.2.0"
@@ -768,6 +770,12 @@ func (r *runner) addExtraEnvVars(env map[string]string) map[string]string {
 	if r.workspaceConfig != nil && r.workspaceConfig.Workspace != nil &&
 		r.workspaceConfig.Workspace.UID != "" {
 		env[pkgconfig.EnvWorkspaceUID] = r.workspaceConfig.Workspace.UID
+	}
+
+	if os.Getenv(pkgconfig.EnvDisableTelemetry) == pkgconfig.BoolTrue {
+		env[pkgconfig.EnvDisableTelemetry] = pkgconfig.BoolTrue
+	} else {
+		env[pkgconfig.EnvTelemetryDistinctID] = distinctid.Get()
 	}
 
 	return env

--- a/pkg/telemetry/analytics/client.go
+++ b/pkg/telemetry/analytics/client.go
@@ -26,7 +26,8 @@ func NewClient() Client {
 	}
 
 	phClient, err := posthog.NewWithConfig(posthogAPIKey, posthog.Config{
-		Endpoint: posthogEndpoint,
+		Endpoint:     posthogEndpoint,
+		DisableGeoIP: new(false),
 	})
 	if err != nil {
 		log.Debugf("failed to initialize analytics client: %v", err)

--- a/pkg/telemetry/collect.go
+++ b/pkg/telemetry/collect.go
@@ -65,6 +65,13 @@ func BootstrapCLI(cmd *cobra.Command) CLICollector {
 		return &noopCollector{}
 	}
 
+	isUI := os.Getenv(config.EnvUI) == config.BoolTrue
+	isProRunner := os.Getenv(config.EnvProRunner) == config.BoolTrue
+	if !isUI && !isProRunner && isCIEnvironment() {
+		log.Debug("telemetry: disabled in CI environment")
+		return &noopCollector{}
+	}
+
 	collector, err := newCLICollector(cmd)
 	if err != nil {
 		log.Infof("telemetry: %s", err.Error())
@@ -191,6 +198,11 @@ func (d *cliCollector) recordEvent(
 	eventPayload[analytics.KeyType] = eventType
 	eventPayload[analytics.KeyMachineID] = machineID
 	eventPayload[analytics.KeyTimestamp] = timestamp
+
+	if wsUID := os.Getenv(config.EnvWorkspaceUID); wsUID != "" {
+		eventPayload["in_container"] = true
+		eventPayload["workspace_id"] = hashScopedID(machineID, wsUID)
+	}
 
 	userPayload := map[string]any{}
 	maps.Copy(userPayload, userProperties)

--- a/pkg/telemetry/distinctid/distinctid.go
+++ b/pkg/telemetry/distinctid/distinctid.go
@@ -1,0 +1,61 @@
+// Package distinctid computes the analytics identity for a Devsy invocation.
+package distinctid
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/machineid"
+	"github.com/devsy-org/devsy/pkg/util"
+)
+
+var (
+	fallbackIDOnce sync.Once
+	fallbackID     string
+)
+
+// Get returns the analytics distinct ID: the DEVSY_TELEMETRY_DISTINCT_ID
+// override when set, otherwise HMAC(machine-id, $HOME) hex-encoded.
+func Get() string {
+	if injected := os.Getenv(config.EnvTelemetryDistinctID); injected != "" {
+		return injected
+	}
+
+	id, err := machineid.ID()
+	if err != nil {
+		// Random fallback prevents every failure-path user from collapsing
+		// into a single HMAC bucket. Cached so repeated calls within one
+		// process agree.
+		id = cachedFallbackID()
+	}
+
+	home, err := util.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+
+	mac := hmac.New(sha256.New, []byte(id))
+	mac.Write([]byte(home))
+	return fmt.Sprintf("%x", mac.Sum(nil))
+}
+
+func cachedFallbackID() string {
+	fallbackIDOnce.Do(func() {
+		fallbackID = randomFallbackID()
+	})
+	return fallbackID
+}
+
+func randomFallbackID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "rand-error"
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/pkg/telemetry/distinctid/distinctid_test.go
+++ b/pkg/telemetry/distinctid/distinctid_test.go
@@ -1,0 +1,28 @@
+package distinctid
+
+import (
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/config"
+)
+
+func TestGetReturnsInjectedID(t *testing.T) {
+	const injected = "owner-distinct-id"
+	t.Setenv(config.EnvTelemetryDistinctID, injected)
+
+	if got := Get(); got != injected {
+		t.Fatalf("Get() = %q, want injected %q", got, injected)
+	}
+}
+
+func TestGetDerivesStableIDWithoutInjection(t *testing.T) {
+	t.Setenv(config.EnvTelemetryDistinctID, "")
+
+	first := Get()
+	if first == "" {
+		t.Fatal("Get() returned empty distinct ID")
+	}
+	if second := Get(); second != first {
+		t.Fatalf("Get() not stable across calls: %q != %q", first, second)
+	}
+}

--- a/pkg/telemetry/helpers.go
+++ b/pkg/telemetry/helpers.go
@@ -2,59 +2,18 @@ package telemetry
 
 import (
 	"crypto/hmac"
-	"crypto/rand"
 	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"os"
-	"sync"
 
-	"github.com/devsy-org/devsy/pkg/config"
-	"github.com/devsy-org/devsy/pkg/machineid"
-	"github.com/devsy-org/devsy/pkg/util"
+	"github.com/devsy-org/devsy/pkg/telemetry/distinctid"
 )
 
-var (
-	fallbackIDOnce sync.Once
-	fallbackID     string
-)
-
-// HMAC(machine-id, $HOME), hex-encoded. Returns the injected distinct ID
-// when DEVSY_TELEMETRY_DISTINCT_ID is set (desktop-spawned CLI).
 func GetMachineID() string {
-	if injected := os.Getenv(config.EnvTelemetryDistinctID); injected != "" {
-		return injected
-	}
-
-	id, err := machineid.ID()
-	if err != nil {
-		// Random fallback prevents every failure-path user from collapsing
-		// into a single HMAC bucket. Cached so the two GetMachineID calls
-		// within one event agree.
-		id = cachedFallbackID()
-	}
-
-	home, err := util.UserHomeDir()
-	if err != nil {
-		home = ""
-	}
-
-	mac := hmac.New(sha256.New, []byte(id))
-	mac.Write([]byte(home))
-	return fmt.Sprintf("%x", mac.Sum(nil))
+	return distinctid.Get()
 }
 
-func cachedFallbackID() string {
-	fallbackIDOnce.Do(func() {
-		fallbackID = randomFallbackID()
-	})
-	return fallbackID
-}
-
-func randomFallbackID() string {
-	var b [16]byte
-	if _, err := rand.Read(b[:]); err != nil {
-		return "rand-error"
-	}
-	return hex.EncodeToString(b[:])
+func hashScopedID(distinctID, value string) string {
+	mac := hmac.New(sha256.New, []byte(distinctID))
+	mac.Write([]byte(value))
+	return fmt.Sprintf("%x", mac.Sum(nil))[:16]
 }


### PR DESCRIPTION
## Summary

Fixes the inflated PostHog unique-user count and improves product-use analytics.

- **Suppress CI-runner telemetry.** `distinct_id` is `HMAC(machine-id, $HOME)`, so every ephemeral CI runner registered as a new unique user. `BootstrapCLI` now returns a no-op collector in CI, exempting the desktop (`DEVSY_UI`) and Pro runners (`DEVSY_PRO_RUNNER`, tracked as their own event type).
- **Attribute devcontainers to their owner.** The in-container agent computed its own identity from the container's `machine-id`/`$HOME`, so each container counted as a separate user. The launching host's distinct ID (and the telemetry opt-out) is now propagated into the container via `addExtraEnvVars`. Container events are tagged with `in_container=true` and a per-workspace `workspace_id` (`HMAC(distinctID, workspace UID)`), so distinct workspaces per user can be measured without exposing raw IDs.
- **Refactor.** Distinct-ID derivation moved into a new leaf package `pkg/telemetry/distinctid` to avoid an import cycle (`pkg/telemetry` → `pkg/devcontainer`).

## Measuring in PostHog
- Filter out remaining noise: none needed for CI (dropped upstream); use `in_container` to separate host vs container activity.
- Devcontainers per user: count distinct `workspace_id` grouped by person.
- Geography: new `$geoip_*` properties (applies to events sent after deploy; no backfill).

## Notes
- Go: `build`, `vet`, tests, and `gofmt` all pass.
- Desktop typecheck was not run locally (deps not installed); the change is two documented `posthog-node` options (v5.34.2) — CI will verify.