### PR TITLE
fix: use a single named docker-credentials dir instead of nested .cache

### DIFF
--- a/pkg/dockercredentials/dockercredentials.go
+++ b/pkg/dockercredentials/dockercredentials.go
@@ -20,8 +20,16 @@ import (
 )
 
 const (
-	windowsOS = "windows"
+	windowsOS                        = "windows"
+	dockerCredentialsDirSuffixLength = 12
 )
+
+func newDockerCredentialsDir(targetFolder string) string {
+	return filepath.Join(
+		targetFolder,
+		"docker-credentials-"+random.String(dockerCredentialsDirSuffixLength),
+	)
+}
 
 func appendToPath(dir string) error {
 	pathSep := ":"
@@ -149,7 +157,7 @@ func buildHelperContent(binaryPath, shebang string, port int) []byte {
 }
 
 func ConfigureCredentialsDockerless(targetFolder string, port int) (string, error) {
-	dockerConfigDir := filepath.Join(targetFolder, ".cache", random.String(6))
+	dockerConfigDir := newDockerCredentialsDir(targetFolder)
 	err := configureCredentials(
 		"",
 		"#!/.dockerless/bin/sh",
@@ -178,7 +186,7 @@ func ConfigureCredentialsDockerless(targetFolder string, port int) (string, erro
 }
 
 func ConfigureCredentialsMachine(targetFolder string, port int) (string, error) {
-	dockerConfigDir := filepath.Join(targetFolder, ".cache", random.String(12))
+	dockerConfigDir := newDockerCredentialsDir(targetFolder)
 	err := configureCredentials("", "#!/bin/sh", dockerConfigDir, dockerConfigDir, port)
 	if err != nil {
 		_ = os.RemoveAll(dockerConfigDir)


### PR DESCRIPTION
## Summary
- The docker-credentials helper directory was built as `.cache/<random>`, colliding in name with the codebase's centralized cache convention (`PathManager.CacheDir()`) without actually being part of it.
- Collapses the two-level path into a single `docker-credentials-<random>` directory and shares the directory-building logic between `ConfigureCredentialsDockerless` and `ConfigureCredentialsMachine` via a new `newDockerCredentialsDir` helper.
- Standardizes the random suffix length (previously inconsistently 6 vs 12) on a single named constant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when creating temporary Docker credential directories.
  * Standardized generated directory names with a clear prefix and uniform random suffix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->