### PR TITLE
feat(up): reopen dev container in recovery mode on build failure

### DIFF
--- a/cmd/internal/agentworkspace/up.go
+++ b/cmd/internal/agentworkspace/up.go
@@ -16,6 +16,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/agent/tunnel"
 	"github.com/devsy-org/devsy/pkg/agent/tunnelserver"
 	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
+	"github.com/devsy-org/devsy/pkg/clierr"
 	"github.com/devsy-org/devsy/pkg/command"
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/credentials"
@@ -151,11 +152,10 @@ func (cmd *UpCmd) up(
 ) error {
 	result, err := cmd.devsyUp(ctx, workspaceInfo)
 	if err != nil {
-		// Forward the structured error back to the host through the tunnel
-		// BEFORE returning so the CLI can surface the actual cause (e.g.
-		// host requirements not met) instead of the generic "did not
-		// receive a result back from agent" fallback.
-		errResult := &config2.Result{Error: err.Error()}
+		errResult := &config2.Result{
+			Error:             err.Error(),
+			RecoveryAvailable: errors.Is(err, clierr.ErrBuildFailedRecoverable),
+		}
 		if sendErr := cmd.sendResult(ctx, errResult, tunnelClient); sendErr != nil {
 			log.Errorf("failed to forward up error %q to host: %v", err, sendErr)
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -212,6 +212,9 @@ func exitCodeForError(err error, machineMode bool) int {
 	if errors.Is(err, workspace.ErrWorkspaceNotFound) {
 		return exitcode.Retryable
 	}
+	if cliErr.Code == clierr.CodeBuildFailedRecoverable {
+		return exitcode.BuildFailedRecoverable
+	}
 	return exitcode.Failure
 }
 

--- a/cmd/workspace/status.go
+++ b/cmd/workspace/status.go
@@ -15,6 +15,7 @@ import (
 	cliflags "github.com/devsy-org/devsy/pkg/flags"
 	"github.com/devsy-org/devsy/pkg/flags/names"
 	"github.com/devsy-org/devsy/pkg/output"
+	"github.com/devsy-org/devsy/pkg/provider"
 	workspace2 "github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
 )
@@ -24,7 +25,8 @@ type StatusCmd struct {
 	*flags.GlobalFlags
 	client2.StatusOptions
 
-	Timeout string
+	Timeout  string
+	Recovery bool
 }
 
 // NewStatusCmd creates a new command.
@@ -55,6 +57,9 @@ func NewStatusCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 			"If enabled shows the workspace container status as well"),
 		cliflags.String(&cmd.Timeout, names.Timeout, "30s",
 			"The timeout to wait until the status can be retrieved"),
+		cliflags.Bool(&cmd.Recovery, names.Recovery, false,
+			"Include whether the running container is a recovery container "+
+				"(JSON output only)"),
 	)
 	return statusCmd
 }
@@ -90,12 +95,20 @@ func (cmd *StatusCmd) Run(
 	case output.ModePlain:
 		_, _ = fmt.Fprintln(os.Stdout, string(instanceStatus))
 	case output.ModeJSON:
-		out, err := json.Marshal(&client2.WorkspaceStatus{
+		status := client2.WorkspaceStatus{
 			ID:       client.Workspace(),
 			Context:  client.Context(),
 			Provider: client.Provider(),
 			State:    string(instanceStatus),
-		})
+		}
+		if cmd.Recovery && instanceStatus == client2.StatusRunning {
+			if result, loadErr := provider.LoadWorkspaceResult(
+				client.Context(), client.Workspace(),
+			); loadErr == nil && result != nil {
+				status.Recovery = result.RecoveryContainer
+			}
+		}
+		out, err := json.Marshal(&status)
 		if err != nil {
 			return err
 		}

--- a/cmd/workspace/status.go
+++ b/cmd/workspace/status.go
@@ -100,13 +100,7 @@ func (cmd *StatusCmd) Run(
 			Context:  client.Context(),
 			Provider: client.Provider(),
 			State:    string(instanceStatus),
-		}
-		if cmd.Recovery && instanceStatus == client2.StatusRunning {
-			if result, loadErr := provider.LoadWorkspaceResult(
-				client.Context(), client.Workspace(),
-			); loadErr == nil && result != nil {
-				status.Recovery = result.RecoveryContainer
-			}
+			Recovery: cmd.resolveRecovery(client, instanceStatus),
 		}
 		out, err := json.Marshal(&status)
 		if err != nil {
@@ -117,6 +111,23 @@ func (cmd *StatusCmd) Run(
 	}
 
 	return nil
+}
+
+// resolveRecovery reports whether the running container was built in recovery
+// mode, looked up from the persisted workspace result. It is opt-in (--recovery)
+// so the frequent status poll pays no extra disk read.
+func (cmd *StatusCmd) resolveRecovery(
+	c client2.BaseWorkspaceClient,
+	status client2.Status,
+) bool {
+	if !cmd.Recovery || status != client2.StatusRunning {
+		return false
+	}
+	result, err := provider.LoadWorkspaceResult(c.Context(), c.Workspace())
+	if err != nil || result == nil {
+		return false
+	}
+	return result.RecoveryContainer
 }
 
 func (cmd *StatusCmd) execute(ctx context.Context, args []string) error {

--- a/cmd/workspace/up/up.go
+++ b/cmd/workspace/up/up.go
@@ -330,8 +330,10 @@ func reportErr(err error, emitJSON bool, out io.Writer) error {
 func emitUpResult(wctx *workspaceContext, ideURL string, out io.Writer) {
 	containerID := config2.GetContainerID(wctx.result)
 	var warnings []string
+	recovery := false
 	if wctx.result != nil {
 		warnings = wctx.result.HostWarnings
+		recovery = wctx.result.RecoveryContainer
 	}
 	_ = config2.WriteResultJSON(out, config2.ResultEnvelope{
 		ContainerID:           containerID,
@@ -339,6 +341,7 @@ func emitUpResult(wctx *workspaceContext, ideURL string, out io.Writer) {
 		RemoteWorkspaceFolder: wctx.workdir,
 		URL:                   ideURL,
 		Warnings:              warnings,
+		Recovery:              recovery,
 	})
 }
 
@@ -472,7 +475,7 @@ func (cmd *UpCmd) executeDevsyUp(
 func validateUpResult(result *config2.Result, err error) error {
 	if resultErr := result.Err(); resultErr != nil {
 		if err != nil {
-			return fmt.Errorf("start workspace: %s: %w", resultErr, err)
+			return fmt.Errorf("start workspace: %w: %w", resultErr, err)
 		}
 		return fmt.Errorf("start workspace: %w", resultErr)
 	}

--- a/cmd/workspace/up/up_flags.go
+++ b/cmd/workspace/up/up_flags.go
@@ -75,6 +75,9 @@ func (cmd *UpCmd) registerBuildFlags(upCmd *cobra.Command) {
 				"instead of writing it"),
 		flags.Bool(&cmd.NoLockfile, names.NoLockfile, false,
 			"Disable devcontainer-lock.json generation and verification"),
+		flags.Bool(&cmd.Recovery, names.Recovery, false,
+			"If the dev container build fails, launch a recovery container with features and "+
+				"lifecycle commands disabled so you can repair devcontainer.json and rebuild"),
 	)
 	flags.RegisterDevContainerModifierFlags(upCmd.Flags(), flags.DevContainerModifierFlags{
 		Image:               &cmd.DevContainerImage,

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -889,9 +889,10 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         (line) => {
           if (!sink.line(formatLogLine(line))) return logStore.onDrain(logPath)
         },
-        (code) => {
+        (code, cliError) => {
           void sink.done(
             formatLogLine(`Exit code: ${code}`, code === 0 ? "INFO" : "ERROR"),
+            code === 0 ? undefined : { level: "error", cliError },
           )
         },
         args.workspaceId,
@@ -927,9 +928,10 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         (line) => {
           if (!sink.line(formatLogLine(line))) return logStore.onDrain(logPath)
         },
-        (code) => {
+        (code, cliError) => {
           void sink.done(
             formatLogLine(`Exit code: ${code}`, code === 0 ? "INFO" : "ERROR"),
+            code === 0 ? undefined : { level: "error", cliError },
           )
         },
         args.workspaceId,

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -240,8 +240,8 @@ export function registerIpcHandlers(deps: IpcDependencies): {
 
   ipcMain.handle(
     "workspace_status",
-    async (_event, args: { workspaceId: string }) => {
-      return cli.runRaw([
+    async (_event, args: { workspaceId: string; recovery?: boolean }) => {
+      const cliArgs = [
         "workspace",
         "status",
         args.workspaceId,
@@ -249,7 +249,9 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         "json",
         "--timeout",
         "5s",
-      ])
+      ]
+      if (args.recovery) cliArgs.push("--recovery")
+      return cli.runRaw(cliArgs)
     },
   )
 
@@ -704,6 +706,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         devcontainer?: string
         prebuildRepository?: string
         platform?: string
+        recovery?: boolean
       },
     ) => {
       trackEvent("workspace_create", {
@@ -723,6 +726,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
       if (args.prebuildRepository)
         cliArgs.push("--prebuild-repo", args.prebuildRepository)
       if (args.platform) cliArgs.push("--platform", args.platform)
+      if (args.recovery) cliArgs.push("--recovery")
 
       const wsId = args.workspaceId ?? args.source
       const cmdId = crypto.randomUUID()
@@ -758,13 +762,14 @@ export function registerIpcHandlers(deps: IpcDependencies): {
 
           if (!sink.line(formatted)) return logStore.onDrain(logPath)
         },
-        (code) => {
+        (code, cliError) => {
           if (tunnelProcesses.get(wsId) === child) {
             tunnelProcesses.delete(wsId)
           }
           if (signalledDone) return
           void sink.done(
             formatLogLine(`Exit code: ${code}`, code === 0 ? "INFO" : "ERROR"),
+            code === 0 ? undefined : { level: "error", cliError },
           )
         },
         wsId,

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceCard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceCard.svelte
@@ -3,11 +3,7 @@ import { goto } from "$lib/router.js"
 import { Button } from "$lib/components/ui/button/index.js"
 import { badgeVariants } from "$lib/components/ui/badge/index.js"
 import ConfirmDialog from "$lib/components/layout/ConfirmDialog.svelte"
-import {
-  workspaceUp,
-  workspaceStop,
-  workspaceDelete,
-} from "$lib/ipc/commands.js"
+import { workspaceStop, workspaceDelete } from "$lib/ipc/commands.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
 import type { Workspace } from "$lib/types/index.js"
@@ -38,17 +34,9 @@ function handleOpen(e: Event) {
   goto(`/workspaces/${workspace.id}?action=open-ide`)
 }
 
-async function handleStart(e: Event) {
+function handleStart(e: Event) {
   e.stopPropagation()
-  acting = true
-  try {
-    await workspaceUp({ source: workspace.id })
-    toasts.success(`Starting ${workspace.id}...`)
-  } catch (err) {
-    toasts.error(`Failed to start: ${extractErrorMessage(err)}`)
-  } finally {
-    acting = false
-  }
+  goto(`/workspaces/${workspace.id}?action=start`)
 }
 
 async function handleStop(e: Event) {
@@ -127,9 +115,7 @@ async function handleDelete() {
         Open
       </Button>
     {:else if isStopped}
-      <Button size="sm" onclick={handleStart} disabled={acting}>
-        {acting ? "Starting..." : "Start"}
-      </Button>
+      <Button size="sm" onclick={handleStart}>Start</Button>
     {/if}
     {#if isRunning || isBusy}
       <Button variant="outline" size="sm" onclick={handleStop} disabled={acting}>

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -11,6 +11,7 @@ import {
   GitBranch,
   FolderOpen,
   Container,
+  LifeBuoy,
 } from "@lucide/svelte"
 import { Button } from "$lib/components/ui/button/index.js"
 import * as Command from "$lib/components/ui/command/index.js"
@@ -48,7 +49,11 @@ import { isImageCompatible } from "$lib/stores/imageCatalog.js"
 import { loadLocalOptions } from "$lib/stores/settings.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
-import { isCommandSuccess, stripAnsi } from "$lib/utils/log-parser.js"
+import {
+  isRecoverableBuildFailure,
+  isCommandSuccess,
+  stripAnsi,
+} from "$lib/utils/log-parser.js"
 import type { UnlistenFn } from "$lib/ipc/types.js"
 
 type Step = "provider" | "source" | "ide" | "review" | "launch"
@@ -218,6 +223,9 @@ let commandId = $state<string | null>(null)
 let outputLines = $state<string[]>([])
 let launchRunning = $state(false)
 let launchError = $state("")
+let launchBuildFailed = $state(false)
+let launchIsRecovery = $state(false)
+let lastAttemptedId = $state("")
 let launchSuccess = $state(false)
 let launchedWorkspaceId = $state<string | null>(null)
 let confirmCancelOpen = $state(false)
@@ -465,14 +473,29 @@ function handleProgress(progress: CommandProgress, wsId: string | undefined) {
     } else {
       launchError = "Workspace creation failed. Check output for details."
       toasts.error(launchError)
+      if (isRecoverableBuildFailure(progress.cliError)) {
+        const pref = loadLocalOptions().onBuildFailure
+        if (pref === "auto-recovery" && !launchIsRecovery) {
+          void handleLaunch(true)
+        } else if (pref !== "nothing") {
+          launchBuildFailed = true
+        }
+      }
     }
   }
 }
 
-async function handleLaunch() {
-  if (resolvedIdInvalid || nameConflict) return
+async function handleLaunch(recovery = false) {
+  // Retrying/recovering the id we already attempted is allowed; only a
+  // genuinely new conflicting id is blocked.
+  if (resolvedIdInvalid || (nameConflict && resolvedId !== lastAttemptedId)) {
+    return
+  }
+  lastAttemptedId = resolvedId
+  launchIsRecovery = recovery
   launchRunning = true
   launchError = ""
+  launchBuildFailed = false
   launchSuccess = false
   outputLines = []
   pendingLines = []
@@ -515,6 +538,7 @@ async function handleLaunch() {
           ? emulationTarget
           : undefined,
       debug: loadLocalOptions().debugFlag,
+      recovery,
     })
 
     commandId = cmdId
@@ -1243,7 +1267,13 @@ function selectTemplate(t: { name: string; source: string }) {
               </Button>
             {:else if launchError}
               <Button variant="outline" onclick={() => (open = false)}>Close</Button>
-              <Button onclick={handleLaunch}>Retry</Button>
+              {#if launchBuildFailed && !launchIsRecovery}
+                <Button variant="secondary" onclick={() => handleLaunch(true)}>
+                  <LifeBuoy class="h-4 w-4" />
+                  Reopen in Recovery Container
+                </Button>
+              {/if}
+              <Button onclick={() => handleLaunch()}>Retry</Button>
             {/if}
           </div>
         </div>

--- a/desktop/src/renderer/src/lib/ipc/commands.test.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.test.ts
@@ -68,6 +68,15 @@ describe("IPC commands", () => {
       })
     })
 
+    it("workspaceUp forwards recovery", async () => {
+      mockInvoke.mockResolvedValue("cmd-recovery")
+      await workspaceUp({ source: "my-repo", recovery: true })
+      expect(mockInvoke).toHaveBeenCalledWith("workspace_up", {
+        source: "my-repo",
+        recovery: true,
+      })
+    })
+
     it("workspaceStop passes workspaceId", async () => {
       await workspaceStop("ws-1")
       expect(mockInvoke).toHaveBeenCalledWith("workspace_stop", {
@@ -94,8 +103,18 @@ describe("IPC commands", () => {
       const result = await workspaceStatus("ws-1")
       expect(mockInvoke).toHaveBeenCalledWith("workspace_status", {
         workspaceId: "ws-1",
+        recovery: false,
       })
       expect(result).toBe('{"state":"Running"}')
+    })
+
+    it("workspaceStatus requests recovery when asked", async () => {
+      mockInvoke.mockResolvedValue('{"state":"Running","recovery":true}')
+      await workspaceStatus("ws-1", true)
+      expect(mockInvoke).toHaveBeenCalledWith("workspace_status", {
+        workspaceId: "ws-1",
+        recovery: true,
+      })
     })
 
     it("workspaceUp forwards devcontainer and prebuildRepository", async () => {

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -46,6 +46,7 @@ export async function workspaceUp(params: {
   devcontainer?: string
   prebuildRepository?: string
   platform?: string
+  recovery?: boolean
 }): Promise<string> {
   return invoke<string>("workspace_up", params)
 }
@@ -78,8 +79,11 @@ export async function workspaceReset(
   return invoke<string>("workspace_reset", { workspaceId, debug })
 }
 
-export async function workspaceStatus(workspaceId: string): Promise<string> {
-  return invoke<string>("workspace_status", { workspaceId })
+export async function workspaceStatus(
+  workspaceId: string,
+  recovery = false,
+): Promise<string> {
+  return invoke<string>("workspace_status", { workspaceId, recovery })
 }
 
 export async function workspaceRename(

--- a/desktop/src/renderer/src/lib/stores/settings.test.ts
+++ b/desktop/src/renderer/src/lib/stores/settings.test.ts
@@ -1,7 +1,13 @@
 import { get } from "svelte/store"
 import { beforeEach, describe, expect, it } from "vitest"
 
-import { applyTheme, cycleTheme, theme } from "./settings.js"
+import {
+  applyTheme,
+  cycleTheme,
+  getWorkspaceRecoveryState,
+  setWorkspaceRecoveryState,
+  theme,
+} from "./settings.js"
 
 describe("settings store", () => {
   beforeEach(() => {
@@ -65,6 +71,39 @@ describe("settings store", () => {
       cycleTheme() // system
       cycleTheme() // light
       expect(get(theme)).toBe("light")
+    })
+  })
+
+  describe("workspace recovery state", () => {
+    it("returns empty state when nothing is stored", () => {
+      expect(getWorkspaceRecoveryState("ws-1")).toEqual({})
+    })
+
+    it("persists and reads back per-workspace state", () => {
+      setWorkspaceRecoveryState("ws-1", {
+        buildFailed: true,
+        inRecovery: false,
+      })
+      expect(getWorkspaceRecoveryState("ws-1")).toEqual({
+        buildFailed: true,
+        inRecovery: false,
+      })
+    })
+
+    it("keeps state isolated per workspace", () => {
+      setWorkspaceRecoveryState("ws-1", { inRecovery: true })
+      setWorkspaceRecoveryState("ws-2", { buildFailed: true })
+      expect(getWorkspaceRecoveryState("ws-1")).toEqual({ inRecovery: true })
+      expect(getWorkspaceRecoveryState("ws-2")).toEqual({ buildFailed: true })
+    })
+
+    it("clears the entry when no flags are set", () => {
+      setWorkspaceRecoveryState("ws-1", { buildFailed: true })
+      setWorkspaceRecoveryState("ws-1", {
+        buildFailed: false,
+        inRecovery: false,
+      })
+      expect(getWorkspaceRecoveryState("ws-1")).toEqual({})
     })
   })
 })

--- a/desktop/src/renderer/src/lib/stores/settings.ts
+++ b/desktop/src/renderer/src/lib/stores/settings.ts
@@ -213,7 +213,8 @@ export interface ContextOptions {
   sshConfigIncludePath: string
 }
 
-// Options stored locally (not supported by Devsy CLI context)
+export type OnBuildFailure = "prompt" | "auto-recovery" | "nothing"
+
 export interface LocalOptions {
   debugFlag: boolean
   sshKeyPath: string
@@ -223,6 +224,7 @@ export interface LocalOptions {
   additionalCliFlags: string
   additionalEnvVars: string
   experimentalMultiDevcontainer: boolean
+  onBuildFailure: OnBuildFailure
 }
 
 export const DEFAULT_CONTEXT_OPTIONS: ContextOptions = {
@@ -254,6 +256,7 @@ export const DEFAULT_LOCAL_OPTIONS: LocalOptions = {
   additionalCliFlags: "",
   additionalEnvVars: "",
   experimentalMultiDevcontainer: false,
+  onBuildFailure: "prompt",
 }
 
 // Map from our keys to Devsy CLI context option keys
@@ -413,6 +416,50 @@ export function setWorkspaceFolder(
       delete map[workspaceId]
     }
     localStorage.setItem(WORKSPACE_FOLDERS_KEY, JSON.stringify(map))
+  } catch {
+    // ignore
+  }
+}
+
+export interface WorkspaceRecoveryState {
+  buildFailed?: boolean
+  inRecovery?: boolean
+}
+
+const WORKSPACE_RECOVERY_KEY = "devsy-workspace-recovery"
+
+export function getWorkspaceRecoveryState(
+  workspaceId: string,
+): WorkspaceRecoveryState {
+  if (!browser) return {}
+  try {
+    const stored = localStorage.getItem(WORKSPACE_RECOVERY_KEY)
+    if (stored) {
+      const map = JSON.parse(stored) as Record<string, WorkspaceRecoveryState>
+      return map[workspaceId] ?? {}
+    }
+  } catch {
+    // ignore
+  }
+  return {}
+}
+
+export function setWorkspaceRecoveryState(
+  workspaceId: string,
+  state: WorkspaceRecoveryState,
+): void {
+  if (!browser) return
+  try {
+    const stored = localStorage.getItem(WORKSPACE_RECOVERY_KEY)
+    const map: Record<string, WorkspaceRecoveryState> = stored
+      ? JSON.parse(stored)
+      : {}
+    if (state.buildFailed || state.inRecovery) {
+      map[workspaceId] = state
+    } else {
+      delete map[workspaceId]
+    }
+    localStorage.setItem(WORKSPACE_RECOVERY_KEY, JSON.stringify(map))
   } catch {
     // ignore
   }

--- a/desktop/src/renderer/src/lib/utils/log-parser.test.ts
+++ b/desktop/src/renderer/src/lib/utils/log-parser.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isRecoverableBuildFailure,
+  parseRecoveryContainer,
+} from "./log-parser.js"
+
+describe("isRecoverableBuildFailure", () => {
+  it("matches the recoverable build-failure code", () => {
+    expect(
+      isRecoverableBuildFailure({ code: "BUILD_FAILED_RECOVERABLE" }),
+    ).toBe(true)
+  })
+
+  it("does not match other error codes (e.g. compose/unknown)", () => {
+    expect(isRecoverableBuildFailure({ code: "UNKNOWN" })).toBe(false)
+  })
+
+  it("returns false when there is no cliError", () => {
+    expect(isRecoverableBuildFailure()).toBe(false)
+    expect(isRecoverableBuildFailure(null)).toBe(false)
+  })
+})
+
+describe("parseRecoveryContainer", () => {
+  it("reads recovery=true from a success envelope", () => {
+    expect(
+      parseRecoveryContainer('{"outcome":"success","recovery":true}'),
+    ).toBe(true)
+  })
+
+  it("returns false for a success envelope without recovery", () => {
+    expect(parseRecoveryContainer('{"outcome":"success"}')).toBe(false)
+  })
+
+  it("returns null for non-success or non-envelope messages", () => {
+    expect(parseRecoveryContainer("Exit code: 0")).toBe(null)
+    expect(parseRecoveryContainer('{"outcome":"error"}')).toBe(null)
+    expect(parseRecoveryContainer(null)).toBe(null)
+  })
+})

--- a/desktop/src/renderer/src/lib/utils/log-parser.ts
+++ b/desktop/src/renderer/src/lib/utils/log-parser.ts
@@ -7,6 +7,14 @@ export function stripAnsi(str: string): string {
   return str.replace(ANSI_RE, "").replace(BRACKET_RE, "")
 }
 
+const RECOVERABLE_BUILD_FAILURE_CODE = "BUILD_FAILED_RECOVERABLE"
+
+export function isRecoverableBuildFailure(
+  cliError?: { code?: string } | null,
+): boolean {
+  return cliError?.code === RECOVERABLE_BUILD_FAILURE_CODE
+}
+
 export function isCommandSuccess(message: string | undefined | null): boolean {
   if (!message) return false
   const { message: body } = parseLogLine(message)
@@ -19,6 +27,23 @@ export function isCommandSuccess(message: string | undefined | null): boolean {
     }
   }
   return body === "Exit code: 0"
+}
+
+// Reads the container's actual recovery state from the success envelope, or
+// null when the message is not a parseable success envelope.
+export function parseRecoveryContainer(
+  message: string | undefined | null,
+): boolean | null {
+  if (!message) return null
+  const { message: body } = parseLogLine(message)
+  if (!body.startsWith("{")) return null
+  try {
+    const envelope = JSON.parse(body)
+    if (envelope.outcome === "success") return envelope.recovery === true
+  } catch {
+    // not valid JSON
+  }
+  return null
 }
 
 export interface ParsedLogLine {

--- a/desktop/src/renderer/src/pages/SettingsPage.svelte
+++ b/desktop/src/renderer/src/pages/SettingsPage.svelte
@@ -28,7 +28,9 @@ import type {
   ColorScheme,
   UIScale,
   LocalOptions,
+  OnBuildFailure,
 } from "$lib/stores/settings.js"
+import * as Select from "$lib/components/ui/select/index.js"
 import UpdatesPanel from "$lib/components/update/UpdatesPanel.svelte"
 import { Skeleton } from "$lib/components/ui/skeleton/index.js"
 import { toasts } from "$lib/stores/toasts.js"
@@ -116,7 +118,14 @@ let local = $state<LocalOptions>({
   additionalCliFlags: "",
   additionalEnvVars: "",
   experimentalMultiDevcontainer: false,
+  onBuildFailure: "prompt",
 })
+
+const ON_BUILD_FAILURE_OPTIONS: { value: OnBuildFailure; label: string }[] = [
+  { value: "prompt", label: "Prompt with recovery options" },
+  { value: "auto-recovery", label: "Automatically open recovery container" },
+  { value: "nothing", label: "Do nothing" },
+]
 
 const shortcuts = [
   { keys: "Cmd/Ctrl + K", action: "Open command palette" },
@@ -196,6 +205,32 @@ function toggleLocal(key: keyof LocalOptions) {
             <p class="text-xs text-muted-foreground">Run all commands with --debug flag</p>
           </div>
           <Switch checked={local.debugFlag} onCheckedChange={() => toggleLocal("debugFlag")} disabled={loading || saving} />
+        </div>
+
+        <div class="flex items-center justify-between">
+          <div>
+            <Label>On Build Failure</Label>
+            <p class="text-xs text-muted-foreground">What to do when a dev container build fails</p>
+          </div>
+          <Select.Root
+            type="single"
+            value={local.onBuildFailure}
+            onValueChange={(v) => {
+              if (v) {
+                local.onBuildFailure = v as OnBuildFailure
+                saveLocal("onBuildFailure", v)
+              }
+            }}
+          >
+            <Select.Trigger class="w-[280px] h-9">
+              <span>{ON_BUILD_FAILURE_OPTIONS.find((o) => o.value === local.onBuildFailure)?.label ?? "Prompt with recovery options"}</span>
+            </Select.Trigger>
+            <Select.Content>
+              {#each ON_BUILD_FAILURE_OPTIONS as o (o.value)}
+                <Select.Item value={o.value} label={o.label} />
+              {/each}
+            </Select.Content>
+          </Select.Root>
         </div>
 
         <div class="space-y-2">

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -6,11 +6,13 @@ import {
   ChevronsUpDown,
   ClipboardCopy,
   Ellipsis,
+  LifeBuoy,
   Monitor,
   Pencil,
   Play,
   RefreshCw,
   RotateCcw,
+  ScrollText,
   Square,
   SquareTerminal,
   Trash2,
@@ -41,6 +43,7 @@ import {
   workspaceDelete,
   workspaceRename,
   workspaceSetIde,
+  workspaceStatus,
   workspaceLogsList,
   workspaceLogRead,
   workspaceLogDelete,
@@ -50,14 +53,21 @@ import {
   loadLocalOptions,
   getWorkspaceFolder,
   setWorkspaceFolder,
+  getWorkspaceRecoveryState,
+  setWorkspaceRecoveryState,
 } from "$lib/stores/settings.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
 import { trackEngagement } from "$lib/analytics.js"
-import type { LogEntry } from "$lib/types/index.js"
+import type { CommandProgress, LogEntry } from "$lib/types/index.js"
 import type { UnlistenFn } from "$lib/ipc/types.js"
 import { formatTimestamp } from "$lib/utils/time.js"
-import { isCommandSuccess, stripAnsi } from "$lib/utils/log-parser.js"
+import {
+  isRecoverableBuildFailure,
+  isCommandSuccess,
+  parseRecoveryContainer,
+  stripAnsi,
+} from "$lib/utils/log-parser.js"
 import { Skeleton } from "$lib/components/ui/skeleton/index.js"
 
 let { params = {} }: { params?: Record<string, string> } = $props()
@@ -116,11 +126,47 @@ function statusBadgeVariant(): "default" | "secondary" | "outline" {
   return "outline"
 }
 
+const BUILD_OPS = new Set(["Start", "Open IDE", "Recovery", "Rebuild", "Reset"])
+
 let activeTab = $state("overview")
 let outputLines = $state<string[]>([])
 let commandId = $state<string | null>(null)
 let operationLabel = $state("")
 let operationRunning = $state(false)
+let buildFailed = $state(false)
+let inRecovery = $state(false)
+// True only for a buildFailed loaded from persistence, so the reconciliation
+// clears stale banners from external rebuilds without touching in-app failures.
+let staleReconcilePending = $state(false)
+
+function persistRecovery() {
+  setWorkspaceRecoveryState(id, { buildFailed, inRecovery })
+}
+
+// Reconcile inRecovery against the container's persisted recovery state (set by
+// the last up, in-app or external), so a rebuild done outside the app is reflected.
+async function reconcileRecoveryFromStatus() {
+  try {
+    const status = JSON.parse(await workspaceStatus(id, true)) as {
+      state?: string
+      recovery?: boolean
+    }
+    if (status.state === "Running") {
+      inRecovery = status.recovery === true
+      persistRecovery()
+    }
+  } catch {
+    // status unavailable; keep persisted state
+  }
+}
+
+$effect(() => {
+  if (staleReconcilePending && isRunning && !operationRunning) {
+    staleReconcilePending = false
+    buildFailed = false
+    persistRecovery()
+  }
+})
 let unlisten: UnlistenFn | null = null
 let pendingLines: string[] = []
 let flushHandle: number | null = null
@@ -206,10 +252,17 @@ onMount(async () => {
           const success = isCommandSuccess(progress.message)
           if (success) {
             toasts.success(`${operationLabel} ${id} succeeded`)
+            if (BUILD_OPS.has(operationLabel)) {
+              buildFailed = false
+              const recovered = parseRecoveryContainer(progress.message)
+              inRecovery = recovered ?? operationLabel === "Recovery"
+              persistRecovery()
+            }
           } else {
             toasts.error(
               `${operationLabel} ${id} failed. Check output for details.`,
             )
+            handleBuildFailure(progress)
           }
           if (operationLabel === "Delete" && success) {
             goto("/workspaces")
@@ -225,18 +278,26 @@ onMount(async () => {
 
   loadLogs()
   customFolder = getWorkspaceFolder(id)
+  const rec = getWorkspaceRecoveryState(id)
+  buildFailed = rec.buildFailed ?? false
+  inRecovery = rec.inRecovery ?? false
+  staleReconcilePending = buildFailed
+  void reconcileRecoveryFromStatus()
 
-  // Auto-trigger IDE open when navigated with ?action=open-ide
   const qs = new URLSearchParams($querystring ?? "")
   const action = qs.get("action")
-  if (action === "open-ide") {
+  if (action === "open-ide" || action === "start") {
     // Clear query param so refresh doesn't re-trigger
     history.replaceState(
       {},
       "",
       window.location.pathname + window.location.hash.split("?")[0],
     )
-    handleOpenIde()
+    if (action === "open-ide") {
+      handleOpenIde()
+    } else {
+      handleStart()
+    }
   }
 })
 
@@ -346,6 +407,8 @@ function isDebug(): boolean {
 function startStreamingOp(label: string) {
   operationLabel = label
   operationRunning = true
+  buildFailed = false
+  persistRecovery()
   outputLines = []
   pendingLines = []
   if (flushHandle !== null) {
@@ -369,6 +432,45 @@ async function handleStart() {
   } catch (err) {
     operationRunning = false
     toasts.error(`Failed to start: ${extractErrorMessage(err)}`)
+  }
+}
+
+function handleBuildFailure(progress: CommandProgress) {
+  if (
+    !BUILD_OPS.has(operationLabel) ||
+    !isRecoverableBuildFailure(progress.cliError)
+  ) {
+    return
+  }
+  const pref = loadLocalOptions().onBuildFailure
+  if (pref === "nothing") return
+  // Avoid a loop: don't auto-retry recovery when recovery itself failed.
+  if (pref === "auto-recovery" && operationLabel !== "Recovery") {
+    void handleRecovery()
+    return
+  }
+  buildFailed = true
+  inRecovery = false
+  persistRecovery()
+}
+
+async function handleRecovery() {
+  const ide = currentIde
+  const folder = customFolder || undefined
+  startStreamingOp("Recovery")
+  try {
+    commandId = await workspaceUp({
+      source: id,
+      ide,
+      recovery: true,
+      debug: isDebug(),
+      workspaceFolder: folder,
+    })
+  } catch (err) {
+    operationRunning = false
+    toasts.error(
+      `Failed to start recovery container: ${extractErrorMessage(err)}`,
+    )
   }
 }
 
@@ -514,6 +616,12 @@ async function handleRenameConfirmed() {
             {#if workspace.status}
               <span class={badgeVariants({ variant: statusBadgeVariant() })}>{workspace.status}</span>
             {/if}
+            {#if inRecovery}
+              <span class="inline-flex items-center gap-1 rounded-md border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs font-medium text-amber-600 dark:text-amber-400">
+                <LifeBuoy class="h-3 w-3" />
+                Recovery mode
+              </span>
+            {/if}
           </div>
 
           <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
@@ -599,6 +707,48 @@ async function handleRenameConfirmed() {
         </ButtonGroup.Root>
       </div>
     </div>
+
+    {#if buildFailed}
+      <div class="flex flex-col gap-3 rounded-lg border border-destructive/30 bg-destructive/10 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex items-start gap-2 text-sm">
+          <LifeBuoy class="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+          <div>
+            <p class="font-medium text-destructive">Dev container build failed</p>
+            <p class="text-muted-foreground">Open a recovery container (features and lifecycle commands disabled) to repair devcontainer.json, or retry the build.</p>
+          </div>
+        </div>
+        <ButtonGroup.Root class="shrink-0">
+          {#if operationLabel !== "Recovery"}
+            <Button variant="default" size="sm" onclick={handleRecovery} disabled={operationRunning}>
+              <LifeBuoy class="h-4 w-4" />
+              Reopen in Recovery Container
+            </Button>
+          {/if}
+          <Button variant="outline" size="sm" onclick={handleStart} disabled={operationRunning}>
+            <RefreshCw class="h-4 w-4" />
+            Retry
+          </Button>
+          <Button variant="outline" size="sm" onclick={() => (activeTab = "logs")}>
+            <ScrollText class="h-4 w-4" />
+            Show Log
+          </Button>
+        </ButtonGroup.Root>
+      </div>
+    {:else if inRecovery}
+      <div class="flex flex-col gap-3 rounded-lg border border-amber-500/40 bg-amber-500/10 p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div class="flex items-start gap-2 text-sm">
+          <LifeBuoy class="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+          <div>
+            <p class="font-medium text-amber-600 dark:text-amber-400">Running in recovery mode</p>
+            <p class="text-muted-foreground">Features and lifecycle commands are disabled. Fix devcontainer.json, then rebuild the full container.</p>
+          </div>
+        </div>
+        <Button variant="default" size="sm" onclick={handleRebuild} disabled={operationRunning}>
+          {#if operationRunning && operationLabel === "Rebuild"}<Spinner />{:else}<RotateCcw class="h-4 w-4" />{/if}
+          Rebuild full container
+        </Button>
+      </div>
+    {/if}
 
     <Tabs.Root bind:value={activeTab} class="min-h-0 flex-1 overflow-hidden">
       <Tabs.List class="h-9 w-fit">

--- a/e2e/tests/up/handles_errors.go
+++ b/e2e/tests/up/handles_errors.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/devsy-org/devsy/pkg/flags/names"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -123,5 +124,40 @@ var _ = ginkgo.Describe(
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(out, initialList)
 		}, ginkgo.SpecTimeout(framework.TimeoutShort()))
+
+		ginkgo.It(
+			"launches a recovery container after a failed build",
+			func(ctx context.Context) {
+				f, err := setupDockerProvider(initialDir+"/bin", "docker")
+				framework.ExpectNoError(err)
+				ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
+					_ = f.DevsyProviderDelete(cleanupCtx, "docker")
+				})
+
+				tempDir, err := framework.CopyToTempDir(
+					"tests/up/testdata/docker-recovery",
+				)
+				framework.ExpectNoError(err)
+				ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+				ginkgo.DeferCleanup(func(cleanupCtx context.Context) {
+					_ = f.DevsyWorkspaceDelete(cleanupCtx, tempDir, "--force")
+				})
+
+				err = f.DevsyUp(ctx, tempDir)
+				framework.ExpectError(err, "expected the failing build to error")
+
+				err = f.DevsyUp(ctx, tempDir, names.Flag(names.Recovery))
+				framework.ExpectNoError(err)
+
+				out, err := f.DevsySSH(ctx, tempDir, "echo -n recovered")
+				framework.ExpectNoError(err)
+				framework.ExpectEqual(
+					out,
+					"recovered",
+					"recovery container should be reachable",
+				)
+			},
+			ginkgo.SpecTimeout(framework.TimeoutLong()),
+		)
 	},
 )

--- a/e2e/tests/up/handles_errors.go
+++ b/e2e/tests/up/handles_errors.go
@@ -2,10 +2,13 @@ package up
 
 import (
 	"context"
+	"errors"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/devsy-org/devsy/e2e/framework"
+	"github.com/devsy-org/devsy/pkg/exitcode"
 	"github.com/devsy-org/devsy/pkg/flags/names"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
@@ -143,8 +146,18 @@ var _ = ginkgo.Describe(
 					_ = f.DevsyWorkspaceDelete(cleanupCtx, tempDir, "--force")
 				})
 
-				err = f.DevsyUp(ctx, tempDir)
-				framework.ExpectError(err, "expected the failing build to error")
+				_, _, err = f.ExecCommandCapture(ctx, []string{
+					"workspace", "up",
+					names.Flag(names.Debug),
+					names.Flag(names.IDE), "none",
+					tempDir,
+				})
+				var exitErr *exec.ExitError
+				gomega.Expect(errors.As(err, &exitErr)).To(gomega.BeTrue(),
+					"expected an exec.ExitError, got %v", err)
+				gomega.Expect(exitErr.ExitCode()).To(
+					gomega.Equal(exitcode.BuildFailedRecoverable),
+					"failed build should exit with the recoverable code")
 
 				err = f.DevsyUp(ctx, tempDir, names.Flag(names.Recovery))
 				framework.ExpectNoError(err)

--- a/e2e/tests/up/handles_errors.go
+++ b/e2e/tests/up/handles_errors.go
@@ -14,6 +14,8 @@ import (
 	"github.com/onsi/gomega"
 )
 
+const cmdWorkspace = "workspace"
+
 var _ = ginkgo.Describe(
 	"testing up command that handles workspace errors",
 	ginkgo.Label("up-handle-errors"),
@@ -147,7 +149,7 @@ var _ = ginkgo.Describe(
 				})
 
 				_, _, err = f.ExecCommandCapture(ctx, []string{
-					"workspace", "up",
+					cmdWorkspace, "up",
 					names.Flag(names.Debug),
 					names.Flag(names.IDE), "none",
 					tempDir,

--- a/e2e/tests/up/testdata/docker-recovery/.devcontainer.json
+++ b/e2e/tests/up/testdata/docker-recovery/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "recovery-test",
+  "build": {
+    "dockerfile": "Dockerfile"
+  }
+}

--- a/e2e/tests/up/testdata/docker-recovery/Dockerfile
+++ b/e2e/tests/up/testdata/docker-recovery/Dockerfile
@@ -1,0 +1,4 @@
+FROM ghcr.io/devsy-org/test-images/base:ubuntu
+
+# Always fails the build so recovery mode can be exercised.
+RUN echo "intentional build failure" && exit 1

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -213,6 +213,7 @@ type WorkspaceStatus struct {
 	Context  string `json:"context,omitempty"`
 	Provider string `json:"provider,omitempty"`
 	State    string `json:"state,omitempty"`
+	Recovery bool   `json:"recovery,omitempty"`
 }
 
 type User struct {

--- a/pkg/clierr/errors.go
+++ b/pkg/clierr/errors.go
@@ -12,9 +12,10 @@ import (
 type Code string
 
 const (
-	CodeRateLimited Code = "RATE_LIMITED"
-	CodePanic       Code = "PANIC"
-	CodeUnknown     Code = "UNKNOWN"
+	CodeRateLimited            Code = "RATE_LIMITED"
+	CodePanic                  Code = "PANIC"
+	CodeUnknown                Code = "UNKNOWN"
+	CodeBuildFailedRecoverable Code = "BUILD_FAILED_RECOVERABLE"
 )
 
 type CLIError struct {
@@ -64,6 +65,23 @@ func (e *CLIError) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 
 var ErrRateLimited = errors.New("rate limited")
 
+var ErrBuildFailedRecoverable = errors.New("dev container build failed")
+
+type recoverableBuildError struct{ err error }
+
+func (e recoverableBuildError) Error() string { return e.err.Error() }
+func (e recoverableBuildError) Unwrap() error { return e.err }
+func (e recoverableBuildError) Is(target error) bool {
+	return target == ErrBuildFailedRecoverable
+}
+
+func Recoverable(err error) error {
+	if err == nil {
+		return nil
+	}
+	return recoverableBuildError{err: err}
+}
+
 func Classify(err error) *CLIError {
 	if err == nil {
 		return nil
@@ -72,6 +90,14 @@ func Classify(err error) *CLIError {
 	var cliErr *CLIError
 	if errors.As(err, &cliErr) && cliErr != nil {
 		return cliErr
+	}
+
+	if errors.Is(err, ErrBuildFailedRecoverable) {
+		return &CLIError{
+			Code:    CodeBuildFailedRecoverable,
+			Message: err.Error(),
+			wrapped: err,
+		}
 	}
 
 	if errors.Is(err, ErrRateLimited) {

--- a/pkg/clierr/errors_test.go
+++ b/pkg/clierr/errors_test.go
@@ -66,6 +66,33 @@ func TestCLIError_UnwrapPreservesChain(t *testing.T) {
 	}
 }
 
+func TestClassify_RecoverableBuildFailure(t *testing.T) {
+	got := Classify(Recoverable(fmt.Errorf("build image: boom")))
+	if got.Code != CodeBuildFailedRecoverable {
+		t.Fatalf("Code = %q, want %q", got.Code, CodeBuildFailedRecoverable)
+	}
+	if got.Message != "build image: boom" {
+		t.Fatalf("Message = %q, want the original message", got.Message)
+	}
+}
+
+func TestClassify_RecoverableThroughWrap(t *testing.T) {
+	wrapped := fmt.Errorf(
+		"start workspace: %w: %w",
+		Recoverable(fmt.Errorf("build image: boom")),
+		fmt.Errorf("agent exited"),
+	)
+	if got := Classify(wrapped); got.Code != CodeBuildFailedRecoverable {
+		t.Fatalf("Code = %q, want %q", got.Code, CodeBuildFailedRecoverable)
+	}
+}
+
+func TestRecoverable_NilStaysNil(t *testing.T) {
+	if Recoverable(nil) != nil {
+		t.Fatal("Recoverable(nil) should be nil")
+	}
+}
+
 func TestNewPanic(t *testing.T) {
 	got := NewPanic("boom")
 	if got.Code != CodePanic {

--- a/pkg/config/labels.go
+++ b/pkg/config/labels.go
@@ -9,6 +9,7 @@ const (
 	DockerResourceLabel    = ReverseDomain + ".resource"
 	DockerVolumeRoleLabel  = ReverseDomain + ".volume-role"
 	DockerSeededLabel      = ReverseDomain + ".seeded"
+	DockerRecoveryLabel    = ReverseDomain + ".recovery"
 	DockerUserLabel        = BinaryName + ".user"
 
 	K8sCreatedLabel          = Domain + "/created"

--- a/pkg/devcontainer/config/envelope.go
+++ b/pkg/devcontainer/config/envelope.go
@@ -13,6 +13,7 @@ type ResultEnvelope struct {
 	RemoteWorkspaceFolder string   `json:"remoteWorkspaceFolder"`
 	URL                   string   `json:"url,omitempty"`
 	Warnings              []string `json:"warnings,omitempty"`
+	Recovery              bool     `json:"recovery,omitempty"`
 }
 
 type ErrorEnvelope struct {

--- a/pkg/devcontainer/config/envelope_test.go
+++ b/pkg/devcontainer/config/envelope_test.go
@@ -197,3 +197,18 @@ func TestWriteErrorJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestWriteResultJSON_Recovery(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteResultJSON(&buf, ResultEnvelope{Recovery: true}); err != nil {
+		t.Fatalf("WriteResultJSON: %v", err)
+	}
+
+	var envelope ResultEnvelope
+	if err := json.Unmarshal(buf.Bytes(), &envelope); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !envelope.Recovery {
+		t.Error("recovery field did not round-trip")
+	}
+}

--- a/pkg/devcontainer/config/result.go
+++ b/pkg/devcontainer/config/result.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"slices"
 
+	"github.com/devsy-org/devsy/pkg/clierr"
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
 )
 
@@ -20,6 +21,9 @@ func (r *Result) Err() error {
 	if r == nil || r.Error == "" {
 		return nil
 	}
+	if r.RecoveryAvailable {
+		return clierr.Recoverable(errors.New(r.Error))
+	}
 	return errors.New(r.Error)
 }
 
@@ -29,13 +33,9 @@ type Result struct {
 	SubstitutionContext        *SubstitutionContext        `json:"SubstitutionContext"`
 	ContainerDetails           *ContainerDetails           `json:"ContainerDetails"`
 	HostWarnings               []string                    `json:"HostWarnings,omitempty"`
-	// Error, when non-empty, indicates the agent failed to produce a usable
-	// devcontainer result and carries the underlying error message. This
-	// allows structured errors (e.g. host requirements not met) to flow back
-	// to the host side via the tunnel before the agent process exits, instead
-	// of being lost to a generic "did not receive a result back from agent"
-	// fallback.
-	Error string `json:"Error,omitempty"`
+	RecoveryContainer          bool                        `json:"RecoveryContainer,omitempty"`
+	Error                      string                      `json:"Error,omitempty"`
+	RecoveryAvailable          bool                        `json:"RecoveryAvailable,omitempty"`
 }
 
 type DevContainerConfigWithPath struct {

--- a/pkg/devcontainer/config/result_test.go
+++ b/pkg/devcontainer/config/result_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/clierr"
 )
 
+const errBoom = "boom"
+
 func TestResultErrRecoveryAvailable(t *testing.T) {
 	err := (&Result{Error: "build image: boom", RecoveryAvailable: true}).Err()
 	if err == nil || err.Error() != "build image: boom" {
@@ -16,7 +18,7 @@ func TestResultErrRecoveryAvailable(t *testing.T) {
 		t.Fatal("recovery-available error must classify as recoverable")
 	}
 
-	plain := (&Result{Error: "boom"}).Err()
+	plain := (&Result{Error: errBoom}).Err()
 	if errors.Is(plain, clierr.ErrBuildFailedRecoverable) {
 		t.Fatal("plain error must not be recoverable")
 	}
@@ -31,7 +33,7 @@ func TestResultErr(t *testing.T) {
 	}{
 		{name: "nil result", result: nil, wantErr: false},
 		{name: "no error", result: &Result{}, wantErr: false},
-		{name: "with error", result: &Result{Error: "boom"}, wantErr: true, wantMsg: "boom"},
+		{name: "with error", result: &Result{Error: errBoom}, wantErr: true, wantMsg: errBoom},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/devcontainer/config/result_test.go
+++ b/pkg/devcontainer/config/result_test.go
@@ -1,6 +1,26 @@
 package config
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	"github.com/devsy-org/devsy/pkg/clierr"
+)
+
+func TestResultErrRecoveryAvailable(t *testing.T) {
+	err := (&Result{Error: "build image: boom", RecoveryAvailable: true}).Err()
+	if err == nil || err.Error() != "build image: boom" {
+		t.Fatalf("Err() = %v, want message preserved", err)
+	}
+	if !errors.Is(err, clierr.ErrBuildFailedRecoverable) {
+		t.Fatal("recovery-available error must classify as recoverable")
+	}
+
+	plain := (&Result{Error: "boom"}).Err()
+	if errors.Is(plain, clierr.ErrBuildFailedRecoverable) {
+		t.Fatal("plain error must not be recoverable")
+	}
+}
 
 func TestResultErr(t *testing.T) {
 	tests := []struct {

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -152,24 +152,35 @@ func (r *runner) Up(
 		timeout:             timeout,
 	}
 
-	var result *config.Result
-	switch {
-	case isDockerFileConfig(substitutedConfig.Config),
-		substitutedConfig.Config.Image != "",
-		substitutedConfig.Config.ContainerID != "":
-		result, err = r.runSingleContainer(ctx, params)
-	case isDockerComposeConfig(substitutedConfig.Config):
-		if options.Recovery {
-			log.Warn("recovery mode is not supported for docker-compose dev containers; proceeding without it")
-		}
-		result, err = r.runDockerCompose(ctx, params)
-	default:
-		result, err = r.runDefaultContainer(ctx, params)
-	}
+	result, err := r.dispatchByConfigKind(ctx, substitutedConfig, params)
 	if result != nil {
 		result.RecoveryContainer = r.recovering
 	}
 	return result, err
+}
+
+// dispatchByConfigKind routes to the container implementation for the config's
+// kind (image/Dockerfile, compose, or default/auto-detected).
+func (r *runner) dispatchByConfigKind(
+	ctx context.Context,
+	substitutedConfig *config.SubstitutedConfig,
+	params *runContainerParams,
+) (*config.Result, error) {
+	switch {
+	case isDockerFileConfig(substitutedConfig.Config),
+		substitutedConfig.Config.Image != "",
+		substitutedConfig.Config.ContainerID != "":
+		return r.runSingleContainer(ctx, params)
+	case isDockerComposeConfig(substitutedConfig.Config):
+		if params.options.Recovery {
+			log.Warn(
+				"recovery mode is not supported for docker-compose dev containers; proceeding without it",
+			)
+		}
+		return r.runDockerCompose(ctx, params)
+	default:
+		return r.runDefaultContainer(ctx, params)
+	}
 }
 
 func (r *runner) Command(ctx context.Context, params CommandParams) error {

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -159,6 +159,29 @@ func (r *runner) Up(
 	return result, err
 }
 
+func (r *runner) Command(ctx context.Context, params CommandParams) error {
+	return r.driver.CommandDevContainer(ctx, &driver.CommandParams{
+		WorkspaceID: r.id,
+		User:        params.User,
+		Command:     params.Command,
+		Stdin:       params.Stdin,
+		Stdout:      params.Stdout,
+		Stderr:      params.Stderr,
+	})
+}
+
+func (r *runner) Find(ctx context.Context) (*config.ContainerDetails, error) {
+	containerDetails, err := r.driver.FindDevContainer(ctx, r.id)
+	if err != nil {
+		return nil, fmt.Errorf("find dev container: %w", err)
+	}
+	return containerDetails, nil
+}
+
+func (r *runner) Logs(ctx context.Context, writer io.Writer) error {
+	return r.driver.GetDevContainerLogs(ctx, r.id, writer, writer)
+}
+
 // dispatchByConfigKind routes to the container implementation for the config's
 // kind (image/Dockerfile, compose, or default/auto-detected).
 func (r *runner) dispatchByConfigKind(
@@ -181,29 +204,6 @@ func (r *runner) dispatchByConfigKind(
 	default:
 		return r.runDefaultContainer(ctx, params)
 	}
-}
-
-func (r *runner) Command(ctx context.Context, params CommandParams) error {
-	return r.driver.CommandDevContainer(ctx, &driver.CommandParams{
-		WorkspaceID: r.id,
-		User:        params.User,
-		Command:     params.Command,
-		Stdin:       params.Stdin,
-		Stdout:      params.Stdout,
-		Stderr:      params.Stderr,
-	})
-}
-
-func (r *runner) Find(ctx context.Context) (*config.ContainerDetails, error) {
-	containerDetails, err := r.driver.FindDevContainer(ctx, r.id)
-	if err != nil {
-		return nil, fmt.Errorf("find dev container: %w", err)
-	}
-	return containerDetails, nil
-}
-
-func (r *runner) Logs(ctx context.Context, writer io.Writer) error {
-	return r.driver.GetDevContainerLogs(ctx, r.id, writer, writer)
 }
 
 // runInitializeCommand runs the host-side initializeCommand hook. The hook is

--- a/pkg/devcontainer/run.go
+++ b/pkg/devcontainer/run.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/devsy-org/devsy/pkg/clierr"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/driver"
 	"github.com/devsy-org/devsy/pkg/driver/drivercreate"
@@ -80,6 +81,8 @@ type runner struct {
 
 	id       string
 	idLabels []string
+
+	recovering bool
 }
 
 func NewRunner(
@@ -127,8 +130,12 @@ func (r *runner) Up(
 	}
 	defer cleanupBuildInformation(substitutedConfig.Config)
 
-	if err := r.runInitializeCommand(ctx, substitutedConfig.Config, options); err != nil {
-		return nil, err
+	// Recovery skips initializeCommand: a failing host hook must not block the
+	// recovery container. In normal mode its failure is recovery-eligible.
+	if !options.Recovery {
+		if err := r.runInitializeCommand(ctx, substitutedConfig.Config, options); err != nil {
+			return nil, clierr.Recoverable(fmt.Errorf("initialize command: %w", err))
+		}
 	}
 
 	params := &runContainerParams{
@@ -138,16 +145,24 @@ func (r *runner) Up(
 		timeout:             timeout,
 	}
 
+	var result *config.Result
 	switch {
 	case isDockerFileConfig(substitutedConfig.Config),
 		substitutedConfig.Config.Image != "",
 		substitutedConfig.Config.ContainerID != "":
-		return r.runSingleContainer(ctx, params)
+		result, err = r.runSingleContainer(ctx, params)
 	case isDockerComposeConfig(substitutedConfig.Config):
-		return r.runDockerCompose(ctx, params)
+		if options.Recovery {
+			log.Warn("recovery mode is not supported for docker-compose dev containers; proceeding without it")
+		}
+		result, err = r.runDockerCompose(ctx, params)
 	default:
-		return r.runDefaultContainer(ctx, params)
+		result, err = r.runDefaultContainer(ctx, params)
 	}
+	if result != nil {
+		result.RecoveryContainer = r.recovering
+	}
+	return result, err
 }
 
 func (r *runner) Command(ctx context.Context, params CommandParams) error {

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -9,17 +9,21 @@ import (
 	"strings"
 
 	"github.com/devsy-org/devsy/pkg/agent/delivery"
+	"github.com/devsy-org/devsy/pkg/clierr"
 	"github.com/devsy-org/devsy/pkg/command"
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/daemon/agent"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/metadata"
 	"github.com/devsy-org/devsy/pkg/driver"
+	"github.com/devsy-org/devsy/pkg/language"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/telemetry/distinctid"
 )
 
 var dockerlessImage = "ghcr.io/devsy-org/dockerless:0.2.0"
+
+var defaultRecoveryImage = language.MapConfig[language.None].Image
 
 const (
 	DevsyExtraEnvVar            = "DEVSY"
@@ -151,6 +155,10 @@ func (r *runner) resolveExistingContainer(
 	containerDetails *config.ContainerDetails,
 	p *resolveParams,
 ) (*resolvedContainer, error) {
+	if isRecoveryContainer(containerDetails) {
+		r.recovering = true
+	}
+
 	containerDetails, err := r.ensureRunning(ctx, containerDetails)
 	if err != nil {
 		return nil, err
@@ -339,14 +347,25 @@ func (r *runner) buildNewContainerConfig(
 	ctx context.Context,
 	p *resolveParams,
 ) (*config.BuildInfo, *config.MergedDevContainerConfig, error) {
+	activeConfig := p.parsedConfig
+
 	buildInfo, err := r.build(
 		ctx,
-		p.parsedConfig,
+		activeConfig,
 		p.substitutionContext,
 		p.options.toBuildOptions(),
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("build image: %w", err)
+		if !p.options.Recovery {
+			log.Info("dev container build failed; re-run with --recovery to " +
+				"start a recovery container with features and lifecycle commands disabled")
+			return nil, nil, clierr.Recoverable(fmt.Errorf("build image: %w", err))
+		}
+		buildInfo, activeConfig, err = r.buildRecoveryContainerConfig(ctx, p, err)
+		if err != nil {
+			return nil, nil, err
+		}
+		r.recovering = true
 	}
 
 	if p.options.Recreate {
@@ -356,7 +375,7 @@ func (r *runner) buildNewContainerConfig(
 	}
 
 	mergedConfig, err := config.MergeConfiguration(
-		p.parsedConfig.Config,
+		activeConfig.Config,
 		buildInfo.ImageMetadata.Config,
 	)
 	if err != nil {
@@ -372,6 +391,61 @@ func (r *runner) buildNewContainerConfig(
 	}
 
 	return buildInfo, mergedConfig, nil
+}
+
+// buildRecoveryContainerConfig rebuilds from a stripped-down config after a
+// failed build, returning the recovery build info and the config that produced it.
+func (r *runner) buildRecoveryContainerConfig(
+	ctx context.Context,
+	p *resolveParams,
+	buildErr error,
+) (*config.BuildInfo, *config.SubstitutedConfig, error) {
+	log.Warnf("dev container build failed: %v", buildErr)
+	log.Warn("recovery mode enabled: retrying with features and lifecycle commands " +
+		"disabled so the workspace can start; fix devcontainer.json and rebuild to " +
+		"restore the full container")
+
+	recoveryConfig := recoveryDevContainerConfig(p.parsedConfig)
+
+	buildInfo, err := r.build(
+		ctx,
+		recoveryConfig,
+		p.substitutionContext,
+		p.options.toBuildOptions(),
+	)
+	if err != nil {
+		return nil, nil, fmt.Errorf(
+			"build recovery image: %w (original build error: %v)", err, buildErr,
+		)
+	}
+
+	return buildInfo, recoveryConfig, nil
+}
+
+// recoveryDevContainerConfig strips features and lifecycle hooks, keeping a
+// plain image but swapping a (possibly broken) Dockerfile for a known-good image.
+// isRecoveryContainer reports whether an existing container was built in
+// recovery mode, read from the label stamped at run time.
+func isRecoveryContainer(details *config.ContainerDetails) bool {
+	return details != nil &&
+		details.Config.Labels[pkgconfig.DockerRecoveryLabel] == pkgconfig.LabelValueTrue
+}
+
+func recoveryDevContainerConfig(parsed *config.SubstitutedConfig) *config.SubstitutedConfig {
+	cloned := config.CloneDevContainerConfig(parsed.Config)
+	cloned.Features = nil
+	cloned.OverrideFeatureInstallOrder = nil
+	cloned.DevContainerActions = config.DevContainerActions{}
+
+	if cloned.Image == "" {
+		cloned.DockerfileContainer = config.DockerfileContainer{}
+		cloned.Image = defaultRecoveryImage
+	}
+
+	return &config.SubstitutedConfig{
+		Config: cloned,
+		Raw:    parsed.Raw,
+	}
 }
 
 // newContainerHostWarnings validates host requirements for a new container,
@@ -730,6 +804,9 @@ func (r *runner) getRunOptions(
 	labels := []string{
 		metadata.ImageMetadataLabel + "=" + string(marshalled),
 		config.UserLabel + "=" + imageUser,
+	}
+	if r.recovering {
+		labels = append(labels, pkgconfig.DockerRecoveryLabel+"="+pkgconfig.LabelValueTrue)
 	}
 
 	user := imageUser

--- a/pkg/devcontainer/single_test.go
+++ b/pkg/devcontainer/single_test.go
@@ -142,7 +142,10 @@ func TestRecoveryDevContainerConfig(t *testing.T) {
 		t.Errorf("Features must be cleared, got %v", got.Config.Features)
 	}
 	if len(got.Config.OverrideFeatureInstallOrder) != 0 {
-		t.Errorf("OverrideFeatureInstallOrder must be cleared, got %v", got.Config.OverrideFeatureInstallOrder)
+		t.Errorf(
+			"OverrideFeatureInstallOrder must be cleared, got %v",
+			got.Config.OverrideFeatureInstallOrder,
+		)
 	}
 	if len(got.Config.PostCreateCommand) != 0 || len(got.Config.OnCreateCommand) != 0 {
 		t.Error("lifecycle hooks must be cleared")
@@ -156,6 +159,14 @@ func TestRecoveryDevContainerConfig(t *testing.T) {
 	if got.Raw != parsed.Raw {
 		t.Error("Raw config must be preserved")
 	}
+}
+
+func TestRecoveryDevContainerConfigNoMutation(t *testing.T) {
+	source := &config.DevContainerConfig{}
+	source.Features = map[string]any{"ghcr.io/x/y:1": map[string]any{}}
+	source.PostCreateCommand = types.LifecycleHook{"install": {"npm install"}}
+
+	recoveryDevContainerConfig(&config.SubstitutedConfig{Config: source, Raw: source})
 
 	if len(source.Features) == 0 {
 		t.Error("source Features must not be mutated")
@@ -176,7 +187,11 @@ func TestRecoveryDevContainerConfigDockerfile(t *testing.T) {
 	got := recoveryDevContainerConfig(parsed)
 
 	if got.Config.Image != defaultRecoveryImage {
-		t.Errorf("Image = %q, want default recovery image %q", got.Config.Image, defaultRecoveryImage)
+		t.Errorf(
+			"Image = %q, want default recovery image %q",
+			got.Config.Image,
+			defaultRecoveryImage,
+		)
 	}
 	if got.Config.Dockerfile != "" || got.Config.Context != "" {
 		t.Error("Dockerfile build fields must be cleared")

--- a/pkg/devcontainer/single_test.go
+++ b/pkg/devcontainer/single_test.go
@@ -3,7 +3,9 @@ package devcontainer
 import (
 	"testing"
 
+	pkgconfig "github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/types"
 )
 
 const mountTypeVolume = "volume"
@@ -118,5 +120,91 @@ func TestWithResolvedUser(t *testing.T) {
 	}
 	if parsed.RemoteUser != "" {
 		t.Error("source config must not be mutated")
+	}
+}
+
+func TestRecoveryDevContainerConfig(t *testing.T) {
+	source := &config.DevContainerConfig{}
+	source.Image = "mcr.microsoft.com/devcontainers/go:1.26"
+	source.Name = "my-project"
+	source.Features = map[string]any{
+		"ghcr.io/devcontainers-extra/features/go-task:1": map[string]any{},
+	}
+	source.OverrideFeatureInstallOrder = []string{"ghcr.io/devcontainers-extra/features/go-task"}
+	source.PostCreateCommand = types.LifecycleHook{"install": {"npm install"}}
+	source.OnCreateCommand = types.LifecycleHook{"setup": {"echo hi"}}
+
+	parsed := &config.SubstitutedConfig{Config: source, Raw: source}
+
+	got := recoveryDevContainerConfig(parsed)
+
+	if len(got.Config.Features) != 0 {
+		t.Errorf("Features must be cleared, got %v", got.Config.Features)
+	}
+	if len(got.Config.OverrideFeatureInstallOrder) != 0 {
+		t.Errorf("OverrideFeatureInstallOrder must be cleared, got %v", got.Config.OverrideFeatureInstallOrder)
+	}
+	if len(got.Config.PostCreateCommand) != 0 || len(got.Config.OnCreateCommand) != 0 {
+		t.Error("lifecycle hooks must be cleared")
+	}
+	if got.Config.Image != source.Image {
+		t.Errorf("Image must be preserved, got %q", got.Config.Image)
+	}
+	if got.Config.Name != source.Name {
+		t.Errorf("Name must be preserved, got %q", got.Config.Name)
+	}
+	if got.Raw != parsed.Raw {
+		t.Error("Raw config must be preserved")
+	}
+
+	if len(source.Features) == 0 {
+		t.Error("source Features must not be mutated")
+	}
+	if len(source.PostCreateCommand) == 0 {
+		t.Error("source lifecycle hooks must not be mutated")
+	}
+}
+
+func TestRecoveryDevContainerConfigDockerfile(t *testing.T) {
+	source := &config.DevContainerConfig{}
+	source.Dockerfile = "Dockerfile"
+	source.Context = "."
+	source.Features = map[string]any{"ghcr.io/x/y:1": map[string]any{}}
+
+	parsed := &config.SubstitutedConfig{Config: source, Raw: source}
+
+	got := recoveryDevContainerConfig(parsed)
+
+	if got.Config.Image != defaultRecoveryImage {
+		t.Errorf("Image = %q, want default recovery image %q", got.Config.Image, defaultRecoveryImage)
+	}
+	if got.Config.Dockerfile != "" || got.Config.Context != "" {
+		t.Error("Dockerfile build fields must be cleared")
+	}
+	if len(got.Config.Features) != 0 {
+		t.Error("Features must be cleared")
+	}
+	if source.Dockerfile != "Dockerfile" {
+		t.Error("source config must not be mutated")
+	}
+}
+
+func TestIsRecoveryContainer(t *testing.T) {
+	if isRecoveryContainer(nil) {
+		t.Error("nil details must not be a recovery container")
+	}
+
+	plain := &config.ContainerDetails{}
+	if isRecoveryContainer(plain) {
+		t.Error("container without the recovery label must not be flagged")
+	}
+
+	recovery := &config.ContainerDetails{
+		Config: config.ContainerDetailsConfig{
+			Labels: map[string]string{pkgconfig.DockerRecoveryLabel: pkgconfig.LabelValueTrue},
+		},
+	}
+	if !isRecoveryContainer(recovery) {
+		t.Error("container with the recovery label must be flagged")
 	}
 }

--- a/pkg/exitcode/codes.go
+++ b/pkg/exitcode/codes.go
@@ -7,4 +7,8 @@ const (
 
 	// Retryable marks a transient failure the caller may retry (sysexits EX_TEMPFAIL).
 	Retryable = 75
+
+	// BuildFailedRecoverable marks a build failure retryable with --recovery.
+	// 79 is just past the sysexits range (64–78).
+	BuildFailedRecoverable = 79
 )

--- a/pkg/flags/names/names.go
+++ b/pkg/flags/names/names.go
@@ -50,6 +50,7 @@ const (
 	Pull                      = "pull"
 	PullFromInsideContainer   = "pull-from-inside-container"
 	Reconfigure               = "reconfigure"
+	Recovery                  = "recovery"
 	Recreate                  = "recreate"
 	RemoteUser                = "remote-user"
 	RemoveVolumes             = "remove-volumes"

--- a/pkg/provider/workspace.go
+++ b/pkg/provider/workspace.go
@@ -243,6 +243,7 @@ type CLIOptions struct {
 	FeatureSecretsFile          string            `json:"featureSecretsFile,omitempty"`
 	InitEnv                     []string          `json:"initEnv,omitempty"`
 	Recreate                    bool              `json:"recreate,omitempty"`
+	Recovery                    bool              `json:"recovery,omitempty"`
 	Prebuild                    bool              `json:"prebuild,omitempty"`
 	Reset                       bool              `json:"reset,omitempty"`
 	DisableDaemon               bool              `json:"disableDaemon,omitempty"`


### PR DESCRIPTION
## Summary

Adds a "Reopen in Recovery Container" capability so a failed dev container build no longer leaves users locked out of their workspace.

**CLI**
- New `up --recovery` flag: on a build failure, rebuilds a stripped-down container — features and lifecycle hooks removed. A plain image is reused as-is; a failing Dockerfile is swapped for the generic base image (`language.None`). Compose configs are unsupported and decline cleanly with a warning.
- Recovery-eligible build failures are classified as a structured `BUILD_FAILED_RECOVERABLE` error and exit with code `79` (just past sysexits `EX__MAX`).
- Recovery containers are labeled `sh.devsy.recovery=true`; the label is read back on container reuse so recovery state survives restarts.
- `workspace status --recovery` surfaces the running container's recovery state (opt-in, so the frequent status poll pays no extra I/O).

**Desktop**
- Build-failure banner with **Reopen in Recovery Container** / **Retry** / **Show Log**, driven by the structured error code (not brittle string matching).
- Recovery-mode indicator; `inRecovery` is set from the authoritative up result and reconciled against the live container on mount (covers rebuilds done outside the app).
- Persisted per-workspace state with stale-banner reconciliation.
- `On build failure` preference (prompt / auto-recovery / do nothing).

**Tests**
- Go unit: config stripping/non-mutation, Dockerfile→image swap, recovery label detection, error classification through multi-`%w` wrapping, envelope/result round-trips.
- e2e (`up-handle-errors`): failing build exits `79`, `--recovery` succeeds, container reachable over SSH.
- Desktop vitest: classifier, envelope/status parsing, arg threading, settings.

Live Docker execution of the recovery path is verified via the e2e harness (`task cli:test:e2e:focus -- up-handle-errors`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recovery-container support for dev container build failures.
  * Added `--recovery` options for workspace start and status commands.
  * Added automatic, prompted, or disabled recovery behavior in Settings.
  * Added recovery status indicators, banners, and actions in workspace views.
  * Added a distinct exit code for recoverable build failures.

* **Bug Fixes**
  * Improved error reporting and recovery guidance when builds fail.
  * Recovery containers now skip features and lifecycle commands to enable repairs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->