### PR TITLE
fix(git): check write/root capability before installing git-lfs

### DIFF
--- a/pkg/git/installer.go
+++ b/pkg/git/installer.go
@@ -107,13 +107,10 @@ type pkgManagerStrategy struct {
 
 func (s *pkgManagerStrategy) name() string { return s.manager }
 
-// isRoot is overridable in tests.
 var isRoot = func() bool { return os.Geteuid() == 0 }
 
 // usable requires root: package installs write to system-owned locations
-// (e.g. apt's lock files, dpkg's database) regardless of whether the host
-// is "local" or devsy-provisioned, so checking privilege directly avoids an
-// install attempt that's guaranteed to fail with permission denied.
+// (e.g. apt's lock files, dpkg's database).
 func (s *pkgManagerStrategy) usable() bool {
 	return command.Exists(s.manager) && isRoot()
 }

--- a/pkg/git/installer.go
+++ b/pkg/git/installer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/devsy-org/devsy/pkg/command"
 	"github.com/devsy-org/devsy/pkg/log"
@@ -106,7 +107,16 @@ type pkgManagerStrategy struct {
 
 func (s *pkgManagerStrategy) name() string { return s.manager }
 
-func (s *pkgManagerStrategy) usable() bool { return command.Exists(s.manager) }
+// isRoot is overridable in tests.
+var isRoot = func() bool { return os.Geteuid() == 0 }
+
+// usable requires root: package installs write to system-owned locations
+// (e.g. apt's lock files, dpkg's database) regardless of whether the host
+// is "local" or devsy-provisioned, so checking privilege directly avoids an
+// install attempt that's guaranteed to fail with permission denied.
+func (s *pkgManagerStrategy) usable() bool {
+	return command.Exists(s.manager) && isRoot()
+}
 
 func (s *pkgManagerStrategy) install(ctx context.Context, t tool) error {
 	log.Infof("installing %s with %s", t.pkg, s.manager)

--- a/pkg/git/installer_release.go
+++ b/pkg/git/installer_release.go
@@ -217,6 +217,9 @@ func ensureDirWritable(dir string) error {
 		return err
 	}
 	name := probe.Name()
-	_ = probe.Close()
+	if err := probe.Close(); err != nil {
+		_ = os.Remove(name)
+		return err
+	}
 	return os.Remove(name)
 }

--- a/pkg/git/installer_release.go
+++ b/pkg/git/installer_release.go
@@ -84,6 +84,13 @@ func (s *releaseSource) install(ctx context.Context, binary string) error {
 		}
 	}
 
+	// Check writability before downloading: a permission error here is
+	// guaranteed regardless of host/provider type, so there's no point
+	// spending a network round trip to discover it after the fact.
+	if err := ensureDirWritable(installDir); err != nil {
+		return fmt.Errorf("install dir %q is not writable: %w", installDir, err)
+	}
+
 	req := fetchRequest{
 		binary:   binary,
 		url:      s.downloadURL(s.version, asset),
@@ -96,9 +103,6 @@ func (s *releaseSource) install(ctx context.Context, binary string) error {
 	}
 	defer cleanup()
 
-	if err := os.MkdirAll(installDir, 0o750); err != nil {
-		return fmt.Errorf("create install dir %q: %w", installDir, err)
-	}
 	dst := filepath.Join(installDir, req.execName)
 	if err := moveExecutable(src, dst); err != nil {
 		return fmt.Errorf("install %s to %q: %w", binary, dst, err)
@@ -205,4 +209,20 @@ func moveExecutable(src, dst string) error {
 	}
 	// #nosec G306,G703 -- dst is internally constructed; an executable must be world-executable
 	return os.WriteFile(dst, data, 0o755)
+}
+
+// ensureDirWritable creates dir if needed and confirms it's actually
+// writable by the current process, without relying on any host/provider
+// heuristic.
+func ensureDirWritable(dir string) error {
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+	probe, err := os.CreateTemp(dir, ".devsy-write-test-*")
+	if err != nil {
+		return err
+	}
+	name := probe.Name()
+	_ = probe.Close()
+	return os.Remove(name)
 }

--- a/pkg/git/installer_release.go
+++ b/pkg/git/installer_release.go
@@ -84,9 +84,6 @@ func (s *releaseSource) install(ctx context.Context, binary string) error {
 		}
 	}
 
-	// Check writability before downloading: a permission error here is
-	// guaranteed regardless of host/provider type, so there's no point
-	// spending a network round trip to discover it after the fact.
 	if err := ensureDirWritable(installDir); err != nil {
 		return fmt.Errorf("install dir %q is not writable: %w", installDir, err)
 	}
@@ -211,9 +208,6 @@ func moveExecutable(src, dst string) error {
 	return os.WriteFile(dst, data, 0o755)
 }
 
-// ensureDirWritable creates dir if needed and confirms it's actually
-// writable by the current process, without relying on any host/provider
-// heuristic.
 func ensureDirWritable(dir string) error {
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return err

--- a/pkg/git/installer_test.go
+++ b/pkg/git/installer_test.go
@@ -3,6 +3,8 @@ package git
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -46,6 +48,40 @@ func TestReleaseStrategyRequiresReleaseSource(t *testing.T) {
 	// git has no release source; the release strategy must refuse it.
 	err := releaseStrategy{}.install(context.Background(), gitTool)
 	assert.Assert(t, err != nil)
+}
+
+func TestPkgManagerStrategyUsableRequiresRoot(t *testing.T) {
+	s := &pkgManagerStrategy{manager: "sh"} // "sh" always exists in test environments
+
+	original := isRoot
+	t.Cleanup(func() { isRoot = original })
+
+	isRoot = func() bool { return true }
+	assert.Assert(t, s.usable())
+
+	isRoot = func() bool { return false }
+	assert.Assert(t, !s.usable())
+}
+
+func TestEnsureDirWritable(t *testing.T) {
+	assert.NilError(t, ensureDirWritable(t.TempDir()))
+}
+
+func TestEnsureDirWritableCreatesMissingDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "does", "not", "exist", "yet")
+	assert.NilError(t, ensureDirWritable(dir))
+}
+
+func TestEnsureDirWritableRejectsReadOnlyDir(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("permission test not meaningful when running as root")
+	}
+
+	dir := t.TempDir()
+	// #nosec G302 -- intentional: testing restrictive perms
+	assert.NilError(t, os.Chmod(dir, 0o500))
+
+	assert.Assert(t, ensureDirWritable(dir) != nil)
 }
 
 // fakeStrategy is a test installStrategy with configurable behavior.


### PR DESCRIPTION
## Summary
- #828 gated git-lfs auto-install on \`isLocalAgent(agentConfig)\` (mirroring \`ensureGit\`'s existing rule for the \`git\` binary), so it only attempts install on non-local/devsy-provisioned hosts. That assumption doesn't hold universally: a remote/SSH machine provider (e.g. \`ws3-ssh\`) is "non-local" but not necessarily privileged — confirmed in production logs where a beta build containing #828 still hit the exact same \`apt\`/\`github-release\` permission-denied noise as before, because the remote user account there isn't root.
- \`pkgManagerStrategy.usable()\` now also requires \`isRoot()\` (overridable in tests) — apt/apk installs write to root-owned locations regardless of host type, so this is a direct capability check rather than a provider-type proxy.
- The release strategy (\`releaseSource.install\`) now calls \`ensureDirWritable\` on the resolved install dir *before* downloading anything, so a doomed install never wastes a network round trip.
- Net effect: git-lfs auto-install is attempted only where it can plausibly succeed, regardless of whether the host is "local," "non-local," or any other provider-type label — fixing the gap in #828 without regressing the case it was designed for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package-manager installation is now restricted to environments with the required permissions.
  * Installations verify that the destination directory exists and is writable before downloading files.
  * Missing destination directories are created automatically, while read-only locations are rejected with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->