### PR TITLE
fix(desktop): make workspace creation Retry button work after failure

### DIFF
--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -469,8 +469,8 @@ function handleProgress(progress: CommandProgress, wsId: string | undefined) {
   }
 }
 
-async function handleLaunch() {
-  if (resolvedIdInvalid || nameConflict) return
+async function handleLaunch(isRetry = false) {
+  if (resolvedIdInvalid || (nameConflict && !isRetry)) return
   launchRunning = true
   launchError = ""
   launchSuccess = false
@@ -1243,7 +1243,7 @@ function selectTemplate(t: { name: string; source: string }) {
               </Button>
             {:else if launchError}
               <Button variant="outline" onclick={() => (open = false)}>Close</Button>
-              <Button onclick={handleLaunch}>Retry</Button>
+              <Button onclick={() => handleLaunch(true)}>Retry</Button>
             {/if}
           </div>
         </div>

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.test.ts
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.test.ts
@@ -430,6 +430,39 @@ describe("WorkspaceWizard", () => {
     unmount()
   })
 
+  it("retries launch even when the failed workspace is already in the store", async () => {
+    providers.set([makeProvider("docker")])
+    const { getByText, queryByText, unmount } = render(WorkspaceWizard, {
+      props: { open: true },
+    })
+    await flushAsync()
+    await advanceToReview(getByText)
+
+    const launchBtn = Array.from(
+      document.querySelectorAll("button"),
+    ).find((b) => b.textContent?.trim() === "Launch") as HTMLButtonElement
+    await fireEvent.click(launchBtn)
+    await flushAsync()
+
+    progressCallback?.({
+      commandId: "cmd-1",
+      message: "Exit code: 1",
+      done: true,
+    } as CommandProgress)
+    await flushAsync()
+
+    workspaces.set([{ id: "python" }])
+    await flushAsync()
+
+    workspaceUp.mockClear()
+    const retryBtn = queryByText("Retry") as HTMLButtonElement
+    await fireEvent.click(retryBtn)
+    await flushAsync()
+
+    expect(workspaceUp).toHaveBeenCalledTimes(1)
+    unmount()
+  })
+
   it("forwards assembled source plus workspaceFolder and build flags to workspaceUp", async () => {
     providers.set([makeProvider("docker")])
     const { getByText, unmount } = render(WorkspaceWizard, {


### PR DESCRIPTION
## Summary

The Retry button in the workspace creation wizard did nothing when clicked after a failed launch.

`handleLaunch` began with the guard `if (resolvedIdInvalid || nameConflict) return`. When creation fails, the workspace id has usually already been registered in the `$workspaces` store (partial creation), so `nameConflict` becomes `true` on retry and the handler returns immediately — no spinner, no error, no toast.

The guard is correct for the initial launch but is a false positive on retry, since we're deliberately re-creating that same workspace and the name is already locked at the launch step. `handleLaunch` now takes an `isRetry` flag that skips the `nameConflict` check; the Retry button passes `true`, while the initial-launch path is unchanged.

Adds a regression test that registers the failed workspace in the store and asserts Retry re-invokes `workspaceUp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace launch retry behavior when a workspace with the same name already exists.
  * Users can now retry a failed workspace launch successfully in this scenario.

* **Tests**
  * Added coverage for retrying failed launches when an existing workspace entry is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->