### PR TITLE
fix(agent): soften binary source fallback log wording

### DIFF
--- a/pkg/agent/binary.go
+++ b/pkg/agent/binary.go
@@ -83,7 +83,7 @@ func (m *BinaryManager) AcquireBinary(ctx context.Context, arch string) (io.Read
 			log.Debugf("acquired binary from %s", source.SourceName())
 			return binary, nil
 		}
-		log.Debugf("source %s failed: %v", source.SourceName(), err)
+		log.Debugf("source %s unavailable, trying next: %v", source.SourceName(), err)
 	}
 	return nil, ErrBinaryNotFound
 }


### PR DESCRIPTION
\`AcquireBinary\` tries a prioritized chain of sources (env override, injected, cache, download) and logs every miss at debug level as it falls through to the next one. The env-var override is checked first specifically so operators *can* set it, but almost never do — so \`"source local path override (DEVSY_AGENT_BINARY) failed: no agent binary path set..."\` showed up on nearly every run, reading like an error for what's actually the expected, routine case of an unused optional source.

Changed the message from `"source %s failed: %v"` to `"source %s unavailable, trying next: %v"` — same debug-level diagnostic info, less alarming wording.