### PR TITLE
refactor(agentcontainer): move context out of setup state struct

### DIFF
--- a/cmd/internal/agentcontainer/setup.go
+++ b/cmd/internal/agentcontainer/setup.go
@@ -81,7 +81,7 @@ func NewSetupContainerCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	return setupContainerCmd
 }
 
-type containerSetupState struct {
+type containerState struct {
 	workspaceInfo *provider2.ContainerWorkspaceInfo
 	setupInfo     *config.Result
 	tunnelClient  tunnel.TunnelClient
@@ -100,17 +100,17 @@ func (cmd *SetupContainerCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	sctx := &containerSetupState{
+	state := &containerState{
 		workspaceInfo: workspaceInfo,
 		setupInfo:     setupInfo,
 		tunnelClient:  tunnelClient,
 	}
 
-	if err := cmd.prepareWorkspace(ctx, sctx); err != nil {
+	if err := cmd.prepareWorkspace(ctx, state); err != nil {
 		return err
 	}
 
-	return cmd.finalizeSetup(ctx, sctx)
+	return cmd.finalizeSetup(ctx, state)
 }
 
 func (cmd *SetupContainerCmd) registerFlags(setupContainerCmd *cobra.Command) {
@@ -184,22 +184,22 @@ func (cmd *SetupContainerCmd) registerDotfilesFlags(setupContainerCmd *cobra.Com
 
 func (cmd *SetupContainerCmd) prepareWorkspace(
 	ctx context.Context,
-	sctx *containerSetupState,
+	state *containerState,
 ) error {
-	if err := cmd.syncMounts(ctx, sctx); err != nil {
+	if err := cmd.syncMounts(ctx, state); err != nil {
 		return err
 	}
 
 	if err := agent.DockerlessBuild(agent.DockerlessBuildOptions{
 		Context:           ctx,
-		SetupInfo:         sctx.setupInfo,
-		DockerlessOptions: &sctx.workspaceInfo.Dockerless,
+		SetupInfo:         state.setupInfo,
+		DockerlessOptions: &state.workspaceInfo.Dockerless,
 		ImageConfigOutput: agent.DefaultImageConfigPath,
 		Debug:             cmd.Debug,
 		ConfigureCredentialsFunc: func(ctx context.Context) (string, error) {
 			serverPort, err := credentials.StartCredentialsServer(
 				ctx,
-				sctx.tunnelClient,
+				state.tunnelClient,
 			)
 			if err != nil {
 				return "", err
@@ -213,20 +213,20 @@ func (cmd *SetupContainerCmd) prepareWorkspace(
 		return fmt.Errorf("dockerless build: %w", err)
 	}
 
-	if err := fillContainerEnv(sctx.setupInfo); err != nil {
+	if err := fillContainerEnv(state.setupInfo); err != nil {
 		return err
 	}
 
 	cleanupFunc := cmd.setupGitCredentials(
 		ctx,
-		sctx.tunnelClient,
+		state.tunnelClient,
 	)
 
 	// Clone repository before cleaning up git credentials
 	cloneErr := cmd.cloneRepositoryIfNeeded(
 		ctx,
-		sctx.workspaceInfo,
-		sctx.setupInfo,
+		state.workspaceInfo,
+		state.setupInfo,
 	)
 
 	// Clean up git credentials after cloning
@@ -259,45 +259,45 @@ func fetchSecrets(
 	return env, mount, nil
 }
 
-func (cmd *SetupContainerCmd) finalizeSetup(ctx context.Context, sctx *containerSetupState) error {
-	secretsEnv, secretsMount, err := fetchSecrets(ctx, sctx.tunnelClient)
+func (cmd *SetupContainerCmd) finalizeSetup(ctx context.Context, state *containerState) error {
+	secretsEnv, secretsMount, err := fetchSecrets(ctx, state.tunnelClient)
 	if err != nil {
-		return cmd.reportSetupFailure(ctx, sctx, err)
+		return cmd.reportSetupFailure(ctx, state, err)
 	}
-	sctx.secretsEnv = secretsEnv
+	state.secretsEnv = secretsEnv
 
 	cfg := &setup.ContainerSetupConfig{
-		SetupInfo:         sctx.setupInfo,
-		ExtraWorkspaceEnv: sctx.workspaceInfo.CLIOptions.WorkspaceEnv,
+		SetupInfo:         state.setupInfo,
+		ExtraWorkspaceEnv: state.workspaceInfo.CLIOptions.WorkspaceEnv,
 		SecretsEnv:        secretsEnv,
 		SecretsMount:      secretsMount,
 		ChownProjects:     cmd.ChownWorkspace,
-		PlatformOptions:   &sctx.workspaceInfo.CLIOptions.Platform,
-		TunnelClient:      sctx.tunnelClient,
+		PlatformOptions:   &state.workspaceInfo.CLIOptions.Platform,
+		TunnelClient:      state.tunnelClient,
 		Prebuild:          cmd.Prebuild,
-		SkipPostCreate:    sctx.workspaceInfo.CLIOptions.SkipPostCreate,
-		SkipPostStart:     sctx.workspaceInfo.CLIOptions.SkipPostStart,
-		SkipPostAttach:    sctx.workspaceInfo.CLIOptions.SkipPostAttach,
-		WaitFor:           setup.LifecyclePhase(sctx.workspaceInfo.CLIOptions.WaitFor),
+		SkipPostCreate:    state.workspaceInfo.CLIOptions.SkipPostCreate,
+		SkipPostStart:     state.workspaceInfo.CLIOptions.SkipPostStart,
+		SkipPostAttach:    state.workspaceInfo.CLIOptions.SkipPostAttach,
+		WaitFor:           setup.LifecyclePhase(state.workspaceInfo.CLIOptions.WaitFor),
 		Dotfiles: setup.DotfilesConfig{
 			Repository:    cmd.DotfilesRepo,
 			InstallScript: cmd.DotfilesScript,
-			RemoteUser:    config.GetRemoteUser(sctx.setupInfo),
+			RemoteUser:    config.GetRemoteUser(state.setupInfo),
 		},
 	}
 
 	deferred, err := setup.SetupContainerPreAttach(ctx, cfg)
 	if err != nil {
-		return cmd.reportSetupFailure(ctx, sctx, err)
+		return cmd.reportSetupFailure(ctx, state, err)
 	}
 
 	if !cmd.Prebuild {
-		if err := cmd.setupPostAttach(sctx, deferred); err != nil {
-			return cmd.reportSetupFailure(ctx, sctx, err)
+		if err := cmd.setupPostAttach(state, deferred); err != nil {
+			return cmd.reportSetupFailure(ctx, state, err)
 		}
 	}
 
-	return cmd.sendSetupResult(ctx, sctx.setupInfo, sctx.tunnelClient)
+	return cmd.sendSetupResult(ctx, state.setupInfo, state.tunnelClient)
 }
 
 // reportSetupFailure forwards a structured error result through the tunnel
@@ -306,11 +306,11 @@ func (cmd *SetupContainerCmd) finalizeSetup(ctx context.Context, sctx *container
 // failure) gets lost to a generic wrapper on the host side.
 func (cmd *SetupContainerCmd) reportSetupFailure(
 	ctx context.Context,
-	sctx *containerSetupState,
+	state *containerState,
 	cause error,
 ) error {
 	errResult := &config.Result{Error: cause.Error()}
-	if sendErr := cmd.sendSetupResult(ctx, errResult, sctx.tunnelClient); sendErr != nil {
+	if sendErr := cmd.sendSetupResult(ctx, errResult, state.tunnelClient); sendErr != nil {
 		// Failure-on-failure: the host will see only the SSH exit code, so
 		// log the original cause alongside the send failure to leave a
 		// breadcrumb for debugging.
@@ -320,23 +320,20 @@ func (cmd *SetupContainerCmd) reportSetupFailure(
 }
 
 func (cmd *SetupContainerCmd) setupPostAttach(
-	sctx *containerSetupState,
+	state *containerState,
 	deferred setup.DeferredHooks,
 ) error {
-	if err := cmd.installIDE(sctx.setupInfo, &sctx.workspaceInfo.IDE); err != nil {
+	if err := cmd.installIDE(state.setupInfo, &state.workspaceInfo.IDE); err != nil {
 		return err
 	}
 
-	shutdownAction := sctx.setupInfo.MergedConfig.ShutdownAction
-	if err := cmd.startContainerDaemon(sctx.workspaceInfo, shutdownAction); err != nil {
+	shutdownAction := state.setupInfo.MergedConfig.ShutdownAction
+	if err := cmd.startContainerDaemon(state.workspaceInfo, shutdownAction); err != nil {
 		return err
 	}
 
 	// Re-serialize the post-substitution setupInfo for background processes.
-	// fillContainerEnv() modifies sctx.setupInfo after initial parsing, so
-	// cmd.SetupInfo (the original CLI arg) has unresolved variables like
-	// ${containerEnv:PATH}. Background hooks need the resolved values.
-	resolvedSetupInfo, err := compressSetupInfo(sctx.setupInfo)
+	resolvedSetupInfo, err := compressSetupInfo(state.setupInfo)
 	if err != nil {
 		return fmt.Errorf("re-serialize setup info: %w", err)
 	}
@@ -344,14 +341,14 @@ func (cmd *SetupContainerCmd) setupPostAttach(
 	if !deferred.Empty() {
 		err = cmd.startDeferredHooks(
 			resolvedSetupInfo, cmd.DotfilesRepo, cmd.DotfilesScript,
-			sctx.secretsEnv,
+			state.secretsEnv,
 		)
 		if err != nil {
 			log.Errorf("failed to start deferred lifecycle hooks: %v", err)
 		}
 	}
 
-	if err := cmd.startPostAttachHooks(sctx); err != nil {
+	if err := cmd.startPostAttachHooks(state); err != nil {
 		log.Errorf("failed to start postAttachCommand: %v", err)
 	}
 
@@ -450,10 +447,10 @@ func (cmd *SetupContainerCmd) parseWorkspaceAndSetupInfo() (*provider2.Container
 	return workspaceInfo, setupInfo, nil
 }
 
-func (cmd *SetupContainerCmd) syncMounts(ctx context.Context, sctx *containerSetupState) error {
-	mounts := config.GetMounts(sctx.setupInfo)
-	if sctx.workspaceInfo.Source.Snapshot != "" {
-		return restoreSnapshotMounts(ctx, sctx, mounts)
+func (cmd *SetupContainerCmd) syncMounts(ctx context.Context, state *containerState) error {
+	mounts := config.GetMounts(state.setupInfo)
+	if state.workspaceInfo.Source.Snapshot != "" {
+		return restoreSnapshotMounts(ctx, state, mounts)
 	}
 
 	if !cmd.StreamMounts {
@@ -462,7 +459,7 @@ func (cmd *SetupContainerCmd) syncMounts(ctx context.Context, sctx *containerSet
 
 	log.Debugf("syncing mounts: %v", mounts)
 	for _, m := range mounts {
-		if !sctx.workspaceInfo.CLIOptions.Reset {
+		if !state.workspaceInfo.CLIOptions.Reset {
 			files, err := os.ReadDir(m.Target)
 			if err == nil && len(files) > 0 {
 				log.Debugf("skip stream mount %s because it is not empty", m.Target)
@@ -472,9 +469,9 @@ func (cmd *SetupContainerCmd) syncMounts(ctx context.Context, sctx *containerSet
 
 		if err := streamMount(
 			ctx,
-			sctx.workspaceInfo,
+			state.workspaceInfo,
 			m,
-			sctx.tunnelClient,
+			state.tunnelClient,
 		); err != nil {
 			return err
 		}
@@ -487,19 +484,19 @@ func (cmd *SetupContainerCmd) syncMounts(ctx context.Context, sctx *containerSet
 // skipping the restore if the sole mount target already has real content.
 func restoreSnapshotMounts(
 	ctx context.Context,
-	sctx *containerSetupState,
+	state *containerState,
 	mounts []*config.Mount,
 ) error {
-	if !sctx.workspaceInfo.CLIOptions.Reset && len(mounts) == 1 &&
+	if !state.workspaceInfo.CLIOptions.Reset && len(mounts) == 1 &&
 		skipSnapshotRestore(mounts[0].Target) {
 		return nil
 	}
-	log.Infof("restoring snapshot volumes from %s", sctx.workspaceInfo.Source.Snapshot)
+	log.Infof("restoring snapshot volumes from %s", state.workspaceInfo.Source.Snapshot)
 	if err := agentsnapshot.RestoreVolumes(
 		ctx,
-		sctx.workspaceInfo.Source.Snapshot,
+		state.workspaceInfo.Source.Snapshot,
 		mounts,
-		sctx.workspaceInfo.CLIOptions.Reset,
+		state.workspaceInfo.CLIOptions.Reset,
 	); err != nil {
 		return fmt.Errorf("restore snapshot volumes: %w", err)
 	}
@@ -628,8 +625,8 @@ func (cmd *SetupContainerCmd) startContainerDaemon(
 	})
 }
 
-func (cmd *SetupContainerCmd) startPostAttachHooks(sctx *containerSetupState) error {
-	if len(sctx.setupInfo.MergedConfig.PostAttachCommands) == 0 {
+func (cmd *SetupContainerCmd) startPostAttachHooks(state *containerState) error {
+	if len(state.setupInfo.MergedConfig.PostAttachCommands) == 0 {
 		return nil
 	}
 
@@ -648,7 +645,7 @@ func (cmd *SetupContainerCmd) startPostAttachHooks(sctx *containerSetupState) er
 			Path: binaryPath,
 			Args: append([]string{binaryPath}, args...),
 		}
-		execCmd.Env = secretsEnvOverride(sctx.secretsEnv)
+		execCmd.Env = secretsEnvOverride(state.secretsEnv)
 
 		return execCmd, nil
 	})

--- a/cmd/internal/agentcontainer/setup.go
+++ b/cmd/internal/agentcontainer/setup.go
@@ -109,11 +109,11 @@ func (cmd *SetupContainerCmd) Run(ctx context.Context) error {
 	_, err = tunnelserver.ReportResult(
 		ctx,
 		tunnelClient,
-		func(_ context.Context) (*config.Result, error) {
-			if err := cmd.prepareWorkspace(ctx, state); err != nil {
+		func(reportCtx context.Context) (*config.Result, error) {
+			if err := cmd.prepareWorkspace(reportCtx, state); err != nil {
 				return nil, err
 			}
-			if err := cmd.finalizeSetup(ctx, state); err != nil {
+			if err := cmd.finalizeSetup(reportCtx, state); err != nil {
 				return nil, err
 			}
 			return state.setupInfo, nil

--- a/cmd/internal/agentcontainer/setup.go
+++ b/cmd/internal/agentcontainer/setup.go
@@ -81,8 +81,7 @@ func NewSetupContainerCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	return setupContainerCmd
 }
 
-type setupContext struct {
-	ctx           context.Context
+type containerSetupState struct {
 	workspaceInfo *provider2.ContainerWorkspaceInfo
 	setupInfo     *config.Result
 	tunnelClient  tunnel.TunnelClient
@@ -101,18 +100,17 @@ func (cmd *SetupContainerCmd) Run(ctx context.Context) error {
 		return err
 	}
 
-	sctx := &setupContext{
-		ctx:           ctx,
+	sctx := &containerSetupState{
 		workspaceInfo: workspaceInfo,
 		setupInfo:     setupInfo,
 		tunnelClient:  tunnelClient,
 	}
 
-	if err := cmd.prepareWorkspace(sctx); err != nil {
+	if err := cmd.prepareWorkspace(ctx, sctx); err != nil {
 		return err
 	}
 
-	return cmd.finalizeSetup(sctx)
+	return cmd.finalizeSetup(ctx, sctx)
 }
 
 func (cmd *SetupContainerCmd) registerFlags(setupContainerCmd *cobra.Command) {
@@ -184,13 +182,16 @@ func (cmd *SetupContainerCmd) registerDotfilesFlags(setupContainerCmd *cobra.Com
 	)
 }
 
-func (cmd *SetupContainerCmd) prepareWorkspace(sctx *setupContext) error {
-	if err := cmd.syncMounts(sctx); err != nil {
+func (cmd *SetupContainerCmd) prepareWorkspace(
+	ctx context.Context,
+	sctx *containerSetupState,
+) error {
+	if err := cmd.syncMounts(ctx, sctx); err != nil {
 		return err
 	}
 
 	if err := agent.DockerlessBuild(agent.DockerlessBuildOptions{
-		Context:           sctx.ctx,
+		Context:           ctx,
 		SetupInfo:         sctx.setupInfo,
 		DockerlessOptions: &sctx.workspaceInfo.Dockerless,
 		ImageConfigOutput: agent.DefaultImageConfigPath,
@@ -217,13 +218,13 @@ func (cmd *SetupContainerCmd) prepareWorkspace(sctx *setupContext) error {
 	}
 
 	cleanupFunc := cmd.setupGitCredentials(
-		sctx.ctx,
+		ctx,
 		sctx.tunnelClient,
 	)
 
 	// Clone repository before cleaning up git credentials
 	cloneErr := cmd.cloneRepositoryIfNeeded(
-		sctx.ctx,
+		ctx,
 		sctx.workspaceInfo,
 		sctx.setupInfo,
 	)
@@ -258,10 +259,10 @@ func fetchSecrets(
 	return env, mount, nil
 }
 
-func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
-	secretsEnv, secretsMount, err := fetchSecrets(sctx.ctx, sctx.tunnelClient)
+func (cmd *SetupContainerCmd) finalizeSetup(ctx context.Context, sctx *containerSetupState) error {
+	secretsEnv, secretsMount, err := fetchSecrets(ctx, sctx.tunnelClient)
 	if err != nil {
-		return cmd.reportSetupFailure(sctx, err)
+		return cmd.reportSetupFailure(ctx, sctx, err)
 	}
 	sctx.secretsEnv = secretsEnv
 
@@ -285,27 +286,31 @@ func (cmd *SetupContainerCmd) finalizeSetup(sctx *setupContext) error {
 		},
 	}
 
-	deferred, err := setup.SetupContainerPreAttach(sctx.ctx, cfg)
+	deferred, err := setup.SetupContainerPreAttach(ctx, cfg)
 	if err != nil {
-		return cmd.reportSetupFailure(sctx, err)
+		return cmd.reportSetupFailure(ctx, sctx, err)
 	}
 
 	if !cmd.Prebuild {
 		if err := cmd.setupPostAttach(sctx, deferred); err != nil {
-			return cmd.reportSetupFailure(sctx, err)
+			return cmd.reportSetupFailure(ctx, sctx, err)
 		}
 	}
 
-	return cmd.sendSetupResult(sctx.ctx, sctx.setupInfo, sctx.tunnelClient)
+	return cmd.sendSetupResult(ctx, sctx.setupInfo, sctx.tunnelClient)
 }
 
 // reportSetupFailure forwards a structured error result through the tunnel
 // before returning the original error. Without this, the outer agent only
 // sees the SSH exit code and the underlying cause (e.g. an IDE install
 // failure) gets lost to a generic wrapper on the host side.
-func (cmd *SetupContainerCmd) reportSetupFailure(sctx *setupContext, cause error) error {
+func (cmd *SetupContainerCmd) reportSetupFailure(
+	ctx context.Context,
+	sctx *containerSetupState,
+	cause error,
+) error {
 	errResult := &config.Result{Error: cause.Error()}
-	if sendErr := cmd.sendSetupResult(sctx.ctx, errResult, sctx.tunnelClient); sendErr != nil {
+	if sendErr := cmd.sendSetupResult(ctx, errResult, sctx.tunnelClient); sendErr != nil {
 		// Failure-on-failure: the host will see only the SSH exit code, so
 		// log the original cause alongside the send failure to leave a
 		// breadcrumb for debugging.
@@ -315,7 +320,7 @@ func (cmd *SetupContainerCmd) reportSetupFailure(sctx *setupContext, cause error
 }
 
 func (cmd *SetupContainerCmd) setupPostAttach(
-	sctx *setupContext,
+	sctx *containerSetupState,
 	deferred setup.DeferredHooks,
 ) error {
 	if err := cmd.installIDE(sctx.setupInfo, &sctx.workspaceInfo.IDE); err != nil {
@@ -445,10 +450,10 @@ func (cmd *SetupContainerCmd) parseWorkspaceAndSetupInfo() (*provider2.Container
 	return workspaceInfo, setupInfo, nil
 }
 
-func (cmd *SetupContainerCmd) syncMounts(sctx *setupContext) error {
+func (cmd *SetupContainerCmd) syncMounts(ctx context.Context, sctx *containerSetupState) error {
 	mounts := config.GetMounts(sctx.setupInfo)
 	if sctx.workspaceInfo.Source.Snapshot != "" {
-		return restoreSnapshotMounts(sctx, mounts)
+		return restoreSnapshotMounts(ctx, sctx, mounts)
 	}
 
 	if !cmd.StreamMounts {
@@ -466,7 +471,7 @@ func (cmd *SetupContainerCmd) syncMounts(sctx *setupContext) error {
 		}
 
 		if err := streamMount(
-			sctx.ctx,
+			ctx,
 			sctx.workspaceInfo,
 			m,
 			sctx.tunnelClient,
@@ -480,14 +485,18 @@ func (cmd *SetupContainerCmd) syncMounts(sctx *setupContext) error {
 
 // restoreSnapshotMounts restores a snapshot-sourced workspace's volumes,
 // skipping the restore if the sole mount target already has real content.
-func restoreSnapshotMounts(sctx *setupContext, mounts []*config.Mount) error {
+func restoreSnapshotMounts(
+	ctx context.Context,
+	sctx *containerSetupState,
+	mounts []*config.Mount,
+) error {
 	if !sctx.workspaceInfo.CLIOptions.Reset && len(mounts) == 1 &&
 		skipSnapshotRestore(mounts[0].Target) {
 		return nil
 	}
 	log.Infof("restoring snapshot volumes from %s", sctx.workspaceInfo.Source.Snapshot)
 	if err := agentsnapshot.RestoreVolumes(
-		sctx.ctx,
+		ctx,
 		sctx.workspaceInfo.Source.Snapshot,
 		mounts,
 		sctx.workspaceInfo.CLIOptions.Reset,
@@ -619,7 +628,7 @@ func (cmd *SetupContainerCmd) startContainerDaemon(
 	})
 }
 
-func (cmd *SetupContainerCmd) startPostAttachHooks(sctx *setupContext) error {
+func (cmd *SetupContainerCmd) startPostAttachHooks(sctx *containerSetupState) error {
 	if len(sctx.setupInfo.MergedConfig.PostAttachCommands) == 0 {
 		return nil
 	}

--- a/cmd/internal/agentcontainer/setup_internal_test.go
+++ b/cmd/internal/agentcontainer/setup_internal_test.go
@@ -156,14 +156,14 @@ func TestSyncMounts_SnapshotRestoresEvenWithStreamMountsFalse(t *testing.T) {
 	}
 
 	cmd := &SetupContainerCmd{StreamMounts: false}
-	sctx := &containerSetupState{
+	state := &containerState{
 		setupInfo: setupInfo,
 		workspaceInfo: &provider2.ContainerWorkspaceInfo{
 			Source: provider2.WorkspaceSource{Snapshot: ref.String()},
 		},
 	}
 
-	require.NoError(t, cmd.syncMounts(ctx, sctx))
+	require.NoError(t, cmd.syncMounts(ctx, state))
 
 	gotPath := filepath.Join(mountTarget, "hello.txt")
 	got, err := os.ReadFile(gotPath) //nolint:gosec // mountTarget is t.TempDir()
@@ -195,17 +195,14 @@ func TestSyncMounts_SnapshotSkipsRestoreWhenMountNotEmpty(t *testing.T) {
 	}
 
 	cmd := &SetupContainerCmd{StreamMounts: false}
-	sctx := &containerSetupState{
+	state := &containerState{
 		setupInfo: setupInfo,
 		workspaceInfo: &provider2.ContainerWorkspaceInfo{
 			Source: provider2.WorkspaceSource{Snapshot: ref.String()},
 		},
 	}
 
-	// No manifest is pushed for ref: if syncMounts attempted a restore here it
-	// would fail pulling the manifest, so a nil error proves the restore was
-	// skipped rather than attempted and silently swallowed.
-	require.NoError(t, cmd.syncMounts(context.Background(), sctx))
+	require.NoError(t, cmd.syncMounts(context.Background(), state))
 
 	gotPath := filepath.Join(mountTarget, "local-change.txt")
 	got, err := os.ReadFile(gotPath) //nolint:gosec // mountTarget is t.TempDir()
@@ -232,7 +229,7 @@ func TestSyncMounts_SnapshotMultiMountFailsLoudly(t *testing.T) {
 	}
 
 	cmd := &SetupContainerCmd{StreamMounts: false}
-	sctx := &containerSetupState{
+	state := &containerState{
 		setupInfo: setupInfo,
 		workspaceInfo: &provider2.ContainerWorkspaceInfo{
 			Source: provider2.WorkspaceSource{
@@ -241,7 +238,7 @@ func TestSyncMounts_SnapshotMultiMountFailsLoudly(t *testing.T) {
 		},
 	}
 
-	err := cmd.syncMounts(context.Background(), sctx)
+	err := cmd.syncMounts(context.Background(), state)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not yet support multiple mounts")
 }

--- a/cmd/internal/agentcontainer/setup_internal_test.go
+++ b/cmd/internal/agentcontainer/setup_internal_test.go
@@ -156,15 +156,14 @@ func TestSyncMounts_SnapshotRestoresEvenWithStreamMountsFalse(t *testing.T) {
 	}
 
 	cmd := &SetupContainerCmd{StreamMounts: false}
-	sctx := &setupContext{
-		ctx:       ctx,
+	sctx := &containerSetupState{
 		setupInfo: setupInfo,
 		workspaceInfo: &provider2.ContainerWorkspaceInfo{
 			Source: provider2.WorkspaceSource{Snapshot: ref.String()},
 		},
 	}
 
-	require.NoError(t, cmd.syncMounts(sctx))
+	require.NoError(t, cmd.syncMounts(ctx, sctx))
 
 	gotPath := filepath.Join(mountTarget, "hello.txt")
 	got, err := os.ReadFile(gotPath) //nolint:gosec // mountTarget is t.TempDir()
@@ -196,8 +195,7 @@ func TestSyncMounts_SnapshotSkipsRestoreWhenMountNotEmpty(t *testing.T) {
 	}
 
 	cmd := &SetupContainerCmd{StreamMounts: false}
-	sctx := &setupContext{
-		ctx:       context.Background(),
+	sctx := &containerSetupState{
 		setupInfo: setupInfo,
 		workspaceInfo: &provider2.ContainerWorkspaceInfo{
 			Source: provider2.WorkspaceSource{Snapshot: ref.String()},
@@ -207,7 +205,7 @@ func TestSyncMounts_SnapshotSkipsRestoreWhenMountNotEmpty(t *testing.T) {
 	// No manifest is pushed for ref: if syncMounts attempted a restore here it
 	// would fail pulling the manifest, so a nil error proves the restore was
 	// skipped rather than attempted and silently swallowed.
-	require.NoError(t, cmd.syncMounts(sctx))
+	require.NoError(t, cmd.syncMounts(context.Background(), sctx))
 
 	gotPath := filepath.Join(mountTarget, "local-change.txt")
 	got, err := os.ReadFile(gotPath) //nolint:gosec // mountTarget is t.TempDir()
@@ -234,8 +232,7 @@ func TestSyncMounts_SnapshotMultiMountFailsLoudly(t *testing.T) {
 	}
 
 	cmd := &SetupContainerCmd{StreamMounts: false}
-	sctx := &setupContext{
-		ctx:       context.Background(),
+	sctx := &containerSetupState{
 		setupInfo: setupInfo,
 		workspaceInfo: &provider2.ContainerWorkspaceInfo{
 			Source: provider2.WorkspaceSource{
@@ -244,7 +241,7 @@ func TestSyncMounts_SnapshotMultiMountFailsLoudly(t *testing.T) {
 		},
 	}
 
-	err := cmd.syncMounts(sctx)
+	err := cmd.syncMounts(context.Background(), sctx)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "does not yet support multiple mounts")
 }


### PR DESCRIPTION
## Summary
- Renames `setupContext`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved container setup and finalization flow for more reliable workspace preparation.
  * Enhanced handling of secrets during post-attach operations.
  * Preserved existing snapshot restoration and mount synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->