### PR TITLE
fix(desktop): simplify update CTA text to 'Restart'

### DIFF
--- a/desktop/src/renderer/src/lib/components/update/UpdateDialog.svelte
+++ b/desktop/src/renderer/src/lib/components/update/UpdateDialog.svelte
@@ -85,7 +85,7 @@ async function onInstall() {
 				{/if}
 				<div class="flex gap-2 justify-end">
 					<Button variant="ghost" onclick={() => (open = false)}>Later</Button>
-					<Button onclick={onInstall}>Restart &amp; Update</Button>
+					<Button onclick={onInstall}>Restart</Button>
 				</div>
 			</div>
 		{:else if s.state === "not-available"}

--- a/desktop/src/renderer/src/lib/components/update/UpdateDialog.test.ts
+++ b/desktop/src/renderer/src/lib/components/update/UpdateDialog.test.ts
@@ -44,7 +44,7 @@ describe("UpdateDialog", () => {
     __setForTest({ state: "downloaded", version: "9.9.9" })
     render(UpdateDialog, { props: { open: true } })
     expect(bodyText()).toMatch(/version 9\.9\.9/i)
-    expect(queryButton(/restart & update/i)).toBeTruthy()
+    expect(queryButton(/restart/i)).toBeTruthy()
   })
 
   it("renders 'downloading' progress", () => {

--- a/desktop/src/renderer/src/lib/components/update/UpdatesPanel.svelte
+++ b/desktop/src/renderer/src/lib/components/update/UpdatesPanel.svelte
@@ -138,7 +138,7 @@ onMount(async () => {
           {#if s.state === "available"}
             <Button size="sm" onclick={() => downloadUpdate()}>Download</Button>
           {:else if s.state === "downloaded"}
-            <Button size="sm" onclick={() => installUpdate()}>Restart &amp; Update</Button>
+            <Button size="sm" onclick={() => installUpdate()}>Restart</Button>
           {:else}
             <Button
               variant="outline"

--- a/desktop/src/renderer/src/lib/components/update/update-toasts.ts
+++ b/desktop/src/renderer/src/lib/components/update/update-toasts.ts
@@ -40,7 +40,7 @@ function fireDownloaded(s: UpdateStatus): void {
   toast.success(`Update v${s.version} ready`, {
     duration: Infinity,
     action: {
-      label: "Restart and Update",
+      label: "Restart",
       onClick: () => {
         installUpdate().catch(() => {
           toast.error("Failed to start update. Try restarting the app manually.")


### PR DESCRIPTION
Simplifies the update call-to-action text from "Restart & Update" / "Restart and Update" to the single word "Restart" across the update dialog, updates panel, and toast, with the test assertion updated to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Updated downloaded-update actions to display **“Restart”** instead of **“Restart & Update”** or **“Restart and Update.”**

* **Tests**
  * Updated coverage to reflect the revised restart button label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->