### PR TITLE
fix(feature): match devcontainer CLI lockfile dependsOn format

### DIFF
--- a/pkg/devcontainer/config/feature.go
+++ b/pkg/devcontainer/config/feature.go
@@ -22,13 +22,18 @@ func objectKeyOrder(data []byte, field string) ([]string, error) {
 		return nil, nil
 	}
 
-	dec := json.NewDecoder(bytes.NewReader(value))
-	tok, err := dec.Token()
-	if err != nil {
-		return nil, err
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(value, &obj); err != nil {
+		return nil, nil //nolint:nilerr // non-object values carry no key order
 	}
-	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
-		return nil, nil
+	return decodeObjectKeys(value)
+}
+
+// decodeObjectKeys reads the keys of a JSON object in document order.
+func decodeObjectKeys(value json.RawMessage) ([]string, error) {
+	dec := json.NewDecoder(bytes.NewReader(value))
+	if _, err := dec.Token(); err != nil { // consume opening '{'
+		return nil, err
 	}
 
 	var keys []string
@@ -37,11 +42,7 @@ func objectKeyOrder(data []byte, field string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		key, ok := keyTok.(string)
-		if !ok {
-			return nil, fmt.Errorf("unexpected %s object key token: %v", field, keyTok)
-		}
-		keys = append(keys, key)
+		keys = append(keys, keyTok.(string))
 		var skip json.RawMessage
 		if err := dec.Decode(&skip); err != nil {
 			return nil, err

--- a/pkg/devcontainer/config/feature.go
+++ b/pkg/devcontainer/config/feature.go
@@ -1,11 +1,54 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/devsy-org/devsy/pkg/types"
 )
+
+// objectKeyOrder returns the keys of the named top-level object field in the
+// order they appear in the JSON document. It returns nil when the field is
+// absent or is not a JSON object.
+func objectKeyOrder(data []byte, field string) ([]string, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, err
+	}
+	value, ok := raw[field]
+	if !ok {
+		return nil, nil
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(value))
+	tok, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	if delim, ok := tok.(json.Delim); !ok || delim != '{' {
+		return nil, nil
+	}
+
+	var keys []string
+	for dec.More() {
+		keyTok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := keyTok.(string)
+		if !ok {
+			return nil, fmt.Errorf("unexpected %s object key token: %v", field, keyTok)
+		}
+		keys = append(keys, key)
+		var skip json.RawMessage
+		if err := dec.Decode(&skip); err != nil {
+			return nil, err
+		}
+	}
+	return keys, nil
+}
 
 type FeatureSet struct {
 	ConfigID string
@@ -78,6 +121,43 @@ type FeatureConfig struct {
 
 	// Origin is the path where the feature was loaded from
 	Origin string `json:"-"`
+
+	// dependsOnOrder preserves the declaration order of DependsOn keys as they
+	// appear in devcontainer-feature.json. The reference devcontainer CLI emits
+	// lockfile dependsOn arrays in this order (Object.keys), so we retain it to
+	// produce byte-identical lockfiles.
+	dependsOnOrder []string `json:"-"`
+}
+
+// UnmarshalJSON decodes a FeatureConfig while capturing the declaration order
+// of the dependsOn object's keys, which a plain map cannot preserve.
+func (c *FeatureConfig) UnmarshalJSON(data []byte) error {
+	type alias FeatureConfig
+	if err := json.Unmarshal(data, (*alias)(c)); err != nil {
+		return err
+	}
+	order, err := objectKeyOrder(data, "dependsOn")
+	if err != nil {
+		return err
+	}
+	c.dependsOnOrder = order
+	return nil
+}
+
+// DependsOnKeys returns the dependency feature identifiers in their original
+// declaration order, matching the reference devcontainer CLI's lockfile output.
+// It falls back to sorted keys when order was not captured (e.g. a
+// programmatically constructed config).
+func (c *FeatureConfig) DependsOnKeys() []string {
+	if len(c.dependsOnOrder) == len(c.DependsOn) {
+		return c.dependsOnOrder
+	}
+	keys := make([]string, 0, len(c.DependsOn))
+	for k := range c.DependsOn {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 type DependsOnField map[string]any

--- a/pkg/devcontainer/config/feature.go
+++ b/pkg/devcontainer/config/feature.go
@@ -150,7 +150,7 @@ func (c *FeatureConfig) UnmarshalJSON(data []byte) error {
 // It falls back to sorted keys when order was not captured (e.g. a
 // programmatically constructed config).
 func (c *FeatureConfig) DependsOnKeys() []string {
-	if len(c.dependsOnOrder) == len(c.DependsOn) {
+	if c.capturedOrderMatchesDeps() {
 		return c.dependsOnOrder
 	}
 	keys := make([]string, 0, len(c.DependsOn))
@@ -159,6 +159,22 @@ func (c *FeatureConfig) DependsOnKeys() []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+// capturedOrderMatchesDeps reports whether the captured declaration order still
+// describes exactly the current DependsOn keys. It guards against DependsOn
+// being mutated after unmarshal (e.g. a key swapped without changing the count),
+// in which case the sorted fallback is used instead of a stale order.
+func (c *FeatureConfig) capturedOrderMatchesDeps() bool {
+	if len(c.dependsOnOrder) != len(c.DependsOn) {
+		return false
+	}
+	for _, k := range c.dependsOnOrder {
+		if _, ok := c.DependsOn[k]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 type DependsOnField map[string]any

--- a/pkg/devcontainer/config/feature.go
+++ b/pkg/devcontainer/config/feature.go
@@ -9,9 +9,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/types"
 )
 
-// objectKeyOrder returns the keys of the named top-level object field in the
-// order they appear in the JSON document. It returns nil when the field is
-// absent or is not a JSON object.
 func objectKeyOrder(data []byte, field string) ([]string, error) {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal(data, &raw); err != nil {
@@ -29,10 +26,9 @@ func objectKeyOrder(data []byte, field string) ([]string, error) {
 	return decodeObjectKeys(value)
 }
 
-// decodeObjectKeys reads the keys of a JSON object in document order.
 func decodeObjectKeys(value json.RawMessage) ([]string, error) {
 	dec := json.NewDecoder(bytes.NewReader(value))
-	if _, err := dec.Token(); err != nil { // consume opening '{'
+	if _, err := dec.Token(); err != nil {
 		return nil, err
 	}
 
@@ -123,15 +119,9 @@ type FeatureConfig struct {
 	// Origin is the path where the feature was loaded from
 	Origin string `json:"-"`
 
-	// dependsOnOrder preserves the declaration order of DependsOn keys as they
-	// appear in devcontainer-feature.json. The reference devcontainer CLI emits
-	// lockfile dependsOn arrays in this order (Object.keys), so we retain it to
-	// produce byte-identical lockfiles.
 	dependsOnOrder []string `json:"-"`
 }
 
-// UnmarshalJSON decodes a FeatureConfig while capturing the declaration order
-// of the dependsOn object's keys, which a plain map cannot preserve.
 func (c *FeatureConfig) UnmarshalJSON(data []byte) error {
 	type alias FeatureConfig
 	if err := json.Unmarshal(data, (*alias)(c)); err != nil {
@@ -145,10 +135,6 @@ func (c *FeatureConfig) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// DependsOnKeys returns the dependency feature identifiers in their original
-// declaration order, matching the reference devcontainer CLI's lockfile output.
-// It falls back to sorted keys when order was not captured (e.g. a
-// programmatically constructed config).
 func (c *FeatureConfig) DependsOnKeys() []string {
 	if c.capturedOrderMatchesDeps() {
 		return c.dependsOnOrder
@@ -161,10 +147,6 @@ func (c *FeatureConfig) DependsOnKeys() []string {
 	return keys
 }
 
-// capturedOrderMatchesDeps reports whether the captured declaration order still
-// describes exactly the current DependsOn keys. It guards against DependsOn
-// being mutated after unmarshal (e.g. a key swapped without changing the count),
-// in which case the sorted fallback is used instead of a stale order.
 func (c *FeatureConfig) capturedOrderMatchesDeps() bool {
 	if len(c.dependsOnOrder) != len(c.DependsOn) {
 		return false

--- a/pkg/devcontainer/config/feature_test.go
+++ b/pkg/devcontainer/config/feature_test.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestFeatureConfig_DependsOnKeysPreservesDeclarationOrder(t *testing.T) {
+	// Keys are intentionally not alphabetical to prove declaration order is
+	// preserved rather than sorted, matching the reference devcontainer CLI.
+	data := []byte(`{
+		"id": "example",
+		"dependsOn": {
+			"ghcr.io/x/zeta:1": {},
+			"ghcr.io/x/alpha:1": {},
+			"ghcr.io/x/mid:1": {}
+		}
+	}`)
+
+	var cfg FeatureConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	want := []string{"ghcr.io/x/zeta:1", "ghcr.io/x/alpha:1", "ghcr.io/x/mid:1"}
+	if got := cfg.DependsOnKeys(); !reflect.DeepEqual(got, want) {
+		t.Errorf("DependsOnKeys() = %v, want %v", got, want)
+	}
+}
+
+func TestFeatureConfig_DependsOnKeysFallsBackToSorted(t *testing.T) {
+	// A programmatically constructed config has no captured order; keys must be
+	// returned deterministically (sorted).
+	cfg := FeatureConfig{DependsOn: DependsOnField{
+		"ghcr.io/x/zeta:1":  map[string]any{},
+		"ghcr.io/x/alpha:1": map[string]any{},
+	}}
+
+	want := []string{"ghcr.io/x/alpha:1", "ghcr.io/x/zeta:1"}
+	if got := cfg.DependsOnKeys(); !reflect.DeepEqual(got, want) {
+		t.Errorf("DependsOnKeys() = %v, want %v", got, want)
+	}
+}
+
+func TestFeatureConfig_DependsOnKeysEmpty(t *testing.T) {
+	var cfg FeatureConfig
+	if got := cfg.DependsOnKeys(); len(got) != 0 {
+		t.Errorf("DependsOnKeys() = %v, want empty", got)
+	}
+}

--- a/pkg/devcontainer/config/feature_test.go
+++ b/pkg/devcontainer/config/feature_test.go
@@ -49,6 +49,27 @@ func TestFeatureConfig_DependsOnKeysFallsBackToSorted(t *testing.T) {
 	}
 }
 
+func TestFeatureConfig_DependsOnKeysFallsBackWhenKeyMutated(t *testing.T) {
+	// Declaration order is captured for zeta+alpha, then a key is swapped for a
+	// different one without changing the map size. The stale captured order must
+	// be rejected in favor of the sorted fallback.
+	data := []byte(
+		`{"id": "example", "dependsOn": {"ghcr.io/x/zeta:1": {}, "ghcr.io/x/alpha:1": {}}}`,
+	)
+
+	var cfg FeatureConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	delete(cfg.DependsOn, depAlpha)
+	cfg.DependsOn[depMid] = map[string]any{}
+
+	want := []string{depMid, depZeta}
+	if got := cfg.DependsOnKeys(); !reflect.DeepEqual(got, want) {
+		t.Errorf("DependsOnKeys() = %v, want %v", got, want)
+	}
+}
+
 func TestFeatureConfig_DependsOnKeysEmpty(t *testing.T) {
 	var cfg FeatureConfig
 	if got := cfg.DependsOnKeys(); len(got) != 0 {

--- a/pkg/devcontainer/config/feature_test.go
+++ b/pkg/devcontainer/config/feature_test.go
@@ -6,6 +6,12 @@ import (
 	"testing"
 )
 
+const (
+	depZeta  = "ghcr.io/x/zeta:1"
+	depAlpha = "ghcr.io/x/alpha:1"
+	depMid   = "ghcr.io/x/mid:1"
+)
+
 func TestFeatureConfig_DependsOnKeysPreservesDeclarationOrder(t *testing.T) {
 	// Keys are intentionally not alphabetical to prove declaration order is
 	// preserved rather than sorted, matching the reference devcontainer CLI.
@@ -23,7 +29,7 @@ func TestFeatureConfig_DependsOnKeysPreservesDeclarationOrder(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	want := []string{"ghcr.io/x/zeta:1", "ghcr.io/x/alpha:1", "ghcr.io/x/mid:1"}
+	want := []string{depZeta, depAlpha, depMid}
 	if got := cfg.DependsOnKeys(); !reflect.DeepEqual(got, want) {
 		t.Errorf("DependsOnKeys() = %v, want %v", got, want)
 	}
@@ -33,11 +39,11 @@ func TestFeatureConfig_DependsOnKeysFallsBackToSorted(t *testing.T) {
 	// A programmatically constructed config has no captured order; keys must be
 	// returned deterministically (sorted).
 	cfg := FeatureConfig{DependsOn: DependsOnField{
-		"ghcr.io/x/zeta:1":  map[string]any{},
-		"ghcr.io/x/alpha:1": map[string]any{},
+		depZeta:  map[string]any{},
+		depAlpha: map[string]any{},
 	}}
 
-	want := []string{"ghcr.io/x/alpha:1", "ghcr.io/x/zeta:1"}
+	want := []string{depAlpha, depZeta}
 	if got := cfg.DependsOnKeys(); !reflect.DeepEqual(got, want) {
 		t.Errorf("DependsOnKeys() = %v, want %v", got, want)
 	}

--- a/pkg/devcontainer/config/feature_test.go
+++ b/pkg/devcontainer/config/feature_test.go
@@ -13,8 +13,6 @@ const (
 )
 
 func TestFeatureConfig_DependsOnKeysPreservesDeclarationOrder(t *testing.T) {
-	// Keys are intentionally not alphabetical to prove declaration order is
-	// preserved rather than sorted, matching the reference devcontainer CLI.
 	data := []byte(`{
 		"id": "example",
 		"dependsOn": {
@@ -36,8 +34,6 @@ func TestFeatureConfig_DependsOnKeysPreservesDeclarationOrder(t *testing.T) {
 }
 
 func TestFeatureConfig_DependsOnKeysFallsBackToSorted(t *testing.T) {
-	// A programmatically constructed config has no captured order; keys must be
-	// returned deterministically (sorted).
 	cfg := FeatureConfig{DependsOn: DependsOnField{
 		depZeta:  map[string]any{},
 		depAlpha: map[string]any{},
@@ -50,9 +46,6 @@ func TestFeatureConfig_DependsOnKeysFallsBackToSorted(t *testing.T) {
 }
 
 func TestFeatureConfig_DependsOnKeysFallsBackWhenKeyMutated(t *testing.T) {
-	// Declaration order is captured for zeta+alpha, then a key is swapped for a
-	// different one without changing the map size. The stale captured order must
-	// be rejected in favor of the sorted fallback.
 	data := []byte(
 		`{"id": "example", "dependsOn": {"ghcr.io/x/zeta:1": {}, "ghcr.io/x/alpha:1": {}}}`,
 	)

--- a/pkg/devcontainer/feature/extend.go
+++ b/pkg/devcontainer/feature/extend.go
@@ -529,7 +529,7 @@ func (p *featureProcessor) recordLockEntry(
 		Integrity: res.integrity,
 	}
 	if len(cfg.DependsOn) > 0 {
-		entry.DependsOn = map[string]any(cfg.DependsOn)
+		entry.DependsOn = cfg.DependsOnKeys()
 	}
 	p.lock.record(featureID, entry)
 }

--- a/pkg/devcontainer/feature/lockfile.go
+++ b/pkg/devcontainer/feature/lockfile.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
@@ -21,51 +20,6 @@ type LockedFeature struct {
 	Resolved  string   `json:"resolved,omitempty"`
 	Integrity string   `json:"integrity,omitempty"`
 	DependsOn []string `json:"dependsOn,omitempty"`
-}
-
-// UnmarshalJSON decodes a LockedFeature, normalizing dependsOn into the array
-// form regardless of how it was persisted. Older lockfiles (and those written
-// by pre-fix devsy builds) stored dependsOn as an object mapping feature IDs to
-// option objects; accepting both keeps pinning working across the transition.
-func (f *LockedFeature) UnmarshalJSON(data []byte) error {
-	type alias LockedFeature
-	aux := struct {
-		DependsOn json.RawMessage `json:"dependsOn,omitempty"`
-		*alias
-	}{alias: (*alias)(f)}
-	if err := json.Unmarshal(data, &aux); err != nil {
-		return err
-	}
-	deps, err := normalizeLockDependsOn(aux.DependsOn)
-	if err != nil {
-		return err
-	}
-	f.DependsOn = deps
-	return nil
-}
-
-// normalizeLockDependsOn converts a persisted dependsOn value into the array
-// form. Array values are returned as-is; legacy object values contribute their
-// keys in sorted order (declaration order is unavailable and irrelevant, as the
-// loaded value is only used for pinning, never rewritten).
-func normalizeLockDependsOn(raw json.RawMessage) ([]string, error) {
-	if len(bytes.TrimSpace(raw)) == 0 {
-		return nil, nil
-	}
-	var arr []string
-	if err := json.Unmarshal(raw, &arr); err == nil {
-		return arr, nil
-	}
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &obj); err != nil {
-		return nil, fmt.Errorf("lockfile dependsOn must be an array or object: %w", err)
-	}
-	keys := make([]string, 0, len(obj))
-	for k := range obj {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys, nil
 }
 
 // Lockfile mirrors the devcontainer-lock.json structure: a map of feature

--- a/pkg/devcontainer/feature/lockfile.go
+++ b/pkg/devcontainer/feature/lockfile.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
@@ -20,6 +21,51 @@ type LockedFeature struct {
 	Resolved  string   `json:"resolved,omitempty"`
 	Integrity string   `json:"integrity,omitempty"`
 	DependsOn []string `json:"dependsOn,omitempty"`
+}
+
+// UnmarshalJSON decodes a LockedFeature, normalizing dependsOn into the array
+// form regardless of how it was persisted. Older lockfiles (and those written
+// by pre-fix devsy builds) stored dependsOn as an object mapping feature IDs to
+// option objects; accepting both keeps pinning working across the transition.
+func (f *LockedFeature) UnmarshalJSON(data []byte) error {
+	type alias LockedFeature
+	aux := struct {
+		DependsOn json.RawMessage `json:"dependsOn,omitempty"`
+		*alias
+	}{alias: (*alias)(f)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	deps, err := normalizeLockDependsOn(aux.DependsOn)
+	if err != nil {
+		return err
+	}
+	f.DependsOn = deps
+	return nil
+}
+
+// normalizeLockDependsOn converts a persisted dependsOn value into the array
+// form. Array values are returned as-is; legacy object values contribute their
+// keys in sorted order (declaration order is unavailable and irrelevant, as the
+// loaded value is only used for pinning, never rewritten).
+func normalizeLockDependsOn(raw json.RawMessage) ([]string, error) {
+	if len(bytes.TrimSpace(raw)) == 0 {
+		return nil, nil
+	}
+	var arr []string
+	if err := json.Unmarshal(raw, &arr); err == nil {
+		return arr, nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil, fmt.Errorf("lockfile dependsOn must be an array or object: %w", err)
+	}
+	keys := make([]string, 0, len(obj))
+	for k := range obj {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys, nil
 }
 
 // Lockfile mirrors the devcontainer-lock.json structure: a map of feature

--- a/pkg/devcontainer/feature/lockfile.go
+++ b/pkg/devcontainer/feature/lockfile.go
@@ -16,10 +16,10 @@ import (
 // LockedFeature is a single pinned entry in a devcontainer-lock.json file. It
 // mirrors the structure produced by the reference devcontainer CLI.
 type LockedFeature struct {
-	Version   string         `json:"version,omitempty"`
-	Resolved  string         `json:"resolved,omitempty"`
-	Integrity string         `json:"integrity,omitempty"`
-	DependsOn map[string]any `json:"dependsOn,omitempty"`
+	Version   string   `json:"version,omitempty"`
+	Resolved  string   `json:"resolved,omitempty"`
+	Integrity string   `json:"integrity,omitempty"`
+	DependsOn []string `json:"dependsOn,omitempty"`
 }
 
 // Lockfile mirrors the devcontainer-lock.json structure: a map of feature

--- a/pkg/devcontainer/feature/lockfile_test.go
+++ b/pkg/devcontainer/feature/lockfile_test.go
@@ -125,6 +125,33 @@ func TestWriteLockfile_CreatesSortedStable(t *testing.T) {
 	}
 }
 
+func TestWriteLockfile_DependsOnIsArray(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devcontainer-lock.json")
+	lf := &Lockfile{Features: map[string]LockedFeature{
+		lockTestFeatureA: {
+			Version:   lockTestVersion,
+			Resolved:  lockTestResolvedA,
+			Integrity: lockTestShaA,
+			DependsOn: []string{"ghcr.io/b/feature:1"},
+		},
+	}}
+
+	if err := WriteLockfile(path, lf, false); err != nil {
+		t.Fatalf("WriteLockfile: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Clean(path))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	// The reference devcontainer CLI serializes dependsOn as an array of
+	// feature identifiers, not an object.
+	if !strings.Contains(content, "\"dependsOn\": [") {
+		t.Errorf("expected dependsOn as JSON array, got:\n%s", content)
+	}
+}
+
 func TestWriteLockfile_SkipsUnchanged(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "devcontainer-lock.json")
 	lf := &Lockfile{Features: map[string]LockedFeature{

--- a/pkg/devcontainer/feature/lockfile_test.go
+++ b/pkg/devcontainer/feature/lockfile_test.go
@@ -3,7 +3,6 @@ package feature
 import (
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -93,65 +92,6 @@ func TestReadLockfile_ParsesEntries(t *testing.T) {
 	}
 }
 
-func TestReadLockfile_NormalizesLegacyObjectDependsOn(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "devcontainer-lock.json")
-	// Legacy/pre-fix lockfiles stored dependsOn as an object mapping IDs to
-	// option objects. ReadLockfile must accept it and keep pinning working.
-	content := `{
-  "features": {
-    "ghcr.io/x/go-task:1": {
-      "version": "1.0.0",
-      "resolved": "ghcr.io/x/go-task@sha256:t",
-      "integrity": "sha256:t",
-      "dependsOn": {
-        "ghcr.io/x/picolayer:1": {}
-      }
-    }
-  }
-}`
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	lf, err := ReadLockfile(path)
-	if err != nil {
-		t.Fatalf("ReadLockfile: %v", err)
-	}
-	entry := lf.Features["ghcr.io/x/go-task:1"]
-	if entry.Integrity != "sha256:t" {
-		t.Errorf("integrity lost: %+v", entry)
-	}
-	want := []string{"ghcr.io/x/picolayer:1"}
-	if !reflect.DeepEqual(entry.DependsOn, want) {
-		t.Errorf("dependsOn = %v, want %v", entry.DependsOn, want)
-	}
-}
-
-func TestReadLockfile_KeepsArrayDependsOn(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "devcontainer-lock.json")
-	content := `{
-  "features": {
-    "ghcr.io/x/go-task:1": {
-      "version": "1.0.0",
-      "integrity": "sha256:t",
-      "dependsOn": ["ghcr.io/x/picolayer:1"]
-    }
-  }
-}`
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	lf, err := ReadLockfile(path)
-	if err != nil {
-		t.Fatalf("ReadLockfile: %v", err)
-	}
-	want := []string{"ghcr.io/x/picolayer:1"}
-	if got := lf.Features["ghcr.io/x/go-task:1"].DependsOn; !reflect.DeepEqual(got, want) {
-		t.Errorf("dependsOn = %v, want %v", got, want)
-	}
-}
-
 func TestWriteLockfile_CreatesSortedStable(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "devcontainer-lock.json")
 	lf := &Lockfile{Features: map[string]LockedFeature{
@@ -205,8 +145,6 @@ func TestWriteLockfile_DependsOnIsArray(t *testing.T) {
 		t.Fatal(err)
 	}
 	content := string(data)
-	// The reference devcontainer CLI serializes dependsOn as an array of
-	// feature identifiers, not an object.
 	if !strings.Contains(content, "\"dependsOn\": [") {
 		t.Errorf("expected dependsOn as JSON array, got:\n%s", content)
 	}

--- a/pkg/devcontainer/feature/lockfile_test.go
+++ b/pkg/devcontainer/feature/lockfile_test.go
@@ -3,6 +3,7 @@ package feature
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -89,6 +90,65 @@ func TestReadLockfile_ParsesEntries(t *testing.T) {
 	}
 	if entry.Version != "1.3.8" || entry.Integrity != "sha256:abc" {
 		t.Errorf("unexpected entry: %+v", entry)
+	}
+}
+
+func TestReadLockfile_NormalizesLegacyObjectDependsOn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devcontainer-lock.json")
+	// Legacy/pre-fix lockfiles stored dependsOn as an object mapping IDs to
+	// option objects. ReadLockfile must accept it and keep pinning working.
+	content := `{
+  "features": {
+    "ghcr.io/x/go-task:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/x/go-task@sha256:t",
+      "integrity": "sha256:t",
+      "dependsOn": {
+        "ghcr.io/x/picolayer:1": {}
+      }
+    }
+  }
+}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	lf, err := ReadLockfile(path)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	entry := lf.Features["ghcr.io/x/go-task:1"]
+	if entry.Integrity != "sha256:t" {
+		t.Errorf("integrity lost: %+v", entry)
+	}
+	want := []string{"ghcr.io/x/picolayer:1"}
+	if !reflect.DeepEqual(entry.DependsOn, want) {
+		t.Errorf("dependsOn = %v, want %v", entry.DependsOn, want)
+	}
+}
+
+func TestReadLockfile_KeepsArrayDependsOn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "devcontainer-lock.json")
+	content := `{
+  "features": {
+    "ghcr.io/x/go-task:1": {
+      "version": "1.0.0",
+      "integrity": "sha256:t",
+      "dependsOn": ["ghcr.io/x/picolayer:1"]
+    }
+  }
+}`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	lf, err := ReadLockfile(path)
+	if err != nil {
+		t.Fatalf("ReadLockfile: %v", err)
+	}
+	want := []string{"ghcr.io/x/picolayer:1"}
+	if got := lf.Features["ghcr.io/x/go-task:1"].DependsOn; !reflect.DeepEqual(got, want) {
+		t.Errorf("dependsOn = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

The devcontainer lockfile generator emitted the `dependsOn` field as a JSON object mapping feature IDs to empty option objects:

```json
"dependsOn": { "ghcr.io/skevetter/features/picolayer:1": {} }
```

The reference [devcontainers CLI](https://github.com/devcontainers/cli) (`generateLockfile`) emits it as an **array of feature IDs** in JSON declaration order (`Object.keys(dependsOn)`):

```json
"dependsOn": ["ghcr.io/skevetter/features/picolayer:1"]
```

This change makes devsy's generated `devcontainer-lock.json` byte-identical to the CLI.

## Changes

- `LockedFeature.DependsOn` retyped from `map[string]any` to `[]string`.
- `FeatureConfig` gains a custom `UnmarshalJSON` that captures the declaration order of `dependsOn` keys (a Go map cannot preserve it), exposed via `DependsOnKeys()`. Falls back to sorted keys for programmatically-built configs so output is always deterministic.
- `recordLockEntry` now writes `cfg.DependsOnKeys()` directly.
- Tests cover declaration-order preservation, the sorted fallback, and array serialization.

The regenerated repo lockfile (array format) ships separately on the devcontainer-features branch (#792).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the declared order of feature dependencies.
  * Updated lockfiles to store `dependsOn` as an array, matching expected devcontainer format.
  * Added deterministic ordering when dependency declaration order is unavailable.

* **Tests**
  * Added coverage for dependency ordering and lockfile serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->