### PR TITLE
fix(lint): enable revive nested-structs

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -51,3 +51,4 @@ linters:
         - name: function-result-limit
           arguments: [3]
         - name: blank-imports
+        - name: nested-structs

--- a/pkg/driver/microsandbox/cliclient.go
+++ b/pkg/driver/microsandbox/cliclient.go
@@ -77,13 +77,14 @@ func (cliClient) Find(ctx context.Context, sandbox string) (*sandboxInfo, error)
 		}
 		return nil, fmt.Errorf("inspect microsandbox VM %q: %w", sandbox, err)
 	}
+	type activeConfig struct {
+		Labels map[string]string `json:"labels"`
+	}
 	var raw struct {
-		Name         string `json:"name"`
-		Status       string `json:"status"`
-		CreatedAt    string `json:"created_at"`
-		ActiveConfig struct {
-			Labels map[string]string `json:"labels"`
-		} `json:"active_config"`
+		Name         string       `json:"name"`
+		Status       string       `json:"status"`
+		CreatedAt    string       `json:"created_at"`
+		ActiveConfig activeConfig `json:"active_config"`
 	}
 	if err := json.Unmarshal(out, &raw); err != nil {
 		return nil, fmt.Errorf("parse microsandbox inspect output: %w", err)


### PR DESCRIPTION
## Summary
- Extracts the anonymous struct nested inside another anonymous struct in `pkg/driver/microsandbox/cliclient.go`'s `Find` method into a named local type (`activeConfig`), used only for JSON unmarshaling of the `msb inspect` CLI output.
- Enables the `nested-structs` revive rule in `.golangci.yaml`.

One rule in the incremental `revive` rollout — fixed and enabled one rule at a time so `main` stays green after every merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal configuration parsing for sandbox information while preserving existing label handling and runtime behavior.
* **Quality Improvements**
  * Strengthened static analysis checks to promote clearer and more maintainable Go code.
* **Bug Fixes**
  * No user-facing bugs or functional changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->