### PR TITLE
fix(git): disable filter.lfs.required when git-lfs binary is missing

### DIFF
--- a/e2e/tests/up/git_lfs_test.go
+++ b/e2e/tests/up/git_lfs_test.go
@@ -74,6 +74,7 @@ func simulateStaleGlobalLFSConfig(t *testing.T) {
 	runGit(t, home, "config", "--global", "filter.lfs.process", "git-lfs filter-process")
 	runGit(t, home, "config", "--global", "filter.lfs.smudge", "git-lfs smudge -- %f")
 	runGit(t, home, "config", "--global", "filter.lfs.clean", "git-lfs clean -- %f")
+	runGit(t, home, "config", "--global", "filter.lfs.required", "true")
 }
 
 // newLFSFixtureRepo creates a repo declaring an LFS-tracked file, using local
@@ -86,6 +87,7 @@ func newLFSFixtureRepo(t *testing.T) string {
 	runGit(t, dir, "config", "filter.lfs.clean", "cat")
 	runGit(t, dir, "config", "filter.lfs.smudge", "cat")
 	runGit(t, dir, "config", "filter.lfs.process", "")
+	runGit(t, dir, "config", "filter.lfs.required", "false")
 
 	writeFile(
 		t,

--- a/pkg/git/lfs.go
+++ b/pkg/git/lfs.go
@@ -21,6 +21,7 @@ var lfsDisableFilterArgs = []string{
 	flagConfig, "filter.lfs.process=",
 	flagConfig, "filter.lfs.smudge=cat",
 	flagConfig, "filter.lfs.clean=cat",
+	flagConfig, "filter.lfs.required=false",
 }
 
 func cloneArgsForLFS() []string {


### PR DESCRIPTION
## Summary
- #813 disables the LFS `process`/`smudge`/`clean` filters when `git-lfs` isn't installed, but leaves `filter.lfs.required` untouched.
- If an image ever ran `git lfs install` (setting `filter.lfs.required=true` in system/global git config) and later had the `git-lfs` binary removed, that flag persists. Since a disabled filter still counts as "configured" to git, checkout treats the (expected) filter failure as fatal and aborts with `smudge filter lfs failed` instead of falling back to the LFS pointer stub.
- Adds `filter.lfs.required=false` to the disable-filter args, and updates the e2e LFS test fixture to simulate the stale `required=true` config so this regresses loudly if reintroduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git LFS filter configuration handling when LFS is disabled.
  * Prevented stale global LFS settings from incorrectly affecting repositories with local filter configurations.
  * Updated end-to-end coverage for required and optional LFS filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->