### PR TITLE
Dev container port-forwarding spec compliance

### DIFF
--- a/cmd/internal/agentcontainer/credentials_server.go
+++ b/cmd/internal/agentcontainer/credentials_server.go
@@ -317,6 +317,10 @@ type forwarder struct {
 	client tunnel.TunnelClient
 }
 
+// Forward relays the auto-discovered port to the client over gRPC, which
+// invokes the client-side pkg/tunnel forwarder's Forward method — that is
+// where onAutoForward openBrowser/openBrowserOnce/openPreview handling
+// lives (see pkg/tunnel/forwarder.go), so this type doesn't duplicate it.
 func (f *forwarder) Forward(port string, attr netstat.PortForwardAttribute) error {
 	if attr.Label != "" {
 		log.Debugf("Forwarding port %s (%s, protocol=%s)", port, attr.Label, attr.Protocol)

--- a/cmd/internal/agentcontainer/credentials_server.go
+++ b/cmd/internal/agentcontainer/credentials_server.go
@@ -317,11 +317,7 @@ type forwarder struct {
 	client tunnel.TunnelClient
 }
 
-// Forward relays the auto-discovered port to the client over gRPC. The
-// client invokes the client-side pkg/tunnel forwarder's Forward method,
-// which is where onAutoForward openBrowser/openBrowserOnce/openPreview
-// handling lives (see pkg/tunnel/forwarder.go), so this type does not
-// duplicate it.
+// Forward relays the auto-discovered port to the client over gRPC.
 func (f *forwarder) Forward(port string, attr netstat.PortForwardAttribute) error {
 	if attr.Label != "" {
 		log.Debugf("Forwarding port %s (%s, protocol=%s)", port, attr.Label, attr.Protocol)

--- a/cmd/internal/agentcontainer/credentials_server.go
+++ b/cmd/internal/agentcontainer/credentials_server.go
@@ -317,10 +317,11 @@ type forwarder struct {
 	client tunnel.TunnelClient
 }
 
-// Forward relays the auto-discovered port to the client over gRPC, which
-// invokes the client-side pkg/tunnel forwarder's Forward method — that is
-// where onAutoForward openBrowser/openBrowserOnce/openPreview handling
-// lives (see pkg/tunnel/forwarder.go), so this type doesn't duplicate it.
+// Forward relays the auto-discovered port to the client over gRPC. The
+// client invokes the client-side pkg/tunnel forwarder's Forward method,
+// which is where onAutoForward openBrowser/openBrowserOnce/openPreview
+// handling lives (see pkg/tunnel/forwarder.go), so this type does not
+// duplicate it.
 func (f *forwarder) Forward(port string, attr netstat.PortForwardAttribute) error {
 	if attr.Label != "" {
 		log.Debugf("Forwarding port %s (%s, protocol=%s)", port, attr.Label, attr.Protocol)

--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -445,7 +446,9 @@ const (
 // It checks portsAttributes in spec precedence order — exact port key,
 // then range key (e.g. "8080-8090"), then any other key treated as a
 // regex tested against the port number's decimal string — then falls
-// back to otherPortsAttributes.
+// back to fallback. When multiple range or regex keys match the same
+// port, the lexicographically smallest key wins, so repeated calls are
+// deterministic.
 func ResolvePortAttribute(
 	port int,
 	portsAttrs map[string]PortAttribute,
@@ -456,17 +459,22 @@ func ResolvePortAttribute(
 		if attr, ok := portsAttrs[portStr]; ok {
 			return attr
 		}
-		for key, attr := range portsAttrs {
+		keys := make([]string, 0, len(portsAttrs))
+		for key := range portsAttrs {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
 			if matchPortRange(key, port) {
-				return attr
+				return portsAttrs[key]
 			}
 		}
-		for key, attr := range portsAttrs {
+		for _, key := range keys {
 			if exactOrRangeKeyPattern.MatchString(key) {
 				continue
 			}
 			if matchPortRegex(key, portStr) {
-				return attr
+				return portsAttrs[key]
 			}
 		}
 	}
@@ -481,11 +489,9 @@ func (p PortAttribute) ShouldAutoForward() bool {
 	return p.OnAutoForward != AutoForwardIgnore
 }
 
-// IsOpenBrowserAction returns true if this port attribute's onAutoForward
-// action should trigger opening a browser once the port is forwarded
-// (openBrowser, openBrowserOnce, openPreview per the dev container spec).
-// devsy has no in-app preview pane, so openPreview is treated the same as
-// openBrowser.
+// IsOpenBrowserAction reports whether the port should trigger a browser
+// open once forwarded. devsy has no in-app preview pane, so openPreview
+// is treated the same as openBrowser.
 func (p PortAttribute) IsOpenBrowserAction() bool {
 	switch p.OnAutoForward {
 	case AutoForwardOpenBrowser, AutoForwardOpenBrowserOnce, AutoForwardOpenPreview:
@@ -495,9 +501,6 @@ func (p PortAttribute) IsOpenBrowserAction() bool {
 	}
 }
 
-// IsOpenOnceAction returns true only for openBrowserOnce, which should
-// trigger the browser open on the first forward of a given port per
-// process lifetime and stay silent on subsequent forwards of that port.
 func (p PortAttribute) IsOpenOnceAction() bool {
 	return p.OnAutoForward == AutoForwardOpenBrowserOnce
 }

--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -442,13 +442,12 @@ const (
 	ProtocolHTTPS              = "https"
 )
 
-// ResolvePortAttribute returns the PortAttribute for a given port number.
-// It checks portsAttributes in spec precedence order. It tries the exact
-// port key first, then a range key such as "8080-8090", then any other
-// key treated as a regex tested against the port number's decimal
-// string, and finally falls back to fallback. When multiple range or
+// ResolvePortAttribute checks portsAttributes in spec precedence order.
+// It tries the exact port key first, then a range key such as "8080-8090",
+// then any other key treated as a regex tested against the port number's
+// decimal string, and finally falls back to fallback. When multiple range or
 // regex keys match the same port, the lexicographically smallest key
-// wins, so repeated calls are deterministic.
+// wins.
 func ResolvePortAttribute(
 	port int,
 	portsAttrs map[string]PortAttribute,
@@ -490,7 +489,7 @@ func (p PortAttribute) ShouldAutoForward() bool {
 }
 
 // IsOpenBrowserAction reports whether the port should trigger a browser
-// open once forwarded. devsy has no in-app preview pane, so openPreview
+// open once forwarded. Devsy has no in-app preview pane, so openPreview
 // is treated the same as openBrowser.
 func (p PortAttribute) IsOpenBrowserAction() bool {
 	switch p.OnAutoForward {
@@ -507,10 +506,7 @@ func (p PortAttribute) IsOpenOnceAction() bool {
 
 // exactOrRangeKeyPattern matches portsAttributes keys that are an exact
 // port number or a "lo-hi" range per the dev container spec's
-// patternProperties grammar. These keys must be excluded from the regex
-// fallback pass. regexp.MatchString is unanchored, so a bare numeric key
-// would otherwise substring-match an unrelated port, for example "3000"
-// matching "13000" or "30001".
+// patternProperties grammar.
 var exactOrRangeKeyPattern = regexp.MustCompile(`^\d+(-\d+)?$`)
 
 func matchPortRange(key string, port int) bool {
@@ -529,11 +525,6 @@ func matchPortRange(key string, port int) bool {
 	return port >= lo && port <= hi
 }
 
-// matchPortRegex treats key as a regex and tests it against portStr, per
-// the dev container spec's portsAttributes patternProperties fallback.
-// An unparseable regex is treated as a non-match rather than an error,
-// because portsAttributes keys are free-form user input that cannot be
-// validated at devcontainer.json parse time.
 func matchPortRegex(key, portStr string) bool {
 	re, err := regexp.Compile(key)
 	if err != nil {

--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -462,6 +462,9 @@ func ResolvePortAttribute(
 			}
 		}
 		for key, attr := range portsAttrs {
+			if exactOrRangeKeyPattern.MatchString(key) {
+				continue
+			}
 			if matchPortRegex(key, portStr) {
 				return attr
 			}
@@ -498,6 +501,14 @@ func (p PortAttribute) IsOpenBrowserAction() bool {
 func (p PortAttribute) IsOpenOnceAction() bool {
 	return p.OnAutoForward == AutoForwardOpenBrowserOnce
 }
+
+// exactOrRangeKeyPattern matches portsAttributes keys that are an exact
+// port number or a "lo-hi" range per the dev container spec's
+// patternProperties grammar. Such keys are not regexes and must not be
+// tried in the regex fallback pass, since regexp.MatchString is
+// unanchored and a bare numeric key would otherwise substring-match
+// unrelated ports (e.g. "3000" matching "13000" or "30001").
+var exactOrRangeKeyPattern = regexp.MustCompile(`^\d+(-\d+)?$`)
 
 func matchPortRange(key string, port int) bool {
 	parts := strings.SplitN(key, "-", 2)

--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -443,12 +443,12 @@ const (
 )
 
 // ResolvePortAttribute returns the PortAttribute for a given port number.
-// It checks portsAttributes in spec precedence order — exact port key,
-// then range key (e.g. "8080-8090"), then any other key treated as a
-// regex tested against the port number's decimal string — then falls
-// back to fallback. When multiple range or regex keys match the same
-// port, the lexicographically smallest key wins, so repeated calls are
-// deterministic.
+// It checks portsAttributes in spec precedence order. It tries the exact
+// port key first, then a range key such as "8080-8090", then any other
+// key treated as a regex tested against the port number's decimal
+// string, and finally falls back to fallback. When multiple range or
+// regex keys match the same port, the lexicographically smallest key
+// wins, so repeated calls are deterministic.
 func ResolvePortAttribute(
 	port int,
 	portsAttrs map[string]PortAttribute,
@@ -507,10 +507,10 @@ func (p PortAttribute) IsOpenOnceAction() bool {
 
 // exactOrRangeKeyPattern matches portsAttributes keys that are an exact
 // port number or a "lo-hi" range per the dev container spec's
-// patternProperties grammar. Such keys are not regexes and must not be
-// tried in the regex fallback pass, since regexp.MatchString is
-// unanchored and a bare numeric key would otherwise substring-match
-// unrelated ports (e.g. "3000" matching "13000" or "30001").
+// patternProperties grammar. These keys must be excluded from the regex
+// fallback pass. regexp.MatchString is unanchored, so a bare numeric key
+// would otherwise substring-match an unrelated port, for example "3000"
+// matching "13000" or "30001".
 var exactOrRangeKeyPattern = regexp.MustCompile(`^\d+(-\d+)?$`)
 
 func matchPortRange(key string, port int) bool {
@@ -530,11 +530,10 @@ func matchPortRange(key string, port int) bool {
 }
 
 // matchPortRegex treats key as a regex and tests it against portStr, per
-// the dev container spec's portsAttributes patternProperties fallback
-// (any key that isn't a bare port number or a "lo-hi" range). An
-// unparseable regex is treated as a non-match rather than an error, since
-// portsAttributes keys are free-form user input we can't validate at
-// devcontainer.json parse time.
+// the dev container spec's portsAttributes patternProperties fallback.
+// An unparseable regex is treated as a non-match rather than an error,
+// because portsAttributes keys are free-form user input that cannot be
+// validated at devcontainer.json parse time.
 func matchPortRegex(key, portStr string) bool {
 	re, err := regexp.Compile(key)
 	if err != nil {

--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -431,15 +432,20 @@ const (
 const SecretsMountDir = "/run/secrets"
 
 const (
-	AutoForwardIgnore = "ignore"
-	AutoForwardNotify = "notify"
-	AutoForwardSilent = "silent"
-	ProtocolHTTPS     = "https"
+	AutoForwardIgnore          = "ignore"
+	AutoForwardNotify          = "notify"
+	AutoForwardSilent          = "silent"
+	AutoForwardOpenBrowser     = "openBrowser"
+	AutoForwardOpenBrowserOnce = "openBrowserOnce"
+	AutoForwardOpenPreview     = "openPreview"
+	ProtocolHTTPS              = "https"
 )
 
 // ResolvePortAttribute returns the PortAttribute for a given port number.
-// It checks portsAttributes (including range keys like "8080-8090") first,
-// then falls back to otherPortsAttributes.
+// It checks portsAttributes in spec precedence order — exact port key,
+// then range key (e.g. "8080-8090"), then any other key treated as a
+// regex tested against the port number's decimal string — then falls
+// back to otherPortsAttributes.
 func ResolvePortAttribute(
 	port int,
 	portsAttrs map[string]PortAttribute,
@@ -455,6 +461,11 @@ func ResolvePortAttribute(
 				return attr
 			}
 		}
+		for key, attr := range portsAttrs {
+			if matchPortRegex(key, portStr) {
+				return attr
+			}
+		}
 	}
 	if fallback != nil {
 		return *fallback
@@ -465,6 +476,27 @@ func ResolvePortAttribute(
 // ShouldAutoForward returns true if the port attribute allows auto-forwarding.
 func (p PortAttribute) ShouldAutoForward() bool {
 	return p.OnAutoForward != AutoForwardIgnore
+}
+
+// IsOpenBrowserAction returns true if this port attribute's onAutoForward
+// action should trigger opening a browser once the port is forwarded
+// (openBrowser, openBrowserOnce, openPreview per the dev container spec).
+// devsy has no in-app preview pane, so openPreview is treated the same as
+// openBrowser.
+func (p PortAttribute) IsOpenBrowserAction() bool {
+	switch p.OnAutoForward {
+	case AutoForwardOpenBrowser, AutoForwardOpenBrowserOnce, AutoForwardOpenPreview:
+		return true
+	default:
+		return false
+	}
+}
+
+// IsOpenOnceAction returns true only for openBrowserOnce, which should
+// trigger the browser open on the first forward of a given port per
+// process lifetime and stay silent on subsequent forwards of that port.
+func (p PortAttribute) IsOpenOnceAction() bool {
+	return p.OnAutoForward == AutoForwardOpenBrowserOnce
 }
 
 func matchPortRange(key string, port int) bool {
@@ -481,6 +513,20 @@ func matchPortRange(key string, port int) bool {
 		return false
 	}
 	return port >= lo && port <= hi
+}
+
+// matchPortRegex treats key as a regex and tests it against portStr, per
+// the dev container spec's portsAttributes patternProperties fallback
+// (any key that isn't a bare port number or a "lo-hi" range). An
+// unparseable regex is treated as a non-match rather than an error, since
+// portsAttributes keys are free-form user input we can't validate at
+// devcontainer.json parse time.
+func matchPortRegex(key, portStr string) bool {
+	re, err := regexp.Compile(key)
+	if err != nil {
+		return false
+	}
+	return re.MatchString(portStr)
 }
 
 type DevsyCustomizations struct {

--- a/pkg/devcontainer/config/port_attribute_test.go
+++ b/pkg/devcontainer/config/port_attribute_test.go
@@ -238,6 +238,34 @@ func TestResolvePortAttribute_RangeKeyDoesNotSubstringMatchOtherPorts(t *testing
 	}
 }
 
+func TestResolvePortAttribute_MultipleRegexMatchesAreDeterministic(t *testing.T) {
+	attrs := map[string]PortAttribute{
+		"^3\\d{3}$":  {Label: "First"},
+		"^30\\d\\d$": {Label: "Second"},
+	}
+	want := ResolvePortAttribute(3042, attrs, nil).Label
+	for range 20 {
+		got := ResolvePortAttribute(3042, attrs, nil).Label
+		if got != want {
+			t.Fatalf("ResolvePortAttribute is non-deterministic: got %q, want %q", got, want)
+		}
+	}
+}
+
+func TestResolvePortAttribute_MultipleRangeMatchesAreDeterministic(t *testing.T) {
+	attrs := map[string]PortAttribute{
+		"3000-3100": {Label: "First"},
+		"3040-3050": {Label: "Second"},
+	}
+	want := ResolvePortAttribute(3042, attrs, nil).Label
+	for range 20 {
+		got := ResolvePortAttribute(3042, attrs, nil).Label
+		if got != want {
+			t.Fatalf("ResolvePortAttribute is non-deterministic: got %q, want %q", got, want)
+		}
+	}
+}
+
 func TestResolvePortAttribute_NonNumericRegexKeyStillMatches(t *testing.T) {
 	attrs := map[string]PortAttribute{
 		"^30\\d\\d$": {Label: "Three-thousands"},

--- a/pkg/devcontainer/config/port_attribute_test.go
+++ b/pkg/devcontainer/config/port_attribute_test.go
@@ -213,3 +213,37 @@ func TestResolvePortAttribute_InvalidRegexKeyIgnored(t *testing.T) {
 		t.Errorf("Label = %q, want empty (invalid regex must not panic or match)", got.Label)
 	}
 }
+
+func TestResolvePortAttribute_BareNumericKeyDoesNotSubstringMatchOtherPorts(t *testing.T) {
+	attrs := map[string]PortAttribute{
+		"3000": {Label: "should-not-leak"},
+	}
+
+	for _, port := range []int{13000, 30001} {
+		got := ResolvePortAttribute(port, attrs, nil)
+		if got.Label != "" {
+			t.Errorf("port %d: Label = %q, want empty (bare numeric key %q must not substring-match a different port)", port, got.Label, "3000")
+		}
+	}
+}
+
+func TestResolvePortAttribute_RangeKeyDoesNotSubstringMatchOtherPorts(t *testing.T) {
+	attrs := map[string]PortAttribute{
+		"8080-8090": {Label: "should-not-leak"},
+	}
+
+	got := ResolvePortAttribute(180809, attrs, nil)
+	if got.Label != "" {
+		t.Errorf("Label = %q, want empty (range key %q must not substring-match a different port)", got.Label, "8080-8090")
+	}
+}
+
+func TestResolvePortAttribute_NonNumericRegexKeyStillMatches(t *testing.T) {
+	attrs := map[string]PortAttribute{
+		"^30\\d\\d$": {Label: "Three-thousands"},
+	}
+	got := ResolvePortAttribute(3042, attrs, nil)
+	if got.Label != "Three-thousands" {
+		t.Errorf("Label = %q, want %q (non-numeric regex key should still match)", got.Label, "Three-thousands")
+	}
+}

--- a/pkg/devcontainer/config/port_attribute_test.go
+++ b/pkg/devcontainer/config/port_attribute_test.go
@@ -99,3 +99,117 @@ func TestShouldAutoForward(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldAutoForward_OpenBrowserVariants(t *testing.T) {
+	tests := []struct {
+		name string
+		attr PortAttribute
+		want bool
+	}{
+		{"openBrowser forwards", PortAttribute{OnAutoForward: AutoForwardOpenBrowser}, true},
+		{"openBrowserOnce forwards", PortAttribute{OnAutoForward: AutoForwardOpenBrowserOnce}, true},
+		{"openPreview forwards", PortAttribute{OnAutoForward: AutoForwardOpenPreview}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.attr.ShouldAutoForward(); got != tt.want {
+				t.Errorf("ShouldAutoForward() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsOpenBrowserAction(t *testing.T) {
+	tests := []struct {
+		name string
+		attr PortAttribute
+		want bool
+	}{
+		{"notify is not open-browser", PortAttribute{OnAutoForward: AutoForwardNotify}, false},
+		{"silent is not open-browser", PortAttribute{OnAutoForward: AutoForwardSilent}, false},
+		{"ignore is not open-browser", PortAttribute{OnAutoForward: AutoForwardIgnore}, false},
+		{"empty is not open-browser", PortAttribute{}, false},
+		{"openBrowser is open-browser", PortAttribute{OnAutoForward: AutoForwardOpenBrowser}, true},
+		{"openBrowserOnce is open-browser", PortAttribute{OnAutoForward: AutoForwardOpenBrowserOnce}, true},
+		{"openPreview is open-browser", PortAttribute{OnAutoForward: AutoForwardOpenPreview}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.attr.IsOpenBrowserAction(); got != tt.want {
+				t.Errorf("IsOpenBrowserAction() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsOpenOnceAction(t *testing.T) {
+	tests := []struct {
+		name string
+		attr PortAttribute
+		want bool
+	}{
+		{"openBrowserOnce is once", PortAttribute{OnAutoForward: AutoForwardOpenBrowserOnce}, true},
+		{"openBrowser is not once", PortAttribute{OnAutoForward: AutoForwardOpenBrowser}, false},
+		{"openPreview is not once", PortAttribute{OnAutoForward: AutoForwardOpenPreview}, false},
+		{"notify is not once", PortAttribute{OnAutoForward: AutoForwardNotify}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.attr.IsOpenOnceAction(); got != tt.want {
+				t.Errorf("IsOpenOnceAction() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolvePortAttribute_RegexKeyMatch(t *testing.T) {
+	attrs := map[string]PortAttribute{
+		"^30\\d\\d$": {Label: "Three-thousands", OnAutoForward: AutoForwardSilent},
+	}
+	got := ResolvePortAttribute(3042, attrs, nil)
+	if got.Label != "Three-thousands" {
+		t.Errorf("Label = %q, want %q", got.Label, "Three-thousands")
+	}
+}
+
+func TestResolvePortAttribute_RegexKeyNoMatch(t *testing.T) {
+	attrs := map[string]PortAttribute{
+		"^30\\d\\d$": {Label: "Three-thousands"},
+	}
+	got := ResolvePortAttribute(4042, attrs, nil)
+	if got.Label != "" {
+		t.Errorf("Label = %q, want empty (no match)", got.Label)
+	}
+}
+
+func TestResolvePortAttribute_ExactBeatsRegex(t *testing.T) {
+	attrs := map[string]PortAttribute{
+		"^30\\d\\d$": {Label: "Regex match"},
+		"3042":       {Label: "Exact match"},
+	}
+	got := ResolvePortAttribute(3042, attrs, nil)
+	if got.Label != "Exact match" {
+		t.Errorf("Label = %q, want %q (exact key should win over regex)", got.Label, "Exact match")
+	}
+}
+
+func TestResolvePortAttribute_RangeBeatsRegex(t *testing.T) {
+	attrs := map[string]PortAttribute{
+		"^30\\d\\d$": {Label: "Regex match"},
+		"3040-3050":  {Label: "Range match"},
+	}
+	got := ResolvePortAttribute(3042, attrs, nil)
+	if got.Label != "Range match" {
+		t.Errorf("Label = %q, want %q (range key should win over regex)", got.Label, "Range match")
+	}
+}
+
+func TestResolvePortAttribute_InvalidRegexKeyIgnored(t *testing.T) {
+	attrs := map[string]PortAttribute{
+		"[invalid(regex": {Label: "Should never match"},
+	}
+	got := ResolvePortAttribute(3042, attrs, nil)
+	if got.Label != "" {
+		t.Errorf("Label = %q, want empty (invalid regex must not panic or match)", got.Label)
+	}
+}

--- a/pkg/devcontainer/config/port_attribute_test.go
+++ b/pkg/devcontainer/config/port_attribute_test.go
@@ -4,6 +4,11 @@ import (
 	"testing"
 )
 
+const (
+	labelThreeThousands    = "Three-thousands"
+	regexKeyThreeThousands = "^30\\d\\d$"
+)
+
 func TestResolvePortAttribute_ExactMatch(t *testing.T) {
 	const wantLabel = "Frontend"
 	attrs := map[string]PortAttribute{
@@ -107,7 +112,11 @@ func TestShouldAutoForward_OpenBrowserVariants(t *testing.T) {
 		want bool
 	}{
 		{"openBrowser forwards", PortAttribute{OnAutoForward: AutoForwardOpenBrowser}, true},
-		{"openBrowserOnce forwards", PortAttribute{OnAutoForward: AutoForwardOpenBrowserOnce}, true},
+		{
+			"openBrowserOnce forwards",
+			PortAttribute{OnAutoForward: AutoForwardOpenBrowserOnce},
+			true,
+		},
 		{"openPreview forwards", PortAttribute{OnAutoForward: AutoForwardOpenPreview}, true},
 	}
 	for _, tt := range tests {
@@ -130,7 +139,11 @@ func TestIsOpenBrowserAction(t *testing.T) {
 		{"ignore is not open-browser", PortAttribute{OnAutoForward: AutoForwardIgnore}, false},
 		{"empty is not open-browser", PortAttribute{}, false},
 		{"openBrowser is open-browser", PortAttribute{OnAutoForward: AutoForwardOpenBrowser}, true},
-		{"openBrowserOnce is open-browser", PortAttribute{OnAutoForward: AutoForwardOpenBrowserOnce}, true},
+		{
+			"openBrowserOnce is open-browser",
+			PortAttribute{OnAutoForward: AutoForwardOpenBrowserOnce},
+			true,
+		},
 		{"openPreview is open-browser", PortAttribute{OnAutoForward: AutoForwardOpenPreview}, true},
 	}
 	for _, tt := range tests {
@@ -164,17 +177,17 @@ func TestIsOpenOnceAction(t *testing.T) {
 
 func TestResolvePortAttribute_RegexKeyMatch(t *testing.T) {
 	attrs := map[string]PortAttribute{
-		"^30\\d\\d$": {Label: "Three-thousands", OnAutoForward: AutoForwardSilent},
+		regexKeyThreeThousands: {Label: labelThreeThousands, OnAutoForward: AutoForwardSilent},
 	}
 	got := ResolvePortAttribute(3042, attrs, nil)
-	if got.Label != "Three-thousands" {
-		t.Errorf("Label = %q, want %q", got.Label, "Three-thousands")
+	if got.Label != labelThreeThousands {
+		t.Errorf("Label = %q, want %q", got.Label, labelThreeThousands)
 	}
 }
 
 func TestResolvePortAttribute_RegexKeyNoMatch(t *testing.T) {
 	attrs := map[string]PortAttribute{
-		"^30\\d\\d$": {Label: "Three-thousands"},
+		regexKeyThreeThousands: {Label: labelThreeThousands},
 	}
 	got := ResolvePortAttribute(4042, attrs, nil)
 	if got.Label != "" {
@@ -184,8 +197,8 @@ func TestResolvePortAttribute_RegexKeyNoMatch(t *testing.T) {
 
 func TestResolvePortAttribute_ExactBeatsRegex(t *testing.T) {
 	attrs := map[string]PortAttribute{
-		"^30\\d\\d$": {Label: "Regex match"},
-		"3042":       {Label: "Exact match"},
+		regexKeyThreeThousands: {Label: "Regex match"},
+		"3042":                 {Label: "Exact match"},
 	}
 	got := ResolvePortAttribute(3042, attrs, nil)
 	if got.Label != "Exact match" {
@@ -195,8 +208,8 @@ func TestResolvePortAttribute_ExactBeatsRegex(t *testing.T) {
 
 func TestResolvePortAttribute_RangeBeatsRegex(t *testing.T) {
 	attrs := map[string]PortAttribute{
-		"^30\\d\\d$": {Label: "Regex match"},
-		"3040-3050":  {Label: "Range match"},
+		regexKeyThreeThousands: {Label: "Regex match"},
+		"3040-3050":            {Label: "Range match"},
 	}
 	got := ResolvePortAttribute(3042, attrs, nil)
 	if got.Label != "Range match" {
@@ -222,7 +235,12 @@ func TestResolvePortAttribute_BareNumericKeyDoesNotSubstringMatchOtherPorts(t *t
 	for _, port := range []int{13000, 30001} {
 		got := ResolvePortAttribute(port, attrs, nil)
 		if got.Label != "" {
-			t.Errorf("port %d: Label = %q, want empty (bare numeric key %q must not substring-match a different port)", port, got.Label, "3000")
+			t.Errorf(
+				"port %d: Label = %q, want empty (bare numeric key %q must not substring-match a different port)",
+				port,
+				got.Label,
+				"3000",
+			)
 		}
 	}
 }
@@ -234,14 +252,18 @@ func TestResolvePortAttribute_RangeKeyDoesNotSubstringMatchOtherPorts(t *testing
 
 	got := ResolvePortAttribute(180809, attrs, nil)
 	if got.Label != "" {
-		t.Errorf("Label = %q, want empty (range key %q must not substring-match a different port)", got.Label, "8080-8090")
+		t.Errorf(
+			"Label = %q, want empty (range key %q must not substring-match a different port)",
+			got.Label,
+			"8080-8090",
+		)
 	}
 }
 
 func TestResolvePortAttribute_MultipleRegexMatchesAreDeterministic(t *testing.T) {
 	attrs := map[string]PortAttribute{
-		"^3\\d{3}$":  {Label: "First"},
-		"^30\\d\\d$": {Label: "Second"},
+		"^3\\d{3}$":            {Label: "First"},
+		regexKeyThreeThousands: {Label: "Second"},
 	}
 	want := ResolvePortAttribute(3042, attrs, nil).Label
 	for range 20 {
@@ -268,10 +290,14 @@ func TestResolvePortAttribute_MultipleRangeMatchesAreDeterministic(t *testing.T)
 
 func TestResolvePortAttribute_NonNumericRegexKeyStillMatches(t *testing.T) {
 	attrs := map[string]PortAttribute{
-		"^30\\d\\d$": {Label: "Three-thousands"},
+		regexKeyThreeThousands: {Label: labelThreeThousands},
 	}
 	got := ResolvePortAttribute(3042, attrs, nil)
-	if got.Label != "Three-thousands" {
-		t.Errorf("Label = %q, want %q (non-numeric regex key should still match)", got.Label, "Three-thousands")
+	if got.Label != labelThreeThousands {
+		t.Errorf(
+			"Label = %q, want %q (non-numeric regex key should still match)",
+			got.Label,
+			labelThreeThousands,
+		)
 	}
 }

--- a/pkg/tunnel/browseronopen.go
+++ b/pkg/tunnel/browseronopen.go
@@ -1,0 +1,42 @@
+package tunnel
+
+import (
+	"context"
+	"fmt"
+
+	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/log"
+	"github.com/devsy-org/devsy/pkg/open"
+)
+
+// openURLFunc is a test seam for pkg/open.Open, which shells out to a host
+// GUI opener and therefore can't run as-is in unit tests.
+var openURLFunc = open.Open
+
+// maybeOpenBrowser opens a browser at http://localhost:<port> when attr's
+// onAutoForward action is openBrowser, openBrowserOnce, or openPreview.
+// For openBrowserOnce it opens at most once per port for this forwarder's
+// lifetime (tracked in f.openedOnce, guarded by the caller's lock — see
+// forwarder.Forward). open.Open blocks (it polls the URL until reachable
+// or ctx is done), so this always launches it in its own goroutine.
+func (f *forwarder) maybeOpenBrowser(ctx context.Context, port string, attr config2.PortAttribute) {
+	if !attr.IsOpenBrowserAction() {
+		return
+	}
+	if attr.IsOpenOnceAction() {
+		if f.openedOnce == nil {
+			f.openedOnce = map[string]bool{}
+		}
+		if f.openedOnce[port] {
+			return
+		}
+		f.openedOnce[port] = true
+	}
+
+	url := fmt.Sprintf("http://localhost:%s", port)
+	go func() {
+		if err := openURLFunc(ctx, url); err != nil {
+			log.Warnf("could not open browser for forwarded port %s: %v", port, err)
+		}
+	}()
+}

--- a/pkg/tunnel/browseronopen.go
+++ b/pkg/tunnel/browseronopen.go
@@ -13,12 +13,9 @@ import (
 // GUI opener and therefore can't run as-is in unit tests.
 var openURLFunc = open.Open
 
-// maybeOpenBrowser opens a browser at http://localhost:<port> when attr's
-// onAutoForward action is openBrowser, openBrowserOnce, or openPreview.
-// For openBrowserOnce it opens at most once per port for this forwarder's
-// lifetime (tracked in f.openedOnce, guarded by the caller's lock — see
-// forwarder.Forward). open.Open blocks (it polls the URL until reachable
-// or ctx is done), so this always launches it in its own goroutine.
+// maybeOpenBrowser is called with f's lock held (see forwarder.Forward).
+// open.Open blocks polling the URL until reachable or ctx is done, so it
+// always runs in its own goroutine.
 func (f *forwarder) maybeOpenBrowser(ctx context.Context, port string, attr config2.PortAttribute) {
 	if !attr.IsOpenBrowserAction() {
 		return

--- a/pkg/tunnel/browseronopen.go
+++ b/pkg/tunnel/browseronopen.go
@@ -25,7 +25,11 @@ func (f *forwarder) maybeOpenBrowser(ctx context.Context, port string, attr conf
 		f.openedOnce[port] = true
 	}
 
-	url := fmt.Sprintf("http://localhost:%s", port)
+	scheme := "http"
+	if attr.Protocol == config2.ProtocolHTTPS {
+		scheme = "https"
+	}
+	url := fmt.Sprintf("%s://localhost:%s", scheme, port)
 	go func() {
 		if err := openURLFunc(ctx, url); err != nil {
 			log.Warnf("could not open browser for forwarded port %s: %v", port, err)

--- a/pkg/tunnel/browseronopen.go
+++ b/pkg/tunnel/browseronopen.go
@@ -9,13 +9,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/open"
 )
 
-// openURLFunc is a test seam for pkg/open.Open, which shells out to a host
-// GUI opener and therefore can't run as-is in unit tests.
 var openURLFunc = open.Open
 
-// maybeOpenBrowser is called with f's lock held (see forwarder.Forward).
-// open.Open blocks polling the URL until reachable or ctx is done, so it
-// always runs in its own goroutine.
 func (f *forwarder) maybeOpenBrowser(ctx context.Context, port string, attr config2.PortAttribute) {
 	if !attr.IsOpenBrowserAction() {
 		return

--- a/pkg/tunnel/browseronopen_test.go
+++ b/pkg/tunnel/browseronopen_test.go
@@ -129,10 +129,10 @@ func TestMaybeOpenBrowser_NilOpenedOnceMap_DoesNotPanic(t *testing.T) {
 			OnAutoForward: config2.AutoForwardOpenBrowserOnce,
 		})
 	})
-	// Wait for the spawned goroutine to finish before the test returns and
-	// t.Cleanup swaps openURLFunc back — otherwise a late-running goroutine
-	// could still be holding the old closure and leak an append into
-	// whichever test's opened slice is live when it finally executes.
+	// A late-running goroutine could still hold the old closure and leak
+	// an append into whichever test's opened slice is live when it
+	// finally executes, so wait for it to finish before t.Cleanup swaps
+	// openURLFunc back.
 	assert.Eventually(t, func() bool {
 		return opened.Len() == 1
 	}, time.Second, 10*time.Millisecond)

--- a/pkg/tunnel/browseronopen_test.go
+++ b/pkg/tunnel/browseronopen_test.go
@@ -59,6 +59,19 @@ func TestMaybeOpenBrowser_OpenBrowserAction_Opens(t *testing.T) {
 	assert.Equal(t, []string{"http://localhost:3000"}, opened.Snapshot())
 }
 
+func TestMaybeOpenBrowser_HTTPSProtocol_UsesHTTPSScheme(t *testing.T) {
+	opened := withFakeOpener(t)
+	f := &forwarder{openedOnce: map[string]bool{}}
+	f.maybeOpenBrowser(context.Background(), "3000", config2.PortAttribute{
+		OnAutoForward: config2.AutoForwardOpenBrowser,
+		Protocol:      config2.ProtocolHTTPS,
+	})
+	assert.Eventually(t, func() bool {
+		return opened.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, []string{"https://localhost:3000"}, opened.Snapshot())
+}
+
 func TestMaybeOpenBrowser_NotifyAction_DoesNotOpen(t *testing.T) {
 	opened := withFakeOpener(t)
 	f := &forwarder{openedOnce: map[string]bool{}}

--- a/pkg/tunnel/browseronopen_test.go
+++ b/pkg/tunnel/browseronopen_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 // openedRecorder records opened URLs behind a mutex, since maybeOpenBrowser
-// invokes openURLFunc from a spawned goroutine. Snapshot() is the only
-// race-safe way to read the recorded URLs from a test goroutine.
+// invokes openURLFunc from a spawned goroutine.
 type openedRecorder struct {
 	mu   sync.Mutex
 	urls []string

--- a/pkg/tunnel/browseronopen_test.go
+++ b/pkg/tunnel/browseronopen_test.go
@@ -126,7 +126,7 @@ func TestMaybeOpenBrowser_NilOpenedOnceMap_DoesNotPanic(t *testing.T) {
 	f := &forwarder{}
 	assert.NotPanics(t, func() {
 		f.maybeOpenBrowser(context.Background(), "5000", config2.PortAttribute{
-			OnAutoForward: config2.AutoForwardOpenBrowser,
+			OnAutoForward: config2.AutoForwardOpenBrowserOnce,
 		})
 	})
 	// Wait for the spawned goroutine to finish before the test returns and

--- a/pkg/tunnel/browseronopen_test.go
+++ b/pkg/tunnel/browseronopen_test.go
@@ -18,12 +18,6 @@ type openedRecorder struct {
 	urls []string
 }
 
-func (r *openedRecorder) record(url string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.urls = append(r.urls, url)
-}
-
 func (r *openedRecorder) Snapshot() []string {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -34,6 +28,12 @@ func (r *openedRecorder) Len() int {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return len(r.urls)
+}
+
+func (r *openedRecorder) record(url string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.urls = append(r.urls, url)
 }
 
 func withFakeOpener(t *testing.T) *openedRecorder {
@@ -118,7 +118,11 @@ func TestMaybeOpenBrowser_OpenBrowserOnce_OpensEachDistinctPortOnce(t *testing.T
 	assert.Eventually(t, func() bool {
 		return opened.Len() == 2
 	}, time.Second, 10*time.Millisecond)
-	assert.ElementsMatch(t, []string{"http://localhost:4000", "http://localhost:4001"}, opened.Snapshot())
+	assert.ElementsMatch(
+		t,
+		[]string{"http://localhost:4000", "http://localhost:4001"},
+		opened.Snapshot(),
+	)
 }
 
 func TestMaybeOpenBrowser_NilOpenedOnceMap_DoesNotPanic(t *testing.T) {

--- a/pkg/tunnel/browseronopen_test.go
+++ b/pkg/tunnel/browseronopen_test.go
@@ -1,0 +1,139 @@
+package tunnel
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// openedRecorder records opened URLs behind a mutex, since maybeOpenBrowser
+// invokes openURLFunc from a spawned goroutine. Snapshot() is the only
+// race-safe way to read the recorded URLs from a test goroutine.
+type openedRecorder struct {
+	mu   sync.Mutex
+	urls []string
+}
+
+func (r *openedRecorder) record(url string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.urls = append(r.urls, url)
+}
+
+func (r *openedRecorder) Snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.urls...)
+}
+
+func (r *openedRecorder) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.urls)
+}
+
+func withFakeOpener(t *testing.T) *openedRecorder {
+	t.Helper()
+	recorder := &openedRecorder{}
+	original := openURLFunc
+	openURLFunc = func(_ context.Context, url string) error {
+		recorder.record(url)
+		return nil
+	}
+	t.Cleanup(func() { openURLFunc = original })
+	return recorder
+}
+
+func TestMaybeOpenBrowser_OpenBrowserAction_Opens(t *testing.T) {
+	opened := withFakeOpener(t)
+	f := &forwarder{openedOnce: map[string]bool{}}
+	f.maybeOpenBrowser(context.Background(), "3000", config2.PortAttribute{
+		OnAutoForward: config2.AutoForwardOpenBrowser,
+	})
+	assert.Eventually(t, func() bool {
+		return opened.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, []string{"http://localhost:3000"}, opened.Snapshot())
+}
+
+func TestMaybeOpenBrowser_NotifyAction_DoesNotOpen(t *testing.T) {
+	opened := withFakeOpener(t)
+	f := &forwarder{openedOnce: map[string]bool{}}
+	f.maybeOpenBrowser(context.Background(), "3000", config2.PortAttribute{
+		OnAutoForward: config2.AutoForwardNotify,
+	})
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, opened.Snapshot())
+}
+
+func TestMaybeOpenBrowser_SilentAction_DoesNotOpen(t *testing.T) {
+	opened := withFakeOpener(t)
+	f := &forwarder{openedOnce: map[string]bool{}}
+	f.maybeOpenBrowser(context.Background(), "3000", config2.PortAttribute{
+		OnAutoForward: config2.AutoForwardSilent,
+	})
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, opened.Snapshot())
+}
+
+func TestMaybeOpenBrowser_OpenPreviewAction_Opens(t *testing.T) {
+	opened := withFakeOpener(t)
+	f := &forwarder{openedOnce: map[string]bool{}}
+	f.maybeOpenBrowser(context.Background(), "8080", config2.PortAttribute{
+		OnAutoForward: config2.AutoForwardOpenPreview,
+	})
+	assert.Eventually(t, func() bool {
+		return opened.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, []string{"http://localhost:8080"}, opened.Snapshot())
+}
+
+func TestMaybeOpenBrowser_OpenBrowserOnce_OpensOnlyFirstTime(t *testing.T) {
+	opened := withFakeOpener(t)
+	f := &forwarder{openedOnce: map[string]bool{}}
+	attr := config2.PortAttribute{OnAutoForward: config2.AutoForwardOpenBrowserOnce}
+
+	f.maybeOpenBrowser(context.Background(), "4000", attr)
+	f.maybeOpenBrowser(context.Background(), "4000", attr)
+	f.maybeOpenBrowser(context.Background(), "4000", attr)
+
+	assert.Eventually(t, func() bool {
+		return opened.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, []string{"http://localhost:4000"}, opened.Snapshot())
+}
+
+func TestMaybeOpenBrowser_OpenBrowserOnce_OpensEachDistinctPortOnce(t *testing.T) {
+	opened := withFakeOpener(t)
+	f := &forwarder{openedOnce: map[string]bool{}}
+	attr := config2.PortAttribute{OnAutoForward: config2.AutoForwardOpenBrowserOnce}
+
+	f.maybeOpenBrowser(context.Background(), "4000", attr)
+	f.maybeOpenBrowser(context.Background(), "4001", attr)
+
+	assert.Eventually(t, func() bool {
+		return opened.Len() == 2
+	}, time.Second, 10*time.Millisecond)
+	assert.ElementsMatch(t, []string{"http://localhost:4000", "http://localhost:4001"}, opened.Snapshot())
+}
+
+func TestMaybeOpenBrowser_NilOpenedOnceMap_DoesNotPanic(t *testing.T) {
+	opened := withFakeOpener(t)
+	f := &forwarder{}
+	assert.NotPanics(t, func() {
+		f.maybeOpenBrowser(context.Background(), "5000", config2.PortAttribute{
+			OnAutoForward: config2.AutoForwardOpenBrowser,
+		})
+	})
+	// Wait for the spawned goroutine to finish before the test returns and
+	// t.Cleanup swaps openURLFunc back — otherwise a late-running goroutine
+	// could still be holding the old closure and leak an append into
+	// whichever test's opened slice is live when it finally executes.
+	assert.Eventually(t, func() bool {
+		return opened.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+}

--- a/pkg/tunnel/forwarder.go
+++ b/pkg/tunnel/forwarder.go
@@ -87,6 +87,12 @@ func (f *forwarder) Forward(port string, _ netstat.PortForwardAttribute) error {
 		)
 		if err != nil {
 			log.Errorf("Error port forwarding %s: %v", port, err)
+			f.Lock()
+			if cancelCtx.Err() == nil && f.portMap[port] != nil {
+				cancel()
+				delete(f.portMap, port)
+			}
+			f.Unlock()
 		}
 	}(port)
 

--- a/pkg/tunnel/forwarder.go
+++ b/pkg/tunnel/forwarder.go
@@ -43,7 +43,8 @@ type forwarder struct {
 	forwardedPorts []string
 	resolver       PortAttributeResolver
 
-	portMap map[string]context.CancelFunc
+	portMap    map[string]context.CancelFunc
+	openedOnce map[string]bool
 }
 
 // Forward opens an SSH channel in the existing connection with channel type "direct-tcpip" to forward the local port.
@@ -88,6 +89,8 @@ func (f *forwarder) Forward(port string, _ netstat.PortForwardAttribute) error {
 			log.Errorf("Error port forwarding %s: %v", port, err)
 		}
 	}(port)
+
+	f.maybeOpenBrowser(cancelCtx, port, attr)
 
 	return nil
 }

--- a/pkg/tunnel/forwarder_test.go
+++ b/pkg/tunnel/forwarder_test.go
@@ -102,6 +102,7 @@ func TestForwarder_Forward_OpenBrowserAction_TriggersOpen(t *testing.T) {
 		openedOnce: map[string]bool{},
 		resolver:   resolver,
 	}
+	t.Cleanup(func() { _ = f.StopForward("19999") })
 
 	err := f.Forward("19999", netstat.PortForwardAttribute{})
 	assert.NoError(t, err)
@@ -122,6 +123,7 @@ func TestForwarder_Forward_NotifyAction_DoesNotTriggerOpen(t *testing.T) {
 		openedOnce: map[string]bool{},
 		resolver:   resolver,
 	}
+	t.Cleanup(func() { _ = f.StopForward("19998") })
 
 	err := f.Forward("19998", netstat.PortForwardAttribute{})
 	assert.NoError(t, err)

--- a/pkg/tunnel/forwarder_test.go
+++ b/pkg/tunnel/forwarder_test.go
@@ -3,8 +3,10 @@ package tunnel
 import (
 	"context"
 	"testing"
+	"time"
 
 	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/netstat"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -88,4 +90,42 @@ func TestForwarder_Protocol_HTTPS(t *testing.T) {
 	resolver := NewPortAttributeResolver(attrs, nil)
 	got := resolver("443")
 	assert.Equal(t, config2.ProtocolHTTPS, got.Protocol)
+}
+
+func TestForwarder_Forward_OpenBrowserAction_TriggersOpen(t *testing.T) {
+	opened := withFakeOpener(t)
+	resolver := func(_ string) config2.PortAttribute {
+		return config2.PortAttribute{OnAutoForward: config2.AutoForwardOpenBrowser}
+	}
+	f := &forwarder{
+		portMap:    map[string]context.CancelFunc{},
+		openedOnce: map[string]bool{},
+		resolver:   resolver,
+	}
+
+	err := f.Forward("19999", netstat.PortForwardAttribute{})
+	assert.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		return opened.Len() == 1
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, "http://localhost:19999", opened.Snapshot()[0])
+}
+
+func TestForwarder_Forward_NotifyAction_DoesNotTriggerOpen(t *testing.T) {
+	opened := withFakeOpener(t)
+	resolver := func(_ string) config2.PortAttribute {
+		return config2.PortAttribute{OnAutoForward: config2.AutoForwardNotify}
+	}
+	f := &forwarder{
+		portMap:    map[string]context.CancelFunc{},
+		openedOnce: map[string]bool{},
+		resolver:   resolver,
+	}
+
+	err := f.Forward("19998", netstat.PortForwardAttribute{})
+	assert.NoError(t, err)
+
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, opened.Snapshot())
 }


### PR DESCRIPTION
## Summary

- Supports the full onAutoForward enum, including openBrowser, openBrowserOnce, and openPreview, and treats non-numeric portsAttributes keys as regexes per the dev container spec.
- Opens the browser on client-side port forward for ports whose resolved attribute uses openBrowser, openBrowserOnce, or openPreview.
- Documents why the in-container forwarder does not duplicate this browser-open handling.
- Fixes a substring-match bug where a bare numeric portsAttributes key could incorrectly match an unrelated port.
- Fixes a non-deterministic map iteration in ResolvePortAttribute so repeated calls with multiple matching range or regex keys return a stable result.
- Fixes a goroutine that left a port stuck in portMap after a failed SSH port forward, blocking retries.
- Cleans up test gaps found in an independent CodeRabbit review and trims comments that only restated the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Forwarded ports can automatically open in a browser or preview.
  - Supports HTTPS forwarding and one-time browser-opening actions.
  - Port settings support exact values, ranges, and regular expressions.
  - Browser-opening failures no longer interrupt port forwarding.

- **Bug Fixes**
  - Improved matching precedence and prevented unintended substring matches.
  - Forwarding state is cleaned up correctly after errors.

- **Tests**
  - Added coverage for browser actions, matching behavior, invalid patterns, and forwarding scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->