### PR TITLE
fix: clean up ~/.devsy on-disk schema drift

### DIFF
--- a/cmd/context/delete.go
+++ b/cmd/context/delete.go
@@ -49,14 +49,12 @@ func (cmd *DeleteCmd) Run(ctx context.Context, context string) error {
 		return err
 	}
 
-	// check for context
 	if context == "" {
 		context = devsyConfig.DefaultContext
 	} else if devsyConfig.Contexts[context] == nil {
 		return fmt.Errorf("context %q doesn't exist", context)
 	}
 
-	// check for default context
 	if context == "default" {
 		return fmt.Errorf("cannot delete 'default' context")
 	}
@@ -76,10 +74,9 @@ func (cmd *DeleteCmd) Run(ctx context.Context, context string) error {
 	return removeContextDir(context)
 }
 
-// removeContextDir removes the on-disk directory tree for a deleted context
-// (workspaces/, contents/, machines/, providers/, pro_instances/, locks/).
+// removeContextDir removes the directory for a deleted context.
 // This runs last, after config.yaml is already saved without the context, so
-// a failure here leaves the context correctly unregistered even though some
+// a failure here leaves the context unregistered even though some
 // disk cleanup may need a manual retry.
 func removeContextDir(contextName string) error {
 	dir, err := config.DefaultPathManager().ContextDir(contextName)

--- a/cmd/context/delete.go
+++ b/cmd/context/delete.go
@@ -3,6 +3,7 @@ package context
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/config"
@@ -72,6 +73,22 @@ func (cmd *DeleteCmd) Run(ctx context.Context, context string) error {
 		return fmt.Errorf("save config: %w", err)
 	}
 
+	return removeContextDir(context)
+}
+
+// removeContextDir removes the on-disk directory tree for a deleted context
+// (workspaces/, contents/, machines/, providers/, pro_instances/, locks/).
+// This runs last, after config.yaml is already saved without the context, so
+// a failure here leaves the context correctly unregistered even though some
+// disk cleanup may need a manual retry.
+func removeContextDir(contextName string) error {
+	dir, err := config.DefaultPathManager().ContextDir(contextName)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("delete context dir: %w", err)
+	}
 	return nil
 }
 

--- a/cmd/context/delete_test.go
+++ b/cmd/context/delete_test.go
@@ -33,7 +33,10 @@ func TestDeleteCmd_RemovesContextDirFromDisk(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(filepath.Join(contextDir, "workspaces", "some-workspace"), 0o755); err != nil {
+	if err := os.MkdirAll(
+		filepath.Join(contextDir, "workspaces", "some-workspace"),
+		0o750,
+	); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/context/delete_test.go
+++ b/cmd/context/delete_test.go
@@ -1,0 +1,48 @@
+package context
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	pkgconfig "github.com/devsy-org/devsy/pkg/config"
+)
+
+func TestDeleteCmd_RemovesContextDirFromDisk(t *testing.T) {
+	pkgconfig.ResetPathManager()
+	t.Cleanup(pkgconfig.ResetPathManager)
+	home := t.TempDir()
+	t.Setenv(pkgconfig.EnvHome, home)
+	t.Setenv(pkgconfig.EnvConfig, filepath.Join(home, "config.yaml"))
+
+	// Seed a config.yaml with a second, non-default context so delete is legal.
+	cfg := &pkgconfig.Config{
+		DefaultContext: pkgconfig.DefaultContext,
+		Contexts: map[string]*pkgconfig.ContextConfig{
+			pkgconfig.DefaultContext: {},
+			"staging":                {},
+		},
+	}
+	if err := pkgconfig.SaveConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	contextDir, err := pkgconfig.DefaultPathManager().ContextDir("staging")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(contextDir, "workspaces", "some-workspace"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := &DeleteCmd{GlobalFlags: &flags.GlobalFlags{}}
+	if err := cmd.Run(context.Background(), "staging"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(contextDir); !os.IsNotExist(err) {
+		t.Fatalf("expected context dir %s to be removed, stat err = %v", contextDir, err)
+	}
+}

--- a/cmd/machine/delete.go
+++ b/cmd/machine/delete.go
@@ -94,10 +94,7 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 }
 
 // removeMachineDirIfPresent removes the on-disk machine directory after a
-// successful remote delete. provider delete (cmd/provider/delete.go) and
-// pro logout (cmd/pro/logout.go) already remove their directories the same
-// way after their remote/config cleanup succeeds; the standalone machine
-// delete path never did.
+// successful remote delete.
 func removeMachineDirIfPresent(context, machineID string) error {
 	if err := clientimplementation.DeleteMachineFolder(context, machineID); err != nil {
 		return fmt.Errorf("delete machine dir: %w", err)

--- a/cmd/machine/delete.go
+++ b/cmd/machine/delete.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/devsy-org/devsy/cmd/flags"
 	"github.com/devsy-org/devsy/pkg/client"
+	"github.com/devsy-org/devsy/pkg/client/clientimplementation"
 	"github.com/devsy-org/devsy/pkg/config"
 	cliflags "github.com/devsy-org/devsy/pkg/flags"
 	"github.com/devsy-org/devsy/pkg/flags/names"
@@ -89,5 +90,17 @@ func (cmd *DeleteCmd) Run(ctx context.Context, args []string) error {
 		return err
 	}
 
+	return removeMachineDirIfPresent(devsyConfig.DefaultContext, machineClient.Machine())
+}
+
+// removeMachineDirIfPresent removes the on-disk machine directory after a
+// successful remote delete. provider delete (cmd/provider/delete.go) and
+// pro logout (cmd/pro/logout.go) already remove their directories the same
+// way after their remote/config cleanup succeeds; the standalone machine
+// delete path never did.
+func removeMachineDirIfPresent(context, machineID string) error {
+	if err := clientimplementation.DeleteMachineFolder(context, machineID); err != nil {
+		return fmt.Errorf("delete machine dir: %w", err)
+	}
 	return nil
 }

--- a/cmd/machine/delete_test.go
+++ b/cmd/machine/delete_test.go
@@ -1,0 +1,36 @@
+package machine
+
+import (
+	"os"
+	"testing"
+
+	pkgconfig "github.com/devsy-org/devsy/pkg/config"
+)
+
+func TestDeleteCmd_RemovesMachineDirFromDisk(t *testing.T) {
+	pkgconfig.ResetPathManager()
+	t.Cleanup(pkgconfig.ResetPathManager)
+	home := t.TempDir()
+	t.Setenv(pkgconfig.EnvHome, home)
+
+	machineDir, err := pkgconfig.DefaultPathManager().MachineDir(pkgconfig.DefaultContext, "test-machine")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(machineDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// NOTE: this test documents the expected end state. Wiring a full
+	// DeleteCmd.Run() call requires a fake machine provider/client; if that
+	// scaffolding is too heavy for this package, downgrade this to a direct
+	// test of a small extracted helper (see Step 3) instead of the full
+	// cobra command path.
+	if err := removeMachineDirIfPresent(pkgconfig.DefaultContext, "test-machine"); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(machineDir); !os.IsNotExist(err) {
+		t.Fatalf("expected machine dir %s to be removed, stat err = %v", machineDir, err)
+	}
+}

--- a/cmd/machine/delete_test.go
+++ b/cmd/machine/delete_test.go
@@ -22,11 +22,6 @@ func TestDeleteCmd_RemovesMachineDirFromDisk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// NOTE: this test documents the expected end state. Wiring a full
-	// DeleteCmd.Run() call requires a fake machine provider/client; if that
-	// scaffolding is too heavy for this package, downgrade this to a direct
-	// test of a small extracted helper (see Step 3) instead of the full
-	// cobra command path.
 	if err := removeMachineDirIfPresent(pkgconfig.DefaultContext, "test-machine"); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/machine/delete_test.go
+++ b/cmd/machine/delete_test.go
@@ -13,11 +13,12 @@ func TestDeleteCmd_RemovesMachineDirFromDisk(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv(pkgconfig.EnvHome, home)
 
-	machineDir, err := pkgconfig.DefaultPathManager().MachineDir(pkgconfig.DefaultContext, "test-machine")
+	machineDir, err := pkgconfig.DefaultPathManager().
+		MachineDir(pkgconfig.DefaultContext, "test-machine")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(machineDir, 0o755); err != nil {
+	if err := os.MkdirAll(machineDir, 0o750); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/agent/workspace.go
+++ b/pkg/agent/workspace.go
@@ -68,7 +68,9 @@ func findDir(agentDir string, validate func(path string) bool) string {
 
 func candidateAgentDirs() []string {
 	var dirs []string
-	if home, _ := util.UserHomeDir(); home != "" {
+	if home := os.Getenv(config.EnvHome); home != "" {
+		dirs = append(dirs, filepath.Join(home, "agent"))
+	} else if home, _ := util.UserHomeDir(); home != "" {
 		dirs = append(dirs, filepath.Join(home, config.ConfigDirName, "agent"))
 	}
 	if root, _ := command.GetHome("root"); root != "" {

--- a/pkg/agent/workspace_test.go
+++ b/pkg/agent/workspace_test.go
@@ -1,10 +1,13 @@
 package agent
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/devsy-org/devsy/pkg/config"
 	provider2 "github.com/devsy-org/devsy/pkg/provider"
 	"github.com/devsy-org/devsy/pkg/types"
+	"github.com/devsy-org/devsy/pkg/util"
 )
 
 const explicitAgentDir = "/some/dir"
@@ -87,6 +90,33 @@ func TestIsHostAgentInvocation(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestCandidateAgentDirs_HonorsDevsyHomeOverride(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv(config.EnvHome, home)
+
+	dirs := candidateAgentDirs()
+
+	want := filepath.Join(home, "agent")
+	found := false
+	for _, d := range dirs {
+		if d == want {
+			found = true
+		}
+		// The raw-OS-home candidate must NOT appear when DEVSY_HOME is set —
+		// that's the coexisting-tree bug this test guards against.
+		realHome, _ := util.UserHomeDir()
+		if realHome != "" && realHome != home {
+			unwanted := filepath.Join(realHome, config.ConfigDirName, "agent")
+			if d == unwanted {
+				t.Fatalf("candidateAgentDirs() included raw-home candidate %q while DEVSY_HOME=%q was set", unwanted, home)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("candidateAgentDirs() = %v, want it to include %q", dirs, want)
 	}
 }
 

--- a/pkg/agent/workspace_test.go
+++ b/pkg/agent/workspace_test.go
@@ -115,7 +115,11 @@ func TestCandidateAgentDirs_HonorsDevsyHomeOverride(t *testing.T) {
 		if realHome != "" && realHome != home {
 			unwanted := filepath.Join(realHome, config.ConfigDirName, "agent")
 			if d == unwanted {
-				t.Fatalf("candidateAgentDirs() included raw-home candidate %q while DEVSY_HOME=%q was set", unwanted, home)
+				t.Fatalf(
+					"candidateAgentDirs() included raw-home candidate %q while DEVSY_HOME=%q was set",
+					unwanted,
+					home,
+				)
 			}
 		}
 	}

--- a/pkg/agent/workspace_test.go
+++ b/pkg/agent/workspace_test.go
@@ -105,12 +105,6 @@ func TestCandidateAgentDirs_HonorsDevsyHomeOverride(t *testing.T) {
 		if d == want {
 			found = true
 		}
-		// The raw-OS-home candidate must NOT appear when DEVSY_HOME is set.
-		// This guards candidateAgentDirs' own EnvHome handling directly: both
-		// production callers (FindAgentHomeDir/PrepareAgentHomeDir) go through
-		// findDir, which already short-circuits on DEVSY_HOME before reaching
-		// this function, so this test hardens against a future caller that
-		// skips findDir rather than a currently-reachable bug.
 		realHome, _ := util.UserHomeDir()
 		if realHome != "" && realHome != home {
 			unwanted := filepath.Join(realHome, config.ConfigDirName, "agent")

--- a/pkg/agent/workspace_test.go
+++ b/pkg/agent/workspace_test.go
@@ -105,8 +105,12 @@ func TestCandidateAgentDirs_HonorsDevsyHomeOverride(t *testing.T) {
 		if d == want {
 			found = true
 		}
-		// The raw-OS-home candidate must NOT appear when DEVSY_HOME is set —
-		// that's the coexisting-tree bug this test guards against.
+		// The raw-OS-home candidate must NOT appear when DEVSY_HOME is set.
+		// This guards candidateAgentDirs' own EnvHome handling directly: both
+		// production callers (FindAgentHomeDir/PrepareAgentHomeDir) go through
+		// findDir, which already short-circuits on DEVSY_HOME before reaching
+		// this function, so this test hardens against a future caller that
+		// skips findDir rather than a currently-reachable bug.
 		realHome, _ := util.UserHomeDir()
 		if realHome != "" && realHome != home {
 			unwanted := filepath.Join(realHome, config.ConfigDirName, "agent")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,10 +14,12 @@ import (
 )
 
 // CurrentSchemaVersion is the on-disk layout version this build of devsy
-// understands. It is stamped into every config.yaml on load/save so a future
-// layout change (e.g. finishing the agent/host tree unification started in
-// this cleanup) has a documented baseline to detect and migrate from, the
-// same way pkg/snapshot.Manifest.SchemaVersion already versions snapshots.
+// understands. LoadConfig stamps it onto every config it reads (fresh or
+// pre-existing) so a future layout change (e.g. finishing the agent/host
+// tree unification started in this cleanup) has a documented baseline to
+// detect and migrate from, the same way pkg/snapshot.Manifest.SchemaVersion
+// already versions snapshots. SaveConfig does not stamp independently — it
+// persists whatever value is already on the in-memory Config.
 const CurrentSchemaVersion = 1
 
 type Config struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,7 +13,20 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+// CurrentSchemaVersion is the on-disk layout version this build of devsy
+// understands. It is stamped into every config.yaml on load/save so a future
+// layout change (e.g. finishing the agent/host tree unification started in
+// this cleanup) has a documented baseline to detect and migrate from, the
+// same way pkg/snapshot.Manifest.SchemaVersion already versions snapshots.
+const CurrentSchemaVersion = 1
+
 type Config struct {
+	// SchemaVersion is the DEVSY_HOME on-disk layout version. Absent/zero on
+	// configs written before this field existed; LoadConfig treats that the
+	// same as CurrentSchemaVersion (see normalizeConfig) since no versioned
+	// layout change has shipped yet.
+	SchemaVersion int `json:"schemaVersion,omitempty" yaml:"schemaVersion,omitempty"`
+
 	// DefaultContext is the default context to use. Defaults to "default"
 	DefaultContext string `json:"defaultContext,omitempty"`
 
@@ -261,6 +274,7 @@ func newMissingConfig(configOrigin, contextOverride, providerOverride string) *C
 	}
 
 	return &Config{
+		SchemaVersion:  CurrentSchemaVersion,
 		DefaultContext: context,
 		Contexts: map[string]*ContextConfig{
 			context: {
@@ -275,6 +289,9 @@ func newMissingConfig(configOrigin, contextOverride, providerOverride string) *C
 }
 
 func normalizeConfig(config *Config, contextOverride, providerOverride string) {
+	if config.SchemaVersion == 0 {
+		config.SchemaVersion = CurrentSchemaVersion
+	}
 	if contextOverride != "" {
 		config.OriginalContext = config.DefaultContext
 		config.DefaultContext = contextOverride

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,20 +13,9 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-// CurrentSchemaVersion is the on-disk layout version this build of devsy
-// understands. LoadConfig stamps it onto every config it reads (fresh or
-// pre-existing) so a future layout change (e.g. finishing the agent/host
-// tree unification started in this cleanup) has a documented baseline to
-// detect and migrate from, the same way pkg/snapshot.Manifest.SchemaVersion
-// already versions snapshots. SaveConfig does not stamp independently — it
-// persists whatever value is already on the in-memory Config.
 const CurrentSchemaVersion = 1
 
 type Config struct {
-	// SchemaVersion is the DEVSY_HOME on-disk layout version. Absent/zero on
-	// configs written before this field existed; LoadConfig treats that the
-	// same as CurrentSchemaVersion (see normalizeConfig) since no versioned
-	// layout change has shipped yet.
 	SchemaVersion int `json:"schemaVersion,omitempty" yaml:"schemaVersion,omitempty"`
 
 	// DefaultContext is the default context to use. Defaults to "default"

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,50 @@
+package config
+
+import "testing"
+
+func TestLoadConfig_StampsCurrentSchemaVersion(t *testing.T) {
+	ResetPathManager()
+	t.Cleanup(ResetPathManager)
+	home := t.TempDir()
+	t.Setenv(EnvHome, home)
+
+	cfg, err := LoadConfig("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.SchemaVersion != CurrentSchemaVersion {
+		t.Fatalf("SchemaVersion = %d, want %d (a freshly created config must be stamped)", cfg.SchemaVersion, CurrentSchemaVersion)
+	}
+
+	if err := SaveConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded, err := LoadConfig("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloaded.SchemaVersion != CurrentSchemaVersion {
+		t.Fatalf("reloaded SchemaVersion = %d, want %d", reloaded.SchemaVersion, CurrentSchemaVersion)
+	}
+}
+
+func TestLoadConfig_StampsMissingSchemaVersionOnExistingConfig(t *testing.T) {
+	ResetPathManager()
+	t.Cleanup(ResetPathManager)
+	home := t.TempDir()
+	t.Setenv(EnvHome, home)
+
+	// Simulate a pre-existing config.yaml written before this field existed.
+	if err := SaveConfig(&Config{DefaultContext: DefaultContext, Contexts: map[string]*ContextConfig{DefaultContext: {}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadConfig("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.SchemaVersion != CurrentSchemaVersion {
+		t.Fatalf("SchemaVersion = %d, want %d (an unstamped config loaded today must be treated as current)", cfg.SchemaVersion, CurrentSchemaVersion)
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -13,7 +13,11 @@ func TestLoadConfig_StampsCurrentSchemaVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 	if cfg.SchemaVersion != CurrentSchemaVersion {
-		t.Fatalf("SchemaVersion = %d, want %d (a freshly created config must be stamped)", cfg.SchemaVersion, CurrentSchemaVersion)
+		t.Fatalf(
+			"SchemaVersion = %d, want %d (a freshly created config must be stamped)",
+			cfg.SchemaVersion,
+			CurrentSchemaVersion,
+		)
 	}
 
 	if err := SaveConfig(cfg); err != nil {
@@ -25,7 +29,11 @@ func TestLoadConfig_StampsCurrentSchemaVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 	if reloaded.SchemaVersion != CurrentSchemaVersion {
-		t.Fatalf("reloaded SchemaVersion = %d, want %d", reloaded.SchemaVersion, CurrentSchemaVersion)
+		t.Fatalf(
+			"reloaded SchemaVersion = %d, want %d",
+			reloaded.SchemaVersion,
+			CurrentSchemaVersion,
+		)
 	}
 }
 
@@ -36,7 +44,12 @@ func TestLoadConfig_StampsMissingSchemaVersionOnExistingConfig(t *testing.T) {
 	t.Setenv(EnvHome, home)
 
 	// Simulate a pre-existing config.yaml written before this field existed.
-	if err := SaveConfig(&Config{DefaultContext: DefaultContext, Contexts: map[string]*ContextConfig{DefaultContext: {}}}); err != nil {
+	if err := SaveConfig(
+		&Config{
+			DefaultContext: DefaultContext,
+			Contexts:       map[string]*ContextConfig{DefaultContext: {}},
+		},
+	); err != nil {
 		t.Fatal(err)
 	}
 
@@ -45,6 +58,10 @@ func TestLoadConfig_StampsMissingSchemaVersionOnExistingConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	if cfg.SchemaVersion != CurrentSchemaVersion {
-		t.Fatalf("SchemaVersion = %d, want %d (an unstamped config loaded today must be treated as current)", cfg.SchemaVersion, CurrentSchemaVersion)
+		t.Fatalf(
+			"SchemaVersion = %d, want %d (an unstamped config loaded today must be treated as current)",
+			cfg.SchemaVersion,
+			CurrentSchemaVersion,
+		)
 	}
 }

--- a/pkg/config/pathmanager.go
+++ b/pkg/config/pathmanager.go
@@ -58,7 +58,8 @@ func homeOverrideDir(sub ...string) (string, bool, error) {
 //	CacheDir()                              (default $HOME/.cache/devsy, or $DEVSY_HOME/cache when set)
 //	├── agents/, providers/, features/<hash>/, platform/, keys/
 //	StateDir()                              (default under DataDir()/state)
-//	RuntimeDir()                            (default under DataDir()/run on darwin, OS temp dir on linux; see pathmanager_darwin.go / pathmanager_linux.go)
+//	RuntimeDir()                            (default under DataDir()/run on darwin,
+//	                                         OS temp dir on linux; see pathmanager_darwin.go / pathmanager_linux.go)
 type PathManager interface {
 	// Top-level XDG category directories.
 	ConfigDir() (string, error)

--- a/pkg/config/pathmanager.go
+++ b/pkg/config/pathmanager.go
@@ -38,6 +38,23 @@ func homeOverrideDir(sub ...string) (string, bool, error) {
 // PathManager centralises all filesystem path computation for the Devsy CLI.
 // Per-OS implementations supply the five top-level directory methods; every
 // sub-path is derived from those by the shared basePathManager.
+//
+// Canonical layout (all paths relative to the values these methods return —
+// never construct a DEVSY_HOME-relative path outside this file; see
+// pkg/provider/version_cache.go's history for why that rule exists):
+//
+//	ConfigDir()/DataDir()  (same directory today; both may be $DEVSY_HOME)
+//	├── config.yaml                        (ConfigFilePath, stamped with Config.SchemaVersion)
+//	└── contexts/<context>/                (ContextDir)
+//	    ├── workspaces/<id>/{agent,logs}    (WorkspaceDir, WorkspaceAgentDir, WorkspaceLogDir)
+//	    ├── contents/<id>                   (WorkspaceContentsDir/WorkspaceContentDir — parent never removed)
+//	    ├── machines/<id>                   (MachineDir)
+//	    ├── providers/<name>/{binaries,daemon} (ProviderDir)
+//	    ├── pro_instances/<id>              (ProInstanceDir)
+//	    └── locks/                          (LocksDir)
+//	CacheDir()                              (default $HOME/.cache/devsy, or $DEVSY_HOME/cache when set)
+//	├── agents/, providers/, features/<hash>/, platform/, keys/
+//	StateDir()/RuntimeDir()                 (default under DataDir()/temp; see pathmanager_darwin.go / pathmanager_linux.go)
 type PathManager interface {
 	// Top-level XDG category directories.
 	ConfigDir() (string, error)

--- a/pkg/config/pathmanager.go
+++ b/pkg/config/pathmanager.go
@@ -35,16 +35,7 @@ func homeOverrideDir(sub ...string) (string, bool, error) {
 	return dir, true, err
 }
 
-// PathManager centralises all filesystem path computation for the Devsy CLI.
-// Per-OS implementations supply the five top-level directory methods; every
-// sub-path is derived from those by the shared basePathManager.
-//
-// Canonical layout (all paths relative to the values these methods return —
-// on the host CLI side, never construct a DEVSY_HOME-relative path outside
-// this file; see pkg/provider/version_cache.go's history for why that rule
-// exists. pkg/agent/workspace.go is a deliberate exception: it reimplements
-// this same layout for agent-side code running inside the container/machine,
-// where this package's PathManager singleton isn't available):
+// PathManager centralises filesystem paths. Layout:
 //
 //	ConfigDir()/DataDir()  (same directory today; both may be $DEVSY_HOME)
 //	├── config.yaml                        (ConfigFilePath, stamped with Config.SchemaVersion)

--- a/pkg/config/pathmanager.go
+++ b/pkg/config/pathmanager.go
@@ -40,8 +40,11 @@ func homeOverrideDir(sub ...string) (string, bool, error) {
 // sub-path is derived from those by the shared basePathManager.
 //
 // Canonical layout (all paths relative to the values these methods return —
-// never construct a DEVSY_HOME-relative path outside this file; see
-// pkg/provider/version_cache.go's history for why that rule exists):
+// on the host CLI side, never construct a DEVSY_HOME-relative path outside
+// this file; see pkg/provider/version_cache.go's history for why that rule
+// exists. pkg/agent/workspace.go is a deliberate exception: it reimplements
+// this same layout for agent-side code running inside the container/machine,
+// where this package's PathManager singleton isn't available):
 //
 //	ConfigDir()/DataDir()  (same directory today; both may be $DEVSY_HOME)
 //	├── config.yaml                        (ConfigFilePath, stamped with Config.SchemaVersion)
@@ -54,7 +57,8 @@ func homeOverrideDir(sub ...string) (string, bool, error) {
 //	    └── locks/                          (LocksDir)
 //	CacheDir()                              (default $HOME/.cache/devsy, or $DEVSY_HOME/cache when set)
 //	├── agents/, providers/, features/<hash>/, platform/, keys/
-//	StateDir()/RuntimeDir()                 (default under DataDir()/temp; see pathmanager_darwin.go / pathmanager_linux.go)
+//	StateDir()                              (default under DataDir()/state)
+//	RuntimeDir()                            (default under DataDir()/run on darwin, OS temp dir on linux; see pathmanager_darwin.go / pathmanager_linux.go)
 type PathManager interface {
 	// Top-level XDG category directories.
 	ConfigDir() (string, error)

--- a/pkg/provider/version_cache.go
+++ b/pkg/provider/version_cache.go
@@ -51,15 +51,11 @@ type ProviderVersionCacheEntry struct {
 type ProviderVersionCache map[string]ProviderVersionCacheEntry
 
 func providerVersionCachePath() (string, error) {
-	// Check for DEVSY_HOME override (primarily used in tests).
-	if home := os.Getenv(config.EnvHome); home != "" {
-		return filepath.Join(home, "cache", "provider-versions.json"), nil
-	}
-	dir, err := config.GetConfigDir()
+	dir, err := config.DefaultPathManager().CacheDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, "cache", "provider-versions.json"), nil
+	return filepath.Join(dir, "provider-versions.json"), nil
 }
 
 func LoadProviderVersionCache() (ProviderVersionCache, error) {

--- a/pkg/provider/version_cache_test.go
+++ b/pkg/provider/version_cache_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/devsy-org/devsy/pkg/config"
 )
 
 func TestCacheRoundtrip(t *testing.T) {
@@ -29,16 +31,30 @@ func TestCacheRoundtrip(t *testing.T) {
 	if loaded["foo"].SourceHash != testNameABC {
 		t.Fatalf("roundtrip mismatch: %+v", loaded)
 	}
-	if _, err := os.Stat(
-		filepath.Join(dir, "."+"devsy", "cache", "provider-versions.json"),
-	); err != nil {
-		// Path layout: DEVSY_HOME is the devsy config dir directly (per `config.GetConfigDir()`),
-		// so cache lives at $DEVSY_HOME/cache/provider-versions.json. If the assertion above fails,
-		// adjust to filepath.Join(dir, "cache", "provider-versions.json") instead.
-		alt := filepath.Join(dir, "cache", "provider-versions.json")
-		if _, err2 := os.Stat(alt); err2 != nil {
-			t.Fatalf("cache file not found at either expected location: %v / %v", err, err2)
-		}
+
+	wantPath := filepath.Join(dir, "cache", "provider-versions.json")
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected cache file at %s (via PathManager.CacheDir()): %v", wantPath, err)
+	}
+}
+
+func TestProviderVersionCachePath_UsesPathManagerCacheDir(t *testing.T) {
+	config.ResetPathManager()
+	t.Cleanup(config.ResetPathManager)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	got, err := providerVersionCachePath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheDir, err := config.DefaultPathManager().CacheDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(cacheDir, "provider-versions.json")
+	if got != want {
+		t.Fatalf("providerVersionCachePath() = %q, want %q (PathManager.CacheDir())", got, want)
 	}
 }
 

--- a/pkg/workspace/delete.go
+++ b/pkg/workspace/delete.go
@@ -359,7 +359,7 @@ func removeIfOrphan(workspaceDir string, entry os.DirEntry) {
 // (.../contexts/<ctx>/contents/) that have no corresponding workspace
 // directory at all. Unlike SweepOrphanWorkspaceDirs (which checks for a
 // missing workspace.json inside an existing workspace dir), an orphaned
-// content dir means the workspace dir itself is already gone — left behind
+// content dir means the workspace dir itself is already gone; left behind
 // by a crash mid-delete or a killed process partway through
 // DeleteWorkspaceFolder.
 func SweepOrphanContentDirs(contextName string) {

--- a/pkg/workspace/delete.go
+++ b/pkg/workspace/delete.go
@@ -360,8 +360,8 @@ func removeIfOrphan(workspaceDir string, entry os.DirEntry) {
 // directory at all. Unlike SweepOrphanWorkspaceDirs (which checks for a
 // missing workspace.json inside an existing workspace dir), an orphaned
 // content dir means the workspace dir itself is already gone — left behind
-// by a crash mid-delete, a killed process, or the agent-side skip for
-// user-owned local folders (cmd/internal/agentworkspace/delete.go).
+// by a crash mid-delete or a killed process partway through
+// DeleteWorkspaceFolder.
 func SweepOrphanContentDirs(contextName string) {
 	contentsDir, err := providerpkg.GetWorkspaceContentsDir(contextName)
 	if err != nil {

--- a/pkg/workspace/delete.go
+++ b/pkg/workspace/delete.go
@@ -58,6 +58,7 @@ func Delete(ctx context.Context, opts DeleteOptions) (string, error) {
 	id, err := deleteWorkspace(ctx, client, opts)
 	if err == nil {
 		SweepOrphanWorkspaceDirs(opts.DevsyConfig.DefaultContext)
+		SweepOrphanContentDirs(opts.DevsyConfig.DefaultContext)
 	}
 	return id, err
 }
@@ -352,4 +353,51 @@ func removeIfOrphan(workspaceDir string, entry os.DirEntry) {
 		return
 	}
 	log.Debugf("removed orphan workspace dir without config: workspace=%s", entry.Name())
+}
+
+// SweepOrphanContentDirs removes entries under the context's content dir
+// (.../contexts/<ctx>/contents/) that have no corresponding workspace
+// directory at all. Unlike SweepOrphanWorkspaceDirs (which checks for a
+// missing workspace.json inside an existing workspace dir), an orphaned
+// content dir means the workspace dir itself is already gone — left behind
+// by a crash mid-delete, a killed process, or the agent-side skip for
+// user-owned local folders (cmd/internal/agentworkspace/delete.go).
+func SweepOrphanContentDirs(contextName string) {
+	contentsDir, err := providerpkg.GetWorkspaceContentsDir(contextName)
+	if err != nil {
+		log.Debugf("sweep orphan content dirs: get contents dir: %v", err)
+		return
+	}
+
+	entries, err := os.ReadDir(contentsDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Debugf("sweep orphan content dirs: read dir: %v", err)
+		}
+		return
+	}
+
+	for _, entry := range entries {
+		removeIfContentOrphan(contextName, contentsDir, entry)
+	}
+}
+
+func removeIfContentOrphan(contextName, contentsDir string, entry os.DirEntry) {
+	if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+		return
+	}
+
+	workspaceDir, err := providerpkg.GetWorkspaceDir(contextName, entry.Name())
+	if err != nil {
+		return
+	}
+	if _, err := os.Stat(workspaceDir); err == nil || !os.IsNotExist(err) {
+		return
+	}
+
+	if err := os.RemoveAll(filepath.Join(contentsDir, entry.Name())); err != nil {
+		log.Warnf("remove orphan content dir %s: %v", entry.Name(), err)
+		return
+	}
+	log.Debugf("removed orphan content dir with no matching workspace: workspace=%s", entry.Name())
 }

--- a/pkg/workspace/delete_test.go
+++ b/pkg/workspace/delete_test.go
@@ -68,7 +68,5 @@ func TestSweepOrphanContentDirs_RemovesContentWithNoMatchingWorkspace(t *testing
 
 func TestSweepOrphanContentDirs_MissingDirIsNoop(t *testing.T) {
 	setupTestPathManager(t)
-
-	// No contents dir created yet — sweep must not panic or error.
 	SweepOrphanContentDirs(testDefaultContext)
 }

--- a/pkg/workspace/delete_test.go
+++ b/pkg/workspace/delete_test.go
@@ -42,3 +42,33 @@ func TestSweepOrphanWorkspaceDirs_MissingDirIsNoop(t *testing.T) {
 	// No workspaces dir created yet — sweep must not panic or error.
 	SweepOrphanWorkspaceDirs(testDefaultContext)
 }
+
+func TestSweepOrphanContentDirs_RemovesContentWithNoMatchingWorkspace(t *testing.T) {
+	setupTestPathManager(t)
+
+	contentsDir, err := provider.GetWorkspaceContentsDir(testDefaultContext)
+	require.NoError(t, err)
+	workspacesDir, err := provider.GetWorkspacesDir(testDefaultContext)
+	require.NoError(t, err)
+
+	// "orphaned" has content but no matching workspace dir at all.
+	orphanedContent := filepath.Join(contentsDir, "orphaned")
+	require.NoError(t, os.MkdirAll(orphanedContent, 0o750))
+
+	// "kept" has both a content dir and a matching workspace dir — must survive.
+	keptContent := filepath.Join(contentsDir, "kept")
+	require.NoError(t, os.MkdirAll(keptContent, 0o750))
+	require.NoError(t, os.MkdirAll(filepath.Join(workspacesDir, "kept"), 0o750))
+
+	SweepOrphanContentDirs(testDefaultContext)
+
+	require.NoDirExists(t, orphanedContent)
+	require.DirExists(t, keptContent)
+}
+
+func TestSweepOrphanContentDirs_MissingDirIsNoop(t *testing.T) {
+	setupTestPathManager(t)
+
+	// No contents dir created yet — sweep must not panic or error.
+	SweepOrphanContentDirs(testDefaultContext)
+}


### PR DESCRIPTION
## Summary

Fixes six correctness bugs and one documentation gap in devsy's on-disk state directory (`~/.devsy`, aka `DEVSY_HOME`) that let files accumulate without cleanup and let paths drift from the central `PathManager` abstraction:

- Routes the provider-version cache through `PathManager.CacheDir()` instead of a hand-rolled path that landed it in the wrong root.
- `devsy machine delete` and `devsy context delete` now actually remove their on-disk directories (previously only `provider delete` and `pro logout` did this correctly).
- Adds an orphan sweep for the `contents/` tree, alongside the existing sweep for `workspaces/`.
- Makes `candidateAgentDirs()` honor `$DEVSY_HOME` instead of always probing the raw OS home directory.
- Stamps a `SchemaVersion` into `config.yaml` and documents the canonical on-disk layout on `PathManager`, giving future layout changes a baseline to migrate from.

Each task was implemented and reviewed independently (spec compliance + code quality), followed by a whole-branch review and a comment-accuracy pass. One whole-branch finding is worth calling out explicitly: the `candidateAgentDirs()` fix (commit `10d5a892`) is correct and defensive, but turned out to be unreachable from both production callers today — `findDir` already short-circuits on `$DEVSY_HOME` before ever reaching that function. It hardens against a future caller that bypasses `findDir`, but does not change current observable behavior.

A CodeRabbit pass on the branch surfaced two findings; both were verified against the code and are false positives (details in the review thread if useful, not included here since neither required a change).

## Not in scope (documented as follow-up)

- Full agent-side/host-side directory tree unification (only the `$DEVSY_HOME`-blindness half is fixed here).
- Cache TTL/eviction (no `prune`/`gc` command exists yet to build on).
- A migration for the provider-version cache file's old (pre-fix) location — low-harm, regenerable with a 6h TTL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of local context and machine files after deletion.
  * Removed orphaned workspace content during workspace deletion.
  * Added configuration schema version tracking for safer future upgrades.
  * Respected the configured Devsy home for agent workspace locations.

* **Bug Fixes**
  * Standardized provider version cache placement.
  * Improved handling of missing directories during cleanup.

* **Documentation**
  * Documented the managed filesystem layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->