### PR TITLE
fix(ui): stop provider delete from surfacing a false error toast

### DIFF
--- a/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
@@ -93,7 +93,9 @@ let hasUnfilledRequired = $derived.by(() => {
   return requiredOptions.some(([key]) => !optionValues[key]?.trim())
 })
 
-let versionEntry = $derived($providerVersions.byProvider[provider.name])
+let versionEntry = $derived(
+  provider ? $providerVersions.byProvider[provider.name] : undefined,
+)
 
 let groupedOptions = $derived.by(() => {
   const groups: Record<string, [string, ProviderOption][]> = {}
@@ -137,7 +139,7 @@ async function loadOptions() {
 }
 
 $effect(() => {
-  if (!open) {
+  if (!open || !provider) {
     loadedFor = null
     return
   }
@@ -253,10 +255,11 @@ async function handleInitialize() {
 }
 
 async function handleDelete() {
+  const name = provider.name
   deleting = true
   try {
-    await providerDelete(provider.name)
-    toasts.success(`Deleted ${provider.name}`)
+    await providerDelete(name)
+    toasts.success(`Deleted ${name}`)
     confirmDeleteOpen = false
     open = false
     ondeleted?.()
@@ -318,6 +321,7 @@ async function handleSaveOptions() {
 }
 </script>
 
+{#if provider}
 <Sheet.Root bind:open>
   <Sheet.ResizableContent>
     <Sheet.Header class="p-6">
@@ -526,3 +530,4 @@ async function handleSaveOptions() {
   loading={switching}
   onconfirm={runSwitch}
 />
+{/if}

--- a/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
+++ b/desktop/src/renderer/src/lib/components/provider/ProviderSheet.svelte
@@ -151,9 +151,10 @@ $effect(() => {
 })
 
 async function handleSetDefault() {
+  const name = provider.name
   try {
-    await providerUse(provider.name)
-    toasts.success(`Set ${provider.name} as default provider`)
+    await providerUse(name)
+    toasts.success(`Set ${name} as default provider`)
   } catch (err) {
     toasts.error(`Failed to set default: ${extractErrorMessage(err)}`)
   }
@@ -181,11 +182,12 @@ function handleUpdate() {
 }
 
 async function runUpdate() {
+  const name = provider.name
   updating = true
   try {
-    await providerUpdate(provider.name)
-    toasts.success(`Updated ${provider.name}`)
-    await loadVersionsFor(provider.name)
+    await providerUpdate(name)
+    toasts.success(`Updated ${name}`)
+    await loadVersionsFor(name)
     await refreshUpdates()
   } catch (err) {
     toasts.error(`Failed to update: ${extractErrorMessage(err)}`)
@@ -196,11 +198,12 @@ async function runUpdate() {
 }
 
 async function runSwitch() {
+  const name = provider.name
   switching = true
   try {
-    await providerSetVersion(provider.name, targetTag)
-    toasts.success(`Switched ${provider.name} to ${targetTag}`)
-    await loadVersionsFor(provider.name)
+    await providerSetVersion(name, targetTag)
+    toasts.success(`Switched ${name} to ${targetTag}`)
+    await loadVersionsFor(name)
     await refreshUpdates()
   } catch (err) {
     toasts.error(`Failed to switch version: ${extractErrorMessage(err)}`)
@@ -227,14 +230,15 @@ function extractCliError(err: unknown): CLIError | null {
 }
 
 async function handleInitialize() {
+  const name = provider.name
   initializing = true
   initError = null
-  markInitializing(provider.name)
+  markInitializing(name)
   try {
-    await providerInit(provider.name)
+    await providerInit(name)
     const updated = await providerList()
     providers.set(updated)
-    toasts.success(`Initialized ${provider.name}`)
+    toasts.success(`Initialized ${name}`)
   } catch (err) {
     const cliError = extractCliError(err)
     if (cliError) {
@@ -242,15 +246,12 @@ async function handleInitialize() {
     } else {
       initError = {
         code: "UNKNOWN",
-        message:
-          err instanceof Error
-            ? err.message
-            : `Failed to initialize ${provider.name}.`,
+        message: err instanceof Error ? err.message : `Failed to initialize ${name}.`,
       }
     }
   } finally {
     initializing = false
-    clearInitializing(provider.name)
+    clearInitializing(name)
   }
 }
 


### PR DESCRIPTION
## Summary
- Deleting a provider raced the `providers` store update (from the `providers-changed` IPC event) against `ProviderSheet`'s post-delete code, so the live `provider` prop could read as `undefined` right after deletion succeeded, throwing and getting reported as `Failed to delete: Cannot read properties of undefined (reading 'name')` even though the delete had worked.
- Snapshot the provider name before calling `providerDelete` and use that local copy afterward instead of re-reading the reactive prop.
- Guard the other reactive reads of `provider` (`versionEntry`, the options-loading effect, and the template) so a transient `undefined` provider renders nothing instead of throwing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider settings behavior when no provider is selected.
  * Prevented provider details from appearing without an available provider.
  * Improved deletion handling and success reporting for providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->