### PR TITLE
fix(workspace): delete cached content folder on workspace delete

### DIFF
--- a/cmd/internal/agentworkspace/delete.go
+++ b/cmd/internal/agentworkspace/delete.go
@@ -91,11 +91,31 @@ func (cmd *DeleteCmd) Run(ctx context.Context) error {
 		}
 	}
 
-	// delete workspace folder
+	removeWorkspaceFolders(workspaceInfo)
+
+	return nil
+}
+
+// removeWorkspaceFolders deletes the workspace's config folder and cached
+// content folder, logging rather than failing on either error since deletion
+// should proceed best-effort once the container/daemon are already gone.
+func removeWorkspaceFolders(workspaceInfo *provider2.AgentWorkspaceInfo) {
 	if err := forceRemoveAll(workspaceInfo.Origin); err != nil {
 		log.Errorf("remove workspace folder: %v", err)
 	}
-	return nil
+	if err := removeContentFolder(workspaceInfo); err != nil {
+		log.Errorf("remove workspace content folder: %v", err)
+	}
+}
+
+// removeContentFolder deletes the workspace's cached content folder, unless
+// it's the user's own local folder mounted directly rather than a devsy copy.
+func removeContentFolder(workspaceInfo *provider2.AgentWorkspaceInfo) error {
+	if workspaceInfo.ContentFolder == "" ||
+		workspaceInfo.ContentFolder == workspaceInfo.Workspace.Source.LocalFolder {
+		return nil
+	}
+	return forceRemoveAll(workspaceInfo.ContentFolder)
 }
 
 func removeContainer(

--- a/cmd/internal/agentworkspace/delete_test.go
+++ b/cmd/internal/agentworkspace/delete_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	provider2 "github.com/devsy-org/devsy/pkg/provider"
 )
 
 func skipIfPermissionsNotEnforced(t *testing.T) {
@@ -118,5 +120,50 @@ func TestForceRemoveAll_NestedReadOnlyDirectories(t *testing.T) {
 func TestForceRemoveAll_EmptyString(t *testing.T) {
 	if err := forceRemoveAll(""); err != nil {
 		t.Fatalf("forceRemoveAll with empty string should not error: %v", err)
+	}
+}
+
+func TestRemoveContentFolder_RemovesDevsyManagedContent(t *testing.T) {
+	dir := t.TempDir()
+	content := filepath.Join(dir, "contents", "my-workspace")
+	if err := os.MkdirAll(content, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	workspaceInfo := &provider2.AgentWorkspaceInfo{
+		ContentFolder: content,
+		Workspace:     &provider2.Workspace{},
+	}
+	if err := removeContentFolder(workspaceInfo); err != nil {
+		t.Fatalf("removeContentFolder failed: %v", err)
+	}
+	assertRemoved(t, content)
+}
+
+func TestRemoveContentFolder_SkipsUsersOwnLocalFolder(t *testing.T) {
+	dir := t.TempDir()
+	local := filepath.Join(dir, "my-project")
+	if err := os.MkdirAll(local, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	workspaceInfo := &provider2.AgentWorkspaceInfo{
+		ContentFolder: local,
+		Workspace: &provider2.Workspace{
+			Source: provider2.WorkspaceSource{LocalFolder: local},
+		},
+	}
+	if err := removeContentFolder(workspaceInfo); err != nil {
+		t.Fatalf("removeContentFolder failed: %v", err)
+	}
+	if _, err := os.Stat(local); err != nil {
+		t.Fatalf("expected local folder to survive, got stat err: %v", err)
+	}
+}
+
+func TestRemoveContentFolder_EmptyContentFolder(t *testing.T) {
+	workspaceInfo := &provider2.AgentWorkspaceInfo{Workspace: &provider2.Workspace{}}
+	if err := removeContentFolder(workspaceInfo); err != nil {
+		t.Fatalf("removeContentFolder with empty ContentFolder should not error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- `devsy workspace delete` removed the container and the workspace's config/metadata folder (`contexts/<ctx>/workspaces/<id>`), but left the cloned repo content in `contexts/<ctx>/contents/<id>` untouched. That's intentional caching (so a later `up --reset` can reuse it, per `pkg/agent/agent.go:287-288`), but plain `delete` silently leaving a full repo checkout — potentially with embedded git credentials — on disk forever, with no cleanup path, is a bug: it violates what a command named "delete" is expected to do, and there's no equivalent of `SweepOrphanWorkspaceDirs` for this directory.
- `DeleteCmd.Run` now also removes `workspaceInfo.ContentFolder`, guarded so it never touches the user's own local folder when the workspace source is `LocalFolder` (mirroring the existing `ContentFolder == Source.LocalFolder` check in `up.go`'s `prepareLocalWorkspace`).
- `up --reset`/`--recreate` behavior is unchanged — that's the existing, correct escape hatch for forcing a fresh clone on `up`; this PR only fixes `delete` not finishing the job.
- Added `TestRemoveContentFolder_*` covering: devsy-managed content gets removed, a local-folder-sourced workspace's own directory is left alone, and an empty `ContentFolder` is a no-op.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace deletion now removes associated origin and cached content folders after cleanup.
  - User-owned local source folders are preserved.
  - Missing or empty content folders no longer prevent workspace deletion.
  - Cleanup errors are handled without failing the deletion command.

- **Tests**
  - Added coverage for managed-folder removal and preservation of local folders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->