### PR TITLE
fix: use SSH_AGENT_FORWARDING context option in generated ssh config

### DIFF
--- a/cmd/workspace/up/configure.go
+++ b/cmd/workspace/up/configure.go
@@ -27,6 +27,7 @@ func (cmd *UpCmd) configureWorkspace(
 		setupGPGAgentForwarding := cmd.GPGAgentForwarding ||
 			devsyConfig.ContextOptionBool(config.ContextOptionGPGAgentForwarding)
 		sshConfigIncludePath := devsyConfig.ContextOption(config.ContextOptionSSHConfigIncludePath)
+		agentForwarding := devsyConfig.ContextOptionBool(config.ContextOptionSSHAgentForwarding)
 
 		if err := configureSSH(client, configureSSHParams{
 			sshConfigPath:        cmd.SSHConfigPath,
@@ -34,6 +35,7 @@ func (cmd *UpCmd) configureWorkspace(
 			user:                 wctx.user,
 			workdir:              wctx.workdir,
 			gpgagent:             setupGPGAgentForwarding,
+			agentForwarding:      agentForwarding,
 			devsyHome:            devsyHome,
 		}); err != nil {
 			return err
@@ -119,6 +121,7 @@ func (cmd *UpCmd) reconfigureSSHWithTunnel(
 		User:                 wctx.user,
 		Workdir:              wctx.workdir,
 		TunnelPort:           wctx.tunnelPort,
+		AgentForwarding:      devsyConfig.ContextOptionBool(config.ContextOptionSSHAgentForwarding),
 		Provider:             client.Provider(),
 	})
 }
@@ -129,6 +132,7 @@ type configureSSHParams struct {
 	user                 string
 	workdir              string
 	gpgagent             bool
+	agentForwarding      bool
 	devsyHome            string
 }
 
@@ -156,6 +160,7 @@ func configureSSH(client client2.BaseWorkspaceClient, params configureSSHParams)
 		User:                 params.user,
 		Workdir:              params.workdir,
 		GPGAgent:             params.gpgagent,
+		AgentForwarding:      params.agentForwarding,
 		DevsyHome:            params.devsyHome,
 		Provider:             client.Provider(),
 	})

--- a/pkg/ssh/config.go
+++ b/pkg/ssh/config.go
@@ -34,6 +34,7 @@ type SSHConfigParams struct {
 	Workdir              string
 	Command              string
 	GPGAgent             bool
+	AgentForwarding      bool
 	DevsyHome            string
 	Provider             string
 	TunnelPort           int // If > 0, use TCP tunnel mode instead of ProxyCommand
@@ -49,17 +50,18 @@ func ConfigureSSHConfig(params SSHConfigParams) error {
 	}
 
 	newFile, err := addHost(addHostParams{
-		path:       targetPath,
-		host:       params.Workspace + config.SSHHostSuffix,
-		user:       params.User,
-		context:    params.Context,
-		workspace:  params.Workspace,
-		workdir:    params.Workdir,
-		command:    params.Command,
-		gpgagent:   params.GPGAgent,
-		devsyHome:  params.DevsyHome,
-		provider:   params.Provider,
-		tunnelPort: params.TunnelPort,
+		path:            targetPath,
+		host:            params.Workspace + config.SSHHostSuffix,
+		user:            params.User,
+		context:         params.Context,
+		workspace:       params.Workspace,
+		workdir:         params.Workdir,
+		command:         params.Command,
+		gpgagent:        params.GPGAgent,
+		agentForwarding: params.AgentForwarding,
+		devsyHome:       params.DevsyHome,
+		provider:        params.Provider,
+		tunnelPort:      params.TunnelPort,
 	})
 	if err != nil {
 		return fmt.Errorf("parse ssh config: %w", err)
@@ -75,17 +77,18 @@ type DevsySSHEntry struct {
 }
 
 type addHostParams struct {
-	path       string
-	host       string
-	user       string
-	context    string
-	workspace  string
-	workdir    string
-	command    string
-	gpgagent   bool
-	devsyHome  string
-	provider   string
-	tunnelPort int
+	path            string
+	host            string
+	user            string
+	context         string
+	workspace       string
+	workdir         string
+	command         string
+	gpgagent        bool
+	agentForwarding bool
+	devsyHome       string
+	provider        string
+	tunnelPort      int
 }
 
 func addHost(params addHostParams) (string, error) {
@@ -172,9 +175,13 @@ func newSSHConfigBuilder(host string) *sshConfigBuilder {
 	}
 }
 
-func (b *sshConfigBuilder) addSSHOptions(provider string) *sshConfigBuilder {
+func (b *sshConfigBuilder) addSSHOptions(provider string, agentForwarding bool) *sshConfigBuilder {
+	forwardAgent := "no"
+	if agentForwarding {
+		forwardAgent = "yes"
+	}
 	b.lines = append(b.lines,
-		"  ForwardAgent yes",
+		"  ForwardAgent "+forwardAgent,
 		"  LogLevel error",
 		"  StrictHostKeyChecking no",
 		"  UserKnownHostsFile /dev/null",
@@ -233,7 +240,7 @@ func buildProxyCommand(execPath string, params addHostParams) string {
 // buildSSHConfigLines creates the SSH config entry lines.
 func buildSSHConfigLines(params addHostParams, proxyCmd string) []string {
 	return newSSHConfigBuilder(params.host).
-		addSSHOptions(params.provider).
+		addSSHOptions(params.provider, params.agentForwarding).
 		addProxyCommand(proxyCmd).
 		addUser(params.user, params.host).
 		build()
@@ -242,7 +249,7 @@ func buildSSHConfigLines(params addHostParams, proxyCmd string) []string {
 // buildTunnelConfigLines creates the SSH config entry lines for TCP tunnel mode.
 func buildTunnelConfigLines(params addHostParams) []string {
 	return newSSHConfigBuilder(params.host).
-		addSSHOptions(params.provider).
+		addSSHOptions(params.provider, params.agentForwarding).
 		addTunnelConnection(params.tunnelPort).
 		addUser(params.user, params.host).
 		build()

--- a/pkg/ssh/config_test.go
+++ b/pkg/ssh/config_test.go
@@ -16,33 +16,35 @@ func TestSSHConfigSuite(t *testing.T) {
 }
 
 var addHostSectionTestCases = []struct {
-	name      string
-	config    string
-	execPath  string
-	host      string
-	user      string
-	context   string
-	workspace string
-	workdir   string
-	command   string
-	gpgagent  bool
-	devsyHome string
-	provider  string
-	expected  string
+	name            string
+	config          string
+	execPath        string
+	host            string
+	user            string
+	context         string
+	workspace       string
+	workdir         string
+	command         string
+	gpgagent        bool
+	agentForwarding bool
+	devsyHome       string
+	provider        string
+	expected        string
 }{
 	{
-		name:      "Basic host addition",
-		config:    "",
-		execPath:  testExecPath,
-		host:      testHostBasic,
-		user:      testUser,
-		context:   testContextAlt,
-		workspace: testWorkspaceAlt,
-		workdir:   "",
-		command:   "",
-		gpgagent:  false,
-		devsyHome: "",
-		provider:  "",
+		name:            "Basic host addition",
+		config:          "",
+		execPath:        testExecPath,
+		host:            testHostBasic,
+		user:            testUser,
+		context:         testContextAlt,
+		workspace:       testWorkspaceAlt,
+		workdir:         "",
+		command:         "",
+		gpgagent:        false,
+		agentForwarding: true,
+		devsyHome:       "",
+		provider:        "",
 		expected: `# Devsy Start testhost
 Host testhost
   ForwardAgent yes
@@ -55,18 +57,19 @@ Host testhost
 # Devsy End testhost`,
 	},
 	{
-		name:      "AWS provider with ConnectTimeout",
-		config:    "",
-		execPath:  testExecPath,
-		host:      testHostBasic,
-		user:      testUser,
-		context:   testContextAlt,
-		workspace: testWorkspaceAlt,
-		workdir:   "",
-		command:   "",
-		gpgagent:  false,
-		devsyHome: "",
-		provider:  "aws",
+		name:            "AWS provider with ConnectTimeout",
+		config:          "",
+		execPath:        testExecPath,
+		host:            testHostBasic,
+		user:            testUser,
+		context:         testContextAlt,
+		workspace:       testWorkspaceAlt,
+		workdir:         "",
+		command:         "",
+		gpgagent:        false,
+		agentForwarding: true,
+		devsyHome:       "",
+		provider:        "aws",
 		expected: `# Devsy Start testhost
 Host testhost
   ForwardAgent yes
@@ -80,18 +83,19 @@ Host testhost
 # Devsy End testhost`,
 	},
 	{
-		name:      "Basic host addition with DEVSY_HOME",
-		config:    "",
-		execPath:  testExecPath,
-		host:      testHostBasic,
-		user:      testUser,
-		context:   testContextAlt,
-		workspace: testWorkspaceAlt,
-		workdir:   "",
-		command:   "",
-		gpgagent:  false,
-		devsyHome: "C:\\\\W S\\d",
-		provider:  "",
+		name:            "Basic host addition with DEVSY_HOME",
+		config:          "",
+		execPath:        testExecPath,
+		host:            testHostBasic,
+		user:            testUser,
+		context:         testContextAlt,
+		workspace:       testWorkspaceAlt,
+		workdir:         "",
+		command:         "",
+		gpgagent:        false,
+		agentForwarding: true,
+		devsyHome:       "C:\\\\W S\\d",
+		provider:        "",
 		//nolint:lll // long ProxyCommand expected output
 		expected: `# Devsy Start testhost
 Host testhost
@@ -105,18 +109,19 @@ Host testhost
 # Devsy End testhost`,
 	},
 	{
-		name:      "Host addition with workdir",
-		config:    "",
-		execPath:  testExecPath,
-		host:      testHostBasic,
-		user:      testUser,
-		context:   testContextAlt,
-		workspace: testWorkspaceAlt,
-		workdir:   "/path/to/workdir",
-		command:   "",
-		gpgagent:  false,
-		devsyHome: "",
-		provider:  "",
+		name:            "Host addition with workdir",
+		config:          "",
+		execPath:        testExecPath,
+		host:            testHostBasic,
+		user:            testUser,
+		context:         testContextAlt,
+		workspace:       testWorkspaceAlt,
+		workdir:         "/path/to/workdir",
+		command:         "",
+		gpgagent:        false,
+		agentForwarding: true,
+		devsyHome:       "",
+		provider:        "",
 		//nolint:lll // long ProxyCommand expected output
 		expected: `# Devsy Start testhost
 Host testhost
@@ -130,18 +135,19 @@ Host testhost
 # Devsy End testhost`,
 	},
 	{
-		name:      "Host addition with gpg agent",
-		config:    "",
-		execPath:  testExecPath,
-		host:      testHostBasic,
-		user:      testUser,
-		context:   testContextAlt,
-		workspace: testWorkspaceAlt,
-		workdir:   "",
-		command:   "",
-		gpgagent:  true,
-		devsyHome: "",
-		provider:  "",
+		name:            "Host addition with gpg agent",
+		config:          "",
+		execPath:        testExecPath,
+		host:            testHostBasic,
+		user:            testUser,
+		context:         testContextAlt,
+		workspace:       testWorkspaceAlt,
+		workdir:         "",
+		command:         "",
+		gpgagent:        true,
+		agentForwarding: true,
+		devsyHome:       "",
+		provider:        "",
 		//nolint:lll // long ProxyCommand expected output
 		expected: `# Devsy Start testhost
 Host testhost
@@ -155,18 +161,19 @@ Host testhost
 # Devsy End testhost`,
 	},
 	{
-		name:      "Host addition with custom command",
-		config:    "",
-		execPath:  testExecPath,
-		host:      testHostBasic,
-		user:      testUser,
-		context:   testContextAlt,
-		workspace: testWorkspaceAlt,
-		workdir:   "",
-		command:   "ssh -W %h:%p bastion",
-		gpgagent:  false,
-		devsyHome: "",
-		provider:  "",
+		name:            "Host addition with custom command",
+		config:          "",
+		execPath:        testExecPath,
+		host:            testHostBasic,
+		user:            testUser,
+		context:         testContextAlt,
+		workspace:       testWorkspaceAlt,
+		workdir:         "",
+		command:         "ssh -W %h:%p bastion",
+		gpgagent:        false,
+		agentForwarding: true,
+		devsyHome:       "",
+		provider:        "",
 		expected: `# Devsy Start testhost
 Host testhost
   ForwardAgent yes
@@ -182,16 +189,17 @@ Host testhost
 		name: "Host addition to existing config",
 		config: `Host existinghost
   User existinguser`,
-		execPath:  testExecPath,
-		host:      testHostBasic,
-		user:      testUser,
-		context:   testContextAlt,
-		workspace: testWorkspaceAlt,
-		workdir:   "",
-		command:   "",
-		gpgagent:  false,
-		devsyHome: "",
-		provider:  "",
+		execPath:        testExecPath,
+		host:            testHostBasic,
+		user:            testUser,
+		context:         testContextAlt,
+		workspace:       testWorkspaceAlt,
+		workdir:         "",
+		command:         "",
+		gpgagent:        false,
+		agentForwarding: true,
+		devsyHome:       "",
+		provider:        "",
 		expected: `# Devsy Start testhost
 Host testhost
   ForwardAgent yes
@@ -220,16 +228,17 @@ Host existingtesthost
 
 Host existinghost
   User existinguser`,
-		execPath:  testExecPath,
-		host:      testHostBasic,
-		user:      testUser,
-		context:   testContextAlt,
-		workspace: testWorkspaceAlt,
-		workdir:   "",
-		command:   "",
-		gpgagent:  false,
-		devsyHome: "",
-		provider:  "",
+		execPath:        testExecPath,
+		host:            testHostBasic,
+		user:            testUser,
+		context:         testContextAlt,
+		workspace:       testWorkspaceAlt,
+		workdir:         "",
+		command:         "",
+		gpgagent:        false,
+		agentForwarding: true,
+		devsyHome:       "",
+		provider:        "",
 		expected: `# Devsy Start testhost
 Host testhost
   ForwardAgent yes
@@ -263,16 +272,17 @@ Include ~/config2
 
 
 Include ~/config3`,
-		execPath:  testExecPath,
-		host:      testHostBasic,
-		user:      testUser,
-		context:   testContextAlt,
-		workspace: testWorkspaceAlt,
-		workdir:   "",
-		command:   "",
-		gpgagent:  false,
-		devsyHome: "",
-		provider:  "",
+		execPath:        testExecPath,
+		host:            testHostBasic,
+		user:            testUser,
+		context:         testContextAlt,
+		workspace:       testWorkspaceAlt,
+		workdir:         "",
+		command:         "",
+		gpgagent:        false,
+		agentForwarding: true,
+		devsyHome:       "",
+		provider:        "",
 		expected: `Include ~/config1
 
 Include ~/config2
@@ -291,22 +301,48 @@ Host testhost
   User testuser
 # Devsy End testhost`,
 	},
+	{
+		name:            "Host addition with agent forwarding disabled",
+		config:          "",
+		execPath:        testExecPath,
+		host:            testHostBasic,
+		user:            testUser,
+		context:         testContextAlt,
+		workspace:       testWorkspaceAlt,
+		workdir:         "",
+		command:         "",
+		gpgagent:        false,
+		agentForwarding: false,
+		devsyHome:       "",
+		provider:        "",
+		expected: `# Devsy Start testhost
+Host testhost
+  ForwardAgent no
+  LogLevel error
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+  HostKeyAlgorithms rsa-sha2-256,rsa-sha2-512,ssh-rsa
+  ProxyCommand "/path/to/exec" workspace ssh --stdio --context testcontext --user testuser testworkspace
+  User testuser
+# Devsy End testhost`,
+	},
 }
 
 func (s *SSHConfigTestSuite) TestAddHostSection() {
 	for _, tt := range addHostSectionTestCases {
 		s.Run(tt.name, func() {
 			result, err := addHostSection(tt.config, tt.execPath, addHostParams{
-				path:      "",
-				host:      tt.host,
-				user:      tt.user,
-				context:   tt.context,
-				workspace: tt.workspace,
-				workdir:   tt.workdir,
-				command:   tt.command,
-				gpgagent:  tt.gpgagent,
-				devsyHome: tt.devsyHome,
-				provider:  tt.provider,
+				path:            "",
+				host:            tt.host,
+				user:            tt.user,
+				context:         tt.context,
+				workspace:       tt.workspace,
+				workdir:         tt.workdir,
+				command:         tt.command,
+				gpgagent:        tt.gpgagent,
+				agentForwarding: tt.agentForwarding,
+				devsyHome:       tt.devsyHome,
+				provider:        tt.provider,
 			})
 
 			assert.NoError(s.T(), err)

--- a/pkg/ssh/config_tunnel_test.go
+++ b/pkg/ssh/config_tunnel_test.go
@@ -38,12 +38,13 @@ func TestSSHConfigTunnelSuite(t *testing.T) {
 
 func (s *SSHConfigTunnelTestSuite) TestAddHostSection_TunnelMode_Basic() {
 	params := addHostParams{
-		host:       testHost,
-		user:       testUser,
-		context:    testContext,
-		workspace:  testWorkspace,
-		tunnelPort: testTunnelPort,
-		provider:   testProvider,
+		host:            testHost,
+		user:            testUser,
+		context:         testContext,
+		workspace:       testWorkspace,
+		tunnelPort:      testTunnelPort,
+		provider:        testProvider,
+		agentForwarding: true,
 	}
 
 	result, err := addHostSection("", testDevsyBin, params)
@@ -141,12 +142,13 @@ func (s *SSHConfigTunnelTestSuite) TestAddHostSection_TunnelMode_ExistingConfig(
 
 func (s *SSHConfigTunnelTestSuite) TestAddHostSection_TunnelMode_FullExpectedOutput() {
 	params := addHostParams{
-		host:       testHostBasic,
-		user:       testUser,
-		context:    testContextAlt,
-		workspace:  testWorkspaceAlt,
-		tunnelPort: testTunnelPort,
-		provider:   "",
+		host:            testHostBasic,
+		user:            testUser,
+		context:         testContextAlt,
+		workspace:       testWorkspaceAlt,
+		tunnelPort:      testTunnelPort,
+		provider:        "",
+		agentForwarding: true,
 	}
 
 	result, err := addHostSection("", testExecPath, params)
@@ -169,12 +171,13 @@ Host testhost
 
 func (s *SSHConfigTunnelTestSuite) TestBuildTunnelConfigLines() {
 	params := addHostParams{
-		host:       testHost,
-		user:       testUser,
-		context:    testContext,
-		workspace:  testWorkspace,
-		tunnelPort: testTunnelPort,
-		provider:   testProvider,
+		host:            testHost,
+		user:            testUser,
+		context:         testContext,
+		workspace:       testWorkspace,
+		tunnelPort:      testTunnelPort,
+		provider:        testProvider,
+		agentForwarding: true,
 	}
 
 	lines := buildTunnelConfigLines(params)


### PR DESCRIPTION
## Summary
- The `~/.ssh/config` `ForwardAgent` line was hardcoded to `yes`, ignoring the `SSH_AGENT_FORWARDING` context option (already respected by devsy's own proxied SSH client).
- `addSSHOptions` now writes `ForwardAgent yes`/`no` based on the context setting, threaded through `SSHConfigParams` → `addHostParams`.

Fixes #898

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable SSH agent forwarding for workspaces.
  * SSH connections now respect whether agent forwarding is enabled or disabled.
  * The setting is consistently applied during initial connections, tunnel-based connections, and SSH reconfiguration.
* **Bug Fixes**
  * Prevented SSH agent forwarding from being enabled automatically when it is turned off in workspace settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->