### PR TITLE
fix(lint): resolve cyclop finding in ResolvePortAttribute

### DIFF
--- a/pkg/devcontainer/config/config.go
+++ b/pkg/devcontainer/config/config.go
@@ -458,29 +458,56 @@ func ResolvePortAttribute(
 		if attr, ok := portsAttrs[portStr]; ok {
 			return attr
 		}
-		keys := make([]string, 0, len(portsAttrs))
-		for key := range portsAttrs {
-			keys = append(keys, key)
+		keys := sortedPortAttrKeys(portsAttrs)
+		if attr, ok := findPortRangeMatch(keys, portsAttrs, port); ok {
+			return attr
 		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			if matchPortRange(key, port) {
-				return portsAttrs[key]
-			}
-		}
-		for _, key := range keys {
-			if exactOrRangeKeyPattern.MatchString(key) {
-				continue
-			}
-			if matchPortRegex(key, portStr) {
-				return portsAttrs[key]
-			}
+		if attr, ok := findPortRegexMatch(keys, portsAttrs, portStr); ok {
+			return attr
 		}
 	}
 	if fallback != nil {
 		return *fallback
 	}
 	return PortAttribute{}
+}
+
+func sortedPortAttrKeys(portsAttrs map[string]PortAttribute) []string {
+	keys := make([]string, 0, len(portsAttrs))
+	for key := range portsAttrs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func findPortRangeMatch(
+	keys []string,
+	portsAttrs map[string]PortAttribute,
+	port int,
+) (PortAttribute, bool) {
+	for _, key := range keys {
+		if matchPortRange(key, port) {
+			return portsAttrs[key], true
+		}
+	}
+	return PortAttribute{}, false
+}
+
+func findPortRegexMatch(
+	keys []string,
+	portsAttrs map[string]PortAttribute,
+	portStr string,
+) (PortAttribute, bool) {
+	for _, key := range keys {
+		if exactOrRangeKeyPattern.MatchString(key) {
+			continue
+		}
+		if matchPortRegex(key, portStr) {
+			return portsAttrs[key], true
+		}
+	}
+	return PortAttribute{}, false
 }
 
 // ShouldAutoForward returns true if the port attribute allows auto-forwarding.


### PR DESCRIPTION
Extracts `sortedPortAttrKeys`, `findPortRangeMatch`, and `findPortRegexMatch` helpers out of `ResolvePortAttribute` to bring its cyclomatic complexity from 10 to under the `cyclop` limit of 8. Behavior unchanged.

Part of the golangci-lint backlog cleanup, one rule per PR — this PR is scoped to the single `cyclop` finding in `pkg/devcontainer/config/config.go`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port attribute resolution for exact ports, port ranges, and regular-expression matches.
  * Exact-port settings now consistently take precedence over broader matches.
  * When multiple range or pattern matches apply, selection is now deterministic and consistently prioritized.
  * Unmatched ports now fall back cleanly without being incorrectly treated as matched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->