### PR TITLE
fix(lint): restore G305 nosec suppression dropped in comment cleanup

### DIFF
--- a/pkg/extract/zip.go
+++ b/pkg/extract/zip.go
@@ -36,8 +36,7 @@ func UnzipFolder(source, destination string) error {
 }
 
 func unzipFile(f *zip.File, destination string) error {
-	// #nosec G305 -- the HasPrefix check below is exactly this guard; gosec
-	// can't verify it statically, but every write path is gated on it
+	// #nosec G305 -- no zip slip
 	filePath := filepath.Join(destination, f.Name)
 	if !strings.HasPrefix(filePath, filepath.Clean(destination)+string(os.PathSeparator)) {
 		return fmt.Errorf("invalid file path: %s", filePath)

--- a/pkg/extract/zip.go
+++ b/pkg/extract/zip.go
@@ -36,6 +36,8 @@ func UnzipFolder(source, destination string) error {
 }
 
 func unzipFile(f *zip.File, destination string) error {
+	// #nosec G305 -- the HasPrefix check below is exactly this guard; gosec
+	// can't verify it statically, but every write path is gated on it
 	filePath := filepath.Join(destination, f.Name)
 	if !strings.HasPrefix(filePath, filepath.Clean(destination)+string(os.PathSeparator)) {
 		return fmt.Errorf("invalid file path: %s", filePath)


### PR DESCRIPTION
## Summary
- A later commit in #879 ("style: update comments") stripped the `#nosec G305` annotation on `unzipFile`'s Zip Slip guard along with unrelated step-numbering comments, reintroducing the gosec G305 finding on `main`.
- Restores the suppression comment; confirmed G305 findings are back to 0 repo-wide (`gosec` total 139 → 138).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Documented the safety validation used during archive extraction to prevent unsafe file paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->