### PR TITLE
fix(desktop): raise workspace status IPC timeout from 5s to 15s

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -383,7 +383,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         "--result-format",
         "json",
         "--timeout",
-        "5s",
+        "15s",
       ]
       if (args.recovery) cliArgs.push("--recovery")
       return cli.runRaw(cliArgs)


### PR DESCRIPTION
## Summary
- The desktop app's `workspace_status` IPC handler hardcoded a 5s `--timeout` for `devsy workspace status`, far tighter than the CLI's own 30s default.
- On slower providers (remote/SSH-backed, first boot, busy Docker daemon) the container status check can exceed 5s, causing the status call to error out and skip the in-progress "Provisioning" override.
- The renderer's status poller (`fetchStatuses` in `workspaces.ts`) silently swallows that failure and keeps the last cached status, so the workspace list/detail pages can get stuck showing a stale "NotFound" badge instead of the real status.
- Bumped the timeout to 15s to give the check realistic headroom to complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the workspace status check timeout to 15 seconds, allowing more time for the CLI to respond successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->