### PR TITLE
fix: add package permissions to push to GHCR

### DIFF
--- a/.github/workflows/publish-agent-helper.yml
+++ b/.github/workflows/publish-agent-helper.yml
@@ -28,6 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      packages: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to support publishing container images to the package registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->