### PR TITLE
test(compose): accept podman as a valid nerdctl compose fallback

### DIFF
--- a/pkg/compose/helper_test.go
+++ b/pkg/compose/helper_test.go
@@ -237,7 +237,7 @@ func (s *HelperTestSuite) TestNewComposeHelperNerdctlRuntimeFallsBackToDocker() 
 		s.T().Skipf("compose binary not available in test environment: %v", err)
 	}
 
-	s.Contains([]string{"nerdctl", testDockerCmd, testDockerComposeCmd}, ch.Command)
+	s.Contains([]string{"nerdctl", testDockerCmd, testDockerComposeCmd, testPodmanCmd}, ch.Command)
 }
 
 func (s *HelperTestSuite) TestTryComposeSubcommandUsesProvidedCommand() {


### PR DESCRIPTION
## Summary
- `TestNewComposeHelperNerdctlRuntimeFallsBackToDocker` started failing on GitHub-hosted `ubuntu-22.04` runners after the runner image bumped Podman from 3.4.4 to 5.8.4 (image `ubuntu22/20260720.234` → `ubuntu22/20260726.241`).
- `NewComposeHelper`'s fallback chain for non-podman runtimes tries `podman compose` before `docker-compose` v1 (`pkg/compose/helper.go:74-80`). Podman 3.x didn't implement the `compose` subcommand, so that probe always failed and the chain fell through to `docker-compose`, which is what the test asserted. Podman 5.x does implement it, so on runners with a new-enough Podman the fallback now legitimately resolves to `"podman"` instead.
- This is correct application behavior, not a regression — the test's expected-values list just never accounted for `"podman"` as a valid outcome of this fallback. Added it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated runtime command validation to support Podman as an accepted container runtime option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->