### PR TITLE
fix(git): gate git-lfs auto-install on provisioned hosts, matching ensureGit

### DIFF
--- a/pkg/agent/workspace.go
+++ b/pkg/agent/workspace.go
@@ -319,10 +319,6 @@ func ensureGit(ctx context.Context, agentConfig *provider2.ProviderAgentConfig) 
 	return git.InstallBinary(ctx)
 }
 
-// isLocalAgent reports whether the agent is running in the user's own local
-// environment, as opposed to a devsy-provisioned remote/cloud host. Devsy
-// only installs missing tools on hosts it provisions and controls, never
-// into a user's local environment.
 func isLocalAgent(agentConfig *provider2.ProviderAgentConfig) bool {
 	local, _ := agentConfig.Local.Bool()
 	return local

--- a/pkg/agent/workspace.go
+++ b/pkg/agent/workspace.go
@@ -313,10 +313,19 @@ func ensureGit(ctx context.Context, agentConfig *provider2.ProviderAgentConfig) 
 	if command.Exists("git") {
 		return nil
 	}
-	if local, _ := agentConfig.Local.Bool(); local {
+	if isLocalAgent(agentConfig) {
 		return errors.New("git not installed: install git and add it to PATH")
 	}
 	return git.InstallBinary(ctx)
+}
+
+// isLocalAgent reports whether the agent is running in the user's own local
+// environment, as opposed to a devsy-provisioned remote/cloud host. Devsy
+// only installs missing tools on hosts it provisions and controls, never
+// into a user's local environment.
+func isLocalAgent(agentConfig *provider2.ProviderAgentConfig) bool {
+	local, _ := agentConfig.Local.Bool()
+	return local
 }
 
 func setupGitSSH(
@@ -418,7 +427,8 @@ func cloneViaGit(ctx context.Context, p CloneWorkspaceParams, extraEnv []string)
 	repo := git.At(p.WorkspaceDir,
 		git.WithStrictHostKeyChecking(p.Options.StrictHostKeyChecking),
 		git.WithEnv(extraEnv))
-	if err := repo.CloneFromInfo(ctx, gitInfo, p.Helper, getGitOptions(p.Options)...); err != nil {
+	gitOpts := getGitOptions(p.Options, p.AgentConfig)
+	if err := repo.CloneFromInfo(ctx, gitInfo, p.Helper, gitOpts...); err != nil {
 		return failedClone(p.WorkspaceDir, "clone repository", err)
 	}
 	return nil
@@ -452,7 +462,10 @@ func applyDevsyIgnore(workspaceDir string) error {
 	return nil
 }
 
-func getGitOptions(options provider2.CLIOptions) []git.Option {
+func getGitOptions(
+	options provider2.CLIOptions,
+	agentConfig *provider2.ProviderAgentConfig,
+) []git.Option {
 	var gitOpts []git.Option
 	if options.GitCloneStrategy != "" {
 		gitOpts = append(gitOpts, git.WithCloneStrategy(options.GitCloneStrategy))
@@ -468,6 +481,7 @@ func getGitOptions(options provider2.CLIOptions) []git.Option {
 	} else {
 		gitOpts = append(gitOpts, git.WithLFSMode(options.GitLFSMode))
 	}
+	gitOpts = append(gitOpts, git.WithAllowLFSInstall(!isLocalAgent(agentConfig)))
 	if options.GitCloneRecursiveSubmodules {
 		gitOpts = append(gitOpts, git.WithRecursiveSubmodules())
 	}

--- a/pkg/agent/workspace_test.go
+++ b/pkg/agent/workspace_test.go
@@ -2,9 +2,32 @@ package agent
 
 import (
 	"testing"
+
+	provider2 "github.com/devsy-org/devsy/pkg/provider"
+	"github.com/devsy-org/devsy/pkg/types"
 )
 
 const explicitAgentDir = "/some/dir"
+
+func TestIsLocalAgent(t *testing.T) {
+	cases := []struct {
+		name  string
+		local types.StrBool
+		want  bool
+	}{
+		{"local true", "true", true},
+		{"local false", "false", false},
+		{"unset defaults to remote", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isLocalAgent(&provider2.ProviderAgentConfig{Local: tc.local})
+			if got != tc.want {
+				t.Errorf("isLocalAgent(%q) = %v, want %v", tc.local, got, tc.want)
+			}
+		})
+	}
+}
 
 func withContainerDetector(t *testing.T, fn func() bool) {
 	t.Helper()

--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -107,9 +107,7 @@ func WithSkipLFS() Option {
 	return WithLFSMode(LFSSkip)
 }
 
-// WithAllowLFSInstall permits SetupLFS to install the git-lfs binary itself
-// when it's missing. Reserve this for environments Devsy provisions and
-// controls; never enable it for a user's local environment.
+// WithAllowLFSInstall permits SetupLFS to install the git-lfs binary itself.
 func WithAllowLFSInstall(allow bool) Option {
 	return func(c *cloneConfig) { c.allowLFSInstall = allow }
 }

--- a/pkg/git/clone.go
+++ b/pkg/git/clone.go
@@ -107,12 +107,20 @@ func WithSkipLFS() Option {
 	return WithLFSMode(LFSSkip)
 }
 
+// WithAllowLFSInstall permits SetupLFS to install the git-lfs binary itself
+// when it's missing. Reserve this for environments Devsy provisions and
+// controls; never enable it for a user's local environment.
+func WithAllowLFSInstall(allow bool) Option {
+	return func(c *cloneConfig) { c.allowLFSInstall = allow }
+}
+
 // cloneConfig is the resolved set of clone options.
 type cloneConfig struct {
 	strategy          CloneStrategy
 	branch            string
 	credentialHelper  string
 	recurseSubmodules bool
+	allowLFSInstall   bool
 	lfsMode           LFSMode
 }
 

--- a/pkg/git/installer.go
+++ b/pkg/git/installer.go
@@ -15,6 +15,11 @@ func InstallBinary(ctx context.Context) error {
 	return newInstaller(defaultRunner).ensure(ctx, gitTool)
 }
 
+// InstallLFS installs the git-lfs binary if it is not already available.
+func InstallLFS(ctx context.Context) error {
+	return newInstaller(defaultRunner).ensure(ctx, lfsTool)
+}
+
 // tool identifies a git-related binary the installer can provide.
 type tool struct {
 	binary  string

--- a/pkg/git/installer.go
+++ b/pkg/git/installer.go
@@ -15,11 +15,6 @@ func InstallBinary(ctx context.Context) error {
 	return newInstaller(defaultRunner).ensure(ctx, gitTool)
 }
 
-// InstallLFS installs the git-lfs binary if it is not already available.
-func InstallLFS(ctx context.Context) error {
-	return newInstaller(defaultRunner).ensure(ctx, lfsTool)
-}
-
 // tool identifies a git-related binary the installer can provide.
 type tool struct {
 	binary  string

--- a/pkg/git/lfs.go
+++ b/pkg/git/lfs.go
@@ -41,14 +41,10 @@ func cloneEnvForLFS() []string {
 	return nil
 }
 
-// lfsInstaller installs git-lfs; overridable in tests to avoid a real
-// package-manager/network install attempt.
+// lfsInstaller is overridable in tests.
 var lfsInstaller = InstallLFS
 
-// SetupLFS configures Git LFS in the repository. When git-lfs isn't
-// installed, it's only installed automatically if allowInstall is set,
-// matching ensureGit's rule of never installing tools into a user's local
-// environment.
+// SetupLFS configures Git LFS in the repository.
 func (r *Repo) SetupLFS(ctx context.Context, mode LFSMode, allowInstall bool) {
 	if mode == LFSSkip {
 		return

--- a/pkg/git/lfs.go
+++ b/pkg/git/lfs.go
@@ -41,8 +41,15 @@ func cloneEnvForLFS() []string {
 	return nil
 }
 
-// SetupLFS configures Git LFS in the repository.
-func (r *Repo) SetupLFS(ctx context.Context, mode LFSMode) {
+// lfsInstaller installs git-lfs; overridable in tests to avoid a real
+// package-manager/network install attempt.
+var lfsInstaller = InstallLFS
+
+// SetupLFS configures Git LFS in the repository. When git-lfs isn't
+// installed, it's only installed automatically if allowInstall is set,
+// matching ensureGit's rule of never installing tools into a user's local
+// environment.
+func (r *Repo) SetupLFS(ctx context.Context, mode LFSMode, allowInstall bool) {
 	if mode == LFSSkip {
 		return
 	}
@@ -51,10 +58,19 @@ func (r *Repo) SetupLFS(ctx context.Context, mode LFSMode) {
 	}
 
 	if !command.Exists(binGitLFS) {
-		log.Info(
-			"repository uses git-lfs but the binary is not installed, LFS files will be pointer stubs",
-		)
-		return
+		if !allowInstall {
+			log.Info(
+				"repository uses git-lfs but the binary is not installed, LFS files will be pointer stubs",
+			)
+			return
+		}
+		if err := lfsInstaller(ctx); err != nil {
+			log.Warnf(
+				"repository uses git-lfs but it could not be installed, LFS files will be pointer stubs: %v",
+				err,
+			)
+			return
+		}
 	}
 
 	if err := r.lfs(ctx, "install", "--local"); err != nil {

--- a/pkg/git/lfs.go
+++ b/pkg/git/lfs.go
@@ -53,20 +53,8 @@ func (r *Repo) SetupLFS(ctx context.Context, mode LFSMode, allowInstall bool) {
 		return
 	}
 
-	if !command.Exists(binGitLFS) {
-		if !allowInstall {
-			log.Info(
-				"repository uses git-lfs but the binary is not installed, LFS files will be pointer stubs",
-			)
-			return
-		}
-		if err := lfsInstaller(ctx); err != nil {
-			log.Warnf(
-				"repository uses git-lfs but it could not be installed, LFS files will be pointer stubs: %v",
-				err,
-			)
-			return
-		}
+	if !command.Exists(binGitLFS) && !ensureLFSBinary(ctx, allowInstall) {
+		return
 	}
 
 	if err := r.lfs(ctx, "install", "--local"); err != nil {
@@ -81,6 +69,25 @@ func (r *Repo) SetupLFS(ctx context.Context, mode LFSMode, allowInstall bool) {
 	if err := r.lfs(ctx, "pull"); err != nil {
 		log.Warnf("git-lfs pull failed, LFS files may be pointer stubs: %v", err)
 	}
+}
+
+// ensureLFSBinary installs git-lfs when allowInstall is set, reporting
+// whether the binary is now available.
+func ensureLFSBinary(ctx context.Context, allowInstall bool) bool {
+	if !allowInstall {
+		log.Info(
+			"repository uses git-lfs but the binary is not installed, LFS files will be pointer stubs",
+		)
+		return false
+	}
+	if err := lfsInstaller(ctx); err != nil {
+		log.Warnf(
+			"repository uses git-lfs but it could not be installed, LFS files will be pointer stubs: %v",
+			err,
+		)
+		return false
+	}
+	return true
 }
 
 // lfs runs a `git lfs <args...>` subcommand in the repository, returning any

--- a/pkg/git/lfs.go
+++ b/pkg/git/lfs.go
@@ -51,13 +51,10 @@ func (r *Repo) SetupLFS(ctx context.Context, mode LFSMode) {
 	}
 
 	if !command.Exists(binGitLFS) {
-		if err := InstallLFS(ctx); err != nil {
-			log.Warnf(
-				"repository uses git-lfs but it could not be installed, LFS files will be pointer stubs: %v",
-				err,
-			)
-			return
-		}
+		log.Info(
+			"repository uses git-lfs but the binary is not installed, LFS files will be pointer stubs",
+		)
+		return
 	}
 
 	if err := r.lfs(ctx, "install", "--local"); err != nil {

--- a/pkg/git/lfs_test.go
+++ b/pkg/git/lfs_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -98,6 +99,32 @@ func TestSetupLFSModeCommands(t *testing.T) {
 			assert.DeepEqual(t, tc.want, got)
 		})
 	}
+}
+
+func TestSetupLFSSkipsWhenBinaryMissing(t *testing.T) {
+	hideGitLFSFromPath(t)
+
+	dir, fake := newLFSRepo(t)
+	At(dir, WithRunner(fake)).SetupLFS(context.Background(), LFSFull)
+
+	if got := lfsSubcommands(fake); got != nil {
+		t.Errorf("lfs subcommands = %v, want none", got)
+	}
+}
+
+func hideGitLFSFromPath(t *testing.T) {
+	t.Helper()
+
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not found on PATH")
+	}
+
+	binDir := t.TempDir()
+	if err := os.Symlink(gitPath, filepath.Join(binDir, "git")); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
 }
 
 func TestRepoUsesLFS(t *testing.T) {

--- a/pkg/git/lfs_test.go
+++ b/pkg/git/lfs_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -90,7 +91,7 @@ func TestSetupLFSModeCommands(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir, fake := newLFSRepo(t)
-			At(dir, WithRunner(fake)).SetupLFS(context.Background(), tc.mode)
+			At(dir, WithRunner(fake)).SetupLFS(context.Background(), tc.mode, false)
 
 			var got []string
 			for _, args := range lfsSubcommands(fake) {
@@ -101,15 +102,46 @@ func TestSetupLFSModeCommands(t *testing.T) {
 	}
 }
 
-func TestSetupLFSSkipsWhenBinaryMissing(t *testing.T) {
+func TestSetupLFSSkipsWhenBinaryMissingAndInstallNotAllowed(t *testing.T) {
 	hideGitLFSFromPath(t)
+	stubLFSInstaller(t, func(context.Context) error {
+		t.Fatal("lfsInstaller must not be called when allowInstall is false")
+		return nil
+	})
 
 	dir, fake := newLFSRepo(t)
-	At(dir, WithRunner(fake)).SetupLFS(context.Background(), LFSFull)
+	At(dir, WithRunner(fake)).SetupLFS(context.Background(), LFSFull, false)
 
 	if got := lfsSubcommands(fake); got != nil {
 		t.Errorf("lfs subcommands = %v, want none", got)
 	}
+}
+
+func TestSetupLFSInstallsWhenBinaryMissingAndInstallAllowed(t *testing.T) {
+	hideGitLFSFromPath(t)
+
+	var called bool
+	stubLFSInstaller(t, func(context.Context) error {
+		called = true
+		return errors.New("install unavailable in this environment")
+	})
+
+	dir, fake := newLFSRepo(t)
+	At(dir, WithRunner(fake)).SetupLFS(context.Background(), LFSFull, true)
+
+	if !called {
+		t.Error("lfsInstaller was not called despite allowInstall being true")
+	}
+	if got := lfsSubcommands(fake); got != nil {
+		t.Errorf("lfs subcommands = %v, want none (install failed)", got)
+	}
+}
+
+func stubLFSInstaller(t *testing.T, fn func(context.Context) error) {
+	t.Helper()
+	original := lfsInstaller
+	lfsInstaller = fn
+	t.Cleanup(func() { lfsInstaller = original })
 }
 
 func hideGitLFSFromPath(t *testing.T) {

--- a/pkg/git/repo.go
+++ b/pkg/git/repo.go
@@ -173,7 +173,7 @@ func (r *Repo) CloneFromInfo(
 
 	// Bare clones have no worktree to hydrate.
 	if c.strategy != BareCloneStrategy {
-		r.SetupLFS(ctx, c.lfsMode)
+		r.SetupLFS(ctx, c.lfsMode, c.allowLFSInstall)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Plain git never installs missing tools on your behalf — when the `filter=lfs` driver isn't configured/available, it silently leaves LFS-tracked files as pointer stubs. `SetupLFS` diverged from that by unconditionally trying to `apt`/GitHub-release install `git-lfs` on every clone that uses it.
- In unprivileged/local environments (no root, no write access to `/usr/local/bin`) that install attempt always fails, wasting a network round trip and logging permission-denied errors that look like real failures even though the fallback works fine.
- `SetupLFS` now takes an `allowInstall bool`. When `git-lfs` is missing: `allowInstall=false` falls back straight to pointer stubs (no install attempt, matching plain git's own default); `allowInstall=true` attempts the install (via the reinstated `InstallLFS`) and still falls back gracefully if that fails.
- `pkg/agent`'s `getGitOptions` sets `allowInstall` to `!isLocalAgent(agentConfig)` — the same `agentConfig.Local` check `ensureGit` already uses to decide whether to auto-install the `git` binary itself. So: a user's local machine never gets an auto-install attempt (matches `ensureGit` refusing to install `git` locally too); a devsy-provisioned remote/cloud host — where devsy already has install rights — gets the same auto-install behavior for `git-lfs` that it gets for `git`.
- `--git-lfs-mode` still defaults to `full` and is unchanged; this only affects what happens when the `git-lfs` binary isn't found.
- Tests: `TestSetupLFSSkipsWhenBinaryMissingAndInstallNotAllowed`, `TestSetupLFSInstallsWhenBinaryMissingAndInstallAllowed` (both stub `lfsInstaller` to avoid a real network call), `TestIsLocalAgent`.