### PR TITLE
docs: fix README image paths after docs site migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 <p align="center">
   <a href="https://www.devsy.sh">
     <picture width="500">
-      <source media="(prefers-color-scheme: dark)" srcset="sites/docs-devsy-sh/static/media/devsy-dark.png">
-      <img alt="Devsy wordmark" width="500" src="sites/docs-devsy-sh/static/media/devsy.png">
+      <source media="(prefers-color-scheme: dark)" srcset="sites/docs-devsy-sh/public/docs/media/devsy-dark.png">
+      <img alt="Devsy wordmark" width="500" src="sites/docs-devsy-sh/public/docs/media/devsy.png">
     </picture>
   </a>
 </p>
@@ -29,7 +29,7 @@ Devsy enables teams and their AI coding agents to scale development using standa
 </tr>
 </table>
 
-![Devsy Flow](sites/docs-devsy-sh/static/media/devsy-flow.gif)
+![Devsy Flow](sites/docs-devsy-sh/public/docs/media/devsy-flow.gif)
 
 <h2 align="center">Downloads</h2>
 


### PR DESCRIPTION
## Summary

PR #865 migrated `sites/docs-devsy-sh`'s docs site from Docusaurus to Fumadocs, moving static assets from `static/media/` to `public/docs/media/` and deleting the old `static/` directory. Three image references in the repo-root `README.md` still pointed at the deleted path and were missed by that migration.

- `sites/docs-devsy-sh/static/media/devsy-dark.png` → `sites/docs-devsy-sh/public/docs/media/devsy-dark.png`
- `sites/docs-devsy-sh/static/media/devsy.png` → `sites/docs-devsy-sh/public/docs/media/devsy.png`
- `sites/docs-devsy-sh/static/media/devsy-flow.gif` → `sites/docs-devsy-sh/public/docs/media/devsy-flow.gif`

Confirmed all three referenced files exist at the new path and no other tracked file in the repo references the old `static/media` path.