### PR TITLE
fix(lint): run CI-parity lint check at pre-commit, not just pre-push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,12 +57,7 @@ repos:
     rev: v2.12.2
     hooks:
       - id: golangci-lint
-        args: [
-          "--timeout=10m",
-          "--new-from-rev=origin/main",
-          "--new=false",
-          "./..."
-        ]
+        args: ["--timeout=10m", "--new-from-rev=origin/main"]
       - id: golangci-lint-fmt
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,7 @@ repos:
     rev: v2.12.2
     hooks:
       - id: golangci-lint
-        args: ["--timeout=10m", "--new-from-rev=origin/main"]
+        args: ["--timeout=10m", "--new-from-rev=HEAD~"]
       - id: golangci-lint-fmt
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
       - id: golangci-lint
         args: [
           "--timeout=10m",
-          "--new-from-patch=$(mktemp && git diff $(git merge-base HEAD origin/main))",
+          "--new-from-rev=origin/main",
           "--new=false",
           "./..."
         ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,12 @@ repos:
     rev: v2.12.2
     hooks:
       - id: golangci-lint
-        args: ["--timeout=10m"]
+        args: [
+          "--timeout=10m",
+          "--new-from-patch=$(mktemp && git diff $(git merge-base HEAD origin/main))",
+          "--new=false",
+          "./..."
+        ]
       - id: golangci-lint-fmt
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary
- Runs the existing `golangci-lint-ci-parity` hook (`task cli:lint:ci`, which mirrors CI's `--new-from-patch` diff-vs-origin/main behavior) at `pre-commit` in addition to `pre-push`, so CI-breaking issues (e.g. formatter violations) are caught before the first commit rather than only at push time.
- Removes the plain `golangci-lint` hook, which lints entire packages with no diff scoping and surfaces pre-existing, unrelated findings on any touched file — noisy and not representative of what CI actually enforces.

Verified locally: reverting to a pre-fix commit and re-running `pre-commit run golangci-lint-ci-parity --hook-stage pre-commit` reproduces the exact golines failure PR #885's CI hit; with the fix applied, the hook passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated code-quality checks by aligning the Go setup with the project configuration.
  * Updated pre-commit checks to run consistently during both commits and pushes.
  * Simplified linting workflow configuration and added the latest Task CLI to the validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->