### PR TITLE
docs(contributing): document testing agent changes against a remote provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,6 +180,35 @@ This requires:
    ./dist/devsy-dev_linux_amd64_v1/devsy-linux-amd64 up examples/simple
    ```
 
+### Testing Agent Changes Against a Remote/SSH Provider
+
+The Quick Start above works because with a local `docker` provider, the CLI
+process you just built *is* the agent. For any remote/SSH/cloud provider, the
+agent runs as a separate binary injected onto that host, so testing a change
+to agent code (`pkg/agent`, `pkg/git`, etc.) needs a couple of extra steps.
+
+1. Build dev binaries for every OS/arch (`task cli:build:dev` builds all of
+   them in one pass: `dist/devsy-dev_<os>_<arch>*/devsy-<os>-<arch>`).
+2. Set `DEVSY_AGENT_BINARY` to the binary matching your **remote host's**
+   OS/arch (not your own machine's) before running `up`/`ssh`/etc. Check
+   `devsy workspace list` for the provider's `HOST`/target arch if unsure.
+3. If you've tested against that workspace before, the remote host likely
+   already has an agent binary cached at the provider's `AGENT_PATH`. A dev
+   build (`version == v0.0.0`) skips the remote version check and only
+   verifies *that a binary exists* there — so a stale cached binary is
+   silently reused instead of your new one. Delete it first to force a fresh
+   injection: `ssh <host> rm -f <AGENT_PATH>` (both values are in
+   `devsy workspace list`'s provider options).
+
+```bash
+task cli:build:dev
+ssh <host> rm -f <AGENT_PATH>
+DEVSY_AGENT_BINARY=./dist/devsy-dev_linux_arm64_v8.0/devsy-linux-arm64 \
+  ./dist/devsy-dev_linux_amd64_v1/devsy-linux-amd64 workspace up <workspace> --reset
+```
+
+`task cli:test:remote` automates this (see below).
+
 ### Using Act for Local CI Testing
 
 ```bash
@@ -265,6 +294,7 @@ task cli:build              # Build CLI for production
 task cli:build:dev          # Build CLI for development
 task cli:lint               # Run linters
 task cli:test               # Run unit tests
+task cli:test:remote        # Test agent changes against a remote/SSH provider workspace
 task cli:tidy               # Tidy go.mod and go.sum
 
 # Desktop tasks

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -88,6 +88,28 @@ tasks:
     desc: run devsy unit tests
     cmd: go test $(go list ./... | grep -v -e /test -e /e2e) -race -coverprofile=dist/profile.out -covermode=atomic
 
+  cli:test:remote:
+    # usage: HOST=user@host AGENT_PATH=/tmp/user/devsy/agent task cli:test:remote -- <workspace> [extra up flags]
+    # HOST/AGENT_PATH come from `devsy workspace list`'s provider options.
+    # GOOS/GOARCH target the remote host (default linux/arm64); override for e.g. an amd64 cloud VM.
+    desc: build a dev binary and inject it into a remote/SSH-provider workspace, bypassing the stale cached-binary reuse
+    vars:
+      GOOS: '{{.GOOS | default "linux"}}'
+      GOARCH: '{{.GOARCH | default "arm64"}}'
+    preconditions:
+      - sh: '[ -n "{{.HOST}}" ]'
+        msg: "HOST is required, e.g. HOST=user@host task cli:test:remote -- my-workspace"
+      - sh: '[ -n "{{.AGENT_PATH}}" ]'
+        msg: "AGENT_PATH is required (see `devsy workspace list`), e.g. AGENT_PATH=/tmp/user/devsy/agent"
+    cmds:
+      - task: cli:build:dev
+      - ssh {{.HOST}} rm -f {{.AGENT_PATH}}
+      - |
+        set -e
+        remote_bin="$(find dist -maxdepth 1 -type d -name 'devsy-dev_{{.GOOS}}_{{.GOARCH}}*')/devsy-{{.GOOS}}-{{.GOARCH}}"
+        local_bin="$(find dist -maxdepth 1 -type d -name "devsy-dev_$(go env GOOS)_$(go env GOARCH)*")/devsy-$(go env GOOS)-$(go env GOARCH)"
+        DEVSY_AGENT_BINARY="$remote_bin" "$local_bin" workspace up {{.CLI_ARGS}} --reset
+
   cli:test:e2e:build:
     desc: build devsy for e2e tests
     status:


### PR DESCRIPTION
## Summary
- The existing "Testing Your Changes" quick start only covers the local `docker` provider case, where the CLI process itself is the agent. For remote/SSH/cloud providers, the agent runs as a separate binary injected onto that host — testing a change there hit two real gotchas while validating #831 against a live `ws3-ssh` workspace:
  - Dev builds (`version == v0.0.0`) skip the remote version check and only verify a binary *exists* at the target path, so a stale cached agent binary is silently reused instead of a freshly built one.
  - `DEVSY_AGENT_BINARY` must match the **remote host's** OS/arch, not the local machine's — a plain `go build .` on a macOS laptop injected onto a Linux ARM64 host fails with `posix_spawn: no such file or directory`.
- Adds a "Testing Agent Changes Against a Remote/SSH Provider" section to `CONTRIBUTING.md` explaining both gotchas and the manual steps.
- Adds `task cli:test:remote` (`Taskfile.yml`) to automate it: builds dev binaries for every OS/arch via the existing `cli:build:dev`, clears the remote's cached binary via SSH, and runs `workspace up --reset` with `DEVSY_AGENT_BINARY` pointed at the binary matching the remote's OS/arch.
- Verified `task cli:test:remote` end-to-end against a real `ws3-ssh` workspace (`HOST=ws3@orb AGENT_PATH=/tmp/skevetter/devsy/agent task cli:test:remote -- <workspace>`) — builds, force-reinjects, and brings the workspace up successfully.