### PR TITLE
fix(provider): represent provider install/init lifecycle in the UI

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -80,8 +80,12 @@ tasks:
     dir: pkg/agent/tunnel
     cmd: |
       # sudo apt install protobuf-compiler
-      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.5.1
-      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.4
+      # Versions must match those recorded in the generated .pb.go headers;
+      # regenerating with a different one rewrites the whole file.
+      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.2
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
+      # protoc resolves plugins via PATH, and `go install` targets GOPATH/bin.
+      export PATH="$(go env GOPATH)/bin:$PATH"
       protoc -I . tunnel.proto --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative
 
   cli:test:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -80,12 +80,8 @@ tasks:
     dir: pkg/agent/tunnel
     cmd: |
       # sudo apt install protobuf-compiler
-      # Versions must match those recorded in the generated .pb.go headers;
-      # regenerating with a different one rewrites the whole file.
       go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.6.2
       go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.11
-      # protoc resolves plugins via PATH, and `go install` targets GOPATH/bin.
-      export PATH="$(go env GOPATH)/bin:$PATH"
       protoc -I . tunnel.proto --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative
 
   cli:test:

--- a/cmd/provider/add.go
+++ b/cmd/provider/add.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/devsy-org/devsy/cmd/flags"
@@ -11,6 +12,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/flags/names"
 	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
+	"github.com/devsy-org/devsy/pkg/status"
 	"github.com/devsy-org/devsy/pkg/types"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
@@ -85,18 +87,31 @@ func (cmd *AddCmd) Run(ctx context.Context, devsyConfig *config.Config, args []s
 		return err
 	}
 
-	providerConfig, options, err := cmd.resolveProviderConfig(ctx, devsyConfig, providerName, args)
+	reporter, err := newStatusReporter(cmd.ResultFormat, os.Stdout)
 	if err != nil {
 		return err
 	}
 
+	status.Enter(reporter, status.PhaseInstallingProvider, providerName)
+	providerConfig, options, err := cmd.resolveProviderConfig(ctx, devsyConfig, providerName, args)
+	if err != nil {
+		status.Fail(reporter, status.PhaseInstallingProvider, err)
+		return err
+	}
+	status.Leave(reporter, status.PhaseInstallingProvider, providerConfig.Name)
+
 	log.Infof("installed provider: providerName=%s", providerConfig.Name)
 	if !cmd.Use {
 		log.Infof("To initialize the provider, run: devsy provider init %s", providerConfig.Name)
+		// No PhaseReady: installed but not initialized.
 		return nil
 	}
 
-	return cmd.useProvider(ctx, devsyConfig, providerConfig, options)
+	if err := cmd.useProvider(ctx, devsyConfig, providerConfig, options, reporter); err != nil {
+		return err
+	}
+	status.Leave(reporter, status.PhaseReady, providerConfig.Name)
+	return nil
 }
 
 func validateOptionalProviderName(providerName string) error {
@@ -158,6 +173,7 @@ func (cmd *AddCmd) useProvider(
 	devsyConfig *config.Config,
 	providerConfig *provider.ProviderConfig,
 	options []string,
+	reporter status.Reporter,
 ) error {
 	// First add: there are no prior user values to merge, so
 	// DiscardPriorValues is moot. Set it explicitly so future readers
@@ -168,6 +184,7 @@ func (cmd *AddCmd) useProvider(
 		UserOptions:        options,
 		DiscardPriorValues: true,
 		SingleMachine:      &cmd.SingleMachine,
+		Reporter:           reporter,
 	})
 	if configureErr != nil {
 		devsyConfig, err := config.LoadConfig(cmd.Context, "")

--- a/cmd/provider/configure_shared.go
+++ b/cmd/provider/configure_shared.go
@@ -10,6 +10,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 	options2 "github.com/devsy-org/devsy/pkg/options"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
+	"github.com/devsy-org/devsy/pkg/status"
 )
 
 // ProviderOptionsConfig parameterizes ConfigureProvider.
@@ -32,6 +33,15 @@ type ProviderOptionsConfig struct {
 	SkipInit           bool
 	SkipSubOptions     bool
 	SingleMachine      *bool
+
+	Reporter status.Reporter
+}
+
+func (cfg ProviderOptionsConfig) reporter() status.Reporter {
+	if cfg.Reporter == nil {
+		return status.Nop()
+	}
+	return cfg.Reporter
 }
 
 func ConfigureProvider(ctx context.Context, cfg ProviderOptionsConfig) error {
@@ -91,13 +101,18 @@ func configureProviderOptions(
 	}
 
 	// fill defaults
+	reporter := cfg.reporter()
+	status.Enter(reporter, status.PhaseResolvingOptions, cfg.Provider.Name)
 	devsyConfig, err = options2.ResolveOptions(
 		ctx, devsyConfig, cfg.Provider, options,
 		cfg.SkipRequired, cfg.SkipSubOptions, cfg.SingleMachine,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("resolve options: %w", err)
+		err = fmt.Errorf("resolve options: %w", err)
+		status.Fail(reporter, status.PhaseResolvingOptions, err)
+		return nil, err
 	}
+	status.Leave(reporter, status.PhaseResolvingOptions, cfg.Provider.Name)
 
 	// run init command
 	if !cfg.SkipInit {
@@ -107,10 +122,13 @@ func configureProviderOptions(
 		stderr := log.Writer(log.LevelError)
 		defer func() { _ = stderr.Close() }()
 
+		status.Enter(reporter, status.PhaseRunningInit, cfg.Provider.Name)
 		err = initProvider(ctx, devsyConfig, cfg.Provider, initIO{stdout: stdout, stderr: stderr})
 		if err != nil {
+			status.Fail(reporter, status.PhaseRunningInit, err)
 			return nil, err
 		}
+		status.Leave(reporter, status.PhaseRunningInit, cfg.Provider.Name)
 	}
 
 	return devsyConfig, nil

--- a/cmd/provider/init.go
+++ b/cmd/provider/init.go
@@ -1,11 +1,14 @@
 package provider
 
 import (
+	"os"
+
 	"github.com/devsy-org/devsy/cmd/completion"
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	cliflags "github.com/devsy-org/devsy/pkg/flags"
 	"github.com/devsy-org/devsy/pkg/flags/names"
+	"github.com/devsy-org/devsy/pkg/status"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
 )
@@ -39,14 +42,23 @@ func NewInitCmd(f *flags.GlobalFlags) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return ConfigureProvider(cobraCmd.Context(), ProviderOptionsConfig{
+			reporter, err := newStatusReporter(cmd.ResultFormat, os.Stdout)
+			if err != nil {
+				return err
+			}
+			if err := ConfigureProvider(cobraCmd.Context(), ProviderOptionsConfig{
 				Provider:           p.Config,
 				ContextName:        devsyConfig.DefaultContext,
 				UserOptions:        cmd.Options,
 				DiscardPriorValues: cmd.Reset,
 				SkipInit:           cmd.SkipInit,
 				SingleMachine:      &cmd.SingleMachine,
-			})
+				Reporter:           reporter,
+			}); err != nil {
+				return err
+			}
+			status.Leave(reporter, status.PhaseReady, name)
+			return nil
 		},
 		ValidArgsFunction: func(
 			rootCmd *cobra.Command,

--- a/cmd/provider/set_source.go
+++ b/cmd/provider/set_source.go
@@ -3,12 +3,14 @@ package provider
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
 	cliflags "github.com/devsy-org/devsy/pkg/flags"
 	"github.com/devsy-org/devsy/pkg/flags/names"
 	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/status"
 	"github.com/devsy-org/devsy/pkg/workspace"
 	"github.com/spf13/cobra"
 )
@@ -67,14 +69,23 @@ func (cmd *SetSourceCmd) Run(ctx context.Context, devsyConfig *config.Config, ar
 		providerSource = args[1]
 	}
 
-	providerConfig, err := workspace.UpdateProvider(ctx, devsyConfig, args[0], providerSource)
+	reporter, err := newStatusReporter(cmd.ResultFormat, os.Stdout)
 	if err != nil {
 		return err
 	}
 
+	status.Enter(reporter, status.PhaseInstallingProvider, args[0])
+	providerConfig, err := workspace.UpdateProvider(ctx, devsyConfig, args[0], providerSource)
+	if err != nil {
+		status.Fail(reporter, status.PhaseInstallingProvider, err)
+		return err
+	}
+	status.Leave(reporter, status.PhaseInstallingProvider, providerConfig.Name)
+
 	log.Infof("updated provider: providerName=%s", providerConfig.Name)
 	if !cmd.Use {
 		log.Infof("To initialize the provider, run: devsy provider init %s", providerConfig.Name)
+		// No PhaseReady: not ready until a following `provider init` runs.
 		return nil
 	}
 
@@ -85,11 +96,16 @@ func (cmd *SetSourceCmd) Run(ctx context.Context, devsyConfig *config.Config, ar
 		Provider:    providerConfig,
 		ContextName: devsyConfig.DefaultContext,
 		UserOptions: cmd.Options,
+		Reporter:    reporter,
 	}); err != nil {
 		return fmt.Errorf("configure provider: %w", err)
 	}
 
-	return writeDefaultProvider(cmd.Context, providerConfig.Name)
+	if err := writeDefaultProvider(cmd.Context, providerConfig.Name); err != nil {
+		return err
+	}
+	status.Leave(reporter, status.PhaseReady, providerConfig.Name)
+	return nil
 }
 
 func (cmd *SetSourceCmd) runPinVersion(

--- a/cmd/provider/status.go
+++ b/cmd/provider/status.go
@@ -11,8 +11,6 @@ import (
 
 // newStatusReporter drives provider progress output: one NDJSON status line
 // per phase transition in JSON mode, human-readable info lines otherwise.
-// Mirrors cmd/workspace/up's reporter so both pipelines look the same to a
-// consumer reading the stream.
 func newStatusReporter(resultFormat string, out io.Writer) (status.Reporter, error) {
 	mode, err := output.ResolveMode(resultFormat)
 	if err != nil {

--- a/cmd/provider/status.go
+++ b/cmd/provider/status.go
@@ -1,0 +1,60 @@
+package provider
+
+import (
+	"io"
+
+	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/output"
+	"github.com/devsy-org/devsy/pkg/status"
+)
+
+// newStatusReporter drives provider progress output: one NDJSON status line
+// per phase transition in JSON mode, human-readable info lines otherwise.
+// Mirrors cmd/workspace/up's reporter so both pipelines look the same to a
+// consumer reading the stream.
+func newStatusReporter(resultFormat string, out io.Writer) (status.Reporter, error) {
+	mode, err := output.ResolveMode(resultFormat)
+	if err != nil {
+		return nil, err
+	}
+
+	var r status.Reporter = plainStatusReporter{}
+	if mode == output.ModeJSON {
+		r = &jsonStatusReporter{out: out}
+	}
+	return status.ForPipeline(r, status.PipelineProvider), nil
+}
+
+type jsonStatusReporter struct {
+	out io.Writer
+}
+
+func (r *jsonStatusReporter) Report(e status.Event) {
+	_ = config2.WriteStatusJSON(r.out, e)
+}
+
+type plainStatusReporter struct{}
+
+func (plainStatusReporter) Report(e status.Event) {
+	switch {
+	case e.Phase == status.PhaseFailed:
+		log.Errorf("provider: phase %q failed: %s", e.Step, e.Err)
+	case e.Started:
+		log.Infof("provider: %s", phaseLabel(e.Phase))
+	}
+}
+
+var phaseLabels = map[status.Phase]string{
+	status.PhaseInstallingProvider: "installing provider",
+	status.PhaseResolvingOptions:   "resolving options",
+	status.PhaseRunningInit:        "running provider init",
+	status.PhaseReady:              "ready",
+}
+
+func phaseLabel(p status.Phase) string {
+	if label, ok := phaseLabels[p]; ok {
+		return label
+	}
+	return string(p)
+}

--- a/cmd/workspace/task.go
+++ b/cmd/workspace/task.go
@@ -185,7 +185,12 @@ func followTask(ctx context.Context, store *task.Store, opts followTaskOptions) 
 	ticker := time.NewTicker(opts.interval)
 	defer ticker.Stop()
 
+	tailer := newLogTailer(opts.id)
+	defer tailer.flush(os.Stderr)
+
 	for {
+		tailer.poll(os.Stderr)
+
 		state, err := store.Get(opts.id)
 		if err != nil {
 			return err

--- a/cmd/workspace/task_tail.go
+++ b/cmd/workspace/task_tail.go
@@ -10,10 +10,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/task"
 )
 
-// logTailer streams a detached worker's captured stdout/stderr (see
-// pkg/command.StartBackground) as it's written, so `task logs --follow`
-// shows the worker's real log output — including debug-level lines —
-// instead of only the synthesized phase-transition events.
+// logTailer streams a detached worker's captured stdout/stderr as it's written.
 type logTailer struct {
 	path string
 	file *os.File
@@ -81,10 +78,6 @@ func (t *logTailer) emit(w io.Writer, chunk []byte) {
 	}
 }
 
-// writeLine skips structured NDJSON envelopes (status/result/error/task):
-// the worker's own stdout carries the same envelopes this command already
-// reports from polled task state, so passing them through here would just
-// duplicate them as noise alongside the worker's actual log lines.
 func (t *logTailer) writeLine(w io.Writer, line []byte) {
 	if isEnvelopeLine(line) {
 		return

--- a/cmd/workspace/task_tail.go
+++ b/cmd/workspace/task_tail.go
@@ -1,0 +1,108 @@
+package workspace
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/task"
+)
+
+// logTailer streams a detached worker's captured stdout/stderr (see
+// pkg/command.StartBackground) as it's written, so `task logs --follow`
+// shows the worker's real log output — including debug-level lines —
+// instead of only the synthesized phase-transition events.
+type logTailer struct {
+	path string
+	file *os.File
+	buf  []byte
+}
+
+func newLogTailer(taskID string) *logTailer {
+	path, err := config.DefaultPathManager().ProcessStreamsFile(task.WorkerProcessName(taskID))
+	if err != nil {
+		return &logTailer{}
+	}
+	return &logTailer{path: path}
+}
+
+// poll emits any output appended since the last call. Safe to call before
+// the worker has created its streams file; it just retries next time.
+func (t *logTailer) poll(w io.Writer) {
+	if t.path == "" {
+		return
+	}
+	if t.file == nil {
+		f, err := os.Open(t.path) // #nosec G304 -- path derived from our own task ID
+		if err != nil {
+			return
+		}
+		t.file = f
+	}
+
+	buf := make([]byte, 32*1024)
+	for {
+		n, err := t.file.Read(buf)
+		if n > 0 {
+			t.emit(w, buf[:n])
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// flush polls one last time and emits any trailing partial line, then
+// releases the file handle. Call once the task has reached a terminal state.
+func (t *logTailer) flush(w io.Writer) {
+	t.poll(w)
+	if len(t.buf) > 0 {
+		t.writeLine(w, t.buf)
+		t.buf = nil
+	}
+	if t.file != nil {
+		_ = t.file.Close()
+		t.file = nil
+	}
+}
+
+func (t *logTailer) emit(w io.Writer, chunk []byte) {
+	t.buf = append(t.buf, chunk...)
+	for {
+		i := bytes.IndexByte(t.buf, '\n')
+		if i < 0 {
+			return
+		}
+		line := t.buf[:i]
+		t.buf = t.buf[i+1:]
+		t.writeLine(w, line)
+	}
+}
+
+// writeLine skips structured NDJSON envelopes (status/result/error/task):
+// the worker's own stdout carries the same envelopes this command already
+// reports from polled task state, so passing them through here would just
+// duplicate them as noise alongside the worker's actual log lines.
+func (t *logTailer) writeLine(w io.Writer, line []byte) {
+	if isEnvelopeLine(line) {
+		return
+	}
+	_, _ = w.Write(line)
+	_, _ = w.Write([]byte("\n"))
+}
+
+func isEnvelopeLine(line []byte) bool {
+	trimmed := bytes.TrimSpace(line)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return false
+	}
+	var probe struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(trimmed, &probe); err != nil {
+		return false
+	}
+	return probe.Kind != ""
+}

--- a/cmd/workspace/task_tail_test.go
+++ b/cmd/workspace/task_tail_test.go
@@ -57,6 +57,7 @@ func TestLogTailerEmitsLinesAsTheyAreAppended(t *testing.T) {
 		t.Fatalf("got %q, want %q", out.String(), "first line\n")
 	}
 
+	// #nosec G304 -- path is t.TempDir()-derived
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
 	if err != nil {
 		t.Fatalf("open for append: %v", err)

--- a/cmd/workspace/task_tail_test.go
+++ b/cmd/workspace/task_tail_test.go
@@ -1,0 +1,191 @@
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/devsy-org/devsy/pkg/config"
+	"github.com/devsy-org/devsy/pkg/task"
+)
+
+func newTestTailer(t *testing.T, taskID string) (*logTailer, string) {
+	t.Helper()
+	dir := t.TempDir()
+	config.SetPathManager(fakeRuntimeDirPathManager{dir: dir})
+	t.Cleanup(config.ResetPathManager)
+
+	tailer := newLogTailer(taskID)
+	if tailer.path == "" {
+		t.Fatal("newLogTailer produced an empty path")
+	}
+	return tailer, tailer.path
+}
+
+// fakeRuntimeDirPathManager overrides only RuntimeDir so tests can point
+// ProcessStreamsFile at a temp directory without touching the real state dir.
+type fakeRuntimeDirPathManager struct {
+	config.PathManager
+	dir string
+}
+
+func (f fakeRuntimeDirPathManager) RuntimeDir() (string, error) { return f.dir, nil }
+
+func (f fakeRuntimeDirPathManager) ProcessStreamsFile(name string) (string, error) {
+	return filepath.Join(f.dir, name+".streams"), nil
+}
+
+func TestLogTailerEmitsLinesAsTheyAreAppended(t *testing.T) {
+	tailer, path := newTestTailer(t, "task1")
+	var out bytes.Buffer
+
+	tailer.poll(&out) // file doesn't exist yet
+	if out.Len() != 0 {
+		t.Fatalf("expected no output before the file exists, got %q", out.String())
+	}
+
+	if err := os.WriteFile(path, []byte("first line\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	tailer.poll(&out)
+	if out.String() != "first line\n" {
+		t.Fatalf("got %q, want %q", out.String(), "first line\n")
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
+	}
+	if _, err := f.WriteString("second line\n"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	_ = f.Close()
+
+	tailer.poll(&out)
+	if out.String() != "first line\nsecond line\n" {
+		t.Fatalf("got %q, want both lines", out.String())
+	}
+}
+
+func TestLogTailerSkipsStructuredEnvelopeLines(t *testing.T) {
+	tailer, path := newTestTailer(t, "task2")
+	content := `{"level":"debug","ts":"2026-01-01T00:00:00.000-0500","msg":"a debug line"}
+{"kind":"status","phase":"building_image","started":true}
+{"kind":"result","outcome":"success","containerId":"abc"}
+plain unstructured line
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var out bytes.Buffer
+	tailer.poll(&out)
+
+	got := out.String()
+	if !bytes.Contains([]byte(got), []byte("a debug line")) {
+		t.Errorf("expected the debug line to pass through, got %q", got)
+	}
+	if !bytes.Contains([]byte(got), []byte("plain unstructured line")) {
+		t.Errorf("expected the unstructured line to pass through, got %q", got)
+	}
+	if bytes.Contains([]byte(got), []byte(`"kind"`)) {
+		t.Errorf("expected structured envelope lines to be filtered out, got %q", got)
+	}
+}
+
+func TestLogTailerFlushEmitsTrailingPartialLine(t *testing.T) {
+	tailer, path := newTestTailer(t, "task3")
+	// No trailing newline: simulates reading mid-write, or the worker's
+	// final line never getting a newline before it exits.
+	if err := os.WriteFile(path, []byte("unterminated"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	var out bytes.Buffer
+	tailer.poll(&out)
+	if out.Len() != 0 {
+		t.Fatalf("expected the partial line to be buffered, not emitted yet, got %q", out.String())
+	}
+
+	tailer.flush(&out)
+	if out.String() != "unterminated\n" {
+		t.Fatalf("got %q, want %q", out.String(), "unterminated\n")
+	}
+}
+
+func TestFollowTaskStreamsWorkerLogOutput(t *testing.T) {
+	// End-to-end: followTask must forward the worker's real log output
+	// (captured in its streams file) to stderr as it polls, not just the
+	// synthesized phase-transition events from task state.
+	dir := t.TempDir()
+	config.SetPathManager(fakeRuntimeDirPathManager{dir: dir})
+	t.Cleanup(config.ResetPathManager)
+
+	store, err := task.NewStoreAt(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewStoreAt: %v", err)
+	}
+	tk, err := store.Create(task.CreateOptions{Command: "up"})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	streamsPath, err := config.DefaultPathManager().
+		ProcessStreamsFile(task.WorkerProcessName(tk.ID()))
+	if err != nil {
+		t.Fatalf("ProcessStreamsFile: %v", err)
+	}
+	line := `{"level":"debug","ts":"2026-01-01T00:00:00.000-0500","msg":"worker debug line"}` + "\n"
+	if err := os.WriteFile(streamsPath, []byte(line), 0o600); err != nil {
+		t.Fatalf("write streams file: %v", err)
+	}
+
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		_ = tk.Succeed(nil)
+	}()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe: %v", err)
+	}
+	origStderr := os.Stderr
+	os.Stderr = w
+	followErr := followTask(context.Background(), store, followTaskOptions{
+		id:       tk.ID(),
+		interval: 10 * time.Millisecond,
+		emitJSON: true,
+	})
+	os.Stderr = origStderr
+	_ = w.Close()
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	if followErr != nil {
+		t.Fatalf("followTask: %v", followErr)
+	}
+	if !strings.Contains(buf.String(), "worker debug line") {
+		t.Errorf("expected the worker's debug line on stderr, got %q", buf.String())
+	}
+}
+
+func TestLogTailerToleratesMissingRuntimeDir(t *testing.T) {
+	config.SetPathManager(
+		fakeRuntimeDirPathManager{dir: filepath.Join(t.TempDir(), "does-not-exist")},
+	)
+	t.Cleanup(config.ResetPathManager)
+
+	tailer := newLogTailer("task4")
+	var out bytes.Buffer
+	tailer.poll(&out)
+	tailer.flush(&out)
+	if out.Len() != 0 {
+		t.Errorf("expected no output when the streams file never appears, got %q", out.String())
+	}
+}

--- a/cmd/workspace/task_tail_test.go
+++ b/cmd/workspace/task_tail_test.go
@@ -27,8 +27,6 @@ func newTestTailer(t *testing.T, taskID string) (*logTailer, string) {
 	return tailer, tailer.path
 }
 
-// fakeRuntimeDirPathManager overrides only RuntimeDir so tests can point
-// ProcessStreamsFile at a temp directory without touching the real state dir.
 type fakeRuntimeDirPathManager struct {
 	config.PathManager
 	dir string
@@ -120,9 +118,6 @@ func TestLogTailerFlushEmitsTrailingPartialLine(t *testing.T) {
 }
 
 func TestFollowTaskStreamsWorkerLogOutput(t *testing.T) {
-	// End-to-end: followTask must forward the worker's real log output
-	// (captured in its streams file) to stderr as it polls, not just the
-	// synthesized phase-transition events from task state.
 	dir := t.TempDir()
 	config.SetPathManager(fakeRuntimeDirPathManager{dir: dir})
 	t.Cleanup(config.ResetPathManager)

--- a/cmd/workspace/up/detach.go
+++ b/cmd/workspace/up/detach.go
@@ -53,7 +53,7 @@ func launchDetached(taskID string) error {
 	}
 
 	args := append(detachedArgs(os.Args[1:]), names.Flag(names.TaskID), taskID)
-	return command.StartBackground("devsy-up-"+taskID, func() (*exec.Cmd, error) {
+	return command.StartBackground(task.WorkerProcessName(taskID), func() (*exec.Cmd, error) {
 		return &exec.Cmd{
 			Path: execPath,
 			Args: append([]string{execPath}, args...),

--- a/cmd/workspace/up/status.go
+++ b/cmd/workspace/up/status.go
@@ -11,10 +11,11 @@ import (
 
 // newStatusReporter drives `up`'s progress output.
 func newStatusReporter(emitJSON bool, out io.Writer) status.Reporter {
+	var r status.Reporter = plainStatusReporter{}
 	if emitJSON {
-		return &jsonStatusReporter{out: out}
+		r = &jsonStatusReporter{out: out}
 	}
-	return plainStatusReporter{}
+	return status.ForPipeline(r, status.PipelineWorkspaceUp)
 }
 
 // jsonStatusReporter serializes write events.

--- a/desktop/e2e/app.e2e.ts
+++ b/desktop/e2e/app.e2e.ts
@@ -1,11 +1,14 @@
 import type { ElectronApplication, Page } from "@playwright/test"
 import { expect, test } from "@playwright/test"
-import { launchApp } from "./electron-app.js"
+import { launchApp, resetMockState } from "./electron-app.js"
 
 let app: ElectronApplication
 let page: Page
 
 test.beforeAll(async () => {
+  // The badge counts below assert the mock's default fixture exactly, so
+  // start from a clean slate rather than inheriting another spec's CRUD.
+  resetMockState()
   ;({ app, page } = await launchApp())
 })
 

--- a/desktop/e2e/app.e2e.ts
+++ b/desktop/e2e/app.e2e.ts
@@ -6,8 +6,6 @@ let app: ElectronApplication
 let page: Page
 
 test.beforeAll(async () => {
-  // The badge counts below assert the mock's default fixture exactly, so
-  // start from a clean slate rather than inheriting another spec's CRUD.
   resetMockState()
   ;({ app, page } = await launchApp())
 })

--- a/desktop/e2e/fixtures/mock-devsy.cjs
+++ b/desktop/e2e/fixtures/mock-devsy.cjs
@@ -415,10 +415,14 @@ function handleDelete(args) {
   setTimeout(() => {
     out("Deleting workspace...")
     out("Workspace deleted.")
-    const idx = state.workspaces.findIndex((w) => w.id === wsId)
+    // Re-read: the snapshot taken at startup is up to 1.5s stale, and
+    // writing it back would clobber any add/delete another spec performed
+    // against this shared fixture meanwhile.
+    const latest = loadState()
+    const idx = latest.workspaces.findIndex((w) => w.id === wsId)
     if (idx !== -1) {
-      state.workspaces.splice(idx, 1)
-      saveState(state)
+      latest.workspaces.splice(idx, 1)
+      saveState(latest)
     }
     process.exit(0)
   }, deleteMs)

--- a/desktop/e2e/fixtures/mock-devsy.cjs
+++ b/desktop/e2e/fixtures/mock-devsy.cjs
@@ -110,7 +110,6 @@ function out(data) {
   )
 }
 
-// Single-line NDJSON status envelope, matching pkg/status + envelope.go.
 function providerStatus(phase, started, step) {
   out(
     JSON.stringify({
@@ -413,7 +412,6 @@ function handleDelete(args) {
   setTimeout(() => {
     out("Deleting workspace...")
     out("Workspace deleted.")
-    // Re-read: avoid clobbering a concurrent spec's writes with our stale snapshot.
     const latest = loadState()
     const idx = latest.workspaces.findIndex((w) => w.id === wsId)
     if (idx !== -1) {
@@ -551,16 +549,12 @@ switch (cmd) {
       case "add": {
         const provName = extra
         if (provName) {
-          // The desktop passes --use=false, which installs without changing
-          // the default provider; only `provider use` does that.
           const takesDefault = !rawArgs.includes("--use=false")
           if (takesDefault) {
             for (const key of Object.keys(state.providers)) {
               state.providers[key].default = false
             }
           }
-          // Written uninitialized, exactly as the real CLI does: `provider
-          // add --use=false` persists before any init runs.
           state.providers[provName] = {
             config: {
               name: provName,
@@ -590,7 +584,6 @@ switch (cmd) {
         // *probe suffix delays init so lifecycle tests can observe in-flight state.
         const initMs = /probe$/.test(provName) ? 5000 : 150
         setTimeout(() => {
-          // Re-read: avoid clobbering a concurrent spec's writes with our stale snapshot.
           const latest = loadState()
           if (provName && latest.providers[provName]) {
             latest.providers[provName].state.initialized = true
@@ -647,8 +640,6 @@ switch (cmd) {
       }
       case "set-source": {
         const provName = extra
-        // Mirrors UpdateProvider: new binaries, so Initialized is cleared and
-        // the caller is expected to chain `provider init`.
         if (provName && state.providers[provName]) {
           state.providers[provName].state.initialized = false
           saveState(state)

--- a/desktop/e2e/fixtures/mock-devsy.cjs
+++ b/desktop/e2e/fixtures/mock-devsy.cjs
@@ -408,14 +408,20 @@ function handleStop(args) {
 function handleDelete(args) {
   const { positional } = parseArgs(args)
   const wsId = positional[0]
-  out("Deleting workspace...")
-  out("Workspace deleted.")
-  const idx = state.workspaces.findIndex((w) => w.id === wsId)
-  if (idx !== -1) {
-    state.workspaces.splice(idx, 1)
-    saveState(state)
-  }
-  process.exit(0)
+  // Workspaces named *probe belong to lifecycle tests, where delete must
+  // outlast the render/poll cycle or there is no in-flight state to observe.
+  // Everything else stays instant so unrelated specs aren't slowed down.
+  const deleteMs = /probe$/.test(wsId) ? 1500 : 0
+  setTimeout(() => {
+    out("Deleting workspace...")
+    out("Workspace deleted.")
+    const idx = state.workspaces.findIndex((w) => w.id === wsId)
+    if (idx !== -1) {
+      state.workspaces.splice(idx, 1)
+      saveState(state)
+    }
+    process.exit(0)
+  }, deleteMs)
 }
 
 function handleRename(args) {
@@ -502,8 +508,15 @@ if (cmd === "workspace") {
     process.stderr.write(`mock-devsy: unknown workspace subcommand '${verb}'\n`)
     process.exit(2)
   }
+  // No unconditional exit here: handleDelete defers its own exit behind a
+  // setTimeout for *probe workspaces, and calling process.exit(0)
+  // immediately after would kill the process before that timer fires.
+  // Handlers that finish synchronously (list, status, rename, ...) just
+  // let the process exit naturally once nothing is left pending. `return`
+  // (not exit) still stops this script falling through to the
+  // provider/machine/context switch below.
   handler(rawArgs.slice(2))
-  process.exit(0)
+  return
 }
 
 // Non-workspace top-level commands (preserved verbatim).

--- a/desktop/e2e/fixtures/mock-devsy.cjs
+++ b/desktop/e2e/fixtures/mock-devsy.cjs
@@ -110,6 +110,19 @@ function out(data) {
   )
 }
 
+// Single-line NDJSON status envelope, matching pkg/status + envelope.go.
+function providerStatus(phase, started, step) {
+  out(
+    JSON.stringify({
+      kind: "status",
+      pipeline: "provider",
+      phase,
+      ...(step ? { step } : {}),
+      started,
+    }),
+  )
+}
+
 // Parse a slice of args (positional + recognized flags) into a result object.
 function parseArgs(args) {
   const positional = []
@@ -530,9 +543,16 @@ switch (cmd) {
       case "add": {
         const provName = extra
         if (provName) {
-          for (const key of Object.keys(state.providers)) {
-            state.providers[key].default = false
+          // The desktop passes --use=false, which installs without changing
+          // the default provider; only `provider use` does that.
+          const takesDefault = !rawArgs.includes("--use=false")
+          if (takesDefault) {
+            for (const key of Object.keys(state.providers)) {
+              state.providers[key].default = false
+            }
           }
+          // Written uninitialized, exactly as the real CLI does: `provider
+          // add --use=false` persists before any init runs.
           state.providers[provName] = {
             config: {
               name: provName,
@@ -544,11 +564,39 @@ switch (cmd) {
               optionGroups: [],
             },
             state: { initialized: false },
-            default: true,
+            default: takesDefault,
           }
           saveState(state)
         }
-        out("")
+        // No ready phase: install finished, init has not run.
+        providerStatus("installing_provider", true)
+        providerStatus("installing_provider", false, provName)
+        process.exit(0)
+        break
+      }
+      case "init": {
+        const provName = extra || providerFlag
+        providerStatus("resolving_options", true, provName)
+        providerStatus("resolving_options", false, provName)
+        providerStatus("running_init", true, provName)
+        // Providers named *probe belong to lifecycle tests, where init must
+        // outlast the ~1.5s a new card takes to render or there is no
+        // in-flight state to observe. Everything else stays fast so unrelated
+        // specs aren't slowed down.
+        const initMs = /probe$/.test(provName) ? 5000 : 150
+        setTimeout(() => {
+          // Re-read: the snapshot taken at startup is up to 5s stale, and
+          // writing it back would clobber any add/delete another spec
+          // performed against this shared fixture meanwhile.
+          const latest = loadState()
+          if (provName && latest.providers[provName]) {
+            latest.providers[provName].state.initialized = true
+            saveState(latest)
+          }
+          providerStatus("running_init", false, provName)
+          providerStatus("ready", false, provName)
+          process.exit(0)
+        }, initMs)
         break
       }
       case "delete": {
@@ -592,6 +640,19 @@ switch (cmd) {
           saveState(state)
         }
         out("")
+        break
+      }
+      case "set-source": {
+        const provName = extra
+        // Mirrors UpdateProvider: new binaries, so Initialized is cleared and
+        // the caller is expected to chain `provider init`.
+        if (provName && state.providers[provName]) {
+          state.providers[provName].state.initialized = false
+          saveState(state)
+        }
+        providerStatus("installing_provider", true, provName)
+        providerStatus("installing_provider", false, provName)
+        process.exit(0)
         break
       }
       case "versions":

--- a/desktop/e2e/fixtures/mock-devsy.cjs
+++ b/desktop/e2e/fixtures/mock-devsy.cjs
@@ -408,16 +408,12 @@ function handleStop(args) {
 function handleDelete(args) {
   const { positional } = parseArgs(args)
   const wsId = positional[0]
-  // Workspaces named *probe belong to lifecycle tests, where delete must
-  // outlast the render/poll cycle or there is no in-flight state to observe.
-  // Everything else stays instant so unrelated specs aren't slowed down.
+  // *probe suffix delays deletion so lifecycle tests can observe in-flight state.
   const deleteMs = /probe$/.test(wsId) ? 1500 : 0
   setTimeout(() => {
     out("Deleting workspace...")
     out("Workspace deleted.")
-    // Re-read: the snapshot taken at startup is up to 1.5s stale, and
-    // writing it back would clobber any add/delete another spec performed
-    // against this shared fixture meanwhile.
+    // Re-read: avoid clobbering a concurrent spec's writes with our stale snapshot.
     const latest = loadState()
     const idx = latest.workspaces.findIndex((w) => w.id === wsId)
     if (idx !== -1) {
@@ -512,13 +508,8 @@ if (cmd === "workspace") {
     process.stderr.write(`mock-devsy: unknown workspace subcommand '${verb}'\n`)
     process.exit(2)
   }
-  // No unconditional exit here: handleDelete defers its own exit behind a
-  // setTimeout for *probe workspaces, and calling process.exit(0)
-  // immediately after would kill the process before that timer fires.
-  // Handlers that finish synchronously (list, status, rename, ...) just
-  // let the process exit naturally once nothing is left pending. `return`
-  // (not exit) still stops this script falling through to the
-  // provider/machine/context switch below.
+  // No unconditional exit(0) here: handleDelete's setTimeout would get killed
+  // before firing. `return` still skips the non-workspace switch below.
   handler(rawArgs.slice(2))
   return
 }
@@ -596,15 +587,10 @@ switch (cmd) {
         providerStatus("resolving_options", true, provName)
         providerStatus("resolving_options", false, provName)
         providerStatus("running_init", true, provName)
-        // Providers named *probe belong to lifecycle tests, where init must
-        // outlast the ~1.5s a new card takes to render or there is no
-        // in-flight state to observe. Everything else stays fast so unrelated
-        // specs aren't slowed down.
+        // *probe suffix delays init so lifecycle tests can observe in-flight state.
         const initMs = /probe$/.test(provName) ? 5000 : 150
         setTimeout(() => {
-          // Re-read: the snapshot taken at startup is up to 5s stale, and
-          // writing it back would clobber any add/delete another spec
-          // performed against this shared fixture meanwhile.
+          // Re-read: avoid clobbering a concurrent spec's writes with our stale snapshot.
           const latest = loadState()
           if (provName && latest.providers[provName]) {
             latest.providers[provName].state.initialized = true

--- a/desktop/e2e/providers.e2e.ts
+++ b/desktop/e2e/providers.e2e.ts
@@ -106,40 +106,42 @@ test.describe("Provider lifecycle badges", () => {
       void api.invoke("provider_init", { name: "lifecycleprobe" })
     })
 
-    const card = main.locator("button", { hasText: "lifecycleprobe" }).first()
-    await expect(card).toBeVisible({ timeout: 10000 })
+    try {
+      const card = main.locator("button", { hasText: "lifecycleprobe" }).first()
+      await expect(card).toBeVisible({ timeout: 10000 })
 
-    // Sample continuously from in-flight through settled. The red badge must
-    // never appear at any point: not during install/init, and not in the
-    // window between the job clearing and the provider list catching up.
-    let sawBusy = false
-    let settled = false
-    const deadline = Date.now() + 8000
-    while (Date.now() < deadline) {
-      const text = ((await card.textContent()) ?? "").toLowerCase()
-      expect(text).not.toContain("not initialized")
-      if (/installing|initializing/.test(text)) sawBusy = true
-      // Reached only once the busy label is replaced by the settled badge.
-      if (sawBusy && /(^|\s)initialized/.test(text)) {
-        settled = true
-        break
-      }
-      await page.waitForTimeout(100)
-    }
-
-    expect(sawBusy, "expected a busy badge during install/init").toBe(true)
-    expect(settled, "expected the card to settle as initialized").toBe(true)
-
-    // Mock CLI state is shared across specs, so don't leave this behind.
-    await page.evaluate(async () => {
-      await (
-        window as unknown as {
-          electronAPI: {
-            invoke: (c: string, a?: Record<string, unknown>) => Promise<unknown>
-          }
+      // Sample continuously from in-flight through settled. The red badge must
+      // never appear at any point: not during install/init, and not in the
+      // window between the job clearing and the provider list catching up.
+      let sawBusy = false
+      let settled = false
+      const deadline = Date.now() + 8000
+      while (Date.now() < deadline) {
+        const text = ((await card.textContent()) ?? "").toLowerCase()
+        expect(text).not.toContain("not initialized")
+        if (/installing|initializing/.test(text)) sawBusy = true
+        // Reached only once the busy label is replaced by the settled badge.
+        if (sawBusy && /(^|\s)initialized/.test(text)) {
+          settled = true
+          break
         }
-      ).electronAPI.invoke("provider_delete", { name: "lifecycleprobe" })
-    })
+        await page.waitForTimeout(100)
+      }
+
+      expect(sawBusy, "expected a busy badge during install/init").toBe(true)
+      expect(settled, "expected the card to settle as initialized").toBe(true)
+    } finally {
+      // Mock CLI state is shared across specs, so don't leave this behind.
+      await page.evaluate(async () => {
+        await (
+          window as unknown as {
+            electronAPI: {
+              invoke: (c: string, a?: Record<string, unknown>) => Promise<unknown>
+            }
+          }
+        ).electronAPI.invoke("provider_delete", { name: "lifecycleprobe" })
+      })
+    }
   })
 
   // An abandoned wizard (skip init, or close mid-flow) leaves the install's
@@ -167,15 +169,17 @@ test.describe("Provider lifecycle badges", () => {
     await api("provider_delete", { name: "skipprobe" })
     await api("provider_add", { name: "skipprobe" })
 
-    const card = main.locator("button", { hasText: "skipprobe" }).first()
-    await expect(card).toContainText(/installing/i, { timeout: 10000 })
+    try {
+      const card = main.locator("button", { hasText: "skipprobe" }).first()
+      await expect(card).toContainText(/installing/i, { timeout: 10000 })
 
-    // What the wizard does on skip/close.
-    await api("provider_release_job", { name: "skipprobe" })
+      // What the wizard does on skip/close.
+      await api("provider_release_job", { name: "skipprobe" })
 
-    // Settles to the honest uninitialized state rather than staying busy.
-    await expect(card).toContainText(/not initialized/i, { timeout: 10000 })
-
-    await api("provider_delete", { name: "skipprobe" })
+      // Settles to the honest uninitialized state rather than staying busy.
+      await expect(card).toContainText(/not initialized/i, { timeout: 10000 })
+    } finally {
+      await api("provider_delete", { name: "skipprobe" })
+    }
   })
 })

--- a/desktop/e2e/providers.e2e.ts
+++ b/desktop/e2e/providers.e2e.ts
@@ -84,9 +84,6 @@ test.describe("Providers Page", () => {
 })
 
 test.describe("Provider lifecycle badges", () => {
-  // The bug this guards: `provider add` persists the provider with
-  // initialized:false before init runs, so the card briefly rendered the red
-  // "not initialized" badge for several seconds.
   test("never shows 'not initialized' while add+init is in flight", async () => {
     const main = page.locator('[data-slot="sidebar-inset"] main')
 
@@ -98,11 +95,8 @@ test.describe("Provider lifecycle badges", () => {
           }
         }
       ).electronAPI
-      // Mock CLI state persists across runs, so start from a clean slate;
-      // a leftover initialized provider would skip the window under test.
       await api.invoke("provider_delete", { name: "lifecycleprobe" })
       await api.invoke("provider_add", { name: "lifecycleprobe" })
-      // Not awaited: the assertions below run while init is still going.
       void api.invoke("provider_init", { name: "lifecycleprobe" })
     })
 
@@ -110,9 +104,6 @@ test.describe("Provider lifecycle badges", () => {
       const card = main.locator("button", { hasText: "lifecycleprobe" }).first()
       await expect(card).toBeVisible({ timeout: 10000 })
 
-      // Sample continuously from in-flight through settled. The red badge must
-      // never appear at any point: not during install/init, and not in the
-      // window between the job clearing and the provider list catching up.
       let sawBusy = false
       let settled = false
       const deadline = Date.now() + 8000
@@ -176,7 +167,7 @@ test.describe("Provider lifecycle badges", () => {
       // What the wizard does on skip/close.
       await api("provider_release_job", { name: "skipprobe" })
 
-      // Settles to the honest uninitialized state rather than staying busy.
+      // Settles to the uninitialized state rather than staying busy.
       await expect(card).toContainText(/not initialized/i, { timeout: 10000 })
     } finally {
       await api("provider_delete", { name: "skipprobe" })

--- a/desktop/e2e/providers.e2e.ts
+++ b/desktop/e2e/providers.e2e.ts
@@ -82,3 +82,100 @@ test.describe("Providers Page", () => {
     await expect(sheet).toContainText("docker")
   })
 })
+
+test.describe("Provider lifecycle badges", () => {
+  // The bug this guards: `provider add` persists the provider with
+  // initialized:false before init runs, so the card briefly rendered the red
+  // "not initialized" badge for several seconds.
+  test("never shows 'not initialized' while add+init is in flight", async () => {
+    const main = page.locator('[data-slot="sidebar-inset"] main')
+
+    await page.evaluate(async () => {
+      const api = (
+        window as unknown as {
+          electronAPI: {
+            invoke: (c: string, a?: Record<string, unknown>) => Promise<unknown>
+          }
+        }
+      ).electronAPI
+      // Mock CLI state persists across runs, so start from a clean slate;
+      // a leftover initialized provider would skip the window under test.
+      await api.invoke("provider_delete", { name: "lifecycleprobe" })
+      await api.invoke("provider_add", { name: "lifecycleprobe" })
+      // Not awaited: the assertions below run while init is still going.
+      void api.invoke("provider_init", { name: "lifecycleprobe" })
+    })
+
+    const card = main.locator("button", { hasText: "lifecycleprobe" }).first()
+    await expect(card).toBeVisible({ timeout: 10000 })
+
+    // Sample continuously from in-flight through settled. The red badge must
+    // never appear at any point: not during install/init, and not in the
+    // window between the job clearing and the provider list catching up.
+    let sawBusy = false
+    let settled = false
+    const deadline = Date.now() + 8000
+    while (Date.now() < deadline) {
+      const text = ((await card.textContent()) ?? "").toLowerCase()
+      expect(text).not.toContain("not initialized")
+      if (/installing|initializing/.test(text)) sawBusy = true
+      // Reached only once the busy label is replaced by the settled badge.
+      if (sawBusy && /(^|\s)initialized/.test(text)) {
+        settled = true
+        break
+      }
+      await page.waitForTimeout(100)
+    }
+
+    expect(sawBusy, "expected a busy badge during install/init").toBe(true)
+    expect(settled, "expected the card to settle as initialized").toBe(true)
+
+    // Mock CLI state is shared across specs, so don't leave this behind.
+    await page.evaluate(async () => {
+      await (
+        window as unknown as {
+          electronAPI: {
+            invoke: (c: string, a?: Record<string, unknown>) => Promise<unknown>
+          }
+        }
+      ).electronAPI.invoke("provider_delete", { name: "lifecycleprobe" })
+    })
+  })
+
+  // An abandoned wizard (skip init, or close mid-flow) leaves the install's
+  // job open. Without an explicit release the card spins on "installing…"
+  // forever, since nothing else will ever finish that job.
+  test("releases the job when a provider is added but never initialized", async () => {
+    const main = page.locator('[data-slot="sidebar-inset"] main')
+
+    const api = async (channel: string, args: Record<string, unknown>) =>
+      page.evaluate(
+        ([c, a]) =>
+          (
+            window as unknown as {
+              electronAPI: {
+                invoke: (
+                  c: string,
+                  a?: Record<string, unknown>,
+                ) => Promise<unknown>
+              }
+            }
+          ).electronAPI.invoke(c as string, a as Record<string, unknown>),
+        [channel, args] as const,
+      )
+
+    await api("provider_delete", { name: "skipprobe" })
+    await api("provider_add", { name: "skipprobe" })
+
+    const card = main.locator("button", { hasText: "skipprobe" }).first()
+    await expect(card).toContainText(/installing/i, { timeout: 10000 })
+
+    // What the wizard does on skip/close.
+    await api("provider_release_job", { name: "skipprobe" })
+
+    // Settles to the honest uninitialized state rather than staying busy.
+    await expect(card).toContainText(/not initialized/i, { timeout: 10000 })
+
+    await api("provider_delete", { name: "skipprobe" })
+  })
+})

--- a/desktop/e2e/workspaces.e2e.ts
+++ b/desktop/e2e/workspaces.e2e.ts
@@ -44,6 +44,52 @@ test.describe("Workspaces Page", () => {
   })
 })
 
+test.describe("Workspace lifecycle badges", () => {
+  const api = async (channel: string, args: Record<string, unknown>) =>
+    page.evaluate(
+      ([c, a]) =>
+        (
+          window as unknown as {
+            electronAPI: {
+              invoke: (
+                c: string,
+                a?: Record<string, unknown>,
+              ) => Promise<unknown>
+            }
+          }
+        ).electronAPI.invoke(c as string, a as Record<string, unknown>),
+      [channel, args] as const,
+    )
+
+  // Deleting a workspace previously left no visual trace until the CLI
+  // exited and the next poll ran, so a slow delete looked like nothing was
+  // happening. It must show a "Deleting" badge for the duration.
+  test("shows a Deleting badge while removal is in flight, then removes the row", async () => {
+    const main = page.locator('[data-slot="sidebar-inset"] main')
+
+    try {
+      await api("workspace_up", {
+        source: "https://example.com/deleteprobe.git",
+        id: "deleteprobe",
+      })
+      await expect(main.locator("text=deleteprobe")).toBeVisible({
+        timeout: 5000,
+      })
+
+      // Not awaited: the assertions below run while the delete is in flight.
+      void api("workspace_delete", { workspaceId: "deleteprobe" })
+
+      await expect(main).toContainText("Deleting", { timeout: 3000 })
+      await expect(main.locator("text=deleteprobe")).not.toBeVisible({
+        timeout: 5000,
+      })
+    } finally {
+      // Mock CLI state is shared across specs, so don't leave this behind.
+      await api("workspace_delete", { workspaceId: "deleteprobe" })
+    }
+  })
+})
+
 test.describe.serial("Create Workspace Wizard", () => {
   test("should open the wizard and show step 1 (provider)", async () => {
     await page.getByRole("button", { name: /create workspace/i }).click()

--- a/desktop/e2e/workspaces.e2e.ts
+++ b/desktop/e2e/workspaces.e2e.ts
@@ -77,7 +77,9 @@ test.describe("Workspace lifecycle badges", () => {
       })
 
       // Not awaited: the assertions below run while the delete is in flight.
-      void api("workspace_delete", { workspaceId: "deleteprobe" })
+      void api("workspace_delete", { workspaceId: "deleteprobe" }).catch(
+        () => undefined,
+      )
 
       await expect(main).toContainText("Deleting", { timeout: 3000 })
       await expect(main.locator("text=deleteprobe")).not.toBeVisible({

--- a/desktop/e2e/workspaces.e2e.ts
+++ b/desktop/e2e/workspaces.e2e.ts
@@ -69,7 +69,7 @@ test.describe("Workspace lifecycle badges", () => {
     try {
       await api("workspace_up", {
         source: "https://example.com/deleteprobe.git",
-        id: "deleteprobe",
+        workspaceId: "deleteprobe",
       })
       await expect(main.locator("text=deleteprobe")).toBeVisible({
         timeout: 5000,

--- a/desktop/e2e/workspaces.e2e.ts
+++ b/desktop/e2e/workspaces.e2e.ts
@@ -61,8 +61,6 @@ test.describe("Workspace lifecycle badges", () => {
       [channel, args] as const,
     )
 
-  // Deleting previously showed no visual trace until the CLI exited and the
-  // next poll ran; it must show a "Deleting" badge for the duration.
   test("shows a Deleting badge while removal is in flight, then removes the row", async () => {
     const main = page.locator('[data-slot="sidebar-inset"] main')
 

--- a/desktop/e2e/workspaces.e2e.ts
+++ b/desktop/e2e/workspaces.e2e.ts
@@ -61,9 +61,8 @@ test.describe("Workspace lifecycle badges", () => {
       [channel, args] as const,
     )
 
-  // Deleting a workspace previously left no visual trace until the CLI
-  // exited and the next poll ran, so a slow delete looked like nothing was
-  // happening. It must show a "Deleting" badge for the duration.
+  // Deleting previously showed no visual trace until the CLI exited and the
+  // next poll ran; it must show a "Deleting" badge for the duration.
   test("shows a Deleting badge while removal is in flight, then removes the row", async () => {
     const main = page.locator('[data-slot="sidebar-inset"] main')
 

--- a/desktop/src/main/__tests__/cli.test.ts
+++ b/desktop/src/main/__tests__/cli.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment node
 import { execFile, spawn } from "node:child_process"
 import { EventEmitter } from "node:events"
+import { Readable } from "node:stream"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { CliRunner } from "../cli.js"
 
@@ -21,6 +22,17 @@ function fakeChild() {
     stdin.written = input
   }
   child.stdin = stdin
+  return child
+}
+
+/** A child whose stdout/stderr are real streams, as readline requires. */
+function fakeStreamingChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: Readable
+    stderr: Readable
+  }
+  child.stdout = new Readable({ read() {} })
+  child.stderr = new Readable({ read() {} })
   return child
 }
 
@@ -210,6 +222,39 @@ describe("CliRunner", () => {
         expect.objectContaining({ env: expect.any(Object) }),
         expect.any(Function),
       )
+    })
+  })
+
+  describe("runStreaming", () => {
+    it("reports an exit when the child fails to spawn", async () => {
+      // A spawn failure emits "error" and never "close". Callers wrap this in
+      // a promise settled from onExit, so without this the promise never
+      // settles and the provider job stays busy forever.
+      const child = fakeStreamingChild()
+      const mockSpawn = vi.mocked(spawn) as unknown as ReturnType<typeof vi.fn>
+      mockSpawn.mockReturnValue(child)
+
+      const onExit = vi.fn()
+      await cli.runStreaming(["provider", "init", "docker"], () => {}, onExit)
+      child.emit("error", new Error("spawn ENOENT"))
+
+      await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1))
+      const [code, cliError] = onExit.mock.calls[0]
+      expect(code).toBe(-1)
+      expect(cliError?.message).toContain("spawn ENOENT")
+    })
+
+    it("reports the exit once when error and close both fire", async () => {
+      const child = fakeStreamingChild()
+      const mockSpawn = vi.mocked(spawn) as unknown as ReturnType<typeof vi.fn>
+      mockSpawn.mockReturnValue(child)
+
+      const onExit = vi.fn()
+      await cli.runStreaming(["provider", "init", "docker"], () => {}, onExit)
+      child.emit("error", new Error("boom"))
+      child.emit("close", 1)
+
+      await vi.waitFor(() => expect(onExit).toHaveBeenCalledTimes(1))
     })
   })
 

--- a/desktop/src/main/__tests__/cli.test.ts
+++ b/desktop/src/main/__tests__/cli.test.ts
@@ -227,9 +227,6 @@ describe("CliRunner", () => {
 
   describe("runStreaming", () => {
     it("reports an exit when the child fails to spawn", async () => {
-      // A spawn failure emits "error" and never "close". Callers wrap this in
-      // a promise settled from onExit, so without this the promise never
-      // settles and the provider job stays busy forever.
       const child = fakeStreamingChild()
       const mockSpawn = vi.mocked(spawn) as unknown as ReturnType<typeof vi.fn>
       mockSpawn.mockReturnValue(child)

--- a/desktop/src/main/__tests__/ipc-provider-jobs.test.ts
+++ b/desktop/src/main/__tests__/ipc-provider-jobs.test.ts
@@ -179,7 +179,6 @@ describe("provider job lifecycle over IPC", () => {
   })
 
   it("does not blame a successful init for a refresh failure afterward", async () => {
-    // `provider init` itself succeeds; only the post-success refresh fails.
     const { providerJobs } = setup(() => ({
       lines: [statusLine("running_init"), statusLine("ready")],
       code: 0,
@@ -188,9 +187,6 @@ describe("provider job lifecycle over IPC", () => {
 
     await invoke("provider_init", { name: "docker" })
 
-    // The bug this guards: finish()'s success path rejecting (via a failed
-    // refresh) must not get caught and re-reported as if the init command
-    // itself had failed with the refresh's error message.
     expect(providerJobs.get("docker")?.error).not.toBe("refresh boom")
   })
 })

--- a/desktop/src/main/__tests__/ipc-provider-jobs.test.ts
+++ b/desktop/src/main/__tests__/ipc-provider-jobs.test.ts
@@ -177,4 +177,20 @@ describe("provider job lifecycle over IPC", () => {
 
     expect(providerJobs.get("docker")?.error).toBeTruthy()
   })
+
+  it("does not blame a successful init for a refresh failure afterward", async () => {
+    // `provider init` itself succeeds; only the post-success refresh fails.
+    const { providerJobs } = setup(() => ({
+      lines: [statusLine("running_init"), statusLine("ready")],
+      code: 0,
+    }))
+    providerJobs.setRefresh(() => Promise.reject(new Error("refresh boom")))
+
+    await invoke("provider_init", { name: "docker" })
+
+    // The bug this guards: finish()'s success path rejecting (via a failed
+    // refresh) must not get caught and re-reported as if the init command
+    // itself had failed with the refresh's error message.
+    expect(providerJobs.get("docker")?.error).not.toBe("refresh boom")
+  })
 })

--- a/desktop/src/main/__tests__/ipc-provider-jobs.test.ts
+++ b/desktop/src/main/__tests__/ipc-provider-jobs.test.ts
@@ -1,0 +1,180 @@
+// @vitest-environment node
+import { EventEmitter } from "node:events"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ProviderJobs } from "../provider-jobs.js"
+
+const handlers = new Map<string, (...args: unknown[]) => unknown>()
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp", getVersion: () => "0.0.0" },
+  dialog: {},
+  ipcMain: {
+    handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, fn)
+    },
+    on: () => undefined,
+  },
+}))
+
+vi.mock("../analytics.js", () => ({
+  hashWorkspaceRef: (v: string) => v,
+  trackEvent: () => undefined,
+}))
+
+const { registerIpcHandlers } = await import("../ipc.js")
+
+/** A child that emits the given stdout lines, then exits with `code`. */
+function fakeChild(lines: string[], code: number) {
+  const child = new EventEmitter() as EventEmitter & {
+    exitCode: number | null
+    signalCode: string | null
+    kill: () => void
+  }
+  child.exitCode = null
+  child.signalCode = null
+  child.kill = () => undefined
+  return { child, lines, code }
+}
+
+function setup(
+  script: (cliArgs: string[]) => { lines: string[]; code: number } = () => ({
+    lines: [],
+    code: 0,
+  }),
+) {
+  const providerJobs = new ProviderJobs()
+  const cli = {
+    run: vi.fn(async () => ({})),
+    runRaw: vi.fn(async () => ""),
+    runStreaming: vi.fn(
+      async (
+        cliArgs: string[],
+        onLine: (line: string, stream: "stdout" | "stderr") => void,
+        onExit: (code: number, cliError?: unknown) => void,
+      ) => {
+        const { lines, code } = script(cliArgs)
+        const { child } = fakeChild(lines, code)
+        // Deliver lines then exit asynchronously, as a real child does.
+        setTimeout(() => {
+          for (const line of lines) onLine(line, "stdout")
+          onExit(code, code === 0 ? undefined : { message: "boom" })
+        }, 0)
+        return child
+      },
+    ),
+    cancelFor: vi.fn(async () => undefined),
+  }
+  const deps = {
+    cli,
+    state: { workspaceContext: () => "ctx", providerList: () => [] },
+    logStore: {
+      createLogFile: () => "/tmp/log.txt",
+      appendLog: () => true,
+      closeLog: async () => undefined,
+      onDrain: async () => undefined,
+    },
+    pty: { cancelFor: vi.fn(async () => undefined) },
+    getMainWindow: () => null,
+    providerJobs,
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: partial test doubles
+  registerIpcHandlers(deps as any)
+  return { providerJobs, cli }
+}
+
+function invoke(channel: string, args: Record<string, unknown>) {
+  const handler = handlers.get(channel)
+  if (!handler) throw new Error(`${channel} not registered`)
+  return handler({}, args)
+}
+
+function statusLine(phase: string) {
+  return JSON.stringify({ kind: "status", pipeline: "provider", phase })
+}
+
+describe("provider job lifecycle over IPC", () => {
+  beforeEach(() => {
+    handlers.clear()
+    vi.clearAllMocks()
+  })
+
+  it("clears the job when init succeeds", async () => {
+    const { providerJobs } = setup(() => ({
+      lines: [statusLine("running_init"), statusLine("ready")],
+      code: 0,
+    }))
+
+    await invoke("provider_init", { name: "docker" })
+
+    expect(providerJobs.get("docker")).toBeUndefined()
+  })
+
+  it("records the failure when init fails", async () => {
+    const { providerJobs } = setup(() => ({ lines: [], code: 1 }))
+
+    const result = (await invoke("provider_init", { name: "docker" })) as {
+      ok: boolean
+    }
+
+    expect(result.ok).toBe(false)
+    expect(providerJobs.get("docker")?.error).toBeTruthy()
+  })
+
+  it("leaves the job open after add, for the chained init to close", async () => {
+    // Closing it here would flash the red badge between add and init.
+    const { providerJobs } = setup(() => ({
+      lines: [statusLine("installing_provider")],
+      code: 0,
+    }))
+
+    await invoke("provider_add", { name: "docker" })
+
+    expect(providerJobs.get("docker")?.activity).toBe("installing")
+  })
+
+  it("releases an abandoned job so the card stops spinning", async () => {
+    const { providerJobs } = setup(() => ({ lines: [], code: 0 }))
+
+    await invoke("provider_add", { name: "docker" })
+    expect(providerJobs.get("docker")).toBeDefined()
+
+    await invoke("provider_release_job", { name: "docker" })
+
+    expect(providerJobs.get("docker")).toBeUndefined()
+  })
+
+  it("keeps a failed job's error when released", async () => {
+    const { providerJobs } = setup(() => ({ lines: [], code: 1 }))
+
+    await invoke("provider_init", { name: "docker" })
+    await invoke("provider_release_job", { name: "docker" })
+
+    expect(providerJobs.get("docker")?.error).toBeTruthy()
+  })
+
+  it("runs set-source then init on update, clearing the job once", async () => {
+    const seen: string[][] = []
+    const { providerJobs } = setup((cliArgs) => {
+      seen.push(cliArgs)
+      return { lines: [], code: 0 }
+    })
+
+    await invoke("provider_update", { name: "docker" })
+
+    expect(seen.map((a) => a[1])).toEqual(["set-source", "init"])
+    expect(providerJobs.get("docker")).toBeUndefined()
+  })
+
+  it("records the failure when the update's chained init fails", async () => {
+    const { providerJobs } = setup((cliArgs) => ({
+      lines: [],
+      code: cliArgs[1] === "init" ? 1 : 0,
+    }))
+
+    await expect(
+      invoke("provider_update", { name: "docker" }),
+    ).rejects.toThrow()
+
+    expect(providerJobs.get("docker")?.error).toBeTruthy()
+  })
+})

--- a/desktop/src/main/__tests__/ipc-workspace-jobs.test.ts
+++ b/desktop/src/main/__tests__/ipc-workspace-jobs.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment node
+import { EventEmitter } from "node:events"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ProviderJobs } from "../provider-jobs.js"
+import { WorkspaceJobs } from "../workspace-jobs.js"
+
+const handlers = new Map<string, (...args: unknown[]) => unknown>()
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp", getVersion: () => "0.0.0" },
+  dialog: {},
+  ipcMain: {
+    handle: (channel: string, fn: (...args: unknown[]) => unknown) => {
+      handlers.set(channel, fn)
+    },
+    on: () => undefined,
+  },
+}))
+
+vi.mock("../analytics.js", () => ({
+  hashWorkspaceRef: (v: string) => v,
+  trackEvent: () => undefined,
+}))
+
+const { registerIpcHandlers } = await import("../ipc.js")
+
+function fakeChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    exitCode: number | null
+    signalCode: string | null
+    kill: () => void
+  }
+  child.exitCode = null
+  child.signalCode = null
+  child.kill = () => undefined
+  return child
+}
+
+function setup(exitCode = 0) {
+  const workspaceJobs = new WorkspaceJobs()
+  const cli = {
+    run: vi.fn(async () => []),
+    runRaw: vi.fn(async () => ""),
+    runStreaming: vi.fn(
+      async (
+        _cliArgs: string[],
+        _onLine: (line: string, stream: "stdout" | "stderr") => void,
+        onExit: (code: number, cliError?: unknown) => void,
+      ) => {
+        const child = fakeChild()
+        setTimeout(() => {
+          onExit(exitCode, exitCode === 0 ? undefined : { message: "boom" })
+        }, 0)
+        return child
+      },
+    ),
+    cancelFor: vi.fn(async () => undefined),
+  }
+  const deps = {
+    cli,
+    state: { workspaceContext: () => "ctx", providerList: () => [] },
+    logStore: {
+      createLogFile: () => "/tmp/log.txt",
+      appendLog: () => true,
+      closeLog: async () => undefined,
+      onDrain: async () => undefined,
+    },
+    pty: { cancelFor: vi.fn(async () => undefined) },
+    getMainWindow: () => null,
+    providerJobs: new ProviderJobs(),
+    workspaceJobs,
+  }
+  // biome-ignore lint/suspicious/noExplicitAny: partial test doubles
+  registerIpcHandlers(deps as any)
+  return { workspaceJobs }
+}
+
+function invoke(channel: string, args: Record<string, unknown>) {
+  const handler = handlers.get(channel)
+  if (!handler) throw new Error(`${channel} not registered`)
+  return handler({}, args)
+}
+
+function waitForExitCallback(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 10))
+}
+
+describe("workspace delete job lifecycle over IPC", () => {
+  beforeEach(() => {
+    handlers.clear()
+    vi.clearAllMocks()
+  })
+
+  it("shows a deleting job while the command runs, then clears it", async () => {
+    const { workspaceJobs } = setup(0)
+
+    // workspace_delete resolves as soon as the CLI command is launched, well
+    // before it exits — the job must already be visible at that point.
+    await invoke("workspace_delete", { workspaceId: "ws1" })
+    expect(workspaceJobs.get("ws1")).toEqual({ activity: "deleting" })
+
+    await waitForExitCallback()
+
+    expect(workspaceJobs.get("ws1")).toBeUndefined()
+  })
+
+  it("retains the failure when the delete command fails", async () => {
+    const { workspaceJobs } = setup(1)
+
+    await invoke("workspace_delete", { workspaceId: "ws1" })
+    await waitForExitCallback()
+
+    expect(workspaceJobs.get("ws1")?.error).toBe("boom")
+  })
+})

--- a/desktop/src/main/__tests__/ipc-workspace-jobs.test.ts
+++ b/desktop/src/main/__tests__/ipc-workspace-jobs.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { EventEmitter } from "node:events"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { ProviderJobs } from "../provider-jobs.js"
 import { WorkspaceJobs } from "../workspace-jobs.js"
 
@@ -81,14 +81,15 @@ function invoke(channel: string, args: Record<string, unknown>) {
   return handler({}, args)
 }
 
-function waitForExitCallback(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 10))
-}
-
 describe("workspace delete job lifecycle over IPC", () => {
   beforeEach(() => {
     handlers.clear()
     vi.clearAllMocks()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   it("shows a deleting job while the command runs, then clears it", async () => {
@@ -99,7 +100,9 @@ describe("workspace delete job lifecycle over IPC", () => {
     await invoke("workspace_delete", { workspaceId: "ws1" })
     expect(workspaceJobs.get("ws1")).toEqual({ activity: "deleting" })
 
-    await waitForExitCallback()
+    // Deterministically flush the mock's exit callback instead of racing it
+    // against a fixed wall-clock wait.
+    await vi.runAllTimersAsync()
 
     expect(workspaceJobs.get("ws1")).toBeUndefined()
   })
@@ -108,7 +111,7 @@ describe("workspace delete job lifecycle over IPC", () => {
     const { workspaceJobs } = setup(1)
 
     await invoke("workspace_delete", { workspaceId: "ws1" })
-    await waitForExitCallback()
+    await vi.runAllTimersAsync()
 
     expect(workspaceJobs.get("ws1")?.error).toBe("boom")
   })

--- a/desktop/src/main/__tests__/provider-jobs.test.ts
+++ b/desktop/src/main/__tests__/provider-jobs.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { ProviderJobs } from "../provider-jobs.js"
+
+describe("ProviderJobs", () => {
+  let jobs: ProviderJobs
+
+  beforeEach(() => {
+    jobs = new ProviderJobs()
+  })
+
+  it("tracks activity and phase transitions", async () => {
+    jobs.start("docker", "installing")
+    expect(jobs.get("docker")).toEqual({ activity: "installing" })
+
+    jobs.report("docker", "installing_provider")
+    expect(jobs.get("docker")).toEqual({
+      activity: "installing",
+      phase: "installing_provider",
+    })
+
+    await jobs.finish("docker")
+    expect(jobs.get("docker")).toBeUndefined()
+  })
+
+  it("ignores phase reports for a provider with no active job", () => {
+    jobs.report("docker", "running_init")
+    expect(jobs.get("docker")).toBeUndefined()
+  })
+
+  it("retains the failure so the UI can explain it", async () => {
+    jobs.start("docker", "initializing")
+    await jobs.finish("docker", "init: boom")
+
+    expect(jobs.get("docker")).toEqual({
+      activity: "initializing",
+      phase: "failed",
+      error: "init: boom",
+    })
+  })
+
+  it("does not let a later release erase a recorded failure", async () => {
+    jobs.start("docker", "initializing")
+    await jobs.finish("docker", "init: boom")
+
+    // The wizard closing after a failed init releases the job; that must not
+    // turn the failure into a clean success.
+    await jobs.finish("docker")
+
+    expect(jobs.get("docker")?.error).toBe("init: boom")
+  })
+
+  it("refreshes provider state before clearing a finished job", async () => {
+    // Clearing first would briefly expose initialized:false from the stale
+    // list — the red badge this class exists to prevent.
+    const order: string[] = []
+    jobs.setRefresh(async () => {
+      order.push(`refresh(job=${jobs.get("docker") ? "present" : "gone"})`)
+    })
+
+    jobs.start("docker", "installing")
+    await jobs.finish("docker")
+
+    expect(order).toEqual(["refresh(job=present)"])
+    expect(jobs.get("docker")).toBeUndefined()
+  })
+
+  it("does not clear a newer job started while refresh was in flight", async () => {
+    // refresh is a real CLI round-trip. If a second command starts during it,
+    // the first finish() must not delete the entry the new one is using —
+    // its report() calls would find no job and the card would look idle.
+    let releaseRefresh: (() => void) | undefined
+    jobs.setRefresh(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRefresh = resolve
+        }),
+    )
+
+    jobs.start("docker", "installing")
+    const finishing = jobs.finish("docker")
+
+    // A re-init lands before the first finish resolves.
+    jobs.start("docker", "initializing")
+    releaseRefresh?.()
+    await finishing
+
+    expect(jobs.get("docker")).toEqual({ activity: "initializing" })
+  })
+
+  it("still tracks phases for the superseding job", async () => {
+    let releaseRefresh: (() => void) | undefined
+    jobs.setRefresh(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRefresh = resolve
+        }),
+    )
+
+    jobs.start("docker", "installing")
+    const finishing = jobs.finish("docker")
+    jobs.start("docker", "initializing")
+    releaseRefresh?.()
+    await finishing
+
+    jobs.report("docker", "running_init")
+
+    expect(jobs.get("docker")?.phase).toBe("running_init")
+  })
+
+  it("notifies listeners on every mutation", () => {
+    const listener = vi.fn()
+    jobs.onChange(listener)
+
+    jobs.start("docker", "installing")
+    jobs.report("docker", "installing_provider")
+    jobs.clear("docker")
+
+    expect(listener).toHaveBeenCalledTimes(3)
+  })
+
+  it("does not notify when clearing an untracked provider", () => {
+    const listener = vi.fn()
+    jobs.onChange(listener)
+
+    jobs.clear("nonexistent")
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it("clears a retained failure so a re-added provider starts clean", () => {
+    jobs.start("docker", "installing")
+    jobs.report("docker", "failed", "boom")
+    jobs.clear("docker")
+
+    expect(jobs.get("docker")).toBeUndefined()
+  })
+})

--- a/desktop/src/main/__tests__/provider-jobs.test.ts
+++ b/desktop/src/main/__tests__/provider-jobs.test.ts
@@ -51,8 +51,6 @@ describe("ProviderJobs", () => {
   })
 
   it("refreshes provider state before clearing a finished job", async () => {
-    // Clearing first would briefly expose initialized:false from the stale
-    // list — the red badge this class exists to prevent.
     const order: string[] = []
     jobs.setRefresh(async () => {
       order.push(`refresh(job=${jobs.get("docker") ? "present" : "gone"})`)
@@ -66,9 +64,6 @@ describe("ProviderJobs", () => {
   })
 
   it("does not clear a newer job started while refresh was in flight", async () => {
-    // refresh is a real CLI round-trip. If a second command starts during it,
-    // the first finish() must not delete the entry the new one is using —
-    // its report() calls would find no job and the card would look idle.
     let releaseRefresh: (() => void) | undefined
     jobs.setRefresh(
       () =>
@@ -80,7 +75,6 @@ describe("ProviderJobs", () => {
     jobs.start("docker", "installing")
     const finishing = jobs.finish("docker")
 
-    // A re-init lands before the first finish resolves.
     jobs.start("docker", "initializing")
     releaseRefresh?.()
     await finishing

--- a/desktop/src/main/__tests__/watcher.test.ts
+++ b/desktop/src/main/__tests__/watcher.test.ts
@@ -47,17 +47,31 @@ describe("Watcher.refreshProviders", () => {
     expect(concurrentCalls).toBe(0)
   })
 
-  it("resolves only after a query that started at-or-after the call", async () => {
-    let callCount = 0
+  it("does not start the second query until the first has finished", async () => {
+    // Counting completed queries isn't enough to prove ordering: two
+    // concurrent queries and two serialized ones both finish two queries.
+    // Recording start/end order is what actually distinguishes them.
+    const events: string[] = []
+    let releaseFirst!: () => void
     const { watcher } = makeWatcher(async () => {
-      callCount++
-      await new Promise((r) => setTimeout(r, 10))
+      const id = events.filter((e) => e.startsWith("start")).length + 1
+      events.push(`start-${id}`)
+      if (id === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve
+        })
+      }
+      events.push(`end-${id}`)
       return {}
     })
 
-    const callsBeforeRefresh = callCount
-    await watcher.refreshProviders()
+    const first = watcher.refreshProviders()
+    await Promise.resolve() // let the first query actually start
+    const second = watcher.refreshProviders()
+    await Promise.resolve()
+    releaseFirst()
+    await Promise.all([first, second])
 
-    expect(callCount).toBeGreaterThan(callsBeforeRefresh)
+    expect(events).toEqual(["start-1", "end-1", "start-2", "end-2"])
   })
 })

--- a/desktop/src/main/__tests__/watcher.test.ts
+++ b/desktop/src/main/__tests__/watcher.test.ts
@@ -15,11 +15,13 @@ function makeWatcher(runProviderList: () => Promise<Record<string, unknown>>) {
     }),
   }
   const providerJobs = { snapshot: vi.fn().mockReturnValue({}) }
+  const workspaceJobs = { snapshot: vi.fn().mockReturnValue({}) }
   const watcher = new Watcher({
     cli: cli as never,
     state: state as never,
     getMainWindow: () => null,
     providerJobs: providerJobs as never,
+    workspaceJobs: workspaceJobs as never,
   })
   return { watcher, cli, state }
 }

--- a/desktop/src/main/__tests__/watcher.test.ts
+++ b/desktop/src/main/__tests__/watcher.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest"
+import { Watcher } from "../watcher.js"
+
+function makeWatcher(runProviderList: () => Promise<Record<string, unknown>>) {
+  const state = {
+    updateProviders: vi.fn().mockReturnValue(false),
+    providerList: vi.fn().mockReturnValue([]),
+  }
+  const cli = {
+    run: vi.fn((args: string[]) => {
+      if (args[0] === "provider" && args[1] === "list") {
+        return runProviderList()
+      }
+      return Promise.resolve([])
+    }),
+  }
+  const providerJobs = { snapshot: vi.fn().mockReturnValue({}) }
+  const watcher = new Watcher({
+    cli: cli as never,
+    state: state as never,
+    getMainWindow: () => null,
+    providerJobs: providerJobs as never,
+  })
+  return { watcher, cli, state }
+}
+
+describe("Watcher.refreshProviders", () => {
+  it("does not run concurrently with another in-flight provider query", async () => {
+    // Simulates the race the fix closes: a manual refresh (e.g. after an
+    // install finishes) landing while a scheduled poll's provider query is
+    // still in flight. Both queries hitting the CLI at once could let the
+    // scheduled poll's stale result overwrite the refresh's fresh one.
+    let inFlight = 0
+    let concurrentCalls = 0
+    const { watcher } = makeWatcher(async () => {
+      inFlight++
+      if (inFlight > 1) concurrentCalls++
+      await new Promise((r) => setTimeout(r, 20))
+      inFlight--
+      return {}
+    })
+
+    const first = watcher.refreshProviders()
+    const second = watcher.refreshProviders()
+    await Promise.all([first, second])
+
+    expect(concurrentCalls).toBe(0)
+  })
+
+  it("resolves only after a query that started at-or-after the call", async () => {
+    let callCount = 0
+    const { watcher } = makeWatcher(async () => {
+      callCount++
+      await new Promise((r) => setTimeout(r, 10))
+      return {}
+    })
+
+    const callsBeforeRefresh = callCount
+    await watcher.refreshProviders()
+
+    expect(callCount).toBeGreaterThan(callsBeforeRefresh)
+  })
+})

--- a/desktop/src/main/__tests__/watcher.test.ts
+++ b/desktop/src/main/__tests__/watcher.test.ts
@@ -28,10 +28,6 @@ function makeWatcher(runProviderList: () => Promise<Record<string, unknown>>) {
 
 describe("Watcher.refreshProviders", () => {
   it("does not run concurrently with another in-flight provider query", async () => {
-    // Simulates the race the fix closes: a manual refresh (e.g. after an
-    // install finishes) landing while a scheduled poll's provider query is
-    // still in flight. Both queries hitting the CLI at once could let the
-    // scheduled poll's stale result overwrite the refresh's fresh one.
     let inFlight = 0
     let concurrentCalls = 0
     const { watcher } = makeWatcher(async () => {
@@ -50,9 +46,6 @@ describe("Watcher.refreshProviders", () => {
   })
 
   it("does not start the second query until the first has finished", async () => {
-    // Counting completed queries isn't enough to prove ordering: two
-    // concurrent queries and two serialized ones both finish two queries.
-    // Recording start/end order is what actually distinguishes them.
     const events: string[] = []
     let releaseFirst!: () => void
     const { watcher } = makeWatcher(async () => {

--- a/desktop/src/main/__tests__/workspace-jobs.test.ts
+++ b/desktop/src/main/__tests__/workspace-jobs.test.ts
@@ -10,16 +10,28 @@ describe("WorkspaceJobs", () => {
   })
 
   it("tracks a delete until it finishes", async () => {
-    jobs.start("ws1")
+    const generation = jobs.start("ws1")
     expect(jobs.get("ws1")).toEqual({ activity: "deleting" })
 
-    await jobs.finish("ws1")
+    await jobs.finish("ws1", generation)
     expect(jobs.get("ws1")).toBeUndefined()
   })
 
+  it("does not let a stale failure land on a newer job", async () => {
+    const first = jobs.start("ws1")
+    const second = jobs.start("ws1")
+
+    // A slow/duplicate exit callback for the first delete arrives after a
+    // retry has already started a second one for the same workspace.
+    await jobs.finish("ws1", first, "boom")
+
+    expect(jobs.get("ws1")).toEqual({ activity: "deleting" })
+    expect(second).not.toBe(first)
+  })
+
   it("retains the failure so the UI can explain it", async () => {
-    jobs.start("ws1")
-    await jobs.finish("ws1", "delete exited with code 1")
+    const generation = jobs.start("ws1")
+    await jobs.finish("ws1", generation, "delete exited with code 1")
 
     expect(jobs.get("ws1")).toEqual({
       activity: "deleting",
@@ -28,17 +40,17 @@ describe("WorkspaceJobs", () => {
   })
 
   it("does not let a later release erase a recorded failure", async () => {
-    jobs.start("ws1")
-    await jobs.finish("ws1", "boom")
+    const generation = jobs.start("ws1")
+    await jobs.finish("ws1", generation, "boom")
 
-    await jobs.finish("ws1")
+    await jobs.finish("ws1", generation)
 
     expect(jobs.get("ws1")?.error).toBe("boom")
   })
 
   it("ignores a failure for a workspace with no active job", async () => {
     // e.g. a stale exit callback firing after clear() already ran.
-    await jobs.finish("ws1", "boom")
+    await jobs.finish("ws1", 1, "boom")
     expect(jobs.get("ws1")).toBeUndefined()
   })
 
@@ -50,8 +62,8 @@ describe("WorkspaceJobs", () => {
       order.push(`refresh(job=${jobs.get("ws1") ? "present" : "gone"})`)
     })
 
-    jobs.start("ws1")
-    await jobs.finish("ws1")
+    const generation = jobs.start("ws1")
+    await jobs.finish("ws1", generation)
 
     expect(order).toEqual(["refresh(job=present)"])
     expect(jobs.get("ws1")).toBeUndefined()
@@ -66,8 +78,8 @@ describe("WorkspaceJobs", () => {
         }),
     )
 
-    jobs.start("ws1")
-    const finishing = jobs.finish("ws1")
+    const generation = jobs.start("ws1")
+    const finishing = jobs.finish("ws1", generation)
 
     // A new delete for the same id is submitted before the first finish
     // resolves (e.g. a quick retry after the first attempt looked stuck).

--- a/desktop/src/main/__tests__/workspace-jobs.test.ts
+++ b/desktop/src/main/__tests__/workspace-jobs.test.ts
@@ -21,8 +21,6 @@ describe("WorkspaceJobs", () => {
     const first = jobs.start("ws1")
     const second = jobs.start("ws1")
 
-    // A slow/duplicate exit callback for the first delete arrives after a
-    // retry has already started a second one for the same workspace.
     await jobs.finish("ws1", first, "boom")
 
     expect(jobs.get("ws1")).toEqual({ activity: "deleting" })
@@ -49,14 +47,11 @@ describe("WorkspaceJobs", () => {
   })
 
   it("ignores a failure for a workspace with no active job", async () => {
-    // e.g. a stale exit callback firing after clear() already ran.
     await jobs.finish("ws1", 1, "boom")
     expect(jobs.get("ws1")).toBeUndefined()
   })
 
   it("refreshes the workspace list before clearing a finished job", async () => {
-    // Clearing first would briefly show the deleted workspace as still
-    // present from the stale list.
     const order: string[] = []
     jobs.setRefresh(async () => {
       order.push(`refresh(job=${jobs.get("ws1") ? "present" : "gone"})`)
@@ -81,8 +76,6 @@ describe("WorkspaceJobs", () => {
     const generation = jobs.start("ws1")
     const finishing = jobs.finish("ws1", generation)
 
-    // A new delete for the same id is submitted before the first finish
-    // resolves (e.g. a quick retry after the first attempt looked stuck).
     jobs.start("ws1")
     releaseRefresh?.()
     await finishing

--- a/desktop/src/main/__tests__/workspace-jobs.test.ts
+++ b/desktop/src/main/__tests__/workspace-jobs.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment node
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { WorkspaceJobs } from "../workspace-jobs.js"
+
+describe("WorkspaceJobs", () => {
+  let jobs: WorkspaceJobs
+
+  beforeEach(() => {
+    jobs = new WorkspaceJobs()
+  })
+
+  it("tracks a delete until it finishes", async () => {
+    jobs.start("ws1")
+    expect(jobs.get("ws1")).toEqual({ activity: "deleting" })
+
+    await jobs.finish("ws1")
+    expect(jobs.get("ws1")).toBeUndefined()
+  })
+
+  it("retains the failure so the UI can explain it", async () => {
+    jobs.start("ws1")
+    await jobs.finish("ws1", "delete exited with code 1")
+
+    expect(jobs.get("ws1")).toEqual({
+      activity: "deleting",
+      error: "delete exited with code 1",
+    })
+  })
+
+  it("does not let a later release erase a recorded failure", async () => {
+    jobs.start("ws1")
+    await jobs.finish("ws1", "boom")
+
+    await jobs.finish("ws1")
+
+    expect(jobs.get("ws1")?.error).toBe("boom")
+  })
+
+  it("ignores a failure for a workspace with no active job", async () => {
+    // e.g. a stale exit callback firing after clear() already ran.
+    await jobs.finish("ws1", "boom")
+    expect(jobs.get("ws1")).toBeUndefined()
+  })
+
+  it("refreshes the workspace list before clearing a finished job", async () => {
+    // Clearing first would briefly show the deleted workspace as still
+    // present from the stale list.
+    const order: string[] = []
+    jobs.setRefresh(async () => {
+      order.push(`refresh(job=${jobs.get("ws1") ? "present" : "gone"})`)
+    })
+
+    jobs.start("ws1")
+    await jobs.finish("ws1")
+
+    expect(order).toEqual(["refresh(job=present)"])
+    expect(jobs.get("ws1")).toBeUndefined()
+  })
+
+  it("does not clear a newer job started while refresh was in flight", async () => {
+    let releaseRefresh: (() => void) | undefined
+    jobs.setRefresh(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRefresh = resolve
+        }),
+    )
+
+    jobs.start("ws1")
+    const finishing = jobs.finish("ws1")
+
+    // A new delete for the same id is submitted before the first finish
+    // resolves (e.g. a quick retry after the first attempt looked stuck).
+    jobs.start("ws1")
+    releaseRefresh?.()
+    await finishing
+
+    expect(jobs.get("ws1")).toEqual({ activity: "deleting" })
+  })
+
+  it("notifies listeners on every mutation", () => {
+    const listener = vi.fn()
+    jobs.onChange(listener)
+
+    jobs.start("ws1")
+    jobs.clear("ws1")
+
+    expect(listener).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not notify when clearing an untracked workspace", () => {
+    const listener = vi.fn()
+    jobs.onChange(listener)
+
+    jobs.clear("nonexistent")
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/desktop/src/main/cli.ts
+++ b/desktop/src/main/cli.ts
@@ -297,7 +297,11 @@ export class CliRunner {
       })
     }
 
-    child.on("close", (code) => {
+    let settled = false
+    const finish = (code: number, cliError?: CLIError): void => {
+      // "error" and "close" can both fire; report the outcome once.
+      if (settled) return
+      settled = true
       this.activeChildren.delete(child)
       if (workspaceId) {
         const bucket = this.childrenByWorkspace.get(workspaceId)
@@ -307,7 +311,18 @@ export class CliRunner {
         }
       }
       this.release()
-      onExit(code ?? -1, lastCliError)
+      onExit(code, cliError)
+    }
+
+    // A spawn failure (missing binary, EACCES) emits "error" and never
+    // "close". Without this, onExit never fires: callers that wrap this in a
+    // promise hang forever, and the concurrency slot is never released.
+    child.on("error", (err) => {
+      finish(-1, { code: "spawn_failed", message: err.message })
+    })
+
+    child.on("close", (code) => {
+      finish(code ?? -1, lastCliError)
     })
 
     return child

--- a/desktop/src/main/cli.ts
+++ b/desktop/src/main/cli.ts
@@ -299,7 +299,6 @@ export class CliRunner {
 
     let settled = false
     const finish = (code: number, cliError?: CLIError): void => {
-      // "error" and "close" can both fire; report the outcome once.
       if (settled) return
       settled = true
       this.activeChildren.delete(child)

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -162,12 +162,7 @@ app.whenReady().then(() => {
     stopAutoUpdater()
   })
 
-  // Shared between the IPC handlers that run provider commands and the
-  // watcher that broadcasts provider state, so in-flight work is reported
-  // alongside what's on disk.
   const providerJobs = new ProviderJobs()
-  // Same idea for workspace delete, which is fire-and-forget from the IPC
-  // handler's perspective.
   const workspaceJobs = new WorkspaceJobs()
 
   // Register IPC handlers
@@ -194,8 +189,6 @@ app.whenReady().then(() => {
     providerJobs,
     workspaceJobs,
   })
-  // Phase transitions are pushed immediately rather than waiting for the
-  // next disk poll, which is what made the old badge lag visible.
   providerJobs.onChange(() => watcher.broadcastProviders())
   providerJobs.setRefresh(() => watcher.refreshProviders())
   workspaceJobs.onChange(() => watcher.broadcastWorkspaces())

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -6,6 +6,7 @@ import { CliRunner } from "./cli.js"
 import { DaemonManager } from "./daemon-manager.js"
 import { registerIpcHandlers } from "./ipc.js"
 import { LogStore } from "./log-store.js"
+import { ProviderJobs } from "./provider-jobs.js"
 import { PtyManager } from "./pty.js"
 import { DaemonState } from "./state.js"
 import { AppTray } from "./tray.js"
@@ -160,6 +161,11 @@ app.whenReady().then(() => {
     stopAutoUpdater()
   })
 
+  // Shared between the IPC handlers that run provider commands and the
+  // watcher that broadcasts provider state, so in-flight work is reported
+  // alongside what's on disk.
+  const providerJobs = new ProviderJobs()
+
   // Register IPC handlers
   const {
     tunnelProcesses,
@@ -171,6 +177,7 @@ app.whenReady().then(() => {
     logStore,
     pty: ptyManager,
     getMainWindow: () => mainWindow,
+    providerJobs,
   })
 
   // Start state watcher
@@ -179,7 +186,13 @@ app.whenReady().then(() => {
     daemon: daemonManager.daemonClient,
     state,
     getMainWindow: () => mainWindow,
+    providerJobs,
   })
+  // Phase transitions are pushed immediately rather than waiting for the
+  // next disk poll, which is what made the old badge lag visible.
+  providerJobs.onChange(() => watcher.broadcastProviders())
+  providerJobs.setRefresh(() => watcher.refreshProviders())
+
   void watcher.start().then(runInitialProviderUpdateCheck)
   scheduleProviderUpdateCheck()
 

--- a/desktop/src/main/index.ts
+++ b/desktop/src/main/index.ts
@@ -12,6 +12,7 @@ import { DaemonState } from "./state.js"
 import { AppTray } from "./tray.js"
 import { initAutoUpdater, stopAutoUpdater } from "./updater.js"
 import { Watcher } from "./watcher.js"
+import { WorkspaceJobs } from "./workspace-jobs.js"
 
 const PROTOCOL = "devsy"
 
@@ -165,6 +166,9 @@ app.whenReady().then(() => {
   // watcher that broadcasts provider state, so in-flight work is reported
   // alongside what's on disk.
   const providerJobs = new ProviderJobs()
+  // Same idea for workspace delete, which is fire-and-forget from the IPC
+  // handler's perspective.
+  const workspaceJobs = new WorkspaceJobs()
 
   // Register IPC handlers
   const {
@@ -178,6 +182,7 @@ app.whenReady().then(() => {
     pty: ptyManager,
     getMainWindow: () => mainWindow,
     providerJobs,
+    workspaceJobs,
   })
 
   // Start state watcher
@@ -187,11 +192,14 @@ app.whenReady().then(() => {
     state,
     getMainWindow: () => mainWindow,
     providerJobs,
+    workspaceJobs,
   })
   // Phase transitions are pushed immediately rather than waiting for the
   // next disk poll, which is what made the old badge lag visible.
   providerJobs.onChange(() => watcher.broadcastProviders())
   providerJobs.setRefresh(() => watcher.refreshProviders())
+  workspaceJobs.onChange(() => watcher.broadcastWorkspaces())
+  workspaceJobs.setRefresh(() => watcher.refreshWorkspaces())
 
   void watcher.start().then(runInitialProviderUpdateCheck)
   scheduleProviderUpdateCheck()

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -294,29 +294,31 @@ export function registerIpcHandlers(deps: IpcDependencies): {
     cliArgs: string[],
   ): Promise<void> {
     return new Promise((resolve, reject) => {
-      void cli.runStreaming(
-        cliArgs,
-        (line, stream) => {
-          if (stream !== "stdout") return
-          const envelope = parseCliEnvelope(line)
-          if (envelope?.kind === "status") {
-            providerJobs.report(
-              name,
-              envelope.phase as ProviderPhase,
-              envelope.error,
-            )
-          }
-        },
-        (code, cliError) => {
-          if (code === 0) {
-            resolve()
-            return
-          }
-          const message =
-            cliError?.message ?? `${cliArgs.join(" ")} exited with ${code}`
-          reject(Object.assign(new Error(message), { cliError }))
-        },
-      )
+      cli
+        .runStreaming(
+          cliArgs,
+          (line, stream) => {
+            if (stream !== "stdout") return
+            const envelope = parseCliEnvelope(line)
+            if (envelope?.kind === "status") {
+              providerJobs.report(
+                name,
+                envelope.phase as ProviderPhase,
+                envelope.error,
+              )
+            }
+          },
+          (code, cliError) => {
+            if (code === 0) {
+              resolve()
+              return
+            }
+            const message =
+              cliError?.message ?? `${cliArgs.join(" ")} exited with ${code}`
+            reject(Object.assign(new Error(message), { cliError }))
+          },
+        )
+        .catch(reject)
     })
   }
 

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -273,15 +273,16 @@ export function registerIpcHandlers(deps: IpcDependencies): {
     fn: () => Promise<T>,
   ): Promise<T> {
     providerJobs.start(name, activity)
+    let result: T
     try {
-      const result = await fn()
-      await providerJobs.finish(name)
-      return result
+      result = await fn()
     } catch (error) {
       const cliError = (error as { cliError?: CLIError }).cliError
       await providerJobs.finish(name, cliError?.message ?? errorMessage(error))
       throw error
     }
+    await providerJobs.finish(name)
+    return result
   }
 
   /**

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -1134,7 +1134,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
       // The card shows "Deleting" until finish() below, whether this
       // succeeds or fails — a failure still leaves the card able to explain
       // why instead of reverting to idle with no context.
-      workspaceJobs.start(args.workspaceId)
+      const jobGeneration = workspaceJobs.start(args.workspaceId)
 
       cli.runStreaming(
         cliArgs,
@@ -1148,6 +1148,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
           )
           void workspaceJobs.finish(
             args.workspaceId,
+            jobGeneration,
             code === 0
               ? undefined
               : cliError?.message ?? `delete exited with code ${code}`,

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -10,6 +10,11 @@ import type { CLIError } from "../shared/cli-error.js"
 import { parseCliEnvelope } from "../shared/cli-error.js"
 import { hashWorkspaceRef, trackEvent } from "./analytics.js"
 import { loadCatalog } from "./image-catalog.js"
+import type {
+  ProviderActivity,
+  ProviderJobs,
+  ProviderPhase,
+} from "./provider-jobs.js"
 import type { CliRunner } from "./cli.js"
 import type { LogStore } from "./log-store.js"
 import type { PtyManager } from "./pty.js"
@@ -90,6 +95,7 @@ interface IpcDependencies {
   logStore: LogStore
   pty: PtyManager
   getMainWindow: () => BrowserWindow | null
+  providerJobs: ProviderJobs
 }
 
 /** Format a line in zap console format so log-parser.ts can parse it. */
@@ -101,7 +107,11 @@ interface ProgressSink {
   line(formatted: string): boolean
   done(
     finalLine: string,
-    extra?: { level?: "info" | "warn" | "error"; cliError?: CLIError },
+    extra?: {
+      level?: "info" | "warn" | "error"
+      cliError?: CLIError
+      success?: boolean
+    },
   ): Promise<void>
 }
 
@@ -122,6 +132,7 @@ function createLogSink(
       message?: string
       level?: "info" | "warn" | "error"
       cliError?: CLIError
+      success?: boolean
     },
   ): void {
     if (timer) {
@@ -161,7 +172,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
   scheduleProviderUpdateCheck: () => void
   runInitialProviderUpdateCheck: () => void
 } {
-  const { cli, state, logStore, pty } = deps
+  const { cli, state, logStore, pty, providerJobs } = deps
   const tunnelProcesses = new Map<
     string,
     import("node:child_process").ChildProcess
@@ -240,6 +251,72 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         cli.cancelFor(workspaceId),
         pty.cancelFor(workspaceId),
       ])
+    })
+  }
+
+  function errorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error)
+  }
+
+  /**
+   * Track a provider job for the duration of fn, so the job cannot outlive the
+   * work it describes. Opening a job in one place and closing it in another
+   * leaves the card spinning forever on any path that forgets — prefer this to
+   * calling start/finish by hand.
+   *
+   * Errors are recorded on the job and rethrown, leaving the caller's own
+   * error handling intact.
+   */
+  async function withProviderJob<T>(
+    name: string,
+    activity: ProviderActivity,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    providerJobs.start(name, activity)
+    try {
+      const result = await fn()
+      await providerJobs.finish(name)
+      return result
+    } catch (error) {
+      const cliError = (error as { cliError?: CLIError }).cliError
+      await providerJobs.finish(name, cliError?.message ?? errorMessage(error))
+      throw error
+    }
+  }
+
+  /**
+   * Run a provider CLI command, feeding its NDJSON status lines into the job
+   * registry so the UI tracks phases as they happen instead of only learning
+   * the outcome at exit.
+   */
+  function runProviderWithStatus(
+    name: string,
+    cliArgs: string[],
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      void cli.runStreaming(
+        cliArgs,
+        (line, stream) => {
+          if (stream !== "stdout") return
+          const envelope = parseCliEnvelope(line)
+          if (envelope?.kind === "status") {
+            providerJobs.report(
+              name,
+              envelope.phase as ProviderPhase,
+              envelope.error,
+            )
+          }
+        },
+        (code, cliError) => {
+          if (code === 0) {
+            resolve()
+            return
+          }
+          const message =
+            cliError?.message ?? `${cliArgs.join(" ")} exited with ${code}`
+          reject(Object.assign(new Error(message), { cliError }))
+        },
+      )
     })
   }
 
@@ -361,14 +438,36 @@ export function registerIpcHandlers(deps: IpcDependencies): {
       if (args.singleMachine) {
         cliArgs.push("--single-machine")
       }
-      await cli.runRaw(cliArgs)
+
+      // Not withProviderJob: the job outlives this call so the badge stays busy
+      // until the wizard's chained provider_init finishes. The opener closes it,
+      // via provider_release_job on any path that abandons the install.
+      providerJobs.start(args.name, "installing")
+      try {
+        await runProviderWithStatus(args.name, cliArgs)
+      } catch (error) {
+        await providerJobs.finish(args.name, errorMessage(error))
+        throw error
+      }
     },
   )
 
   ipcMain.handle("provider_delete", async (_event, args: { name: string }) => {
     trackEvent("provider_delete")
     await cli.runRaw(["provider", "delete", args.name])
+    // Drop any retained failure so a re-added provider starts clean.
+    providerJobs.clear(args.name)
   })
+
+  // Releases a job the caller opened but will not finish — e.g. the wizard
+  // installs a provider, then the user skips initialization or closes the
+  // dialog. Without this the card would spin on "installing…" indefinitely.
+  ipcMain.handle(
+    "provider_release_job",
+    async (_event, args: { name: string }) => {
+      await providerJobs.finish(args.name)
+    },
+  )
 
   ipcMain.handle("provider_use", async (_event, args: { name: string }) => {
     await cli.runRaw(["provider", "use", args.name])
@@ -380,12 +479,13 @@ export function registerIpcHandlers(deps: IpcDependencies): {
   // own-properties, so a thrown Error with a .cliError attached would lose it.
   ipcMain.handle("provider_init", async (_event, args: { name: string }) => {
     try {
-      await cli.runRaw(["provider", "init", args.name])
+      await withProviderJob(args.name, "initializing", () =>
+        runProviderWithStatus(args.name, ["provider", "init", args.name]),
+      )
       return { ok: true } as const
     } catch (err) {
       const cliError = (err as { cliError?: CLIError }).cliError
-      const message = err instanceof Error ? err.message : String(err)
-      return { ok: false, message, cliError } as const
+      return { ok: false, message: errorMessage(err), cliError } as const
     }
   })
 
@@ -395,9 +495,24 @@ export function registerIpcHandlers(deps: IpcDependencies): {
       const cmdId = crypto.randomUUID()
       const win = deps.getMainWindow()
 
+      // Not withProviderJob: the job outlives the handler, closed from onExit.
+      providerJobs.start(args.name, "initializing")
       await cli.runStreaming(
         ["provider", "init", args.name],
-        (line, _stream, meta) => {
+        (line, stream, meta) => {
+          // Status envelopes drive the job registry; everything else is log
+          // text for the wizard's output pane.
+          if (stream === "stdout") {
+            const envelope = parseCliEnvelope(line)
+            if (envelope?.kind === "status") {
+              providerJobs.report(
+                args.name,
+                envelope.phase as ProviderPhase,
+                envelope.error,
+              )
+              return
+            }
+          }
           const formatted = formatLogLine(line)
           win?.webContents.send("command-progress", {
             commandId: cmdId,
@@ -406,7 +521,15 @@ export function registerIpcHandlers(deps: IpcDependencies): {
             done: false,
           })
         },
-        (code, cliError) => {
+        async (code, cliError) => {
+          // Finish first: it refreshes the provider list, so the wizard's
+          // done signal can't arrive while the card still reads uninitialized.
+          await providerJobs.finish(
+            args.name,
+            code === 0
+              ? undefined
+              : (cliError?.message ?? `provider init exited with ${code}`),
+          )
           const exitMsg = formatLogLine(
             `Exit code: ${code}`,
             code === 0 ? "INFO" : "ERROR",
@@ -415,6 +538,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
             commandId: cmdId,
             message: exitMsg,
             level: code === 0 ? "info" : "error",
+            success: code === 0,
             cliError,
             done: true,
           })
@@ -425,8 +549,19 @@ export function registerIpcHandlers(deps: IpcDependencies): {
     },
   )
 
+  // set-source installs replacement binaries and clears Initialized, since
+  // the new binary has not run its init. Chain init so the provider ends up
+  // usable rather than sitting in a needs-re-init state the user must notice.
   ipcMain.handle("provider_update", async (_event, args: { name: string }) => {
-    await cli.runRaw(["provider", "set-source", args.name, "--use=false"])
+    await withProviderJob(args.name, "updating", async () => {
+      await runProviderWithStatus(args.name, [
+        "provider",
+        "set-source",
+        args.name,
+        "--use=false",
+      ])
+      await runProviderWithStatus(args.name, ["provider", "init", args.name])
+    })
   })
 
   ipcMain.handle("provider_options", async (_event, args: { name: string }) => {
@@ -485,13 +620,18 @@ export function registerIpcHandlers(deps: IpcDependencies): {
   ipcMain.handle(
     "provider_set_version",
     async (_event, args: { name: string; tag: string }) => {
-      await cli.runRaw([
-        "provider",
-        "set-source",
-        args.name,
-        "--version",
-        args.tag,
-      ])
+      // Pinning a version swaps binaries via the same update path, so it
+      // clears Initialized and needs the same re-init as a source change.
+      await withProviderJob(args.name, "updating", async () => {
+        await runProviderWithStatus(args.name, [
+          "provider",
+          "set-source",
+          args.name,
+          "--version",
+          args.tag,
+        ])
+        await runProviderWithStatus(args.name, ["provider", "init", args.name])
+      })
     },
   )
 
@@ -813,6 +953,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
           const err = error as Error & { cliError?: CLIError }
           void sink.done(formatLogLine(err.message, "ERROR"), {
             level: "error",
+            success: false,
             cliError: err.cliError ?? {
               code: "up_failed",
               message: err.message,
@@ -859,7 +1000,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
               if (envelope?.kind === "result") {
                 signalledDone = true
                 releaseTask()
-                void sink.done(formatted)
+                void sink.done(formatted, { success: true })
                 return
               }
 
@@ -868,6 +1009,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
                 releaseTask()
                 void sink.done(formatted, {
                   level: "error",
+                  success: false,
                   cliError: { code: "up_failed", message: envelope.message },
                 })
                 return
@@ -887,7 +1029,9 @@ export function registerIpcHandlers(deps: IpcDependencies): {
                   `Exit code: ${code}`,
                   code === 0 ? "INFO" : "ERROR",
                 ),
-                code === 0 ? undefined : { level: "error", cliError },
+                code === 0
+                  ? { success: true }
+                  : { level: "error", success: false, cliError },
               )
             },
             wsId,
@@ -899,6 +1043,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
           const err = error as Error & { cliError?: CLIError }
           void sink.done(formatLogLine(err.message, "ERROR"), {
             level: "error",
+            success: false,
             cliError: err.cliError ?? {
               code: "up_follow_failed",
               message: err.message,
@@ -943,6 +1088,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         (code) => {
           void sink.done(
             formatLogLine(`Exit code: ${code}`, code === 0 ? "INFO" : "ERROR"),
+            { success: code === 0 },
           )
         },
         args.workspaceId,
@@ -988,6 +1134,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         (code) => {
           void sink.done(
             formatLogLine(`Exit code: ${code}`, code === 0 ? "INFO" : "ERROR"),
+            { success: code === 0 },
           )
         },
         args.workspaceId,
@@ -1026,7 +1173,9 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         (code, cliError) => {
           void sink.done(
             formatLogLine(`Exit code: ${code}`, code === 0 ? "INFO" : "ERROR"),
-            code === 0 ? undefined : { level: "error", cliError },
+            code === 0
+              ? { success: true }
+              : { level: "error", success: false, cliError },
           )
         },
         args.workspaceId,
@@ -1065,7 +1214,9 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         (code, cliError) => {
           void sink.done(
             formatLogLine(`Exit code: ${code}`, code === 0 ? "INFO" : "ERROR"),
-            code === 0 ? undefined : { level: "error", cliError },
+            code === 0
+              ? { success: true }
+              : { level: "error", success: false, cliError },
           )
         },
         args.workspaceId,

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -32,6 +32,7 @@ import {
   setReleaseChannel,
 } from "./updater.js"
 import { type ProviderEntry, parseProviderEntries } from "./watcher.js"
+import type { WorkspaceJobs } from "./workspace-jobs.js"
 
 const execFileAsync = promisify(execFile)
 
@@ -96,6 +97,7 @@ interface IpcDependencies {
   pty: PtyManager
   getMainWindow: () => BrowserWindow | null
   providerJobs: ProviderJobs
+  workspaceJobs: WorkspaceJobs
 }
 
 /** Format a line in zap console format so log-parser.ts can parse it. */
@@ -172,7 +174,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
   scheduleProviderUpdateCheck: () => void
   runInitialProviderUpdateCheck: () => void
 } {
-  const { cli, state, logStore, pty, providerJobs } = deps
+  const { cli, state, logStore, pty, providerJobs, workspaceJobs } = deps
   const tunnelProcesses = new Map<
     string,
     import("node:child_process").ChildProcess
@@ -1129,15 +1131,26 @@ export function registerIpcHandlers(deps: IpcDependencies): {
       if (args.debug) cliArgs.push("--debug")
       cliArgs.push("--force")
 
+      // The card shows "Deleting" until finish() below, whether this
+      // succeeds or fails — a failure still leaves the card able to explain
+      // why instead of reverting to idle with no context.
+      workspaceJobs.start(args.workspaceId)
+
       cli.runStreaming(
         cliArgs,
         (line) => {
           if (!sink.line(formatLogLine(line))) return logStore.onDrain(logPath)
         },
-        (code) => {
+        (code, cliError) => {
           void sink.done(
             formatLogLine(`Exit code: ${code}`, code === 0 ? "INFO" : "ERROR"),
             { success: code === 0 },
+          )
+          void workspaceJobs.finish(
+            args.workspaceId,
+            code === 0
+              ? undefined
+              : cliError?.message ?? `delete exited with code ${code}`,
           )
         },
         args.workspaceId,

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -263,8 +263,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
   /**
    * Track a provider job for the duration of fn, so the job cannot outlive the
    * work it describes. Opening a job in one place and closing it in another
-   * leaves the card spinning forever on any path that forgets — prefer this to
-   * calling start/finish by hand.
+   * leaves the card spinning forever on any path that forgets.
    *
    * Errors are recorded on the job and rethrown, leaving the caller's own
    * error handling intact.
@@ -1131,9 +1130,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
       if (args.debug) cliArgs.push("--debug")
       cliArgs.push("--force")
 
-      // The card shows "Deleting" until finish() below, whether this
-      // succeeds or fails — a failure still leaves the card able to explain
-      // why instead of reverting to idle with no context.
+      // The card shows "Deleting" until finish() below
       const jobGeneration = workspaceJobs.start(args.workspaceId)
 
       cli.runStreaming(

--- a/desktop/src/main/provider-jobs.ts
+++ b/desktop/src/main/provider-jobs.ts
@@ -88,8 +88,9 @@ export class ProviderJobs {
   async finish(name: string, error?: string): Promise<void> {
     if (error) {
       const job = this.jobs.get(name)
+      if (!job) return
       this.jobs.set(name, {
-        activity: job?.activity ?? "initializing",
+        activity: job.activity,
         phase: "failed",
         error,
       })

--- a/desktop/src/main/provider-jobs.ts
+++ b/desktop/src/main/provider-jobs.ts
@@ -11,7 +11,7 @@
  * which is exactly when a multi-second install is still running.
  */
 
-/** Phases emitted by the Go provider pipeline (pkg/status). */
+/** Phases emitted by the Go provider pipeline. */
 export type ProviderPhase =
   | "installing_provider"
   | "resolving_options"

--- a/desktop/src/main/provider-jobs.ts
+++ b/desktop/src/main/provider-jobs.ts
@@ -1,0 +1,132 @@
+/**
+ * Tracks in-flight provider install/init/update work in the main process.
+ *
+ * The persisted `initialized` flag answers "is this provider usable", which
+ * is false both for a provider the user never initialized and for one being
+ * installed right now. Those render very differently, so the transient half
+ * of the lifecycle lives here rather than being inferred from disk state.
+ *
+ * Main-process ownership is deliberate: a renderer-local pending set is lost
+ * when the wizard closes, the user navigates away, or the window reloads,
+ * which is exactly when a multi-second install is still running.
+ */
+
+/** Phases emitted by the Go provider pipeline (pkg/status). */
+export type ProviderPhase =
+  | "installing_provider"
+  | "resolving_options"
+  | "running_init"
+  | "ready"
+  | "failed"
+
+export type ProviderActivity = "installing" | "initializing" | "updating"
+
+export interface ProviderJob {
+  activity: ProviderActivity
+  phase?: ProviderPhase
+  /** Set when the job ended in failure; the job is retained so the UI can show why. */
+  error?: string
+}
+
+export class ProviderJobs {
+  private jobs = new Map<string, ProviderJob>()
+  // Lets an in-flight finish() tell whether it still owns the entry.
+  private generations = new Map<string, number>()
+  private lastGeneration = 0
+  private listeners = new Set<() => void>()
+
+  /**
+   * Register a callback fired after every mutation, so a phase transition
+   * reaches the renderer without waiting for the next 3s disk poll.
+   */
+  onChange(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) listener()
+  }
+
+  /** Begin tracking work on a provider, clearing any previous failure. */
+  start(name: string, activity: ProviderActivity): void {
+    this.jobs.set(name, { activity })
+    this.generations.set(name, ++this.lastGeneration)
+    this.emit()
+  }
+
+  /**
+   * Record a phase transition. Ignored when no job is active, so a stray
+   * event can't resurrect a provider the UI already considers settled.
+   */
+  report(name: string, phase: ProviderPhase, error?: string): void {
+    const job = this.jobs.get(name)
+    if (!job) return
+    if (phase === "failed") {
+      this.jobs.set(name, { ...job, phase, error: error ?? "failed" })
+    } else {
+      this.jobs.set(name, { ...job, phase })
+    }
+    this.emit()
+  }
+
+  /** Stop tracking a provider, discarding any recorded failure. */
+  clear(name: string): void {
+    this.generations.delete(name)
+    if (this.jobs.delete(name)) this.emit()
+  }
+
+  /**
+   * Finish a job. A failure is retained so the UI can explain it; success
+   * drops the entry and lets the persisted `initialized` flag speak.
+   *
+   * On success the caller must have refreshed the provider list first:
+   * clearing the job while the list still shows the pre-init `initialized:
+   * false` would expose the same red badge this class exists to prevent,
+   * until the next poll caught up.
+   */
+  async finish(name: string, error?: string): Promise<void> {
+    if (error) {
+      const job = this.jobs.get(name)
+      this.jobs.set(name, {
+        activity: job?.activity ?? "initializing",
+        phase: "failed",
+        error,
+      })
+      this.emit()
+      return
+    }
+    const job = this.jobs.get(name)
+    if (!job) return
+    // A recorded failure survives a later success-shaped finish.
+    if (job.error) return
+
+    const generation = this.generations.get(name)
+    await this.refresh?.()
+    // refresh is a CLI round-trip; a newer job may own the entry by now.
+    if (this.generations.get(name) !== generation) return
+
+    this.jobs.delete(name)
+    this.generations.delete(name)
+    this.emit()
+  }
+
+  /**
+   * Supplies a way to re-read provider state from disk, so a finished job
+   * isn't cleared before the list reflects what the command just wrote.
+   */
+  setRefresh(refresh: () => Promise<void>): void {
+    this.refresh = refresh
+  }
+
+  private refresh?: () => Promise<void>
+
+  get(name: string): ProviderJob | undefined {
+    return this.jobs.get(name)
+  }
+
+  /** Snapshot for IPC, keyed by provider name. */
+  snapshot(): Record<string, ProviderJob> {
+    return Object.fromEntries(this.jobs)
+  }
+}

--- a/desktop/src/main/watcher.ts
+++ b/desktop/src/main/watcher.ts
@@ -5,6 +5,7 @@ import { watch } from "chokidar"
 import type { BrowserWindow } from "electron"
 import type { CliRunner } from "./cli.js"
 import type { DaemonClient } from "./daemon-client.js"
+import type { ProviderJobs } from "./provider-jobs.js"
 import type { DaemonState } from "./state.js"
 
 interface WatcherDeps {
@@ -12,6 +13,7 @@ interface WatcherDeps {
   daemon?: DaemonClient
   state: DaemonState
   getMainWindow: () => BrowserWindow | null
+  providerJobs: ProviderJobs
 }
 
 interface ContextEntry {
@@ -144,6 +146,11 @@ export class Watcher {
     }
   }
 
+  /** Re-read provider state from disk now, without waiting for the poll. */
+  async refreshProviders(): Promise<void> {
+    await this.pollProviders()
+  }
+
   private async pollProviders(): Promise<void> {
     try {
       const raw = await this.queryWithFallback(
@@ -160,13 +167,23 @@ export class Watcher {
       const providers = parseProviderEntries(raw)
       const changed = this.deps.state.updateProviders(providers as any[])
       if (changed) {
-        this.send("providers-changed", {
-          providers: this.deps.state.providerList(),
-        })
+        this.broadcastProviders()
       }
     } catch {
       // Silently ignore poll failures
     }
+  }
+
+  /**
+   * Push the provider list plus in-flight job state. Sent on one channel so
+   * the two can't arrive out of order and render a provider as idle-and-
+   * uninitialized between an install finishing and its job clearing.
+   */
+  broadcastProviders(): void {
+    this.send("providers-changed", {
+      providers: this.deps.state.providerList(),
+      jobs: this.deps.providerJobs.snapshot(),
+    })
   }
 
   private async pollMachines(): Promise<void> {

--- a/desktop/src/main/watcher.ts
+++ b/desktop/src/main/watcher.ts
@@ -150,12 +150,7 @@ export class Watcher {
     }
   }
 
-  /**
-   * Re-read provider state from disk now, without waiting for the next
-   * scheduled poll. Queued behind any poll already in flight, so the
-   * result reflects a read that started after this call rather than one
-   * a concurrent scheduled poll is about to overwrite.
-   */
+  /** Re-read provider state from disk now, without waiting for the next scheduled poll. */
   async refreshProviders(): Promise<void> {
     await this.queueProviderPoll()
   }

--- a/desktop/src/main/watcher.ts
+++ b/desktop/src/main/watcher.ts
@@ -57,6 +57,10 @@ export class Watcher {
   private fsWatcher: ReturnType<typeof watch> | null = null
   private polling = false
   private pollQueued = false
+  // Serializes pollProviders so a manual refreshProviders() can never
+  // overlap a scheduled poll; each queued call is guaranteed a fresh read
+  // that starts after it was requested.
+  private providerPollChain: Promise<void> = Promise.resolve()
 
   constructor(private deps: WatcherDeps) {}
 
@@ -100,7 +104,7 @@ export class Watcher {
     try {
       await Promise.allSettled([
         this.pollWorkspaces(),
-        this.pollProviders(),
+        this.queueProviderPoll(),
         this.pollMachines(),
         this.pollContexts(),
       ])
@@ -146,9 +150,20 @@ export class Watcher {
     }
   }
 
-  /** Re-read provider state from disk now, without waiting for the poll. */
+  /**
+   * Re-read provider state from disk now, without waiting for the next
+   * scheduled poll. Queued behind any poll already in flight, so the
+   * result reflects a read that started after this call rather than one
+   * a concurrent scheduled poll is about to overwrite.
+   */
   async refreshProviders(): Promise<void> {
-    await this.pollProviders()
+    await this.queueProviderPoll()
+  }
+
+  private queueProviderPoll(): Promise<void> {
+    const run = this.providerPollChain.then(() => this.pollProviders())
+    this.providerPollChain = run
+    return run
   }
 
   private async pollProviders(): Promise<void> {

--- a/desktop/src/main/watcher.ts
+++ b/desktop/src/main/watcher.ts
@@ -7,6 +7,7 @@ import type { CliRunner } from "./cli.js"
 import type { DaemonClient } from "./daemon-client.js"
 import type { ProviderJobs } from "./provider-jobs.js"
 import type { DaemonState } from "./state.js"
+import type { WorkspaceJobs } from "./workspace-jobs.js"
 
 interface WatcherDeps {
   cli: CliRunner
@@ -14,6 +15,7 @@ interface WatcherDeps {
   state: DaemonState
   getMainWindow: () => BrowserWindow | null
   providerJobs: ProviderJobs
+  workspaceJobs: WorkspaceJobs
 }
 
 interface ContextEntry {
@@ -61,6 +63,9 @@ export class Watcher {
   // overlap a scheduled poll; each queued call is guaranteed a fresh read
   // that starts after it was requested.
   private providerPollChain: Promise<void> = Promise.resolve()
+  // Same serialization for pollWorkspaces, so a manual refreshWorkspaces()
+  // (e.g. after a delete finishes) can't overlap a scheduled poll.
+  private workspacePollChain: Promise<void> = Promise.resolve()
 
   constructor(private deps: WatcherDeps) {}
 
@@ -103,7 +108,7 @@ export class Watcher {
     this.polling = true
     try {
       await Promise.allSettled([
-        this.pollWorkspaces(),
+        this.queueWorkspacePoll(),
         this.queueProviderPoll(),
         this.pollMachines(),
         this.pollContexts(),
@@ -131,6 +136,17 @@ export class Watcher {
     return cliFn()
   }
 
+  /** Re-read the workspace list from disk now, without waiting for the next scheduled poll. */
+  async refreshWorkspaces(): Promise<void> {
+    await this.queueWorkspacePoll()
+  }
+
+  private queueWorkspacePoll(): Promise<void> {
+    const run = this.workspacePollChain.then(() => this.pollWorkspaces())
+    this.workspacePollChain = run
+    return run
+  }
+
   private async pollWorkspaces(): Promise<void> {
     try {
       const workspaces = await this.queryWithFallback(
@@ -141,13 +157,23 @@ export class Watcher {
       )
       const changed = this.deps.state.updateWorkspaces(workspaces as any[])
       if (changed) {
-        this.send("workspaces-changed", {
-          workspaces: this.deps.state.workspaceList(),
-        })
+        this.broadcastWorkspaces()
       }
     } catch {
       // Silently ignore poll failures
     }
+  }
+
+  /**
+   * Push the workspace list plus in-flight job state. Sent on one channel so
+   * the two can't arrive out of order and show a deleted-but-still-listed
+   * workspace as idle between the delete finishing and the list catching up.
+   */
+  broadcastWorkspaces(): void {
+    this.send("workspaces-changed", {
+      workspaces: this.deps.state.workspaceList(),
+      jobs: this.deps.workspaceJobs.snapshot(),
+    })
   }
 
   /** Re-read provider state from disk now, without waiting for the next scheduled poll. */

--- a/desktop/src/main/workspace-jobs.ts
+++ b/desktop/src/main/workspace-jobs.ts
@@ -1,0 +1,95 @@
+/**
+ * Tracks in-flight workspace delete operations in the main process, the
+ * same way ProviderJobs tracks provider install/init work: workspace_delete
+ * is fire-and-forget from the IPC handler's perspective (it returns as soon
+ * as the CLI command is launched, so the log-streaming UI isn't blocked),
+ * so nothing else records that a delete is running. Main-process ownership
+ * means the "Deleting" badge survives navigating away from the list or
+ * reloading the window while the delete is still in flight.
+ */
+
+export interface WorkspaceJob {
+  activity: "deleting"
+  /** Set when the job ended in failure; the job is retained so the UI can show why. */
+  error?: string
+}
+
+export class WorkspaceJobs {
+  private jobs = new Map<string, WorkspaceJob>()
+  // Lets an in-flight finish() tell whether it still owns the entry.
+  private generations = new Map<string, number>()
+  private lastGeneration = 0
+  private listeners = new Set<() => void>()
+  private refresh?: () => Promise<void>
+
+  /**
+   * Register a callback fired after every mutation, so starting or
+   * finishing a delete reaches the renderer without waiting for the next
+   * disk poll.
+   */
+  onChange(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  private emit(): void {
+    for (const listener of this.listeners) listener()
+  }
+
+  /** Begin tracking a delete, clearing any previous failure. */
+  start(id: string): void {
+    this.jobs.set(id, { activity: "deleting" })
+    this.generations.set(id, ++this.lastGeneration)
+    this.emit()
+  }
+
+  /** Stop tracking a workspace, discarding any recorded failure. */
+  clear(id: string): void {
+    this.generations.delete(id)
+    if (this.jobs.delete(id)) this.emit()
+  }
+
+  /**
+   * Finish a job. A failure is retained so the UI can explain it; success
+   * drops the entry once the workspace list has caught up, so the card
+   * doesn't flash back to its pre-delete state for one poll cycle.
+   */
+  async finish(id: string, error?: string): Promise<void> {
+    if (error) {
+      const job = this.jobs.get(id)
+      if (!job) return
+      this.jobs.set(id, { activity: "deleting", error })
+      this.emit()
+      return
+    }
+    const job = this.jobs.get(id)
+    if (!job) return
+    if (job.error) return
+
+    const generation = this.generations.get(id)
+    await this.refresh?.()
+    // refresh is a CLI round-trip; a newer job may own the entry by now.
+    if (this.generations.get(id) !== generation) return
+
+    this.jobs.delete(id)
+    this.generations.delete(id)
+    this.emit()
+  }
+
+  /**
+   * Supplies a way to re-read the workspace list from disk, so a finished
+   * job isn't cleared before the list reflects the deletion.
+   */
+  setRefresh(refresh: () => Promise<void>): void {
+    this.refresh = refresh
+  }
+
+  get(id: string): WorkspaceJob | undefined {
+    return this.jobs.get(id)
+  }
+
+  /** Snapshot for IPC, keyed by workspace id. */
+  snapshot(): Record<string, WorkspaceJob> {
+    return Object.fromEntries(this.jobs)
+  }
+}

--- a/desktop/src/main/workspace-jobs.ts
+++ b/desktop/src/main/workspace-jobs.ts
@@ -36,11 +36,18 @@ export class WorkspaceJobs {
     for (const listener of this.listeners) listener()
   }
 
-  /** Begin tracking a delete, clearing any previous failure. */
-  start(id: string): void {
+  /**
+   * Begin tracking a delete, clearing any previous failure. Returns a
+   * generation token the caller must pass to finish() so a stale exit
+   * callback from an earlier delete of the same workspace can't land on
+   * a retry that has already superseded it.
+   */
+  start(id: string): number {
     this.jobs.set(id, { activity: "deleting" })
-    this.generations.set(id, ++this.lastGeneration)
+    const generation = ++this.lastGeneration
+    this.generations.set(id, generation)
     this.emit()
+    return generation
   }
 
   /** Stop tracking a workspace, discarding any recorded failure. */
@@ -50,14 +57,16 @@ export class WorkspaceJobs {
   }
 
   /**
-   * Finish a job. A failure is retained so the UI can explain it; success
-   * drops the entry once the workspace list has caught up, so the card
-   * doesn't flash back to its pre-delete state for one poll cycle.
+   * Finish the job started under `generation`. A failure is retained so the
+   * UI can explain it; success drops the entry once the workspace list has
+   * caught up, so the card doesn't flash back to its pre-delete state for
+   * one poll cycle. Either way, a generation mismatch means a retry has
+   * already superseded this job, so the call is a no-op.
    */
-  async finish(id: string, error?: string): Promise<void> {
+  async finish(id: string, generation: number, error?: string): Promise<void> {
+    if (this.generations.get(id) !== generation) return
+
     if (error) {
-      const job = this.jobs.get(id)
-      if (!job) return
       this.jobs.set(id, { activity: "deleting", error })
       this.emit()
       return
@@ -66,7 +75,6 @@ export class WorkspaceJobs {
     if (!job) return
     if (job.error) return
 
-    const generation = this.generations.get(id)
     await this.refresh?.()
     // refresh is a CLI round-trip; a newer job may own the entry by now.
     if (this.generations.get(id) !== generation) return

--- a/desktop/src/renderer/src/lib/components/provider/ProviderCard.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderCard.svelte
@@ -3,12 +3,13 @@ import { badgeVariants } from "$lib/components/ui/badge/index.js"
 import { Star, Loader2 } from "@lucide/svelte"
 import ProviderIcon from "./ProviderIcon.svelte"
 import { providerVersions } from "$lib/stores/providerVersions.js"
-import { initializingProviders } from "$lib/stores/providers.js"
+import { providerJobs } from "$lib/stores/providers.js"
+import { providerStatus } from "$lib/utils/provider-status.js"
 import type { Provider } from "$lib/types/index.js"
 
 let { provider, onopen }: { provider: Provider; onopen?: () => void } = $props()
 
-let isInitializing = $derived($initializingProviders.has(provider.name))
+let status = $derived(providerStatus(provider, $providerJobs[provider.name]))
 
 function sourceDisplay(p: Provider): string {
   if (p.source?.github) return p.source.github
@@ -41,15 +42,19 @@ function sourceDisplay(p: Provider): string {
       {/if}
     </div>
     <div class="flex gap-1.5 shrink-0">
-      {#if provider.state?.initialized}
-        <span class={badgeVariants({ variant: "secondary" })}>initialized</span>
-      {:else if isInitializing}
+      {#if status.kind === "ready"}
+        <span class={badgeVariants({ variant: "secondary" })}>{status.label}</span>
+      {:else if status.kind === "busy"}
         <span class="{badgeVariants({ variant: 'outline' })} gap-1">
           <Loader2 class="size-3 animate-spin" />
-          initializing…
+          {status.label}
+        </span>
+      {:else if status.kind === "failed"}
+        <span class={badgeVariants({ variant: "destructive" })} title={status.error}>
+          {status.label}
         </span>
       {:else}
-        <span class={badgeVariants({ variant: "destructive" })}>not initialized</span>
+        <span class={badgeVariants({ variant: "destructive" })}>{status.label}</span>
       {/if}
       {#if provider.version}
         <span class={badgeVariants({ variant: "outline" })}>{provider.version}</span>

--- a/desktop/src/renderer/src/lib/components/provider/ProviderCard.test.ts
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderCard.test.ts
@@ -64,8 +64,6 @@ describe("ProviderCard", () => {
     unmount()
   })
 
-  // The original bug: `provider add` persists the provider before init runs,
-  // so the watcher reports initialized:false while the install is in flight.
   it("shows installing rather than not initialized during install", () => {
     providerJobs.set({
       ssh: { activity: "installing", phase: "installing_provider" },

--- a/desktop/src/renderer/src/lib/components/provider/ProviderCard.test.ts
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderCard.test.ts
@@ -14,11 +14,7 @@ vi.mock("$lib/stores/providerVersions.js", async () => {
 })
 
 import ProviderCard from "./ProviderCard.svelte"
-import {
-  initializingProviders,
-  markInitializing,
-  clearInitializing,
-} from "$lib/stores/providers.js"
+import { providerJobs } from "$lib/stores/providers.js"
 
 function makeProvider(name: string, extras: Partial<Provider> = {}): Provider {
   return {
@@ -56,8 +52,7 @@ describe("ProviderCard", () => {
   })
 
   it("shows the initializing badge while an uninitialized provider is in flight", () => {
-    initializingProviders.set(new Set())
-    markInitializing("ssh")
+    providerJobs.set({ ssh: { activity: "initializing", phase: "running_init" } })
     const { container, unmount } = render(ProviderCard, {
       props: { provider: makeProvider("ssh", { state: { initialized: false } }) },
     })
@@ -65,12 +60,44 @@ describe("ProviderCard", () => {
     const text = container.textContent ?? ""
     expect(text.toLowerCase()).toContain("initializing")
     expect(text.toLowerCase()).not.toContain("not initialized")
-    clearInitializing("ssh")
+    providerJobs.set({})
     unmount()
   })
 
-  it("shows not initialized when no init is in flight", () => {
-    initializingProviders.set(new Set())
+  // The original bug: `provider add` persists the provider before init runs,
+  // so the watcher reports initialized:false while the install is in flight.
+  it("shows installing rather than not initialized during install", () => {
+    providerJobs.set({
+      ssh: { activity: "installing", phase: "installing_provider" },
+    })
+    const { container, unmount } = render(ProviderCard, {
+      props: { provider: makeProvider("ssh", { state: { initialized: false } }) },
+    })
+
+    const text = (container.textContent ?? "").toLowerCase()
+    expect(text).toContain("installing")
+    expect(text).not.toContain("not initialized")
+    providerJobs.set({})
+    unmount()
+  })
+
+  it("shows a failure badge when the job recorded an error", () => {
+    providerJobs.set({
+      ssh: { activity: "initializing", phase: "failed", error: "init: boom" },
+    })
+    const { container, unmount } = render(ProviderCard, {
+      props: { provider: makeProvider("ssh", { state: { initialized: false } }) },
+    })
+
+    const text = (container.textContent ?? "").toLowerCase()
+    expect(text).toContain("failed")
+    expect(text).not.toContain("not initialized")
+    providerJobs.set({})
+    unmount()
+  })
+
+  it("shows not initialized when no job is in flight", () => {
+    providerJobs.set({})
     const { container, unmount } = render(ProviderCard, {
       props: { provider: makeProvider("ssh", { state: { initialized: false } }) },
     })

--- a/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
@@ -28,11 +28,7 @@ import {
   providerRename,
   providerSetVersion,
 } from "$lib/ipc/commands.js"
-import {
-  providers,
-  markInitializing,
-  clearInitializing,
-} from "$lib/stores/providers.js"
+import { providers, providerJobs } from "$lib/stores/providers.js"
 import {
   providerVersions,
   loadVersionsFor,
@@ -40,6 +36,7 @@ import {
 } from "$lib/stores/providerVersions.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
+import { providerStatus } from "$lib/utils/provider-status.js"
 import type { Provider, ProviderOption } from "$lib/types/index.js"
 
 let {
@@ -70,6 +67,7 @@ let updating = $state(false)
 let confirmSwitchOpen = $state(false)
 let targetTag = $state("")
 let switching = $state(false)
+let status = $derived(providerStatus(provider, $providerJobs[provider.name]))
 
 function openVersionSwitch(tag: string) {
   targetTag = tag
@@ -181,8 +179,11 @@ function handleUpdate() {
 async function runUpdate() {
   updating = true
   try {
+    // Also re-initializes: the new binaries have not run their init, and
+    // set-source clears the initialized flag accordingly.
     await providerUpdate(provider.name)
     toasts.success(`Updated ${provider.name}`)
+    providers.set(await providerList())
     await loadVersionsFor(provider.name)
     await refreshUpdates()
   } catch (err) {
@@ -198,6 +199,7 @@ async function runSwitch() {
   try {
     await providerSetVersion(provider.name, targetTag)
     toasts.success(`Switched ${provider.name} to ${targetTag}`)
+    providers.set(await providerList())
     await loadVersionsFor(provider.name)
     await refreshUpdates()
   } catch (err) {
@@ -227,7 +229,6 @@ function extractCliError(err: unknown): CLIError | null {
 async function handleInitialize() {
   initializing = true
   initError = null
-  markInitializing(provider.name)
   try {
     await providerInit(provider.name)
     const updated = await providerList()
@@ -248,7 +249,6 @@ async function handleInitialize() {
     }
   } finally {
     initializing = false
-    clearInitializing(provider.name)
   }
 }
 
@@ -367,8 +367,19 @@ async function handleSaveOptions() {
             Default
           </span>
         {/if}
-        {#if provider.state?.initialized}
-          <span class={badgeVariants({ variant: "secondary" })}>initialized</span>
+        {#if status.kind === "ready"}
+          <span class={badgeVariants({ variant: "secondary" })}>{status.label}</span>
+        {:else if status.kind === "busy"}
+          <span class="{badgeVariants({ variant: 'outline' })} gap-1">
+            <Spinner class="size-3" />
+            {status.label}
+          </span>
+        {:else if status.kind === "failed"}
+          <span class={badgeVariants({ variant: "destructive" })} title={status.error}>
+            {status.label}
+          </span>
+        {:else}
+          <span class={badgeVariants({ variant: "destructive" })}>{status.label}</span>
         {/if}
       </Sheet.Title>
       {#if provider.description}
@@ -377,7 +388,7 @@ async function handleSaveOptions() {
     </Sheet.Header>
 
     <div class="flex items-center gap-2 px-6">
-      {#if provider.state?.initialized !== true}
+      {#if status.kind !== "ready" && status.kind !== "busy"}
         <Button variant="outline" size="sm" onclick={handleInitialize} disabled={initializing}>
           {#if initializing}
             <Spinner class="mr-2 size-3" />

--- a/desktop/src/renderer/src/lib/components/provider/ProviderSheet.test.ts
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderSheet.test.ts
@@ -31,9 +31,7 @@ vi.mock("$lib/stores/providers.js", async () => {
   const { writable } = await import("svelte/store")
   return {
     providers: writable([]),
-    initializingProviders: writable(new Set()),
-    markInitializing: vi.fn(),
-    clearInitializing: vi.fn(),
+    providerJobs: writable({}),
   }
 })
 

--- a/desktop/src/renderer/src/lib/components/provider/ProviderWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderWizard.svelte
@@ -128,14 +128,6 @@ let visibleOptions = $derived(
 )
 
 function reset() {
-  // provider_add leaves its job open so the badge stays busy across the
-  // add→init handoff. If we're leaving without a finished init, nothing else
-  // will ever close it, so the card would spin on "installing…" forever.
-  //
-  // Not when init is still running: that job belongs to a live command which
-  // closes it from its own exit handler, and the badge should keep tracking it
-  // after the wizard is gone. A failed job is safe to release either way —
-  // finish() preserves the recorded failure.
   if (providerName && currentStep !== "complete" && !initRunning) {
     void providerReleaseJob(providerName).catch(() => undefined)
   }

--- a/desktop/src/renderer/src/lib/components/provider/ProviderWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderWizard.svelte
@@ -20,14 +20,11 @@ import {
   providerInitStreaming,
   providerList,
   providerOptions,
+  providerReleaseJob,
   providerSetOptions,
 } from "$lib/ipc/commands.js"
 import { onCommandProgress } from "$lib/ipc/events.js"
-import {
-  providers,
-  markInitializing,
-  clearInitializing,
-} from "$lib/stores/providers.js"
+import { providers } from "$lib/stores/providers.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
 import { isCommandSuccess } from "$lib/utils/log-parser.js"
@@ -131,6 +128,17 @@ let visibleOptions = $derived(
 )
 
 function reset() {
+  // provider_add leaves its job open so the badge stays busy across the
+  // add→init handoff. If we're leaving without a finished init, nothing else
+  // will ever close it, so the card would spin on "installing…" forever.
+  //
+  // Not when init is still running: that job belongs to a live command which
+  // closes it from its own exit handler, and the badge should keep tracking it
+  // after the wizard is gone. A failed job is safe to release either way —
+  // finish() preserves the recorded failure.
+  if (providerName && currentStep !== "complete" && !initRunning) {
+    void providerReleaseJob(providerName).catch(() => undefined)
+  }
   currentStep = "select"
   error = ""
   source = ""
@@ -166,8 +174,7 @@ onMount(async () => {
       }
       if (progress.done) {
         initRunning = false
-        clearInitializing(providerName)
-        if (isCommandSuccess(progress.message)) {
+        if (isCommandSuccess(progress.message, progress.success)) {
           refreshAndComplete()
         } else {
           initError =
@@ -284,12 +291,10 @@ async function startInit() {
   initError = null
   initStartError = ""
   initLines = []
-  markInitializing(providerName)
   try {
     initCommandId = await providerInitStreaming(providerName)
   } catch (err) {
     initRunning = false
-    clearInitializing(providerName)
     initStartError = `Failed to start initialization: ${err instanceof Error ? err.message : String(err)}`
   }
 }
@@ -304,8 +309,12 @@ async function refreshAndComplete() {
   currentStep = "complete"
 }
 
-function handleSkipInit() {
-  refreshAndComplete()
+// Skipping init leaves the provider installed but uninitialized, which is a
+// settled state: release the job so the card shows that rather than staying
+// busy on the install that already finished.
+async function handleSkipInit() {
+  await providerReleaseJob(providerName).catch(() => undefined)
+  await refreshAndComplete()
 }
 
 function handleDone() {

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -465,7 +465,7 @@ function handleProgress(progress: CommandProgress, wsId: string | undefined) {
     flushLines()
     launchRunning = false
     clearWatchdog()
-    if (isCommandSuccess(progress.message)) {
+    if (isCommandSuccess(progress.message, progress.success)) {
       launchSuccess = true
       launchedWorkspaceId = wsId ?? null
       toasts.success(`Workspace ${wsId ?? "created"} is ready`)

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -140,6 +140,14 @@ export async function providerInitStreaming(name: string): Promise<string> {
   return invoke<string>("provider_init_streaming", { name })
 }
 
+/**
+ * Release a provider job the caller opened but will not finish, e.g. when the
+ * user skips initialization or abandons the add wizard after the install.
+ */
+export async function providerReleaseJob(name: string): Promise<void> {
+  return invoke<void>("provider_release_job", { name })
+}
+
 export async function providerUpdate(name: string): Promise<void> {
   return invoke("provider_update", { name })
 }

--- a/desktop/src/renderer/src/lib/ipc/events.ts
+++ b/desktop/src/renderer/src/lib/ipc/events.ts
@@ -3,6 +3,7 @@ import type {
   Context,
   Machine,
   Provider,
+  ProviderJob,
   Workspace,
   WorkspaceStatus,
 } from "$lib/types/index.js"
@@ -58,6 +59,7 @@ interface WorkspacesPayload {
 }
 interface ProvidersPayload {
   providers: Provider[]
+  jobs?: Record<string, ProviderJob>
 }
 interface MachinesPayload {
   machines: Machine[]
@@ -76,10 +78,10 @@ export function onWorkspacesChanged(
 }
 
 export function onProvidersChanged(
-  callback: (providers: Provider[]) => void,
+  callback: (providers: Provider[], jobs: Record<string, ProviderJob>) => void,
 ): Promise<UnlistenFn> {
   return listen<ProvidersPayload>(EVENT_NAMES.PROVIDERS_CHANGED, (event) => {
-    callback(event.payload.providers)
+    callback(event.payload.providers, event.payload.jobs ?? {})
   })
 }
 

--- a/desktop/src/renderer/src/lib/ipc/events.ts
+++ b/desktop/src/renderer/src/lib/ipc/events.ts
@@ -5,6 +5,7 @@ import type {
   Provider,
   ProviderJob,
   Workspace,
+  WorkspaceJob,
   WorkspaceStatus,
 } from "$lib/types/index.js"
 import { listen } from "./bridge.js"
@@ -56,6 +57,7 @@ export const EVENT_NAMES = {
 
 interface WorkspacesPayload {
   workspaces: Workspace[]
+  jobs?: Record<string, WorkspaceJob>
 }
 interface ProvidersPayload {
   providers: Provider[]
@@ -70,10 +72,13 @@ interface ContextsPayload {
 }
 
 export function onWorkspacesChanged(
-  callback: (workspaces: Workspace[]) => void,
+  callback: (
+    workspaces: Workspace[],
+    jobs: Record<string, WorkspaceJob>,
+  ) => void,
 ): Promise<UnlistenFn> {
   return listen<WorkspacesPayload>(EVENT_NAMES.WORKSPACES_CHANGED, (event) => {
-    callback(event.payload.workspaces)
+    callback(event.payload.workspaces, event.payload.jobs ?? {})
   })
 }
 

--- a/desktop/src/renderer/src/lib/ipc/mock.ts
+++ b/desktop/src/renderer/src/lib/ipc/mock.ts
@@ -196,6 +196,7 @@ const COMMANDS: Record<string, Handler> = {
   provider_update: () => undefined,
   provider_options: () => PROVIDER_OPTIONS,
   provider_set_options: () => undefined,
+  provider_release_job: () => undefined,
 
   // Machines
   machine_list: () => MACHINES,

--- a/desktop/src/renderer/src/lib/stores/providers.ts
+++ b/desktop/src/renderer/src/lib/stores/providers.ts
@@ -2,27 +2,14 @@ import { writable } from "svelte/store"
 import { providerList } from "$lib/ipc/commands.js"
 import { onProvidersChanged } from "$lib/ipc/events.js"
 import type { UnlistenFn } from "$lib/ipc/types.js"
-import type { Provider } from "$lib/types/index.js"
+import type { Provider, ProviderJob } from "$lib/types/index.js"
 
 export const providers = writable<Provider[]>([])
 export const providersLoading = writable(true)
 
-// Names of providers whose initialization is currently in flight. Lets cards
-// show an "initializing…" state instead of the red "not initialized" badge
-// during the multi-second init that runs after a provider is added.
-export const initializingProviders = writable<Set<string>>(new Set())
-
-export function markInitializing(name: string) {
-  initializingProviders.update((set) => new Set(set).add(name))
-}
-
-export function clearInitializing(name: string) {
-  initializingProviders.update((set) => {
-    const next = new Set(set)
-    next.delete(name)
-    return next
-  })
-}
+// In-flight provider work, keyed by provider name. Owned by the main process
+// so it survives the wizard closing, navigation, and window reload.
+export const providerJobs = writable<Record<string, ProviderJob>>({})
 
 let unlisten: UnlistenFn | null = null
 
@@ -38,8 +25,9 @@ export async function initProviders() {
   }
 
   try {
-    unlisten = await onProvidersChanged((updated) => {
+    unlisten = await onProvidersChanged((updated, jobs) => {
       providers.set(updated)
+      providerJobs.set(jobs)
     })
   } catch {
     // Event listener setup failed

--- a/desktop/src/renderer/src/lib/stores/workspaces.ts
+++ b/desktop/src/renderer/src/lib/stores/workspaces.ts
@@ -2,10 +2,14 @@ import { get, writable } from "svelte/store"
 import { workspaceList, workspaceStatus } from "$lib/ipc/commands.js"
 import { onWorkspacesChanged } from "$lib/ipc/events.js"
 import type { UnlistenFn } from "$lib/ipc/types.js"
-import type { Workspace } from "$lib/types/index.js"
+import type { Workspace, WorkspaceJob } from "$lib/types/index.js"
 
 export const workspaces = writable<Workspace[]>([])
 export const workspacesLoading = writable(true)
+
+// In-flight workspace deletes, keyed by workspace id. Owned by the main
+// process so it survives navigation and window reload.
+export const workspaceJobs = writable<Record<string, WorkspaceJob>>({})
 
 let unlisten: UnlistenFn | null = null
 let pollInterval: ReturnType<typeof setInterval> | null = null
@@ -25,8 +29,9 @@ export async function initWorkspaces() {
   }
 
   try {
-    unlisten = await onWorkspacesChanged((updated) => {
+    unlisten = await onWorkspacesChanged((updated, jobs) => {
       workspaces.set(updated)
+      workspaceJobs.set(jobs)
       fetchStatuses(updated)
     })
   } catch {

--- a/desktop/src/renderer/src/lib/types/index.ts
+++ b/desktop/src/renderer/src/lib/types/index.ts
@@ -92,6 +92,16 @@ export interface ProviderJob {
   error?: string
 }
 
+/**
+ * In-flight workspace delete, tracked by the main process for the same
+ * reason as ProviderJob: workspace_delete returns as soon as the CLI
+ * command is launched, so nothing else records that a delete is running.
+ */
+export interface WorkspaceJob {
+  activity: "deleting"
+  error?: string
+}
+
 export interface ProviderVersion {
   tag: string
   publishedAt: string

--- a/desktop/src/renderer/src/lib/types/index.ts
+++ b/desktop/src/renderer/src/lib/types/index.ts
@@ -81,6 +81,17 @@ export interface Provider {
   }
 }
 
+/**
+ * In-flight provider work, tracked by the main process. Distinct from
+ * `Provider.state.initialized`, which records whether the provider on disk
+ * has run its init — false both for "never initialized" and "installing now".
+ */
+export interface ProviderJob {
+  activity: "installing" | "initializing" | "updating"
+  phase?: string
+  error?: string
+}
+
 export interface ProviderVersion {
   tag: string
   publishedAt: string
@@ -141,6 +152,12 @@ export interface CommandProgress {
   /** Optional log level; populated when the underlying stderr line was JSON. */
   level?: "info" | "warn" | "error"
   done: boolean
+  /**
+   * Whether the command succeeded. Set on the final (done: true) event by the
+   * main process, which knows the exit code — consumers should read this
+   * rather than pattern-matching the log text.
+   */
+  success?: boolean
   /**
    * Structured CLI error. Present only on the final (done: true) event when the
    * CLI emitted a `cliError` field on its zap JSON output.

--- a/desktop/src/renderer/src/lib/utils/log-parser.test.ts
+++ b/desktop/src/renderer/src/lib/utils/log-parser.test.ts
@@ -8,8 +8,6 @@ import {
 
 describe("isCommandSuccess", () => {
   it("trusts an explicit success flag over the message", () => {
-    // The flag comes from the real exit code, so it wins even when the text
-    // would sniff the other way.
     expect(isCommandSuccess("Exit code: 0", false)).toBe(false)
     expect(isCommandSuccess("something went wrong", true)).toBe(true)
   })

--- a/desktop/src/renderer/src/lib/utils/log-parser.test.ts
+++ b/desktop/src/renderer/src/lib/utils/log-parser.test.ts
@@ -1,9 +1,26 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  isCommandSuccess,
   isRecoverableBuildFailure,
   parseRecoveryContainer,
 } from "./log-parser.js"
+
+describe("isCommandSuccess", () => {
+  it("trusts an explicit success flag over the message", () => {
+    // The flag comes from the real exit code, so it wins even when the text
+    // would sniff the other way.
+    expect(isCommandSuccess("Exit code: 0", false)).toBe(false)
+    expect(isCommandSuccess("something went wrong", true)).toBe(true)
+  })
+
+  it("falls back to message sniffing when no flag is given", () => {
+    expect(isCommandSuccess("Exit code: 0")).toBe(true)
+    expect(isCommandSuccess("Exit code: 1")).toBe(false)
+    expect(isCommandSuccess('{"outcome":"success"}')).toBe(true)
+    expect(isCommandSuccess(null)).toBe(false)
+  })
+})
 
 describe("isRecoverableBuildFailure", () => {
   it("matches the recoverable build-failure code", () => {

--- a/desktop/src/renderer/src/lib/utils/log-parser.ts
+++ b/desktop/src/renderer/src/lib/utils/log-parser.ts
@@ -15,7 +15,17 @@ export function isRecoverableBuildFailure(
   return cliError?.code === RECOVERABLE_BUILD_FAILURE_CODE
 }
 
-export function isCommandSuccess(message: string | undefined | null): boolean {
+/**
+ * Whether a finished command succeeded.
+ *
+ * Prefer `progress.success`, which the main process sets from the actual exit
+ * code. The message-sniffing fallback only covers events emitted without it.
+ */
+export function isCommandSuccess(
+  message: string | undefined | null,
+  success?: boolean,
+): boolean {
+  if (success !== undefined) return success
   if (!message) return false
   const { message: body } = parseLogLine(message)
   if (body.startsWith("{")) {

--- a/desktop/src/renderer/src/lib/utils/provider-status.ts
+++ b/desktop/src/renderer/src/lib/utils/provider-status.ts
@@ -1,0 +1,48 @@
+import type { Provider, ProviderJob } from "$lib/types/index.js"
+
+export type ProviderStatusKind = "ready" | "busy" | "failed" | "uninitialized"
+
+export interface ProviderStatus {
+  kind: ProviderStatusKind
+  label: string
+  /** Present when kind is "failed". */
+  error?: string
+}
+
+const PHASE_LABELS: Record<string, string> = {
+  installing_provider: "installing…",
+  resolving_options: "resolving options…",
+  running_init: "initializing…",
+}
+
+const ACTIVITY_LABELS: Record<ProviderJob["activity"], string> = {
+  installing: "installing…",
+  initializing: "initializing…",
+  updating: "updating…",
+}
+
+/**
+ * Collapse the two lifecycle axes into one thing to render.
+ *
+ * An active job wins over the persisted flag: `initialized` is false while a
+ * provider is still installing, and showing "not initialized" then is the bug
+ * this exists to prevent. A recorded failure also wins, so a provider that
+ * failed to initialize reads as failed rather than merely not-initialized.
+ */
+export function providerStatus(
+  provider: Provider,
+  job?: ProviderJob,
+): ProviderStatus {
+  if (job?.error) {
+    return { kind: "failed", label: "failed", error: job.error }
+  }
+  if (job) {
+    const label =
+      (job.phase && PHASE_LABELS[job.phase]) ?? ACTIVITY_LABELS[job.activity]
+    return { kind: "busy", label }
+  }
+  if (provider.state?.initialized) {
+    return { kind: "ready", label: "initialized" }
+  }
+  return { kind: "uninitialized", label: "not initialized" }
+}

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -249,7 +249,7 @@ onMount(async () => {
           }
           flushLines()
           operationRunning = false
-          const success = isCommandSuccess(progress.message)
+          const success = isCommandSuccess(progress.message, progress.success)
           if (success) {
             toasts.success(`${operationLabel} ${id} succeeded`)
             if (BUILD_OPS.has(operationLabel)) {

--- a/desktop/src/renderer/src/pages/WorkspacesPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspacesPage.svelte
@@ -96,10 +96,8 @@ function isStopped(ws: Workspace) {
   )
 }
 
-// The delete job wins over the polled status: a delete in flight would
-// otherwise still read as "running" or "stopped" until the next poll. A
-// failed delete drops out of "deleting" so the row isn't stuck disabled
-// forever; retrying (workspaceJobs.start()) clears the recorded error.
+// The delete job wins over the polled status until the next poll catches up.
+// A failed delete drops out of "deleting" so the row isn't stuck forever.
 function isDeleting(ws: Workspace): boolean {
   const job = $workspaceJobs[ws.id]
   return job?.activity === "deleting" && !job.error

--- a/desktop/src/renderer/src/pages/WorkspacesPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspacesPage.svelte
@@ -26,7 +26,11 @@ import {
 } from "$lib/ipc/commands.js"
 import { toasts } from "$lib/stores/toasts.js"
 import { extractErrorMessage } from "$lib/utils/error.js"
-import { workspaces, workspacesLoading } from "$lib/stores/workspaces.js"
+import {
+  workspaceJobs,
+  workspaces,
+  workspacesLoading,
+} from "$lib/stores/workspaces.js"
 import type { Workspace } from "$lib/types/index.js"
 import { timeAgo } from "$lib/utils/time.js"
 
@@ -90,6 +94,12 @@ function isStopped(ws: Workspace) {
     ws.status.toLowerCase() === "stopped" ||
     ws.status.toLowerCase() === "notfound"
   )
+}
+
+// The delete job wins over the polled status: a delete in flight would
+// otherwise still read as "running" or "stopped" until the next poll.
+function isDeleting(ws: Workspace): boolean {
+  return $workspaceJobs[ws.id]?.activity === "deleting"
 }
 
 async function handleStart(ws: Workspace) {
@@ -199,7 +209,7 @@ async function handleDelete() {
         </Table.Header>
         <Table.Body>
           {#each filtered as ws (ws.id)}
-            {@const busy = actingOn === ws.id}
+            {@const busy = actingOn === ws.id || isDeleting(ws)}
             <Table.Row
               class="cursor-pointer"
               onclick={() => goto(`/workspaces/${ws.id}`)}
@@ -216,7 +226,9 @@ async function handleDelete() {
                 {/if}
               </Table.Cell>
               <Table.Cell>
-                {#if ws.status}
+                {#if isDeleting(ws)}
+                  <span class={badgeVariants({ variant: "secondary" })}>Deleting</span>
+                {:else if ws.status}
                   <span class={badgeVariants({ variant: statusVariant(ws.status) })}>{ws.status}</span>
                 {/if}
               </Table.Cell>

--- a/desktop/src/renderer/src/pages/WorkspacesPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspacesPage.svelte
@@ -97,9 +97,16 @@ function isStopped(ws: Workspace) {
 }
 
 // The delete job wins over the polled status: a delete in flight would
-// otherwise still read as "running" or "stopped" until the next poll.
+// otherwise still read as "running" or "stopped" until the next poll. A
+// failed delete drops out of "deleting" so the row isn't stuck disabled
+// forever; retrying (workspaceJobs.start()) clears the recorded error.
 function isDeleting(ws: Workspace): boolean {
-  return $workspaceJobs[ws.id]?.activity === "deleting"
+  const job = $workspaceJobs[ws.id]
+  return job?.activity === "deleting" && !job.error
+}
+
+function deleteError(ws: Workspace): string | undefined {
+  return $workspaceJobs[ws.id]?.error
 }
 
 async function handleStart(ws: Workspace) {
@@ -228,6 +235,10 @@ async function handleDelete() {
               <Table.Cell>
                 {#if isDeleting(ws)}
                   <span class={badgeVariants({ variant: "secondary" })}>Deleting</span>
+                {:else if deleteError(ws)}
+                  <span class={badgeVariants({ variant: "destructive" })} title={deleteError(ws)}>
+                    Delete failed
+                  </span>
                 {:else if ws.status}
                   <span class={badgeVariants({ variant: statusVariant(ws.status) })}>{ws.status}</span>
                 {/if}

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -436,6 +436,8 @@ func (t *tunnelServer) Status(
 	ctx context.Context,
 	update *tunnel.StatusUpdate,
 ) (*tunnel.Empty, error) {
+	// No Pipeline: the tunnel only carries container-side up events, and the
+	// host's reporter stamps the pipeline on arrival.
 	t.statusReporter.Report(status.Event{
 		Phase:   status.Phase(update.Phase),
 		Step:    update.Step,

--- a/pkg/devcontainer/config/envelope.go
+++ b/pkg/devcontainer/config/envelope.go
@@ -37,11 +37,14 @@ type ErrorEnvelope struct {
 // pipeline. Started is a pointer so an omitted field is distinguishable
 // from an explicit false.
 type StatusEnvelope struct {
-	Kind    string `json:"kind"`
-	Phase   string `json:"phase"`
-	Step    string `json:"step,omitempty"`
-	Started *bool  `json:"started"`
-	Error   string `json:"error,omitempty"`
+	Kind string `json:"kind"`
+	// Pipeline names the command being reported. Omitted by pre-discriminator
+	// CLIs, so an empty value means workspace up.
+	Pipeline string `json:"pipeline,omitempty"`
+	Phase    string `json:"phase"`
+	Step     string `json:"step,omitempty"`
+	Started  *bool  `json:"started"`
+	Error    string `json:"error,omitempty"`
 }
 
 // TaskEnvelope is the single line `up --detach` writes to stdout.
@@ -100,10 +103,11 @@ func ParseStatusLine(line string) (status.Event, bool) {
 		return status.Event{}, false
 	}
 	return status.Event{
-		Phase:   status.Phase(env.Phase),
-		Step:    env.Step,
-		Started: *env.Started,
-		Err:     env.Error,
+		Pipeline: status.Pipeline(env.Pipeline),
+		Phase:    status.Phase(env.Phase),
+		Step:     env.Step,
+		Started:  *env.Started,
+		Err:      env.Error,
 	}, true
 }
 
@@ -111,11 +115,12 @@ func ParseStatusLine(line string) (status.Event, bool) {
 func WriteStatusJSON(w io.Writer, e status.Event) error {
 	started := e.Started
 	env := StatusEnvelope{
-		Kind:    KindStatus,
-		Phase:   string(e.Phase),
-		Step:    e.Step,
-		Started: &started,
-		Error:   e.Err,
+		Kind:     KindStatus,
+		Pipeline: string(e.Pipeline),
+		Phase:    string(e.Phase),
+		Step:     e.Step,
+		Started:  &started,
+		Error:    e.Err,
 	}
 	data, err := json.Marshal(env)
 	if err != nil {

--- a/pkg/devcontainer/config/envelope.go
+++ b/pkg/devcontainer/config/envelope.go
@@ -37,9 +37,7 @@ type ErrorEnvelope struct {
 // pipeline. Started is a pointer so an omitted field is distinguishable
 // from an explicit false.
 type StatusEnvelope struct {
-	Kind string `json:"kind"`
-	// Pipeline names the command being reported. Omitted by pre-discriminator
-	// CLIs, so an empty value means workspace up.
+	Kind     string `json:"kind"`
 	Pipeline string `json:"pipeline,omitempty"`
 	Phase    string `json:"phase"`
 	Step     string `json:"step,omitempty"`

--- a/pkg/devcontainer/config/envelope_test.go
+++ b/pkg/devcontainer/config/envelope_test.go
@@ -284,3 +284,41 @@ func TestParseStatusLineAcceptsExplicitStartedFalse(t *testing.T) {
 		t.Errorf("Started = true, want false")
 	}
 }
+
+func TestStatusLineRoundTripsPipeline(t *testing.T) {
+	var buf bytes.Buffer
+	want := status.Event{
+		Pipeline: status.PipelineProvider,
+		Phase:    status.Phase("downloading_binaries"),
+		Step:     "docker",
+		Started:  true,
+	}
+	if err := WriteStatusJSON(&buf, want); err != nil {
+		t.Fatalf("WriteStatusJSON: %v", err)
+	}
+
+	got, ok := ParseStatusLine(buf.String())
+	if !ok {
+		t.Fatalf("ParseStatusLine did not recognize %q", buf.String())
+	}
+	if got != want {
+		t.Errorf("round-trip: got %+v, want %+v", got, want)
+	}
+}
+
+func TestParseStatusLineWithoutPipeline(t *testing.T) {
+	// A CLI predating the field omits it; parsing must still recognize the
+	// line rather than rejecting it as a non-status envelope.
+	line := `{"kind":"status","phase":"ready","started":false}`
+
+	got, ok := ParseStatusLine(line)
+	if !ok {
+		t.Fatalf("ParseStatusLine(%q) = not ok", line)
+	}
+	if got.Pipeline != "" {
+		t.Errorf("pipeline = %q, want empty", got.Pipeline)
+	}
+	if got.Phase != status.PhaseReady {
+		t.Errorf("phase = %q, want %q", got.Phase, status.PhaseReady)
+	}
+}

--- a/pkg/devcontainer/config/envelope_test.go
+++ b/pkg/devcontainer/config/envelope_test.go
@@ -307,8 +307,6 @@ func TestStatusLineRoundTripsPipeline(t *testing.T) {
 }
 
 func TestParseStatusLineWithoutPipeline(t *testing.T) {
-	// A CLI predating the field omits it; parsing must still recognize the
-	// line rather than rejecting it as a non-status envelope.
 	line := `{"kind":"status","phase":"ready","started":false}`
 
 	got, ok := ParseStatusLine(line)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -2,9 +2,7 @@
 // long-running commands.
 package status
 
-// Pipeline identifies which command's progress an Event describes. Consumers
-// share one event stream, so phase names alone are ambiguous: without this a
-// sink cannot tell a provider install from a workspace up.
+// Pipeline identifies which command's progress an Event describes.
 type Pipeline string
 
 const (
@@ -13,7 +11,7 @@ const (
 )
 
 // Phase identifies a step in a pipeline. PhaseReady and PhaseFailed are
-// shared terminal phases; the rest belong to one pipeline.
+// shared terminal phases.
 type Phase string
 
 // Workspace up phases.
@@ -41,9 +39,6 @@ const (
 
 // Event is one phase transition.
 type Event struct {
-	// Pipeline is stamped by ForPipeline rather than at each call site, so it
-	// is empty on a directly-constructed event. Consumers should treat empty
-	// as PipelineWorkspaceUp, which is what pre-discriminator CLIs emitted.
 	Pipeline Pipeline `json:"pipeline,omitempty"`
 	Phase    Phase    `json:"phase"`
 	Step     string   `json:"step,omitempty"`

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -2,9 +2,21 @@
 // long-running commands.
 package status
 
-// Phase identifies a step in the up pipeline.
+// Pipeline identifies which command's progress an Event describes. Consumers
+// share one event stream, so phase names alone are ambiguous: without this a
+// sink cannot tell a provider install from a workspace up.
+type Pipeline string
+
+const (
+	PipelineWorkspaceUp Pipeline = "workspace_up"
+	PipelineProvider    Pipeline = "provider"
+)
+
+// Phase identifies a step in a pipeline. PhaseReady and PhaseFailed are
+// shared terminal phases; the rest belong to one pipeline.
 type Phase string
 
+// Workspace up phases.
 const (
 	PhaseCloningRepository    Phase = "cloning_repository"
 	PhaseResolvingConfig      Phase = "resolving_config"
@@ -18,12 +30,25 @@ const (
 	PhaseFailed               Phase = "failed"
 )
 
+// Provider phases. Installing covers source resolution and binary download;
+// ResolvingOptions and RunningInit are the two halves of provider init, split
+// because only the latter executes provider-supplied code.
+const (
+	PhaseInstallingProvider Phase = "installing_provider"
+	PhaseResolvingOptions   Phase = "resolving_options"
+	PhaseRunningInit        Phase = "running_init"
+)
+
 // Event is one phase transition.
 type Event struct {
-	Phase   Phase  `json:"phase"`
-	Step    string `json:"step,omitempty"`
-	Started bool   `json:"started"`
-	Err     string `json:"error,omitempty"`
+	// Pipeline is stamped by ForPipeline rather than at each call site, so it
+	// is empty on a directly-constructed event. Consumers should treat empty
+	// as PipelineWorkspaceUp, which is what pre-discriminator CLIs emitted.
+	Pipeline Pipeline `json:"pipeline,omitempty"`
+	Phase    Phase    `json:"phase"`
+	Step     string   `json:"step,omitempty"`
+	Started  bool     `json:"started"`
+	Err      string   `json:"error,omitempty"`
 }
 
 // Reporter receives status events as they occur. Implementations must be
@@ -45,6 +70,23 @@ func Fail(r Reporter, phase Phase, err error) {
 		return
 	}
 	r.Report(Event{Phase: PhaseFailed, Step: string(phase), Err: err.Error()})
+}
+
+// ForPipeline stamps every event a reporter receives with pipeline, so the
+// Enter/Leave/Fail helpers stay pipeline-agnostic and each producer declares
+// its pipeline once where it builds its reporter.
+func ForPipeline(r Reporter, pipeline Pipeline) Reporter {
+	return pipelineReporter{next: r, pipeline: pipeline}
+}
+
+type pipelineReporter struct {
+	next     Reporter
+	pipeline Pipeline
+}
+
+func (p pipelineReporter) Report(e Event) {
+	e.Pipeline = p.pipeline
+	p.next.Report(e)
 }
 
 type nopReporter struct{}

--- a/pkg/status/status_test.go
+++ b/pkg/status/status_test.go
@@ -56,6 +56,35 @@ func TestNopDiscardsEvents(t *testing.T) {
 	Enter(Nop(), PhaseReady, "")
 }
 
+func TestForPipelineStampsEveryEvent(t *testing.T) {
+	r := &recordingReporter{}
+	stamped := ForPipeline(r, PipelineProvider)
+
+	Enter(stamped, PhaseBuildingImage, "")
+	Fail(stamped, PhaseBuildingImage, errors.New("boom"))
+
+	if len(r.events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(r.events))
+	}
+	for i, e := range r.events {
+		if e.Pipeline != PipelineProvider {
+			t.Errorf("event %d: pipeline = %q, want %q", i, e.Pipeline, PipelineProvider)
+		}
+	}
+}
+
+func TestForPipelineOverridesInboundPipeline(t *testing.T) {
+	r := &recordingReporter{}
+	ForPipeline(r, PipelineProvider).Report(Event{
+		Phase:    PhaseReady,
+		Pipeline: PipelineWorkspaceUp,
+	})
+
+	if r.events[0].Pipeline != PipelineProvider {
+		t.Errorf("pipeline = %q, want it restamped to %q", r.events[0].Pipeline, PipelineProvider)
+	}
+}
+
 func TestTeeForwardsToEachReporter(t *testing.T) {
 	a, b := &recordingReporter{}, &recordingReporter{}
 	Enter(Tee(a, b), PhaseReady, "")

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -20,6 +20,14 @@ var (
 	ErrAbandoned = errors.New("worker exited without recording a result")
 )
 
+// WorkerProcessName returns the background-process name a detached task's
+// worker is registered under, matching StartBackground's naming. Shared so
+// a caller can locate the worker's captured stdout/stderr via
+// pkg/config.PathManager.ProcessStreamsFile without duplicating the scheme.
+func WorkerProcessName(id string) string {
+	return "devsy-up-" + id
+}
+
 type Status string
 
 const (

--- a/pkg/task/task.go
+++ b/pkg/task/task.go
@@ -21,9 +21,7 @@ var (
 )
 
 // WorkerProcessName returns the background-process name a detached task's
-// worker is registered under, matching StartBackground's naming. Shared so
-// a caller can locate the worker's captured stdout/stderr via
-// pkg/config.PathManager.ProcessStreamsFile without duplicating the scheme.
+// worker is registered under.
 func WorkerProcessName(id string) string {
 	return "devsy-up-" + id
 }

--- a/pkg/workspace/provider.go
+++ b/pkg/workspace/provider.go
@@ -336,6 +336,7 @@ func updateProvider(ctx context.Context, p ProviderParams) (*provider.ProviderCo
 	}
 
 	cleanupOldOptions(p.DevsyConfig, providerConfig)
+	clearInitialized(p.DevsyConfig, providerConfig.Name)
 
 	if err := config.SaveConfig(p.DevsyConfig); err != nil {
 		return nil, err
@@ -413,6 +414,16 @@ func downloadAndSaveProvider(
 	}
 
 	return provider.SaveProviderConfig(p.DevsyConfig.DefaultContext, providerConfig)
+}
+
+// clearInitialized marks a provider uninitialized after its source changes.
+// The replacement binaries have not run their Exec.Init, so the old source's
+// result says nothing about this one; leaving it set reports the provider as
+// ready to loadInitializedProvider when it may not be.
+func clearInitialized(devsyConfig *config.Config, providerName string) {
+	if providerState := devsyConfig.Current().Providers[providerName]; providerState != nil {
+		providerState.Initialized = false
+	}
 }
 
 func cleanupOldOptions(devsyConfig *config.Config, providerConfig *provider.ProviderConfig) {

--- a/pkg/workspace/provider_update_test.go
+++ b/pkg/workspace/provider_update_test.go
@@ -3,8 +3,49 @@ package workspace
 import (
 	"testing"
 
+	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestClearInitialized(t *testing.T) {
+	newConfig := func(providers map[string]*config.ProviderConfig) *config.Config {
+		return &config.Config{
+			DefaultContext: testDefaultContext,
+			Contexts: map[string]*config.ContextConfig{
+				testDefaultContext: {Providers: providers},
+			},
+		}
+	}
+
+	const updated, other = "updated-provider", "other-provider"
+
+	t.Run("resets an initialized provider", func(t *testing.T) {
+		cfg := newConfig(map[string]*config.ProviderConfig{
+			updated: {Initialized: true},
+		})
+
+		clearInitialized(cfg, updated)
+
+		assert.False(t, cfg.Current().Providers[updated].Initialized)
+	})
+
+	t.Run("leaves other providers untouched", func(t *testing.T) {
+		cfg := newConfig(map[string]*config.ProviderConfig{
+			updated: {Initialized: true},
+			other:   {Initialized: true},
+		})
+
+		clearInitialized(cfg, updated)
+
+		assert.True(t, cfg.Current().Providers[other].Initialized)
+	})
+
+	t.Run("no-ops for an unknown provider", func(t *testing.T) {
+		cfg := newConfig(map[string]*config.ProviderConfig{})
+
+		assert.NotPanics(t, func() { clearInitialized(cfg, "missing") })
+	})
+}
 
 func TestShouldSkipProviderUpdate(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #798.** Base is `feat/async-workspace-up`, so this diff shows only the provider work. Merge #798 first; the base then retargets to `main` automatically.

Adding a provider showed a red **"not initialized"** badge for several seconds before flipping to "initialized".

`provider add --use=false` persists the provider to `config.yaml` *before* init runs (`cmd/provider/add.go` returns early, skipping the only code that sets `Initialized = true`), and the watcher faithfully reported that. `parseProviderEntries` collapsed "not yet known" and "genuinely not initialized" into the same `false`, so the card rendered the destructive badge for both.

The existing mitigation was a renderer-local pending set that only covered init, and was marked *after* `providerAdd` had already returned — missing the entire multi-second install.

## Approach

Two lifecycle axes were collapsed into one boolean. They're now separate:

- **Persisted truth** stays `Initialized bool` on disk — "did *this* binary run `Exec.Init`". No schema change, no migration.
- **Transient job state** moves to a main-process `ProviderJobs` registry, fed by the CLI's structured status events and broadcast on the existing `providers-changed` channel. Main-process ownership means it survives the wizard closing, navigation, and window reload — exactly when a long install is still running.

This also distinguishes states the flag cannot: installing vs initializing vs updating, and failed vs never-initialized.

## Also included

- **`provider add`/`init`/`set-source` emit structured progress** (`pkg/status` Phase/Event/Reporter, as `workspace up` does), replacing the desktop's `"Exit code: 0"` string-sniffing. `pkg/devcontainer/status` → `pkg/status`, since it's no longer devcontainer-specific.
- **Correctness fix:** `set-source` left `Initialized` stale, so a provider updated to a new binary still reported `initialized: true` though the new binary's init never ran — a false *positive* admitting an uninitialized provider through `loadInitializedProvider`. Update and version-pin now chain `provider init`.
- **`runStreaming` hang:** it registered `close` but not `error`, so a spawn failure never invoked `onExit` — callers hung forever and the concurrency slot leaked. Affected every streaming command, not just providers.
- **Tooling:** `task cli:build:grpc` pinned generator versions that didn't match the committed `.pb.go` files and didn't put the plugin dir on `PATH`, so it failed or produced a 162-line phantom diff.

## Verification

Driven against the running Electron app, not just tests — that's what caught two bugs the unit tests missed (a job cleared before the provider list refreshed, and a premature `ready` phase).

- E2E **50/50** from both clean and dirty mock state
- Unit **306 pass**; typecheck (main + renderer) and `golangci-lint` clean
- Each fix verified to fail without it, including the two races

A CodeRabbit review of this branch surfaced 5 findings (3 major); all are addressed in `c6c1cbb`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added real-time provider statuses for installation, initialization, updates, readiness, and failures.
  * Added workspace deletion progress and failure indicators.
  * Workspace and provider commands now report reliable success or failure states.
  * Detached workspace tasks now stream worker logs while running.

* **Bug Fixes**
  * Prevented stale updates and overlapping refreshes.
  * Improved handling of command startup failures and asynchronous completion.
  * Provider source changes now correctly require re-initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->