### PR TITLE
fix(lint): resolve function-result-limit findings

### DIFF
--- a/pkg/devcontainer/buildkit/remote.go
+++ b/pkg/devcontainer/buildkit/remote.go
@@ -48,12 +48,12 @@ func BuildRemote(ctx context.Context, opts BuildRemoteOptions) (*config.BuildInf
 		return nil, err
 	}
 
-	c, info, tmpDir, err := setupBuildKitClient(ctx, opts.Options)
+	bk, err := setupBuildKitClient(ctx, opts.Options)
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-	defer func() { _ = c.Close() }()
+	defer func() { _ = os.RemoveAll(bk.CertsDir) }()
+	defer func() { _ = bk.Client.Close() }()
 
 	repo := strings.TrimSuffix(opts.Options.CLIOptions.Platform.Build.Repository, "/")
 	imageName := path.Join(repo, build.GetImageName(opts.LocalWorkspaceFolder, opts.PrebuildHash))
@@ -80,8 +80,8 @@ func BuildRemote(ctx context.Context, opts BuildRemoteOptions) (*config.BuildInf
 
 	if err := executeBuild(executeBuildParams{
 		Ctx:       ctx,
-		Client:    c,
-		Info:      info,
+		Client:    bk.Client,
+		Info:      bk.Info,
 		SolveOpts: solveOpts,
 	}); err != nil {
 		return nil, err
@@ -149,18 +149,27 @@ func validateRemoteBuildOptions(options provider.BuildOptions) error {
 	return nil
 }
 
+// buildKitClient bundles the connection setupBuildKitClient establishes:
+// the client itself, the remote builder's info, and the local directory
+// holding the certs it was authenticated with (the caller owns cleanup).
+type buildKitClient struct {
+	Client   *client.Client
+	Info     *client.Info
+	CertsDir string
+}
+
 func setupBuildKitClient(
 	ctx context.Context,
 	options provider.BuildOptions,
-) (*client.Client, *client.Info, string, error) {
+) (*buildKitClient, error) {
 	remoteURL, err := url.Parse(options.CLIOptions.Platform.Build.RemoteAddress)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, err
 	}
 
 	certs, err := ensureCertPaths(options.CLIOptions.Platform.Build)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("ensure certificates: %w", err)
+		return nil, fmt.Errorf("ensure certificates: %w", err)
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -173,17 +182,17 @@ func setupBuildKitClient(
 	)
 	if err != nil {
 		_ = os.RemoveAll(certs.ParentDir)
-		return nil, nil, "", fmt.Errorf("get client: %w", err)
+		return nil, fmt.Errorf("get client: %w", err)
 	}
 
 	info, err := c.Info(timeoutCtx)
 	if err != nil {
 		_ = c.Close()
 		_ = os.RemoveAll(certs.ParentDir)
-		return nil, nil, "", fmt.Errorf("get remote builder info: %w", err)
+		return nil, fmt.Errorf("get remote builder info: %w", err)
 	}
 
-	return c, info, certs.ParentDir, nil
+	return &buildKitClient{Client: c, Info: info, CertsDir: certs.ParentDir}, nil
 }
 
 func resolveImageReference(

--- a/pkg/options/resolver/resolve.go
+++ b/pkg/options/resolver/resolve.go
@@ -60,7 +60,7 @@ func (r *Resolver) resolveOption(
 	}
 
 	// get existing values
-	userValue, userValueOk, beforeValue, beforeValueOk, err := r.getValue(
+	existing, err := r.getValue(
 		optionName,
 		option,
 		resolvedOptionValues,
@@ -72,9 +72,9 @@ func (r *Resolver) resolveOption(
 	skip, err := r.shouldSkipResolve(skipResolveParams{
 		optionName:    optionName,
 		option:        option,
-		userValueOk:   userValueOk,
-		beforeValue:   beforeValue,
-		beforeValueOk: beforeValueOk,
+		userValueOk:   existing.userValueOk,
+		beforeValue:   existing.beforeValue,
+		beforeValueOk: existing.beforeValueOk,
 	})
 	if err != nil {
 		return err
@@ -86,19 +86,19 @@ func (r *Resolver) resolveOption(
 	if err := r.computeOptionValue(ctx, computeOptionValueParams{
 		optionName:           optionName,
 		option:               option,
-		userValue:            userValue,
-		userValueOk:          userValueOk,
-		beforeValue:          beforeValue,
+		userValue:            existing.userValue,
+		userValueOk:          existing.userValueOk,
+		beforeValue:          existing.beforeValue,
 		resolvedOptionValues: resolvedOptionValues,
 	}); err != nil {
 		return err
 	}
 
-	if err := r.resolveRequired(optionName, option, userValueOk, resolvedOptionValues); err != nil {
+	if err := r.resolveRequired(optionName, option, existing.userValueOk, resolvedOptionValues); err != nil {
 		return err
 	}
 
-	r.invalidateChangedChildren(optionName, beforeValue, resolvedOptionValues)
+	r.invalidateChangedChildren(optionName, existing.beforeValue, resolvedOptionValues)
 
 	return nil
 }
@@ -289,11 +289,21 @@ func (r *Resolver) invalidateChangedChildren(
 	}
 }
 
+// existingOptionValue bundles the user-provided and previously-resolved
+// values getValue looks up for an option, along with whether each was
+// present.
+type existingOptionValue struct {
+	userValue     string
+	userValueOk   bool
+	beforeValue   config.OptionValue
+	beforeValueOk bool
+}
+
 func (r *Resolver) getValue(
 	optionName string,
 	option *types.Option,
 	resolvedOptionValues map[string]config.OptionValue,
-) (string, bool, config.OptionValue, bool, error) {
+) (existingOptionValue, error) {
 	// check if user value exists
 	userValue, userValueOk := r.userOptions[optionName]
 
@@ -304,7 +314,7 @@ func (r *Resolver) getValue(
 	if userValueOk {
 		err := validateUserValue(optionName, userValue, option)
 		if err != nil {
-			return "", false, config.OptionValue{}, false, err
+			return existingOptionValue{}, err
 		}
 	}
 
@@ -319,7 +329,12 @@ func (r *Resolver) getValue(
 		}
 	}
 
-	return userValue, userValueOk, beforeValue, beforeValueOk, nil
+	return existingOptionValue{
+		userValue:     userValue,
+		userValueOk:   userValueOk,
+		beforeValue:   beforeValue,
+		beforeValueOk: beforeValueOk,
+	}, nil
 }
 
 func (r *Resolver) refreshSubOptions(

--- a/pkg/options/resolver/resolve.go
+++ b/pkg/options/resolver/resolve.go
@@ -94,7 +94,12 @@ func (r *Resolver) resolveOption(
 		return err
 	}
 
-	if err := r.resolveRequired(optionName, option, existing.userValueOk, resolvedOptionValues); err != nil {
+	if err := r.resolveRequired(
+		optionName,
+		option,
+		existing.userValueOk,
+		resolvedOptionValues,
+	); err != nil {
 		return err
 	}
 

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -74,14 +74,14 @@ func Resolve(
 		return nil, err
 	}
 
-	provider, workspace, machine, err := resolveWorkspace(ctx, devsyConfig, params)
+	resolved, err := resolveWorkspace(ctx, devsyConfig, params)
 	if err != nil {
 		return nil, err
 	}
 
-	workspace, err = ideparse.RefreshIDEOptions(
+	workspace, err := ideparse.RefreshIDEOptions(
 		devsyConfig,
-		workspace,
+		resolved.workspace,
 		params.IDE,
 		params.IDEOptions,
 	)
@@ -93,7 +93,7 @@ func Resolve(
 		return nil, err
 	}
 
-	workspaceClient, err := getWorkspaceClient(devsyConfig, provider, workspace, machine)
+	workspaceClient, err := getWorkspaceClient(devsyConfig, resolved.provider, workspace, resolved.machine)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ type GetOptions struct {
 // are given.
 func Get(ctx context.Context, opts GetOptions) (client.BaseWorkspaceClient, error) {
 	if len(opts.Args) == 0 {
-		provider, workspace, machine, err := selectWorkspace(
+		resolved, err := selectWorkspace(
 			ctx,
 			opts.DevsyConfig,
 			selectWorkspaceParams{
@@ -196,7 +196,7 @@ func Get(ctx context.Context, opts GetOptions) (client.BaseWorkspaceClient, erro
 			return nil, err
 		}
 
-		return getWorkspaceClient(opts.DevsyConfig, provider, workspace, machine)
+		return getWorkspaceClient(opts.DevsyConfig, resolved.provider, resolved.workspace, resolved.machine)
 	}
 
 	workspace, err := findWorkspaceByArgs(ctx, opts)
@@ -207,7 +207,7 @@ func Get(ctx context.Context, opts GetOptions) (client.BaseWorkspaceClient, erro
 		return nil, fmt.Errorf("%w for args: %v", ErrWorkspaceNotFound, opts.Args)
 	}
 
-	provider, workspace, machine, err := loadExistingWorkspace(
+	resolved, err := loadExistingWorkspace(
 		opts.DevsyConfig,
 		workspace.ID,
 		opts.ChangeLastUsed,
@@ -216,7 +216,7 @@ func Get(ctx context.Context, opts GetOptions) (client.BaseWorkspaceClient, erro
 		return nil, err
 	}
 
-	return getWorkspaceClient(opts.DevsyConfig, provider, workspace, machine)
+	return getWorkspaceClient(opts.DevsyConfig, resolved.provider, resolved.workspace, resolved.machine)
 }
 
 func findWorkspaceByArgs(ctx context.Context, opts GetOptions) (*providerpkg.Workspace, error) {
@@ -249,10 +249,9 @@ func resolveWorkspace(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	params ResolveParams,
-) (*providerpkg.ProviderConfig, *providerpkg.Workspace, *providerpkg.Machine, error) {
+) (resolvedWorkspace, error) {
 	if len(params.Args) == 0 {
-		rw, err := resolveWorkspaceWithoutArgs(ctx, devsyConfig, params)
-		return rw.provider, rw.workspace, rw.machine, err
+		return resolveWorkspaceWithoutArgs(ctx, devsyConfig, params)
 	}
 
 	isLocalPath, name := file.IsLocalDir(params.Args[0])
@@ -269,7 +268,7 @@ func resolveWorkspace(
 		return loadExistingWorkspace(devsyConfig, workspaceID, params.ChangeLastUsed)
 	}
 
-	provider, workspace, machine, err := createWorkspace(ctx, devsyConfig, createWorkspaceParams{
+	resolved, err := createWorkspace(ctx, devsyConfig, createWorkspaceParams{
 		workspaceID:          workspaceID,
 		name:                 name,
 		desiredMachine:       params.DesiredMachine,
@@ -289,10 +288,10 @@ func resolveWorkspace(
 				SSHConfigIncludePath: params.SSHConfigIncludePath,
 			},
 		)
-		return nil, nil, nil, err
+		return resolvedWorkspace{}, err
 	}
 
-	return provider, workspace, machine, nil
+	return resolved, nil
 }
 
 type resolvedWorkspace struct {
@@ -314,19 +313,15 @@ func resolveWorkspaceWithoutArgs(
 		if workspace == nil {
 			return resolvedWorkspace{}, fmt.Errorf("workspace %s doesn't exist", params.DesiredID)
 		}
-		provider, ws, machine, err := loadExistingWorkspace(
-			devsyConfig, workspace.ID, params.ChangeLastUsed,
-		)
-		return resolvedWorkspace{provider, ws, machine}, err
+		return loadExistingWorkspace(devsyConfig, workspace.ID, params.ChangeLastUsed)
 	}
 
-	provider, ws, machine, err := selectWorkspace(ctx, devsyConfig, selectWorkspaceParams{
+	return selectWorkspace(ctx, devsyConfig, selectWorkspaceParams{
 		changeLastUsed:       params.ChangeLastUsed,
 		sshConfigPath:        params.SSHConfigPath,
 		sshConfigIncludePath: params.SSHConfigIncludePath,
 		owner:                params.Owner,
 	})
-	return resolvedWorkspace{provider, ws, machine}, err
 }
 
 type createWorkspaceParams struct {
@@ -347,10 +342,10 @@ func createWorkspace(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	params createWorkspaceParams,
-) (*providerpkg.ProviderConfig, *providerpkg.Workspace, *providerpkg.Machine, error) {
+) (resolvedWorkspace, error) {
 	provider, err := loadInitializedProvider(devsyConfig)
 	if err != nil {
-		return nil, nil, nil, err
+		return resolvedWorkspace{}, err
 	}
 
 	workspace := resolveWorkspaceConfig(ctx, provider, devsyConfig, resolveWorkspaceConfigParams{
@@ -364,7 +359,7 @@ func createWorkspace(
 	})
 
 	if err := assignDesiredMachine(provider, workspace, params.desiredMachine); err != nil {
-		return nil, nil, nil, err
+		return resolvedWorkspace{}, err
 	}
 
 	workspace, machineConfig, err := provisionWorkspaceBacking(ctx, machineProvisionParams{
@@ -374,10 +369,10 @@ func createWorkspace(
 		providerUserOptions: params.providerUserOptions,
 	})
 	if err != nil {
-		return nil, nil, nil, err
+		return resolvedWorkspace{}, err
 	}
 
-	return provider.Config, workspace, machineConfig, nil
+	return resolvedWorkspace{provider: provider.Config, workspace: workspace, machine: machineConfig}, nil
 }
 
 func provisionWorkspaceBacking(
@@ -731,32 +726,32 @@ func selectWorkspace(
 	ctx context.Context,
 	devsyConfig *config.Config,
 	params selectWorkspaceParams,
-) (*providerpkg.ProviderConfig, *providerpkg.Workspace, *providerpkg.Machine, error) {
+) (resolvedWorkspace, error) {
 	if !terminal.IsTerminalIn {
-		return nil, nil, nil, errProvideWorkspaceArg
+		return resolvedWorkspace{}, errProvideWorkspaceArg
 	}
 
 	workspaces, err := listSelectableWorkspaces(ctx, devsyConfig, params)
 	if err != nil {
-		return nil, nil, nil, err
+		return resolvedWorkspace{}, err
 	}
 	if len(workspaces) == 0 {
-		return nil, nil, nil, errors.Join(ErrNoWorkspaceFound, errProvideWorkspaceArg)
+		return resolvedWorkspace{}, errors.Join(ErrNoWorkspaceFound, errProvideWorkspaceArg)
 	}
 
 	selectedWorkspace, err := promptWorkspaceSelection(workspaces)
 	if err != nil {
-		return nil, nil, nil, err
+		return resolvedWorkspace{}, err
 	}
 
 	sel, err := selectProWorkspace(
 		devsyConfig, workspaces, selectedWorkspace, params,
 	)
 	if err != nil {
-		return nil, nil, nil, err
+		return resolvedWorkspace{}, err
 	}
 	if sel.handled {
-		return sel.provider, sel.workspace, nil, nil
+		return resolvedWorkspace{provider: sel.provider, workspace: sel.workspace}, nil
 	}
 
 	return loadExistingWorkspace(devsyConfig, selectedWorkspace.ID, params.changeLastUsed)
@@ -879,21 +874,21 @@ func loadExistingWorkspace(
 	devsyConfig *config.Config,
 	workspaceID string,
 	changeLastUsed bool,
-) (*providerpkg.ProviderConfig, *providerpkg.Workspace, *providerpkg.Machine, error) {
+) (resolvedWorkspace, error) {
 	workspaceConfig, err := providerpkg.LoadWorkspaceConfig(devsyConfig.DefaultContext, workspaceID)
 	if err != nil {
-		return nil, nil, nil, err
+		return resolvedWorkspace{}, err
 	}
 
 	providerWithOptions, err := FindProvider(devsyConfig, workspaceConfig.Provider.Name)
 	if err != nil {
-		return nil, nil, nil, err
+		return resolvedWorkspace{}, err
 	}
 
 	if changeLastUsed {
 		workspaceConfig.LastUsedTimestamp = types.Now()
 		if err := providerpkg.SaveWorkspaceConfig(workspaceConfig); err != nil {
-			return nil, nil, nil, err
+			return resolvedWorkspace{}, err
 		}
 	}
 
@@ -904,11 +899,15 @@ func loadExistingWorkspace(
 			workspaceConfig.Machine.ID,
 		)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("load machine config: %w", err)
+			return resolvedWorkspace{}, fmt.Errorf("load machine config: %w", err)
 		}
 	}
 
-	return providerWithOptions.Config, workspaceConfig, machineConfig, nil
+	return resolvedWorkspace{
+		provider:  providerWithOptions.Config,
+		workspace: workspaceConfig,
+		machine:   machineConfig,
+	}, nil
 }
 
 type proInstanceParams struct {

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -93,7 +93,12 @@ func Resolve(
 		return nil, err
 	}
 
-	workspaceClient, err := getWorkspaceClient(devsyConfig, resolved.provider, workspace, resolved.machine)
+	workspaceClient, err := getWorkspaceClient(
+		devsyConfig,
+		resolved.provider,
+		workspace,
+		resolved.machine,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +201,12 @@ func Get(ctx context.Context, opts GetOptions) (client.BaseWorkspaceClient, erro
 			return nil, err
 		}
 
-		return getWorkspaceClient(opts.DevsyConfig, resolved.provider, resolved.workspace, resolved.machine)
+		return getWorkspaceClient(
+			opts.DevsyConfig,
+			resolved.provider,
+			resolved.workspace,
+			resolved.machine,
+		)
 	}
 
 	workspace, err := findWorkspaceByArgs(ctx, opts)
@@ -216,7 +226,12 @@ func Get(ctx context.Context, opts GetOptions) (client.BaseWorkspaceClient, erro
 		return nil, err
 	}
 
-	return getWorkspaceClient(opts.DevsyConfig, resolved.provider, resolved.workspace, resolved.machine)
+	return getWorkspaceClient(
+		opts.DevsyConfig,
+		resolved.provider,
+		resolved.workspace,
+		resolved.machine,
+	)
 }
 
 func findWorkspaceByArgs(ctx context.Context, opts GetOptions) (*providerpkg.Workspace, error) {
@@ -372,7 +387,11 @@ func createWorkspace(
 		return resolvedWorkspace{}, err
 	}
 
-	return resolvedWorkspace{provider: provider.Config, workspace: workspace, machine: machineConfig}, nil
+	return resolvedWorkspace{
+		provider:  provider.Config,
+		workspace: workspace,
+		machine:   machineConfig,
+	}, nil
 }
 
 func provisionWorkspaceBacking(


### PR DESCRIPTION
## Summary
- Bundles `setupBuildKitClient`'s 4 return values into a `buildKitClient` struct in `pkg/devcontainer/buildkit/remote.go`
- Bundles `getValue`'s 5 return values into an `existingOptionValue` struct in `pkg/options/resolver/resolve.go`
- Converts `resolveWorkspace`, `createWorkspace`, `selectWorkspace`, and `loadExistingWorkspace` in `pkg/workspace/workspace.go` to return the existing `resolvedWorkspace` struct instead of 4 positional values (already used by `resolveWorkspaceWithoutArgs`)

No `.golangci.yaml` change needed — `function-result-limit` was already enabled.