### PR TITLE
revert(e2e): fix raise timeout for agent-socket cleanup

### DIFF
--- a/e2e/tests/ssh/agent_forward.go
+++ b/e2e/tests/ssh/agent_forward.go
@@ -233,11 +233,6 @@ var _ = ginkgo.Describe(
 				closeCM()
 				closed = true
 
-				// The cleanup hop traverses the devsy proxy → in-container
-				// SSH server's ctx.Done(), which can take several seconds
-				// under CI load. Each devsy ssh observation runs on a fresh
-				// connection so the just-closed socket's filesystem state is
-				// always up-to-date.
 				gomega.Eventually(func() string {
 					pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 					defer cancel()
@@ -311,9 +306,6 @@ var _ = ginkgo.Describe(
 				exitCmd.Env = append(os.Environ(), "SSH_AUTH_SOCK="+authSock)
 				_ = exitCmd.Run()
 
-				// On a fresh devsy ssh connection, assert no devsy-ssh-agent-*
-				// directories remain. With lazy allocation, none are ever
-				// created; with the cleanup goroutine, any leftover is removed.
 				gomega.Eventually(func() string {
 					pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 					defer cancel()

--- a/e2e/tests/ssh/agent_forward.go
+++ b/e2e/tests/ssh/agent_forward.go
@@ -233,17 +233,21 @@ var _ = ginkgo.Describe(
 				closeCM()
 				closed = true
 
-				// Per-poll budget must exceed a cold devsy ssh connection's
-				// setup, or the poll is killed mid-connect and returns empty.
-				gomega.Eventually(func() (string, error) {
-					pollCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				// The cleanup hop traverses the devsy proxy → in-container
+				// SSH server's ctx.Done(), which can take several seconds
+				// under CI load. Each devsy ssh observation runs on a fresh
+				// connection so the just-closed socket's filesystem state is
+				// always up-to-date.
+				gomega.Eventually(func() string {
+					pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 					defer cancel()
-					return f.DevsySSH(
+					out, _ := f.DevsySSH(
 						pollCtx,
 						tempDir,
 						"test -S "+sockPath+" && echo PRESENT || echo GONE",
 					)
-				}).WithTimeout(90*time.Second).WithPolling(3*time.Second).
+					return out
+				}).WithTimeout(30*time.Second).WithPolling(500*time.Millisecond).
 					Should(
 						gomega.ContainSubstring("GONE"),
 						"socket %s must be cleaned up after connection close",
@@ -307,17 +311,19 @@ var _ = ginkgo.Describe(
 				exitCmd.Env = append(os.Environ(), "SSH_AUTH_SOCK="+authSock)
 				_ = exitCmd.Run()
 
-				// Assert no devsy-ssh-agent-* dirs remain after close.
-				gomega.Eventually(func() (string, error) {
-					pollCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+				// On a fresh devsy ssh connection, assert no devsy-ssh-agent-*
+				// directories remain. With lazy allocation, none are ever
+				// created; with the cleanup goroutine, any leftover is removed.
+				gomega.Eventually(func() string {
+					pollCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 					defer cancel()
-					out, err := f.DevsySSH(
+					out, _ := f.DevsySSH(
 						pollCtx,
 						tempDir,
 						"sh -c 'ls -d \"$XDG_RUNTIME_DIR\"/devsy-ssh-agent-* 2>/dev/null | wc -l'",
 					)
-					return strings.TrimSpace(out), err
-				}).WithTimeout(90*time.Second).WithPolling(3*time.Second).
+					return strings.TrimSpace(out)
+				}).WithTimeout(30*time.Second).WithPolling(500*time.Millisecond).
 					Should(
 						gomega.Equal("0"),
 						"no devsy-ssh-agent-* dir must remain after a no-forward connection closes",


### PR DESCRIPTION
Reverts devsy-org/devsy#786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and responsiveness when verifying SSH agent-forwarding socket cleanup after disconnect.
  * Reduced delays in detecting cleanup issues by using more frequent polling and shorter command timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->