### PR TITLE
fix(devcontainer): propagate platform and docker env into compose builds

### DIFF
--- a/pkg/compose/helper.go
+++ b/pkg/compose/helper.go
@@ -377,7 +377,13 @@ func (h *ComposeHelper) buildCmd(ctx context.Context, args ...string) *exec.Cmd 
 	var allArgs []string
 	allArgs = append(allArgs, h.Args...)
 	allArgs = append(allArgs, args...)
-	return exec.CommandContext(ctx, h.Command, allArgs...)
+	cmd := exec.CommandContext(ctx, h.Command, allArgs...)
+	// Mirrors DockerHelper.buildCmd, else compose ignores the provider's
+	// configured DOCKER_HOST/env and hits the default daemon.
+	if h.Docker != nil && h.Docker.Environment != nil {
+		cmd.Env = append(os.Environ(), h.Docker.Environment...)
+	}
+	return cmd
 }
 
 // runCmdCapture runs the provided command, capturing stdout and stderr separately.

--- a/pkg/compose/helper.go
+++ b/pkg/compose/helper.go
@@ -379,8 +379,6 @@ func (h *ComposeHelper) buildCmd(ctx context.Context, args ...string) *exec.Cmd 
 	allArgs = append(allArgs, args...)
 	//nolint:gosec // G204: command and args come from trusted provider config
 	cmd := exec.CommandContext(ctx, h.Command, allArgs...)
-	// Mirrors DockerHelper.buildCmd, else compose ignores the provider's
-	// configured DOCKER_HOST/env and hits the default daemon.
 	if h.Docker != nil && h.Docker.Environment != nil {
 		cmd.Env = append(os.Environ(), h.Docker.Environment...)
 	}

--- a/pkg/compose/helper.go
+++ b/pkg/compose/helper.go
@@ -377,6 +377,7 @@ func (h *ComposeHelper) buildCmd(ctx context.Context, args ...string) *exec.Cmd 
 	var allArgs []string
 	allArgs = append(allArgs, h.Args...)
 	allArgs = append(allArgs, args...)
+	//nolint:gosec // G204: command and args come from trusted provider config
 	cmd := exec.CommandContext(ctx, h.Command, allArgs...)
 	// Mirrors DockerHelper.buildCmd, else compose ignores the provider's
 	// configured DOCKER_HOST/env and hits the default daemon.

--- a/pkg/compose/helper_test.go
+++ b/pkg/compose/helper_test.go
@@ -170,6 +170,29 @@ func (s *HelperTestSuite) TestComposeHelperBuildCmdPodman() {
 	s.Contains(cmd.Args, "-d")
 }
 
+func (s *HelperTestSuite) TestComposeHelperBuildCmdAppliesDockerEnvironment() {
+	helper := &ComposeHelper{
+		Command: testPodmanCmd,
+		Args:    []string{testComposeArg},
+		Docker: &docker.DockerHelper{
+			Environment: []string{"DOCKER_HOST=unix:///custom/docker.sock"},
+		},
+	}
+
+	cmd := helper.buildCmd(context.TODO(), "build")
+	s.Contains(cmd.Env, "DOCKER_HOST=unix:///custom/docker.sock")
+}
+
+func (s *HelperTestSuite) TestComposeHelperBuildCmdWithoutDockerEnvironment() {
+	helper := &ComposeHelper{
+		Command: testPodmanCmd,
+		Args:    []string{testComposeArg},
+	}
+
+	cmd := helper.buildCmd(context.TODO(), "build")
+	s.Nil(cmd.Env)
+}
+
 // stubRuntime implements docker.ContainerRuntime for testing detection order.
 type stubRuntime struct {
 	name docker.RuntimeName

--- a/pkg/devcontainer/compose_build.go
+++ b/pkg/devcontainer/compose_build.go
@@ -545,7 +545,7 @@ func (r *runner) createComposeService(params *composeServiceParams) *composetype
 	composeService := params.composeService
 	featuresBuildInfo := params.featuresBuildInfo
 
-	// Clone Build instead of starting empty, so fields this function doesn't
+	// Clone Build instead of starting empty, so fields this function does not
 	// set explicitly (Platforms, ShmSize, CacheFrom, ...) aren't dropped.
 	var build composetypes.BuildConfig
 	if composeService.Build != nil {

--- a/pkg/devcontainer/compose_build.go
+++ b/pkg/devcontainer/compose_build.go
@@ -545,12 +545,18 @@ func (r *runner) createComposeService(params *composeServiceParams) *composetype
 	composeService := params.composeService
 	featuresBuildInfo := params.featuresBuildInfo
 
+	// Clone Build instead of starting empty, so fields this function doesn't
+	// set explicitly (Platforms, ShmSize, CacheFrom, ...) aren't dropped.
+	var build composetypes.BuildConfig
+	if composeService.Build != nil {
+		build = *composeService.Build
+	}
+	build.Dockerfile = params.dockerfilePathInContext
+	build.Context = params.buildContext
+
 	service := &composetypes.ServiceConfig{
-		Name: composeService.Name,
-		Build: &composetypes.BuildConfig{
-			Dockerfile: params.dockerfilePathInContext,
-			Context:    params.buildContext,
-		},
+		Name:  composeService.Name,
+		Build: &build,
 	}
 	if params.buildImageName != "" {
 		service.Image = stripDigestFromImageRef(params.buildImageName)
@@ -563,6 +569,12 @@ func (r *runner) createComposeService(params *composeServiceParams) *composetype
 	service.Build.Args = composetypes.NewMappingWithEquals([]string{"BUILDKIT_INLINE_CACHE=1"})
 	for k, v := range featuresBuildInfo.BuildArgs {
 		service.Build.Args[k] = &v
+	}
+
+	// Platform and Build.Platforms are independent compose fields; fall back
+	// to Platform only if the clone above didn't already set Build.Platforms.
+	if composeService.Platform != "" && len(service.Build.Platforms) == 0 {
+		service.Build.Platforms = composetypes.StringList{composeService.Platform}
 	}
 
 	return service

--- a/pkg/devcontainer/compose_test.go
+++ b/pkg/devcontainer/compose_test.go
@@ -174,6 +174,86 @@ func (s *ComposeSuite) TestCreateComposeServiceUsesBuildImageName() {
 	s.requireBuildArgValue(service.Build.Args, "BUILDKIT_INLINE_CACHE", "1")
 }
 
+func (s *ComposeSuite) TestCreateComposeServiceCarriesPlatform() {
+	r := &runner{}
+	service := r.createComposeService(&composeServiceParams{
+		composeService: &composetypes.ServiceConfig{
+			Name:     "app",
+			Image:    "ghcr.io/example/shared-base:latest",
+			Platform: "linux/amd64",
+		},
+		buildImageName:          "workspace-app:latest",
+		dockerfilePathInContext: "Dockerfile-with-features",
+		buildContext:            "/tmp/context",
+		featuresBuildInfo: &feature.BuildInfo{
+			OverrideTarget: "dev_containers_target_stage",
+		},
+	})
+
+	s.Require().NotNil(service.Build)
+	s.Equal(composetypes.StringList{"linux/amd64"}, service.Build.Platforms)
+}
+
+func (s *ComposeSuite) TestCreateComposeServiceOmitsPlatformWhenUnset() {
+	r := &runner{}
+	service := r.createComposeService(&composeServiceParams{
+		composeService: &composetypes.ServiceConfig{
+			Name:  "app",
+			Image: "ghcr.io/example/shared-base:latest",
+		},
+		buildImageName:          "workspace-app:latest",
+		dockerfilePathInContext: "Dockerfile-with-features",
+		buildContext:            "/tmp/context",
+		featuresBuildInfo: &feature.BuildInfo{
+			OverrideTarget: "dev_containers_target_stage",
+		},
+	})
+
+	s.Require().NotNil(service.Build)
+	s.Nil(service.Build.Platforms)
+}
+
+func (s *ComposeSuite) TestCreateComposeServiceClonesBuildPlatforms() {
+	r := &runner{}
+	service := r.createComposeService(&composeServiceParams{
+		composeService: &composetypes.ServiceConfig{
+			Name: "app",
+			Build: &composetypes.BuildConfig{
+				Platforms: composetypes.StringList{"linux/amd64", "linux/arm64"},
+			},
+		},
+		dockerfilePathInContext: "Dockerfile-with-features",
+		buildContext:            "/tmp/context",
+		featuresBuildInfo:       &feature.BuildInfo{},
+	})
+
+	s.Require().NotNil(service.Build)
+	s.Equal(composetypes.StringList{"linux/amd64", "linux/arm64"}, service.Build.Platforms)
+}
+
+func (s *ComposeSuite) TestCreateComposeServiceClonesUnrelatedBuildFields() {
+	r := &runner{}
+	service := r.createComposeService(&composeServiceParams{
+		composeService: &composetypes.ServiceConfig{
+			Name: "app",
+			Build: &composetypes.BuildConfig{
+				ShmSize:   64 * 1024 * 1024,
+				CacheFrom: composetypes.StringList{"type=registry,ref=example.com/cache"},
+			},
+		},
+		dockerfilePathInContext: "Dockerfile-with-features",
+		buildContext:            "/tmp/context",
+		featuresBuildInfo:       &feature.BuildInfo{},
+	})
+
+	s.Require().NotNil(service.Build)
+	s.EqualValues(64*1024*1024, service.Build.ShmSize)
+	s.Equal(
+		composetypes.StringList{"type=registry,ref=example.com/cache"},
+		service.Build.CacheFrom,
+	)
+}
+
 func (s *ComposeSuite) requireBuildArgValue(
 	args composetypes.MappingWithEquals,
 	key, want string,

--- a/pkg/devcontainer/compose_test.go
+++ b/pkg/devcontainer/compose_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const (
+	platformLinuxAMD64 = "linux/amd64"
+	platformLinuxARM64 = "linux/arm64"
+)
+
 type composeBuildImageNameTestCase struct {
 	name          string
 	composeHelper *compose.ComposeHelper
@@ -180,7 +185,7 @@ func (s *ComposeSuite) TestCreateComposeServiceCarriesPlatform() {
 		composeService: &composetypes.ServiceConfig{
 			Name:     "app",
 			Image:    "ghcr.io/example/shared-base:latest",
-			Platform: "linux/amd64",
+			Platform: platformLinuxAMD64,
 		},
 		buildImageName:          "workspace-app:latest",
 		dockerfilePathInContext: "Dockerfile-with-features",
@@ -191,7 +196,7 @@ func (s *ComposeSuite) TestCreateComposeServiceCarriesPlatform() {
 	})
 
 	s.Require().NotNil(service.Build)
-	s.Equal(composetypes.StringList{"linux/amd64"}, service.Build.Platforms)
+	s.Equal(composetypes.StringList{platformLinuxAMD64}, service.Build.Platforms)
 }
 
 func (s *ComposeSuite) TestCreateComposeServiceOmitsPlatformWhenUnset() {
@@ -219,7 +224,7 @@ func (s *ComposeSuite) TestCreateComposeServiceClonesBuildPlatforms() {
 		composeService: &composetypes.ServiceConfig{
 			Name: "app",
 			Build: &composetypes.BuildConfig{
-				Platforms: composetypes.StringList{"linux/amd64", "linux/arm64"},
+				Platforms: composetypes.StringList{platformLinuxAMD64, platformLinuxARM64},
 			},
 		},
 		dockerfilePathInContext: "Dockerfile-with-features",
@@ -228,7 +233,10 @@ func (s *ComposeSuite) TestCreateComposeServiceClonesBuildPlatforms() {
 	})
 
 	s.Require().NotNil(service.Build)
-	s.Equal(composetypes.StringList{"linux/amd64", "linux/arm64"}, service.Build.Platforms)
+	s.Equal(
+		composetypes.StringList{platformLinuxAMD64, platformLinuxARM64},
+		service.Build.Platforms,
+	)
 }
 
 func (s *ComposeSuite) TestCreateComposeServiceClonesUnrelatedBuildFields() {


### PR DESCRIPTION
## Summary
- `createComposeService` rebuilt the feature-extended compose override's `BuildConfig` from scratch, silently dropping fields (e.g. `platform`) that weren't in its explicit copy list. It now clones the original `BuildConfig` so unrelated fields survive automatically.
- `ComposeHelper.buildCmd` never applied the provider's configured Docker environment (`DOCKER_HOST`, etc.) to spawned `docker compose`/`docker-compose` processes, unlike `DockerHelper.buildCmd`. Compose builds could silently target the wrong daemon on providers with a non-default `DOCKER_HOST`.
