### PR TITLE
fix(provider): honor --result-format for provider list --available

### DIFF
--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -167,6 +167,11 @@ func (cmd *ListCmd) renderInstalledJSON(
 
 // runAvailable lists providers available for installation.
 func (cmd *ListCmd) runAvailable(ctx context.Context) error {
+	mode, err := output.ResolveMode(cmd.ResultFormat)
+	if err != nil {
+		return err
+	}
+
 	jsonResult, err := fetchProviderRepos(ctx)
 	if err != nil {
 		return err
@@ -183,10 +188,6 @@ func (cmd *ListCmd) runAvailable(ctx context.Context) error {
 		}
 	}
 
-	mode, err := output.ResolveMode(cmd.ResultFormat)
-	if err != nil {
-		return err
-	}
 	switch mode {
 	case output.ModePlain:
 		return cmd.renderAvailablePlain(providers)
@@ -219,7 +220,7 @@ func (cmd *ListCmd) renderAvailableJSON(providers []string) error {
 		return err
 	}
 	//nolint:forbidigo
-	fmt.Print(string(out))
+	fmt.Println(string(out))
 
 	return nil
 }

--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -160,7 +160,7 @@ func (cmd *ListCmd) renderInstalledJSON(
 		return err
 	}
 	//nolint:forbidigo
-	fmt.Print(string(out))
+	fmt.Println(string(out))
 
 	return nil
 }

--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -172,18 +172,54 @@ func (cmd *ListCmd) runAvailable(ctx context.Context) error {
 		return err
 	}
 
-	_, _ = fmt.Fprintln(os.Stdout, "List of available providers from "+config.RepoOwner+":")
-	var rows [][]string
+	var providers []string
 	for _, v := range jsonResult {
 		name, ok := v["name"].(string)
 		if !ok || name == "" {
 			continue
 		}
 		if after, ok0 := strings.CutPrefix(name, config.ProviderPrefix); ok0 {
-			rows = append(rows, []string{after})
+			providers = append(providers, after)
 		}
 	}
+
+	mode, err := output.ResolveMode(cmd.ResultFormat)
+	if err != nil {
+		return err
+	}
+	switch mode {
+	case output.ModePlain:
+		return cmd.renderAvailablePlain(providers)
+	case output.ModeJSON:
+		return cmd.renderAvailableJSON(providers)
+	}
+
+	return nil
+}
+
+// renderAvailablePlain renders available providers in plain text format.
+func (cmd *ListCmd) renderAvailablePlain(providers []string) error {
+	_, _ = fmt.Fprintln(os.Stdout, "List of available providers from "+config.RepoOwner+":")
+	rows := make([][]string, 0, len(providers))
+	for _, name := range providers {
+		rows = append(rows, []string{name})
+	}
 	table.Print([]string{"Provider"}, rows)
+
+	return nil
+}
+
+// renderAvailableJSON renders available providers in JSON format.
+func (cmd *ListCmd) renderAvailableJSON(providers []string) error {
+	if providers == nil {
+		providers = []string{}
+	}
+	out, err := json.MarshalIndent(providers, "", "  ")
+	if err != nil {
+		return err
+	}
+	//nolint:forbidigo
+	fmt.Print(string(out))
 
 	return nil
 }


### PR DESCRIPTION
`devsy provider list --available --result-format json` printed the human-readable table instead of JSON.

`runAvailable` in `cmd/provider/list.go` never called `output.ResolveMode(cmd.ResultFormat)`, unlike `runInstalled`. It refactors the available path to collect provider names, resolve the output mode, and dispatch to a plain (header + table) or JSON renderer. Empty results serialize to `[]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON output support for the available providers command.
  * Improved plain-text output with a clear header and streamlined provider listing.
  * JSON responses now return an empty list when no providers are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->