### PR TITLE
fix(agent): only use podman unshare for rootless podman volume writes

### DIFF
--- a/pkg/agent/delivery/local_docker.go
+++ b/pkg/agent/delivery/local_docker.go
@@ -238,7 +238,7 @@ func (d *LocalDockerDelivery) populateVolumeDirectCopy(
 
 	destPath := filepath.Join(mountpoint, binaryName())
 
-	if d.isPodman() {
+	if d.isRootlessPodman(ctx) {
 		return d.populateVolumeViaUnshare(ctx, destPath, data)
 	}
 
@@ -270,6 +270,21 @@ func (d *LocalDockerDelivery) populateVolumeViaUnshare(
 
 func (d *LocalDockerDelivery) isPodman() bool {
 	return filepath.Base(d.dockerCommand()) == podmanCmd
+}
+
+// isRootlessPodman reports whether the configured podman is running rootless.
+// Only rootless podman requires "podman unshare" to write into a volume's
+// mountpoint; rootful podman's mountpoint is directly writable like docker's.
+func (d *LocalDockerDelivery) isRootlessPodman(ctx context.Context) bool {
+	if !d.isPodman() {
+		return false
+	}
+	out, err := d.cmd(ctx, "info", "--format", "{{.Host.Security.Rootless}}").Output()
+	if err != nil {
+		log.Debugf("failed to detect podman rootless mode, assuming rootful: %v", err)
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
 }
 
 func (d *LocalDockerDelivery) volumeMountpoint(


### PR DESCRIPTION
## Summary
- The direct-copy fallback for delivering the agent binary into a volume inferred rootless-vs-rootful podman purely from the docker binary name, so it always tried `podman unshare` for any podman invocation.
- Rootful podman rejects `podman unshare` with `please use unshare with rootless`, breaking delivery on rootful podman hosts (see `provider_podman.go` "should use custom image" rootful e2e test).
- Added `isRootlessPodman` which checks `podman info --format {{.Host.Security.Rootless}}` and only routes through `podman unshare` when podman is actually rootless; rootful podman now writes directly to the volume mountpoint like docker does.