### PR TITLE
fix(lint): enable revive blank-imports, remove unused import

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -50,3 +50,4 @@ linters:
           arguments: [4]
         - name: function-result-limit
           arguments: [3]
+        - name: blank-imports

--- a/pkg/ide/rstudio/rstudio.go
+++ b/pkg/ide/rstudio/rstudio.go
@@ -3,7 +3,6 @@ package rstudio
 import (
 	"bytes"
 	"context"
-	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"


### PR DESCRIPTION
## Summary
- Removes the unused `_ "embed"` blank import in `pkg/ide/rstudio/rstudio.go` — it had no `//go:embed` directive anywhere in the package, so the import had no effect.
- Enables the `blank-imports` revive rule in `.golangci.yaml`.

This is one rule in an incremental rollout of `revive`'s full rule set, fixed and enabled one rule at a time so `main` stays green after every merge.