### PR TITLE
chore(lint): enable funcorder.function and revive.enable-all-rules

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,9 +44,18 @@ linters:
   settings:
     cyclop:
       max-complexity: 8
+    funcorder:
+      function: true
     revive:
+      enable-all-rules: true
       rules:
         - name: argument-limit
           arguments: [4]
         - name: function-result-limit
           arguments: [3]
+        - name: line-length-limit
+          disabled: true
+        - name: cyclomatic
+          disabled: true
+        - name: function-length
+          disabled: true


### PR DESCRIPTION
## Summary
- Enables `funcorder.function: true` and `revive.enable-all-rules: true` in `.golangci.yaml`.
- Disables 3 revive sub-rules that duplicate already-enabled, already-tuned linters: `line-length-limit` (duplicates `lll`), `cyclomatic` (duplicates `cyclop`, tuned to `max-complexity: 8`), `function-length` (duplicates `funlen`). Pure config consolidation, no suppression of real issues.

## Scope note
This is PR1 of a 5-PR stack rolling out these rules across the codebase. It intentionally does **not** fix the `funcorder` findings the config change surfaces (11 of them, across `pkg/agent/tunnelserver`, `pkg/apple`, `pkg/client/clientimplementation`, `pkg/dockerfile`, `pkg/driver/kubernetes`, `pkg/ide/jetbrains`, `pkg/ide/openvscode`, `pkg/platform/client`, `pkg/platform/remotecommand`, `pkg/stdio`) or the much larger `revive.enable-all-rules` backlog (~6,800 findings repo-wide, uncapped) — those land in PR2–PR5. Since CI's `golangci-lint-action` runs with `only-new-issues: true`, this config-only diff should not fail CI on pre-existing findings.

Marked as draft pending the full stack's review sequencing.