### PR TITLE
fix: wait for gpg-agent forward readiness before opening browser IDEs

### DIFF
--- a/cmd/workspace/gpg_tunnel.go
+++ b/cmd/workspace/gpg_tunnel.go
@@ -64,6 +64,11 @@ type gpgTunnel struct {
 	// failureReported prevents a repeated OSC 9977 notification while the
 	// tunnel stays down across health-check ticks.
 	failureReported bool
+
+	// readySignaled prevents signaling gpg forward readiness more than once:
+	// it's sent the first time ensure reports the tunnel is live, whether
+	// that's the initial synchronous call or a later health-check retry.
+	readySignaled bool
 }
 
 // newGPGTunnel reports whether GPG-agent forwarding was requested via flag
@@ -94,27 +99,30 @@ func (t *gpgTunnel) run(ctx context.Context, sshClient *ssh.Client) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			t.ensure(ctx, sshClient)
+			if t.ensure(ctx, sshClient) {
+				t.signalReadyOnce()
+			}
 		}
 	}
 }
 
 // ensure checks whether the GPG tunnel is currently live and, if not,
-// (re-)establishes it. A setup failure is only reported if the tunnel is
-// still down immediately after: a concurrent terminal may have won the bind
-// race in the interim, which is not a real failure. The OSC failure
-// notification fires only on the healthy-to-failed transition, not on
-// every health-check tick.
-func (t *gpgTunnel) ensure(ctx context.Context, sshClient *ssh.Client) {
+// (re-)establishes it. It reports whether the tunnel is live when it
+// returns. A setup failure is only reported if the tunnel is still down
+// immediately after: a concurrent terminal may have won the bind race in
+// the interim, which is not a real failure. The OSC failure notification
+// fires only on the healthy-to-failed transition, not on every health-check
+// tick.
+func (t *gpgTunnel) ensure(ctx context.Context, sshClient *ssh.Client) bool {
 	if gpg.IsGpgTunnelRunning(ctx, t.cmd.User, sshClient) {
 		log.Debugf("GPG tunnel is running, skipping setup")
 		t.failureReported = false
-		return
+		return true
 	}
 	err := t.setup(ctx, sshClient)
 	if err == nil {
 		t.failureReported = false
-		return
+		return true
 	}
 	if gpg.IsGpgTunnelRunning(ctx, t.cmd.User, sshClient) {
 		log.Debugf(
@@ -122,17 +130,17 @@ func (t *gpgTunnel) ensure(ctx context.Context, sshClient *ssh.Client) {
 			err,
 		)
 		t.failureReported = false
-		return
+		return true
 	}
 	if ctx.Err() != nil {
 		// ctx was cancelled (session ending); the failure above is an
 		// artifact of that, not a real forwarding problem worth reporting.
 		log.Debugf("GPG tunnel setup aborted by context cancellation: %v", err)
-		return
+		return false
 	}
 	log.Warnf("GPG agent forwarding failed (continuing without it): %v", err)
 	if t.failureReported {
-		return
+		return false
 	}
 	t.failureReported = true
 	// The desktop toast gets a fixed, concise reason rather than err.Error():
@@ -140,6 +148,7 @@ func (t *gpgTunnel) ensure(ctx context.Context, sshClient *ssh.Client) {
 	// something to surface verbatim in the UI. Full detail stays in the log
 	// line above (visible with --debug).
 	writeGPGForwardFailedOSC(os.Stderr, "check logs for details")
+	return false
 }
 
 // setup runs the remote setup-gpg command, which imports the host's owner trust
@@ -247,27 +256,46 @@ func (t *gpgTunnel) ensureForwardBound(
 	return nil
 }
 
+// signalReadyOnce signals gpg forward readiness at most once per gpgTunnel:
+// once the write actually succeeds, so a later health-check retry that also
+// succeeds doesn't write the readiness byte again. If the write fails, it's
+// not recorded as signaled, so a later successful ensure retries it instead
+// of leaving ForwardAgent to wait out its full timeout despite the tunnel
+// being live.
+func (t *gpgTunnel) signalReadyOnce() {
+	if t.readySignaled {
+		return
+	}
+	t.readySignaled = signalGPGForwardReady()
+}
+
 // signalGPGForwardReady is a no-op unless this process was spawned by
 // pkg/gpg.ForwardAgent, which is the only caller that sets ForwardReadyFDEnv.
-func signalGPGForwardReady() {
+// It reports whether the readiness byte was written successfully.
+func signalGPGForwardReady() bool {
 	fdStr := os.Getenv(gpg.ForwardReadyFDEnv)
 	if fdStr == "" {
-		return
+		return false
 	}
 	fd, err := strconv.Atoi(fdStr)
 	if err != nil {
 		log.Debugf("invalid %s=%q: %v", gpg.ForwardReadyFDEnv, fdStr, err)
-		return
+		return false
 	}
 	f := os.NewFile(uintptr(fd), "gpg-forward-ready")
 	if f == nil {
 		log.Debugf("invalid %s=%q: file descriptor is not open", gpg.ForwardReadyFDEnv, fdStr)
-		return
+		return false
 	}
-	defer func() { _ = f.Close() }()
 	if _, err := f.Write([]byte{1}); err != nil {
 		log.Debugf("signal gpg forward ready: %v", err)
+		// Leave f open: the fd may still be usable for a later retry, and
+		// closing it here would risk the fd number being reused elsewhere
+		// before that retry runs.
+		return false
 	}
+	_ = f.Close()
+	return true
 }
 
 // runGPGTunnelInBackground runs the tunnel's first setup synchronously, so
@@ -283,9 +311,8 @@ func runGPGTunnelInBackground(
 	t *gpgTunnel,
 	sshClient *ssh.Client,
 ) (wait func()) {
-	if t.enabled {
-		t.ensure(ctx, sshClient)
-		signalGPGForwardReady()
+	if t.enabled && t.ensure(ctx, sshClient) {
+		t.signalReadyOnce()
 	}
 
 	tunnelCtx, cancel := context.WithCancel(ctx)

--- a/cmd/workspace/gpg_tunnel.go
+++ b/cmd/workspace/gpg_tunnel.go
@@ -255,21 +255,19 @@ func (t *gpgTunnel) signalReadyOnce() {
 	t.readySignaled = signalGPGForwardReady()
 }
 
-// signalGPGForwardReady is a no-op unless this process was spawned by
-// pkg/gpg.ForwardAgent, which is the only caller that sets ForwardReadyFDEnv.
 func signalGPGForwardReady() bool {
-	fdStr := os.Getenv(gpg.ForwardReadyFDEnv)
+	fdStr := os.Getenv(gpg.EnvForwardReadyFD)
 	if fdStr == "" {
 		return false
 	}
 	fd, err := strconv.Atoi(fdStr)
 	if err != nil {
-		log.Debugf("invalid %s=%q: %v", gpg.ForwardReadyFDEnv, fdStr, err)
+		log.Debugf("invalid %s=%q: %v", gpg.EnvForwardReadyFD, fdStr, err)
 		return false
 	}
 	f := os.NewFile(uintptr(fd), "gpg-forward-ready")
 	if f == nil {
-		log.Debugf("invalid %s=%q: file descriptor is not open", gpg.ForwardReadyFDEnv, fdStr)
+		log.Debugf("invalid %s=%q: file descriptor is not open", gpg.EnvForwardReadyFD, fdStr)
 		return false
 	}
 	if _, err := f.Write([]byte{1}); err != nil {

--- a/cmd/workspace/gpg_tunnel.go
+++ b/cmd/workspace/gpg_tunnel.go
@@ -269,7 +269,6 @@ func (t *gpgTunnel) signalGPGForwardReady() bool {
 		log.Debugf("invalid %s=%q: %v", gpg.EnvForwardReadyFD, fdStr, err)
 		return false
 	}
-	// Reuse the retained file if we've already wrapped this fd.
 	if t.readyFile == nil {
 		t.readyFile = os.NewFile(uintptr(fd), "gpg-forward-ready")
 		if t.readyFile == nil {
@@ -279,9 +278,7 @@ func (t *gpgTunnel) signalGPGForwardReady() bool {
 	}
 	if _, err := t.readyFile.Write([]byte{1}); err != nil {
 		log.Debugf("signal gpg forward ready: %v", err)
-		// Keep t.readyFile set: the fd may still be usable for a later retry,
-		// and releasing it here would let the runtime finalize and close the fd
-		// before that retry runs.
+		// the fd may still be usable for a later retry
 		return false
 	}
 	_ = t.readyFile.Close()

--- a/cmd/workspace/gpg_tunnel.go
+++ b/cmd/workspace/gpg_tunnel.go
@@ -67,6 +67,10 @@ type gpgTunnel struct {
 
 	// readySignaled prevents signaling gpg forward readiness more than once.
 	readySignaled bool
+
+	// readyFile retains the *os.File wrapping the readiness fd across failed
+	// write attempts, preventing premature finalization/closure of the fd.
+	readyFile *os.File
 }
 
 // newGPGTunnel reports whether GPG-agent forwarding was requested via flag
@@ -252,10 +256,10 @@ func (t *gpgTunnel) signalReadyOnce() {
 	if t.readySignaled {
 		return
 	}
-	t.readySignaled = signalGPGForwardReady()
+	t.readySignaled = t.signalGPGForwardReady()
 }
 
-func signalGPGForwardReady() bool {
+func (t *gpgTunnel) signalGPGForwardReady() bool {
 	fdStr := os.Getenv(gpg.EnvForwardReadyFD)
 	if fdStr == "" {
 		return false
@@ -265,19 +269,23 @@ func signalGPGForwardReady() bool {
 		log.Debugf("invalid %s=%q: %v", gpg.EnvForwardReadyFD, fdStr, err)
 		return false
 	}
-	f := os.NewFile(uintptr(fd), "gpg-forward-ready")
-	if f == nil {
-		log.Debugf("invalid %s=%q: file descriptor is not open", gpg.EnvForwardReadyFD, fdStr)
-		return false
+	// Reuse the retained file if we've already wrapped this fd.
+	if t.readyFile == nil {
+		t.readyFile = os.NewFile(uintptr(fd), "gpg-forward-ready")
+		if t.readyFile == nil {
+			log.Debugf("invalid %s=%q: file descriptor is not open", gpg.EnvForwardReadyFD, fdStr)
+			return false
+		}
 	}
-	if _, err := f.Write([]byte{1}); err != nil {
+	if _, err := t.readyFile.Write([]byte{1}); err != nil {
 		log.Debugf("signal gpg forward ready: %v", err)
-		// Leave f open: the fd may still be usable for a later retry, and
-		// closing it here would risk the fd number being reused elsewhere
+		// Keep t.readyFile set: the fd may still be usable for a later retry,
+		// and releasing it here would let the runtime finalize and close the fd
 		// before that retry runs.
 		return false
 	}
-	_ = f.Close()
+	_ = t.readyFile.Close()
+	t.readyFile = nil
 	return true
 }
 

--- a/cmd/workspace/gpg_tunnel.go
+++ b/cmd/workspace/gpg_tunnel.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -246,6 +247,29 @@ func (t *gpgTunnel) ensureForwardBound(
 	return nil
 }
 
+// signalGPGForwardReady is a no-op unless this process was spawned by
+// pkg/gpg.ForwardAgent, which is the only caller that sets ForwardReadyFDEnv.
+func signalGPGForwardReady() {
+	fdStr := os.Getenv(gpg.ForwardReadyFDEnv)
+	if fdStr == "" {
+		return
+	}
+	fd, err := strconv.Atoi(fdStr)
+	if err != nil {
+		log.Debugf("invalid %s=%q: %v", gpg.ForwardReadyFDEnv, fdStr, err)
+		return
+	}
+	f := os.NewFile(uintptr(fd), "gpg-forward-ready")
+	if f == nil {
+		log.Debugf("invalid %s=%q: file descriptor is not open", gpg.ForwardReadyFDEnv, fdStr)
+		return
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.Write([]byte{1}); err != nil {
+		log.Debugf("signal gpg forward ready: %v", err)
+	}
+}
+
 // runGPGTunnelInBackground runs the tunnel's first setup synchronously, so
 // the SSH command that follows does not race a still-forwarding gpg-agent,
 // then starts t.run's periodic health-check loop in a goroutine tied to a
@@ -261,6 +285,7 @@ func runGPGTunnelInBackground(
 ) (wait func()) {
 	if t.enabled {
 		t.ensure(ctx, sshClient)
+		signalGPGForwardReady()
 	}
 
 	tunnelCtx, cancel := context.WithCancel(ctx)

--- a/cmd/workspace/gpg_tunnel.go
+++ b/cmd/workspace/gpg_tunnel.go
@@ -65,9 +65,7 @@ type gpgTunnel struct {
 	// tunnel stays down across health-check ticks.
 	failureReported bool
 
-	// readySignaled prevents signaling gpg forward readiness more than once:
-	// it's sent the first time ensure reports the tunnel is live, whether
-	// that's the initial synchronous call or a later health-check retry.
+	// readySignaled prevents signaling gpg forward readiness more than once.
 	readySignaled bool
 }
 
@@ -108,11 +106,7 @@ func (t *gpgTunnel) run(ctx context.Context, sshClient *ssh.Client) {
 
 // ensure checks whether the GPG tunnel is currently live and, if not,
 // (re-)establishes it. It reports whether the tunnel is live when it
-// returns. A setup failure is only reported if the tunnel is still down
-// immediately after: a concurrent terminal may have won the bind race in
-// the interim, which is not a real failure. The OSC failure notification
-// fires only on the healthy-to-failed transition, not on every health-check
-// tick.
+// returns.
 func (t *gpgTunnel) ensure(ctx context.Context, sshClient *ssh.Client) bool {
 	if gpg.IsGpgTunnelRunning(ctx, t.cmd.User, sshClient) {
 		log.Debugf("GPG tunnel is running, skipping setup")
@@ -133,8 +127,6 @@ func (t *gpgTunnel) ensure(ctx context.Context, sshClient *ssh.Client) bool {
 		return true
 	}
 	if ctx.Err() != nil {
-		// ctx was cancelled (session ending); the failure above is an
-		// artifact of that, not a real forwarding problem worth reporting.
 		log.Debugf("GPG tunnel setup aborted by context cancellation: %v", err)
 		return false
 	}
@@ -143,10 +135,7 @@ func (t *gpgTunnel) ensure(ctx context.Context, sshClient *ssh.Client) bool {
 		return false
 	}
 	t.failureReported = true
-	// The desktop toast gets a fixed, concise reason rather than err.Error():
-	// the underlying error can wrap remote SSH exit output, which isn't
-	// something to surface verbatim in the UI. Full detail stays in the log
-	// line above (visible with --debug).
+	// Emit OSC code for UI to detect.
 	writeGPGForwardFailedOSC(os.Stderr, "check logs for details")
 	return false
 }
@@ -258,10 +247,7 @@ func (t *gpgTunnel) ensureForwardBound(
 
 // signalReadyOnce signals gpg forward readiness at most once per gpgTunnel:
 // once the write actually succeeds, so a later health-check retry that also
-// succeeds doesn't write the readiness byte again. If the write fails, it's
-// not recorded as signaled, so a later successful ensure retries it instead
-// of leaving ForwardAgent to wait out its full timeout despite the tunnel
-// being live.
+// succeeds does not write the readiness byte again.
 func (t *gpgTunnel) signalReadyOnce() {
 	if t.readySignaled {
 		return
@@ -271,7 +257,6 @@ func (t *gpgTunnel) signalReadyOnce() {
 
 // signalGPGForwardReady is a no-op unless this process was spawned by
 // pkg/gpg.ForwardAgent, which is the only caller that sets ForwardReadyFDEnv.
-// It reports whether the readiness byte was written successfully.
 func signalGPGForwardReady() bool {
 	fdStr := os.Getenv(gpg.ForwardReadyFDEnv)
 	if fdStr == "" {

--- a/pkg/gpg/forward.go
+++ b/pkg/gpg/forward.go
@@ -76,15 +76,21 @@ type forwardSpec struct {
 
 func superviseForward(ctx context.Context, spec forwardSpec, ready chan<- struct{}) {
 	delay := spec.backoff.min
-	firstAttemptReady := ready
+	// pendingReady stays non-nil across attempts (setup failures, crashes,
+	// restarts) until one attempt actually reports readiness: a failed first
+	// attempt must not make ForwardAgent give up waiting on a retry that
+	// would succeed within its timeout.
+	pendingReady := ready
 	for {
 		if ctx.Err() != nil {
 			return
 		}
 
 		start := time.Now()
-		runErr := runForwardOnce(ctx, spec.execPath, spec.args, firstAttemptReady)
-		firstAttemptReady = nil // only the first attempt reports readiness
+		reported, runErr := runForwardOnce(ctx, spec.execPath, spec.args, pendingReady)
+		if reported {
+			pendingReady = nil // readiness has been reported; no need to keep trying
+		}
 		if ctx.Err() != nil {
 			return
 		}
@@ -104,25 +110,26 @@ func superviseForward(ctx context.Context, spec forwardSpec, ready chan<- struct
 }
 
 // runForwardOnce runs a single attempt of the forwarding child. If ready is
-// non-nil, it's signaled once the child reports readiness via
-// ForwardReadyFDEnv, or once the child exits without ever reporting.
+// non-nil, it reports whether the child actually signaled readiness via
+// ForwardReadyFDEnv (a written byte), so callers can keep offering the
+// readiness pipe to later attempts when this one merely failed to set up or
+// exited without ever reporting.
 func runForwardOnce(
 	ctx context.Context,
 	execPath string,
 	args []string,
 	ready chan<- struct{},
-) error {
+) (reported bool, err error) {
 	//nolint:gosec // execPath comes from os.Executable()
 	cmd := exec.CommandContext(ctx, execPath, args...)
 
 	if ready == nil {
-		return cmd.Run()
+		return false, cmd.Run()
 	}
 
 	r, w, err := os.Pipe()
 	if err != nil {
-		signalOnce(ready)
-		return cmd.Run()
+		return false, cmd.Run()
 	}
 	cmd.ExtraFiles = []*os.File{w}
 	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=3", ForwardReadyFDEnv))
@@ -130,19 +137,24 @@ func runForwardOnce(
 	if err := cmd.Start(); err != nil {
 		_ = w.Close()
 		_ = r.Close()
-		signalOnce(ready)
-		return err
+		return false, err
 	}
 	_ = w.Close() // the child holds the only remaining write end
 
+	signaled := make(chan bool, 1)
 	go func() {
 		buf := make([]byte, 1)
-		_, _ = r.Read(buf)
+		n, _ := r.Read(buf)
 		_ = r.Close()
-		signalOnce(ready)
+		ok := n > 0
+		if ok {
+			signalOnce(ready)
+		}
+		signaled <- ok
 	}()
 
-	return cmd.Wait()
+	err = cmd.Wait()
+	return <-signaled, err
 }
 
 func signalOnce(ready chan<- struct{}) {

--- a/pkg/gpg/forward.go
+++ b/pkg/gpg/forward.go
@@ -2,6 +2,7 @@ package gpg
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"time"
@@ -18,8 +19,20 @@ type backoff struct {
 
 var forwardRestartBackoff = backoff{min: time.Second, max: 30 * time.Second}
 
-// ForwardAgent starts a supervised background SSH connection that forwards the
-// local GPG agent, restarting it until ctx is cancelled.
+// ForwardReadyFDEnv is the contract with cmd/workspace/gpg_tunnel.go's
+// runGPGTunnelInBackground: the fd number it names is where that process
+// writes one byte once its gpg-agent tunnel setup finishes.
+const ForwardReadyFDEnv = "DEVSY_GPG_FORWARD_READY_FD"
+
+// forwardReadyTimeout bounds ForwardAgent's wait so a stuck forward can't
+// block the caller indefinitely.
+const forwardReadyTimeout = 30 * time.Second
+
+// ForwardAgent starts a supervised background SSH connection that forwards
+// the local GPG agent, restarting it until ctx is cancelled. It waits for the
+// first attempt's tunnel setup to finish so callers that immediately hand
+// control to the workspace (e.g. opening a browser IDE terminal) don't race
+// an agent that isn't forwarded yet.
 func ForwardAgent(ctx context.Context, client client2.BaseWorkspaceClient) error {
 	execPath, err := os.Executable()
 	if err != nil {
@@ -39,27 +52,45 @@ func ForwardAgent(ctx context.Context, client client2.BaseWorkspaceClient) error
 
 	args := buildForwardArgs(remoteUser, client.Context(), client.Workspace())
 
-	go superviseForward(ctx, execPath, args, forwardRestartBackoff)
+	spec := forwardSpec{execPath: execPath, args: args, backoff: forwardRestartBackoff}
+	ready := make(chan struct{}, 1)
+	go superviseForward(ctx, spec, ready)
+
+	select {
+	case <-ready:
+	case <-time.After(forwardReadyTimeout):
+		log.Warnf(
+			"timed out waiting for gpg-agent forward to become ready; continuing without waiting",
+		)
+	case <-ctx.Done():
+	}
 
 	return nil
 }
 
-func superviseForward(ctx context.Context, execPath string, args []string, b backoff) {
-	delay := b.min
+type forwardSpec struct {
+	execPath string
+	args     []string
+	backoff  backoff
+}
+
+func superviseForward(ctx context.Context, spec forwardSpec, ready chan<- struct{}) {
+	delay := spec.backoff.min
+	firstAttemptReady := ready
 	for {
 		if ctx.Err() != nil {
 			return
 		}
 
 		start := time.Now()
-		//nolint:gosec // execPath comes from os.Executable()
-		runErr := exec.CommandContext(ctx, execPath, args...).Run()
+		runErr := runForwardOnce(ctx, spec.execPath, spec.args, firstAttemptReady)
+		firstAttemptReady = nil // only the first attempt reports readiness
 		if ctx.Err() != nil {
 			return
 		}
 
-		if time.Since(start) >= b.max {
-			delay = b.min
+		if time.Since(start) >= spec.backoff.max {
+			delay = spec.backoff.min
 		}
 		log.Errorf("gpg-agent forward exited (%v); restarting in %s", runErr, delay)
 
@@ -68,7 +99,56 @@ func superviseForward(ctx context.Context, execPath string, args []string, b bac
 			return
 		case <-time.After(delay):
 		}
-		delay = min(2*delay, b.max)
+		delay = min(2*delay, spec.backoff.max)
+	}
+}
+
+// runForwardOnce runs a single attempt of the forwarding child. If ready is
+// non-nil, it's signaled once the child reports readiness via
+// ForwardReadyFDEnv, or once the child exits without ever reporting.
+func runForwardOnce(
+	ctx context.Context,
+	execPath string,
+	args []string,
+	ready chan<- struct{},
+) error {
+	//nolint:gosec // execPath comes from os.Executable()
+	cmd := exec.CommandContext(ctx, execPath, args...)
+
+	if ready == nil {
+		return cmd.Run()
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		signalOnce(ready)
+		return cmd.Run()
+	}
+	cmd.ExtraFiles = []*os.File{w}
+	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=3", ForwardReadyFDEnv))
+
+	if err := cmd.Start(); err != nil {
+		_ = w.Close()
+		_ = r.Close()
+		signalOnce(ready)
+		return err
+	}
+	_ = w.Close() // the child holds the only remaining write end
+
+	go func() {
+		buf := make([]byte, 1)
+		_, _ = r.Read(buf)
+		_ = r.Close()
+		signalOnce(ready)
+	}()
+
+	return cmd.Wait()
+}
+
+func signalOnce(ready chan<- struct{}) {
+	select {
+	case ready <- struct{}{}:
+	default:
 	}
 }
 

--- a/pkg/gpg/forward.go
+++ b/pkg/gpg/forward.go
@@ -19,20 +19,17 @@ type backoff struct {
 
 var forwardRestartBackoff = backoff{min: time.Second, max: 30 * time.Second}
 
-// ForwardReadyFDEnv is the contract with cmd/workspace/gpg_tunnel.go's
-// runGPGTunnelInBackground: the fd number it names is where that process
-// writes one byte once its gpg-agent tunnel setup finishes.
-const ForwardReadyFDEnv = "DEVSY_GPG_FORWARD_READY_FD"
+const EnvForwardReadyFD = "DEVSY_GPG_FORWARD_READY_FD"
 
-// forwardReadyTimeout bounds ForwardAgent's wait so a stuck forward can't
+// forwardReadyTimeout bounds ForwardAgent's wait so a stuck forward cannot
 // block the caller indefinitely.
 const forwardReadyTimeout = 30 * time.Second
 
 // ForwardAgent starts a supervised background SSH connection that forwards
 // the local GPG agent, restarting it until ctx is cancelled. It waits for the
 // first attempt's tunnel setup to finish so callers that immediately hand
-// control to the workspace (e.g. opening a browser IDE terminal) don't race
-// an agent that isn't forwarded yet.
+// control to the workspace (e.g. opening a browser IDE terminal) do not race
+// an agent that is not forwarded yet.
 func ForwardAgent(ctx context.Context, client client2.BaseWorkspaceClient) error {
 	execPath, err := os.Executable()
 	if err != nil {
@@ -76,10 +73,6 @@ type forwardSpec struct {
 
 func superviseForward(ctx context.Context, spec forwardSpec, ready chan<- struct{}) {
 	delay := spec.backoff.min
-	// pendingReady stays non-nil across attempts (setup failures, crashes,
-	// restarts) until one attempt actually reports readiness: a failed first
-	// attempt must not make ForwardAgent give up waiting on a retry that
-	// would succeed within its timeout.
 	pendingReady := ready
 	for {
 		if ctx.Err() != nil {
@@ -111,7 +104,7 @@ func superviseForward(ctx context.Context, spec forwardSpec, ready chan<- struct
 
 // runForwardOnce runs a single attempt of the forwarding child. If ready is
 // non-nil, it reports whether the child actually signaled readiness via
-// ForwardReadyFDEnv (a written byte), so callers can keep offering the
+// EnvForwardReadyFD (a written byte), so callers can keep offering the
 // readiness pipe to later attempts when this one merely failed to set up or
 // exited without ever reporting.
 func runForwardOnce(
@@ -132,7 +125,7 @@ func runForwardOnce(
 		return false, cmd.Run()
 	}
 	cmd.ExtraFiles = []*os.File{w}
-	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=3", ForwardReadyFDEnv))
+	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=3", EnvForwardReadyFD))
 
 	if err := cmd.Start(); err != nil {
 		_ = w.Close()

--- a/pkg/gpg/forward_test.go
+++ b/pkg/gpg/forward_test.go
@@ -52,8 +52,11 @@ func TestSuperviseForward_RestartsUntilCancelled(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		superviseForward(ctx, "/bin/sh", []string{"-c", "printf x >> " + runs},
-			backoff{min: 10 * time.Millisecond, max: 20 * time.Millisecond})
+		superviseForward(ctx, forwardSpec{
+			execPath: "/bin/sh",
+			args:     []string{"-c", "printf x >> " + runs},
+			backoff:  backoff{min: 10 * time.Millisecond, max: 20 * time.Millisecond},
+		}, make(chan struct{}, 1))
 		close(done)
 	}()
 
@@ -77,8 +80,11 @@ func TestSuperviseForward_StopsImmediatelyIfCancelled(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		superviseForward(ctx, "/bin/sh", []string{"-c", "exit 0"},
-			backoff{min: 10 * time.Millisecond, max: 20 * time.Millisecond})
+		superviseForward(ctx, forwardSpec{
+			execPath: "/bin/sh",
+			args:     []string{"-c", "exit 0"},
+			backoff:  backoff{min: 10 * time.Millisecond, max: 20 * time.Millisecond},
+		}, make(chan struct{}, 1))
 		close(done)
 	}()
 
@@ -87,4 +93,50 @@ func TestSuperviseForward_StopsImmediatelyIfCancelled(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("superviseForward should return promptly when ctx is already cancelled")
 	}
+}
+
+func TestRunForwardOnce_SignalsReadyOnChildWrite(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ready := make(chan struct{}, 1)
+	done := make(chan error, 1)
+	go func() {
+		done <- runForwardOnce(ctx, "/bin/sh", []string{"-c", "printf x >&3; exec 3>&-; exec sleep 5"}, ready)
+	}()
+
+	select {
+	case <-ready:
+	case <-time.After(2 * time.Second):
+		t.Fatal("ready was not signaled after child wrote to its ready fd")
+	}
+
+	select {
+	case <-done:
+		t.Fatal("runForwardOnce returned before cancellation")
+	default:
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runForwardOnce did not return after ctx cancel")
+	}
+}
+
+func TestRunForwardOnce_SignalsReadyOnChildExitWithoutWriting(t *testing.T) {
+	ready := make(chan struct{}, 1)
+	err := runForwardOnce(context.Background(), "/bin/sh", []string{"-c", "exit 1"}, ready)
+	require.Error(t, err)
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-ready:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 5*time.Millisecond, "ready should be signaled even though the child never wrote")
 }

--- a/pkg/gpg/forward_test.go
+++ b/pkg/gpg/forward_test.go
@@ -100,9 +100,16 @@ func TestRunForwardOnce_SignalsReadyOnChildWrite(t *testing.T) {
 	defer cancel()
 
 	ready := make(chan struct{}, 1)
-	done := make(chan error, 1)
+	type result struct {
+		reported bool
+		err      error
+	}
+	done := make(chan result, 1)
 	go func() {
-		done <- runForwardOnce(ctx, "/bin/sh", []string{"-c", "printf x >&3; exec 3>&-; exec sleep 5"}, ready)
+		reported, err := runForwardOnce(
+			ctx, "/bin/sh", []string{"-c", "printf x >&3; exec 3>&-; exec sleep 5"}, ready,
+		)
+		done <- result{reported, err}
 	}()
 
 	select {
@@ -120,23 +127,64 @@ func TestRunForwardOnce_SignalsReadyOnChildWrite(t *testing.T) {
 	cancel()
 
 	select {
-	case <-done:
+	case res := <-done:
+		assert.True(t, res.reported, "runForwardOnce should report readiness after a real write")
 	case <-time.After(2 * time.Second):
 		t.Fatal("runForwardOnce did not return after ctx cancel")
 	}
 }
 
-func TestRunForwardOnce_SignalsReadyOnChildExitWithoutWriting(t *testing.T) {
+func TestRunForwardOnce_DoesNotSignalReadyOnChildExitWithoutWriting(t *testing.T) {
 	ready := make(chan struct{}, 1)
-	err := runForwardOnce(context.Background(), "/bin/sh", []string{"-c", "exit 1"}, ready)
+	reported, err := runForwardOnce(
+		context.Background(), "/bin/sh", []string{"-c", "exit 1"}, ready,
+	)
 	require.Error(t, err)
+	assert.False(t, reported, "a child that exits without writing must not be treated as ready")
 
-	require.Eventually(t, func() bool {
-		select {
-		case <-ready:
-			return true
-		default:
-			return false
-		}
-	}, time.Second, 5*time.Millisecond, "ready should be signaled even though the child never wrote")
+	select {
+	case <-ready:
+		t.Fatal("ready must not be signaled when the child never wrote")
+	default:
+	}
+}
+
+func TestSuperviseForward_ReportsReadyOnlyAfterSuccessfulRetry(t *testing.T) {
+	runs := filepath.Join(t.TempDir(), "runs")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ready := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go func() {
+		superviseForward(ctx, forwardSpec{
+			execPath: "/bin/sh",
+			args: []string{
+				"-c",
+				"printf x >> " + runs + "; " +
+					"if [ $(wc -c < " + runs + ") -lt 2 ]; then exit 1; fi; " +
+					"printf x >&3; exec 3>&-; exec sleep 5",
+			},
+			backoff: backoff{min: 5 * time.Millisecond, max: 10 * time.Millisecond},
+		}, ready)
+		close(done)
+	}()
+
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ready was never signaled after a successful retry")
+	}
+
+	data, err := os.ReadFile(runs) //nolint:gosec // test path is created by the test
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, strings.Count(string(data), "x"), 2,
+		"the first (failing) attempt should not have consumed readiness reporting")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("superviseForward did not stop after ctx cancel")
+	}
 }

--- a/pkg/gpg/forward_test.go
+++ b/pkg/gpg/forward_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testShellPath = "/bin/sh"
+
 func TestBuildForwardArgs(t *testing.T) {
 	got := buildForwardArgs("root", "test-context", "test-workspace")
 	expected := []string{
@@ -53,7 +55,7 @@ func TestSuperviseForward_RestartsUntilCancelled(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		superviseForward(ctx, forwardSpec{
-			execPath: "/bin/sh",
+			execPath: testShellPath,
 			args:     []string{"-c", "printf x >> " + runs},
 			backoff:  backoff{min: 10 * time.Millisecond, max: 20 * time.Millisecond},
 		}, make(chan struct{}, 1))
@@ -81,7 +83,7 @@ func TestSuperviseForward_StopsImmediatelyIfCancelled(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		superviseForward(ctx, forwardSpec{
-			execPath: "/bin/sh",
+			execPath: testShellPath,
 			args:     []string{"-c", "exit 0"},
 			backoff:  backoff{min: 10 * time.Millisecond, max: 20 * time.Millisecond},
 		}, make(chan struct{}, 1))
@@ -107,7 +109,7 @@ func TestRunForwardOnce_SignalsReadyOnChildWrite(t *testing.T) {
 	done := make(chan result, 1)
 	go func() {
 		reported, err := runForwardOnce(
-			ctx, "/bin/sh", []string{"-c", "printf x >&3; exec 3>&-; exec sleep 5"}, ready,
+			ctx, testShellPath, []string{"-c", "printf x >&3; exec 3>&-; exec sleep 5"}, ready,
 		)
 		done <- result{reported, err}
 	}()
@@ -137,7 +139,7 @@ func TestRunForwardOnce_SignalsReadyOnChildWrite(t *testing.T) {
 func TestRunForwardOnce_DoesNotSignalReadyOnChildExitWithoutWriting(t *testing.T) {
 	ready := make(chan struct{}, 1)
 	reported, err := runForwardOnce(
-		context.Background(), "/bin/sh", []string{"-c", "exit 1"}, ready,
+		context.Background(), testShellPath, []string{"-c", "exit 1"}, ready,
 	)
 	require.Error(t, err)
 	assert.False(t, reported, "a child that exits without writing must not be treated as ready")
@@ -158,7 +160,7 @@ func TestSuperviseForward_ReportsReadyOnlyAfterSuccessfulRetry(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		superviseForward(ctx, forwardSpec{
-			execPath: "/bin/sh",
+			execPath: testShellPath,
 			args: []string{
 				"-c",
 				"printf x >> " + runs + "; " +

--- a/pkg/ssh/forward_test.go
+++ b/pkg/ssh/forward_test.go
@@ -178,9 +178,17 @@ func TestPortForwarding_ReleasesListenerOnTransportDeath(t *testing.T) {
 		t.Fatal("portForwarding did not return after transport death (listener leaked)")
 	}
 
-	l2, err := net.Listen("tcp", addr)
-	if err != nil {
-		t.Fatalf("rebind on %s failed after transport death: %v", addr, err)
+	var l2 net.Listener
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		l2, err = net.Listen("tcp", addr)
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("rebind on %s failed after transport death: %v", addr, err)
+		}
+		time.Sleep(20 * time.Millisecond)
 	}
 	_ = l2.Close()
 }


### PR DESCRIPTION
## Summary
- GPG-agent forwarding for browser IDEs (vscode-web, openvscode, code-server, jupyter, marimo, rstudio) was set up by a fire-and-forget background process (`pkg/gpg.ForwardAgent`), so the browser terminal could open before the forwarding child had finished connecting and running remote `setup-gpg`. The first `gpg` command in that terminal would then create a fresh local keyring instead of seeing the forwarded agent.
- `ForwardAgent` now waits for its child's first attempt to signal readiness over an inherited pipe (bounded by a timeout so a stuck forward can't block the caller indefinitely), mirroring the synchronous wait the SSH-terminal path (`cmd/workspace/gpg_tunnel.go`) already had.
- Normal interactive `devsy ssh` sessions are unaffected — the readiness signal is a no-op unless the process was spawned by `ForwardAgent`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPG agent forwarding startup reliability by detecting when forwarding is ready.
  * Added a timeout so startup can continue when readiness is not explicitly reported.
  * Preserved automatic forwarding restarts and cancellation behavior after failures.
  * Improved handling of missing, invalid, unavailable, or unsuccessful readiness signals.
  * Improved resilience when SSH forwarding listeners need to be rebound after transport interruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->