### PR TITLE
ci: force runc for podman e2e jobs and cache apt packages

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -589,22 +589,45 @@ jobs:
           image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
           skipClusterLogsExport: true
 
+      - name: cache apt packages (podman/runc)
+        if: (matrix.install-podman == 'rootless' || matrix.install-podman == 'rootful') && runner.os == 'Linux'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: /var/cache/apt/archives
+          key: apt-podman-runc-${{ runner.os }}-v1
+
       - name: Install Podman (Linux rootless)
         if: matrix.install-podman == 'rootless' && runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y podman
+          sudo apt-get install -y podman runc
+
+          # podman defaults to crun, which has been observed to fail with
+          # "OCI runtime error: crun: unknown version specified" on this
+          # runner image. Force runc, which is known-good, and fail fast
+          # with diagnostics if it isn't.
+          mkdir -p ~/.config/containers
+          printf '[engine]\nruntime = "runc"\n' > ~/.config/containers/containers.conf
+
           podman info
+          podman run --rm busybox:latest echo "podman runtime preflight OK"
 
       - name: Install Podman (Linux rootful)
         if: matrix.install-podman == 'rootful' && runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y podman
+          sudo apt-get install -y podman runc
+
+          # See the rootless step above: force runc over the default crun,
+          # which has been observed to fail on this runner image.
+          sudo mkdir -p /etc/containers
+          printf '[engine]\nruntime = "runc"\n' | sudo tee /etc/containers/containers.conf
+
           sudo systemctl enable --now podman.socket
           timeout 30 bash -c 'until sudo podman info >/dev/null 2>&1; do sleep 1; done'
           echo "DOCKER_HOST=unix:///run/podman/podman.sock" >> "$GITHUB_ENV"
           sudo podman info
+          sudo podman run --rm busybox:latest echo "podman runtime preflight OK"
 
       - name: Install microsandbox (Linux)
         if: matrix.install-microsandbox == true && runner.os == 'Linux'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -593,14 +593,19 @@ jobs:
         if: (matrix.install-podman == 'rootless' || matrix.install-podman == 'rootful') && runner.os == 'Linux'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: /var/cache/apt/archives
+          path: ${{ runner.temp }}/apt-archives
           key: apt-podman-runc-${{ runner.os }}-v1
 
       - name: Install Podman (Linux rootless)
         if: matrix.install-podman == 'rootless' && runner.os == 'Linux'
+        env:
+          APT_CACHE_DIR: ${{ runner.temp }}/apt-archives
         run: |
-          sudo apt-get update
-          sudo apt-get install -y podman runc
+          # Cache into a runner-owned dir: /var/cache/apt/archives is root-owned
+          # and actions/cache (running unprivileged) can't write into it on restore.
+          mkdir -p "$APT_CACHE_DIR"
+          sudo apt-get -o Dir::Cache::Archives="$APT_CACHE_DIR" update
+          sudo apt-get -o Dir::Cache::Archives="$APT_CACHE_DIR" install -y podman runc
 
           # podman defaults to crun, which has been observed to fail with
           # "OCI runtime error: crun: unknown version specified" on this
@@ -610,13 +615,18 @@ jobs:
           printf '[engine]\nruntime = "runc"\n' > ~/.config/containers/containers.conf
 
           podman info
-          podman run --rm busybox:latest echo "podman runtime preflight OK"
+          podman run --rm busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d echo "podman runtime preflight OK"
 
       - name: Install Podman (Linux rootful)
         if: matrix.install-podman == 'rootful' && runner.os == 'Linux'
+        env:
+          APT_CACHE_DIR: ${{ runner.temp }}/apt-archives
         run: |
-          sudo apt-get update
-          sudo apt-get install -y podman runc
+          # Cache into a runner-owned dir: /var/cache/apt/archives is root-owned
+          # and actions/cache (running unprivileged) can't write into it on restore.
+          mkdir -p "$APT_CACHE_DIR"
+          sudo apt-get -o Dir::Cache::Archives="$APT_CACHE_DIR" update
+          sudo apt-get -o Dir::Cache::Archives="$APT_CACHE_DIR" install -y podman runc
 
           # See the rootless step above: force runc over the default crun,
           # which has been observed to fail on this runner image.
@@ -624,10 +634,15 @@ jobs:
           printf '[engine]\nruntime = "runc"\n' | sudo tee /etc/containers/containers.conf
 
           sudo systemctl enable --now podman.socket
-          timeout 30 bash -c 'until sudo podman info >/dev/null 2>&1; do sleep 1; done'
+          if ! timeout 30 bash -c 'until sudo podman info >/dev/null 2>&1; do sleep 1; done'; then
+            echo "::error::podman.socket did not become ready within 30s"
+            sudo systemctl status podman.socket --no-pager || true
+            sudo journalctl -u podman.socket --no-pager -n 100 || true
+            exit 1
+          fi
           echo "DOCKER_HOST=unix:///run/podman/podman.sock" >> "$GITHUB_ENV"
           sudo podman info
-          sudo podman run --rm busybox:latest echo "podman runtime preflight OK"
+          sudo podman run --rm busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d echo "podman runtime preflight OK"
 
       - name: Install microsandbox (Linux)
         if: matrix.install-microsandbox == true && runner.os == 'Linux'


### PR DESCRIPTION
## Summary
- Both podman e2e jobs (`up-provider-podman` rootless and rootful) have been failing entirely: crun on the `ubuntu-latest` runner image rejects podman-generated OCI specs with `OCI runtime error: crun: unknown version specified`, which breaks every `podman run` and cascades into all 43 specs in each suite failing from one shared root cause (confirmed by pulling the actual job logs — reproduces on the very first spec in both jobs, independent of rootless/rootful mode).
- Force podman to use `runc` instead of the default `crun` via `containers.conf` (`~/.config/containers/containers.conf` for rootless, `/etc/containers/containers.conf` for rootful), and install `runc` alongside `podman`.
- Add a preflight `podman run --rm busybox:latest echo ...` right after install so a broken runtime fails in seconds with clear diagnostics instead of failing 43 specs ~4 minutes in.
- Cache the podman/runc apt archives (`/var/cache/apt/archives`) via `actions/cache` to speed up repeated installs across runs.

This is kept separate from the app-level fix for the `podman unshare` rootless/rootful mismatch (a real but unrelated bug in the volume delivery fallback), since that fix alone doesn't resolve this CI-environment issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Linux integration test environment reliability for Podman-based testing.
  * Added preflight validation to confirm containers can run successfully.
  * Added package caching to help reduce setup time.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->