### PR TITLE
fix(ui): enlarge workspace and provider wizard dialogs

### DIFF
--- a/desktop/src/renderer/src/lib/components/provider/ProviderWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderWizard.svelte
@@ -315,7 +315,7 @@ function handleDone() {
 </script>
 
 <Dialog.Root bind:open>
-  <Dialog.Content class="sm:max-w-lg max-h-[85vh] flex flex-col gap-0 p-0 overflow-hidden">
+  <Dialog.Content class="sm:max-w-2xl max-h-[90vh] flex flex-col gap-0 p-0 overflow-hidden">
     <Dialog.Header class="sr-only">
       <Dialog.Title>Add Provider</Dialog.Title>
       <Dialog.Description>

--- a/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
+++ b/desktop/src/renderer/src/lib/components/workspace/WorkspaceWizard.svelte
@@ -786,7 +786,7 @@ function selectTemplate(t: { name: string; source: string }) {
 {/snippet}
 
 <Dialog.Root {open} onOpenChange={handleOpenChange}>
-  <Dialog.Content class="sm:max-w-2xl max-h-[90vh] flex flex-col gap-0 p-0 overflow-hidden">
+  <Dialog.Content class="sm:max-w-4xl max-h-[92vh] flex flex-col gap-0 p-0 overflow-hidden">
     <Dialog.Header class="sr-only">
       <Dialog.Title>Create Workspace</Dialog.Title>
       <Dialog.Description>


### PR DESCRIPTION
## Summary
- Widen the Create Workspace wizard dialog (`sm:max-w-2xl` → `sm:max-w-4xl`, `max-h-[90vh]` → `max-h-[92vh]`)
- Widen the Create Provider wizard dialog (`sm:max-w-lg` → `sm:max-w-2xl`, `max-h-[85vh]` → `max-h-[90vh]`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the provider setup dialog width for improved content visibility.
  * Expanded the workspace setup dialog width and maximum height for a more comfortable setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->