### PR TITLE
fix(log): route Writer through the structured encoder instead of raw passthrough

### DIFF
--- a/pkg/log/writer.go
+++ b/pkg/log/writer.go
@@ -1,23 +1,20 @@
 package log
 
 import (
+	"bytes"
 	"io"
+	"strings"
+	"sync"
 
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
-// Writer returns an io.WriteCloser that writes each line as a log entry at the given level.
-// Level uses the package constants: LevelInfo, LevelDebug, etc.
+// Writer returns an io.WriteCloser that logs each complete line written to
+// it as a structured entry at the given level, through the same encoder as
+// every other log call. Primarily used as a subprocess's Stdout/Stderr.
+// Close flushes any trailing line left without a newline.
 func Writer(level int) io.WriteCloser {
-	zapLevel := verbosityConstToZapLevel(level)
-	w, closer, _ := zap.Open("stderr")
-	_ = closer // stderr doesn't need closing
-	return &levelWriter{
-		sink:  w,
-		level: zapLevel,
-		core:  sugar.Load().Desugar().Core(),
-	}
+	return &levelWriter{level: verbosityConstToZapLevel(level)}
 }
 
 func verbosityConstToZapLevel(level int) zapcore.Level {
@@ -34,18 +31,54 @@ func verbosityConstToZapLevel(level int) zapcore.Level {
 }
 
 type levelWriter struct {
-	sink  zapcore.WriteSyncer
 	level zapcore.Level
-	core  zapcore.Core
+
+	mu  sync.Mutex
+	buf bytes.Buffer
 }
 
 func (w *levelWriter) Write(p []byte) (int, error) {
-	if !w.core.Enabled(w.level) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if !sugar.Load().Desugar().Core().Enabled(w.level) {
 		return len(p), nil // discard if below current level
 	}
-	return w.sink.Write(p)
+
+	w.buf.Write(p)
+	for {
+		line, err := w.buf.ReadString('\n')
+		if err != nil {
+			// Incomplete line: put it back for the next Write/Close.
+			w.buf.Reset()
+			w.buf.WriteString(line)
+			break
+		}
+		w.logLine(strings.TrimSuffix(line, "\n"))
+	}
+	return len(p), nil
+}
+
+func (w *levelWriter) logLine(line string) {
+	if line == "" {
+		return
+	}
+	switch w.level {
+	case zapcore.DebugLevel:
+		Debug(line)
+	case zapcore.ErrorLevel:
+		Error(line)
+	default:
+		Info(line)
+	}
 }
 
 func (w *levelWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.buf.Len() > 0 {
+		w.logLine(w.buf.String())
+		w.buf.Reset()
+	}
 	return nil
 }

--- a/pkg/log/writer.go
+++ b/pkg/log/writer.go
@@ -3,11 +3,15 @@ package log
 import (
 	"bytes"
 	"io"
-	"strings"
 	"sync"
 
 	"go.uber.org/zap/zapcore"
 )
+
+// maxPendingLine bounds how much unterminated output levelWriter buffers
+// before logging it anyway, so a subprocess that never emits a newline
+// can't grow the pending line without limit.
+const maxPendingLine = 64 * 1024
 
 func Writer(level int) io.WriteCloser {
 	return &levelWriter{level: verbosityConstToZapLevel(level)}
@@ -41,18 +45,23 @@ func (w *levelWriter) Write(p []byte) (int, error) {
 		return len(p), nil // discard if below current level
 	}
 
-	w.buf.Write(p)
+	total := len(p)
 	for {
-		line, err := w.buf.ReadString('\n')
-		if err != nil {
-			// Incomplete line: put it back for the next Write/Close.
-			w.buf.Reset()
-			w.buf.WriteString(line)
+		i := bytes.IndexByte(p, '\n')
+		if i < 0 {
 			break
 		}
-		w.logLine(strings.TrimSuffix(line, "\n"))
+		w.buf.Write(p[:i])
+		w.logLine(w.buf.String())
+		w.buf.Reset()
+		p = p[i+1:]
 	}
-	return len(p), nil
+	w.buf.Write(p)
+	if w.buf.Len() > maxPendingLine {
+		w.logLine(w.buf.String())
+		w.buf.Reset()
+	}
+	return total, nil
 }
 
 func (w *levelWriter) Close() error {
@@ -66,9 +75,6 @@ func (w *levelWriter) Close() error {
 }
 
 func (w *levelWriter) logLine(line string) {
-	if line == "" {
-		return
-	}
 	switch w.level {
 	case zapcore.DebugLevel:
 		Debug(line)

--- a/pkg/log/writer.go
+++ b/pkg/log/writer.go
@@ -59,6 +59,16 @@ func (w *levelWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+func (w *levelWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.buf.Len() > 0 {
+		w.logLine(w.buf.String())
+		w.buf.Reset()
+	}
+	return nil
+}
+
 func (w *levelWriter) logLine(line string) {
 	if line == "" {
 		return
@@ -71,14 +81,4 @@ func (w *levelWriter) logLine(line string) {
 	default:
 		Info(line)
 	}
-}
-
-func (w *levelWriter) Close() error {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if w.buf.Len() > 0 {
-		w.logLine(w.buf.String())
-		w.buf.Reset()
-	}
-	return nil
 }

--- a/pkg/log/writer.go
+++ b/pkg/log/writer.go
@@ -9,10 +9,6 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
-// Writer returns an io.WriteCloser that logs each complete line written to
-// it as a structured entry at the given level, through the same encoder as
-// every other log call. Primarily used as a subprocess's Stdout/Stderr.
-// Close flushes any trailing line left without a newline.
 func Writer(level int) io.WriteCloser {
 	return &levelWriter{level: verbosityConstToZapLevel(level)}
 }

--- a/pkg/log/writer_test.go
+++ b/pkg/log/writer_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 )
 
+const testFormatJSON = "json"
+
 func TestWriter_EmitsStructuredJSONLine(t *testing.T) {
-	Init(Config{Verbosity: 2, Format: "json"})
+	Init(Config{Verbosity: 2, Format: testFormatJSON})
 
 	var sink bytes.Buffer
 	remove := AddSink(&sink)
@@ -33,7 +35,7 @@ func TestWriter_EmitsStructuredJSONLine(t *testing.T) {
 }
 
 func TestWriter_SplitsMultipleLinesInOneWrite(t *testing.T) {
-	Init(Config{Verbosity: 2, Format: "json"})
+	Init(Config{Verbosity: 2, Format: testFormatJSON})
 
 	var sink bytes.Buffer
 	remove := AddSink(&sink)
@@ -58,7 +60,7 @@ func TestWriter_SplitsMultipleLinesInOneWrite(t *testing.T) {
 }
 
 func TestWriter_FlushesTrailingPartialLineOnClose(t *testing.T) {
-	Init(Config{Verbosity: 2, Format: "json"})
+	Init(Config{Verbosity: 2, Format: testFormatJSON})
 
 	var sink bytes.Buffer
 	remove := AddSink(&sink)
@@ -82,7 +84,7 @@ func TestWriter_FlushesTrailingPartialLineOnClose(t *testing.T) {
 }
 
 func TestWriter_DiscardsBelowConfiguredLevel(t *testing.T) {
-	Init(Config{Verbosity: 1, Format: "json"}) // info+ only, debug disabled
+	Init(Config{Verbosity: 1, Format: testFormatJSON}) // info+ only, debug disabled
 
 	var sink bytes.Buffer
 	remove := AddSink(&sink)

--- a/pkg/log/writer_test.go
+++ b/pkg/log/writer_test.go
@@ -1,0 +1,99 @@
+package log
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestWriter_EmitsStructuredJSONLine(t *testing.T) {
+	Init(Config{Verbosity: 2, Format: "json"})
+
+	var sink bytes.Buffer
+	remove := AddSink(&sink)
+	defer remove()
+
+	w := Writer(LevelInfo)
+	_, err := w.Write([]byte("Cloning into 'repo'...\n"))
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	_ = Sync()
+
+	got := strings.TrimSpace(sink.String())
+	if !strings.HasPrefix(got, "{") || !strings.HasSuffix(got, "}") {
+		t.Fatalf("expected a single JSON object, got %q", got)
+	}
+	if !strings.Contains(got, `"msg":"Cloning into 'repo'..."`) {
+		t.Errorf("missing expected msg field: %q", got)
+	}
+	if !strings.Contains(got, `"level":"info"`) {
+		t.Errorf("missing expected level field: %q", got)
+	}
+}
+
+func TestWriter_SplitsMultipleLinesInOneWrite(t *testing.T) {
+	Init(Config{Verbosity: 2, Format: "json"})
+
+	var sink bytes.Buffer
+	remove := AddSink(&sink)
+	defer remove()
+
+	w := Writer(LevelInfo)
+	_, err := w.Write([]byte("line one\nline two\n"))
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	_ = Sync()
+
+	lines := strings.Split(strings.TrimSpace(sink.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2: %q", len(lines), lines)
+	}
+	for _, l := range lines {
+		if !strings.HasPrefix(l, "{") || !strings.HasSuffix(l, "}") {
+			t.Errorf("line is not valid single-object JSON: %q", l)
+		}
+	}
+}
+
+func TestWriter_FlushesTrailingPartialLineOnClose(t *testing.T) {
+	Init(Config{Verbosity: 2, Format: "json"})
+
+	var sink bytes.Buffer
+	remove := AddSink(&sink)
+	defer remove()
+
+	w := Writer(LevelInfo)
+	_, _ = w.Write([]byte("no trailing newline"))
+	_ = Sync()
+	if sink.Len() != 0 {
+		t.Errorf("expected nothing logged before Close, got %q", sink.String())
+	}
+
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	_ = Sync()
+
+	if !strings.Contains(sink.String(), "no trailing newline") {
+		t.Errorf("expected trailing partial line flushed on Close, got %q", sink.String())
+	}
+}
+
+func TestWriter_DiscardsBelowConfiguredLevel(t *testing.T) {
+	Init(Config{Verbosity: 1, Format: "json"}) // info+ only, debug disabled
+
+	var sink bytes.Buffer
+	remove := AddSink(&sink)
+	defer remove()
+
+	w := Writer(LevelDebug)
+	_, _ = w.Write([]byte("should not appear\n"))
+	_ = w.Close()
+	_ = Sync()
+
+	if sink.Len() != 0 {
+		t.Errorf("expected debug output discarded below configured level, got %q", sink.String())
+	}
+}

--- a/pkg/log/writer_test.go
+++ b/pkg/log/writer_test.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -46,16 +47,43 @@ func TestWriter_SplitsMultipleLinesInOneWrite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Write: %v", err)
 	}
+
+	// A line split across two Write calls (as os/exec delivers subprocess
+	// output in arbitrary chunks) must still be logged as one complete
+	// record, not two fragments.
+	if _, err := w.Write([]byte("line three\nline ")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := w.Write([]byte("four\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
 	_ = Sync()
 
 	lines := strings.Split(strings.TrimSpace(sink.String()), "\n")
-	if len(lines) != 2 {
-		t.Fatalf("got %d lines, want 2: %q", len(lines), lines)
+	wantMsgs := []string{"line one", "line two", "line three", "line four"}
+	if len(lines) != len(wantMsgs) {
+		t.Fatalf("got %d lines, want %d: %q", len(lines), len(wantMsgs), lines)
 	}
-	for _, l := range lines {
-		if !strings.HasPrefix(l, "{") || !strings.HasSuffix(l, "}") {
-			t.Errorf("line is not valid single-object JSON: %q", l)
-		}
+	for i, l := range lines {
+		assertJSONLineMsg(t, i, l, wantMsgs[i])
+	}
+}
+
+func assertJSONLineMsg(t *testing.T, i int, line, wantMsg string) {
+	t.Helper()
+	if !strings.HasPrefix(line, "{") || !strings.HasSuffix(line, "}") {
+		t.Errorf("line %d is not valid single-object JSON: %q", i, line)
+		return
+	}
+	var rec struct {
+		Msg string `json:"msg"`
+	}
+	if err := json.Unmarshal([]byte(line), &rec); err != nil {
+		t.Errorf("line %d: json.Unmarshal: %v", i, err)
+		return
+	}
+	if rec.Msg != wantMsg {
+		t.Errorf("line %d msg = %q, want %q", i, rec.Msg, wantMsg)
 	}
 }
 
@@ -80,6 +108,28 @@ func TestWriter_FlushesTrailingPartialLineOnClose(t *testing.T) {
 
 	if !strings.Contains(sink.String(), "no trailing newline") {
 		t.Errorf("expected trailing partial line flushed on Close, got %q", sink.String())
+	}
+}
+
+func TestWriter_PreservesBlankLines(t *testing.T) {
+	Init(Config{Verbosity: 2, Format: testFormatJSON})
+
+	var sink bytes.Buffer
+	remove := AddSink(&sink)
+	defer remove()
+
+	w := Writer(LevelInfo)
+	if _, err := w.Write([]byte("one\n\ntwo\n")); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	_ = Sync()
+
+	lines := strings.Split(strings.TrimSpace(sink.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("got %d lines, want 3 (blank line preserved): %q", len(lines), lines)
+	}
+	if !strings.Contains(lines[1], `"msg":""`) {
+		t.Errorf("line 1 = %q, want an empty msg field", lines[1])
 	}
 }
 


### PR DESCRIPTION
log.Writer() is used as a subprocess's Stdout/Stderr at ~65 call sites (docker build, buildkit, SSH, IDE installers, git clone, etc). Its levelWriter.Write previously wrote raw bytes directly to the sink, bypassing zap's encoder and producing unencoded lines in what should be a uniform JSON/text/logfmt stream in `--log-output json` mode.

levelWriter now line-buffers and calls Info/Debug/Error per complete line, so subprocess output goes through the same encoder as every other log call. Close flushes any trailing partial line (previously silently dropped).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log output handling by buffering writes and splitting newline-delimited content into separate entries.
  * Ensured partial final log lines are emitted when the writer is closed.
  * Enforced verbosity filtering so messages below the configured level are omitted.
  * Preserved blank lines so they generate entries with an empty message.
* **Tests**
  * Added JSON writer tests covering single-line output, multi-line splitting across writes, flush-on-close behavior, blank line handling, and verbosity filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->