### PR TITLE
fix(agent): stop docker image-pull output from leaking into version log

### DIFF
--- a/pkg/agent/delivery/local_docker.go
+++ b/pkg/agent/delivery/local_docker.go
@@ -163,9 +163,6 @@ func (d *LocalDockerDelivery) detectVolumeVersion(ctx context.Context, volumeNam
 		"sh", "-c", script,
 	}
 
-	// Stdout only: stderr carries docker's own diagnostics, including a full
-	// image-pull transcript when the helper image isn't cached yet, which
-	// CombinedOutput would fold into the detected "version" string.
 	out, err := d.cmd(ctx, args...).Output()
 	if err != nil {
 		log.Debugf("failed to detect agent version in volume: %v", err)

--- a/pkg/agent/delivery/local_docker.go
+++ b/pkg/agent/delivery/local_docker.go
@@ -163,7 +163,10 @@ func (d *LocalDockerDelivery) detectVolumeVersion(ctx context.Context, volumeNam
 		"sh", "-c", script,
 	}
 
-	out, err := d.cmd(ctx, args...).CombinedOutput()
+	// Stdout only: stderr carries docker's own diagnostics, including a full
+	// image-pull transcript when the helper image isn't cached yet, which
+	// CombinedOutput would fold into the detected "version" string.
+	out, err := d.cmd(ctx, args...).Output()
 	if err != nil {
 		log.Debugf("failed to detect agent version in volume: %v", err)
 		return ""

--- a/pkg/agent/delivery/local_docker_test.go
+++ b/pkg/agent/delivery/local_docker_test.go
@@ -266,10 +266,6 @@ func TestDetectVolumeVersion_ReturnsEmptyOnFailure(t *testing.T) {
 
 func TestDetectVolumeVersion_IgnoresStderrNoise(t *testing.T) {
 	tmpDir := t.TempDir()
-
-	// Simulates docker writing an image-pull transcript to stderr (as it
-	// does when the helper image isn't cached) alongside the script's real
-	// stdout output. Only the stdout content should be returned.
 	scriptPath := filepath.Join(tmpDir, "fake-docker.sh")
 	script := "#!/bin/sh\n" +
 		"case \"$1\" in\n" +

--- a/pkg/agent/delivery/local_docker_test.go
+++ b/pkg/agent/delivery/local_docker_test.go
@@ -264,6 +264,31 @@ func TestDetectVolumeVersion_ReturnsEmptyOnFailure(t *testing.T) {
 	assert.Empty(t, ver)
 }
 
+func TestDetectVolumeVersion_IgnoresStderrNoise(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Simulates docker writing an image-pull transcript to stderr (as it
+	// does when the helper image isn't cached) alongside the script's real
+	// stdout output. Only the stdout content should be returned.
+	scriptPath := filepath.Join(tmpDir, "fake-docker.sh")
+	script := "#!/bin/sh\n" +
+		"case \"$1\" in\n" +
+		"  run)\n" +
+		"    echo \"Unable to find image 'busybox:latest' locally\" >&2\n" +
+		"    echo \"latest: Pulling from library/busybox\" >&2\n" +
+		"    echo \"v1.2.3\"\n" +
+		"    ;;\n" +
+		"  *) exit 1 ;;\n" +
+		"esac\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+	// #nosec G302 -- test script must be executable
+	require.NoError(t, os.Chmod(scriptPath, 0o755))
+
+	d := &LocalDockerDelivery{DockerCommand: scriptPath}
+	ver := d.detectVolumeVersion(context.Background(), "test-vol")
+	assert.Equal(t, "v1.2.3", ver)
+}
+
 func TestDetectVolumeVersion_ReturnsEmptyWhenNoBinary(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
`detectVolumeVersion` used `CombinedOutput()` to run its `docker run ... --version` probe, which merges the container's stdout with docker's own stderr diagnostics. When the helper image wasn't cached, that stderr carried a full multi-line image-pull transcript, which then got treated as the detected "version" string and interpolated into a single `log.Infof` call — producing a garbled, multi-line log entry:

```
upgraded remote agent from Unable to find image 'busybox:latest' locally
latest: Pulling from library/busybox
b05093807bb0: Pulling fs layer
...
Status: Downloaded newer image for busybox:latest to v0.0.0
```

`Output()` only captures stdout, so the detected version is just whatever the container's script actually printed.