### PR TITLE
fix(ide): pass flag to browser tunnel ide opener to forward gpg agent

### DIFF
--- a/cmd/internal/browser_tunnel.go
+++ b/cmd/internal/browser_tunnel.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	cliflags "github.com/devsy-org/devsy/pkg/flags"
 	"github.com/devsy-org/devsy/pkg/flags/names"
+	"github.com/devsy-org/devsy/pkg/gpg"
 	"github.com/devsy-org/devsy/pkg/ide/opener"
 	pkglog "github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/tunnel"
@@ -25,14 +26,15 @@ import (
 type BrowserTunnelCmd struct {
 	*flags.GlobalFlags
 
-	Workspace        string
-	TargetURL        string
-	AuthSockID       string
-	ForwardPorts     bool
-	ExtraPorts       []string
-	User             string
-	GitSSHSigningKey string
-	InheritListeners []string
+	Workspace          string
+	TargetURL          string
+	AuthSockID         string
+	ForwardPorts       bool
+	ExtraPorts         []string
+	User               string
+	GitSSHSigningKey   string
+	GPGAgentForwarding bool
+	InheritListeners   []string
 	// OpenBrowser tells the helper to probe TargetURL and open the host
 	// browser once the listener accepts. The parent CLI exits in
 	// milliseconds after spawning the helper, so the auto-open must be
@@ -61,6 +63,7 @@ func NewBrowserTunnelCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		cliflags.StringArray(&cmd.ExtraPorts, names.ExtraPorts, nil, "Extra ports to forward"),
 		cliflags.String(&cmd.User, names.User, "", "Remote user"),
 		cliflags.String(&cmd.GitSSHSigningKey, names.GitSSHSigningKey, "", "Git SSH signing key"),
+		cliflags.Bool(&cmd.GPGAgentForwarding, names.SSHGPGForwarding, false, "Whether to forward the local GPG agent"),
 		cliflags.StringArray(
 			&cmd.InheritListeners,
 			names.InheritListener,
@@ -181,6 +184,12 @@ func (cmd *BrowserTunnelCmd) Run(ctx context.Context) error {
 		return fmt.Errorf("parse inherited listeners: %w", err)
 	}
 
+	if cmd.GPGAgentForwarding {
+		if err := gpg.ForwardAgent(ctx, client); err != nil {
+			return fmt.Errorf("forward gpg agent: %w", err)
+		}
+	}
+
 	// Launch the probe-then-open goroutine before the blocking
 	// StartBrowserTunnel call so the TCP probe runs concurrently with
 	// SSH dial + listener bind. The probe observes ctx so it unwinds
@@ -190,15 +199,16 @@ func (cmd *BrowserTunnelCmd) Run(ctx context.Context) error {
 	}
 
 	return tunnel.StartBrowserTunnel(ctx, tunnel.BrowserTunnelParams{
-		DevsyConfig:      devsyConfig,
-		Client:           client,
-		User:             cmd.User,
-		TargetURL:        cmd.TargetURL,
-		ForwardPorts:     cmd.ForwardPorts,
-		ExtraPorts:       cmd.ExtraPorts,
-		AuthSockID:       cmd.AuthSockID,
-		GitSSHSigningKey: cmd.GitSSHSigningKey,
-		ExtraListeners:   extraListeners,
+		DevsyConfig:        devsyConfig,
+		Client:             client,
+		User:               cmd.User,
+		TargetURL:          cmd.TargetURL,
+		ForwardPorts:       cmd.ForwardPorts,
+		ExtraPorts:         cmd.ExtraPorts,
+		AuthSockID:         cmd.AuthSockID,
+		GitSSHSigningKey:   cmd.GitSSHSigningKey,
+		GPGAgentForwarding: cmd.GPGAgentForwarding,
+		ExtraListeners:     extraListeners,
 		// Helper lifecycle is owned by opener.KillBrowserTunnel and
 		// devsy stop/delete; the EXIT_AFTER_TIMEOUT idle shutdown
 		// would otherwise close the port-forward shortly after the

--- a/cmd/internal/browser_tunnel.go
+++ b/cmd/internal/browser_tunnel.go
@@ -63,7 +63,12 @@ func NewBrowserTunnelCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		cliflags.StringArray(&cmd.ExtraPorts, names.ExtraPorts, nil, "Extra ports to forward"),
 		cliflags.String(&cmd.User, names.User, "", "Remote user"),
 		cliflags.String(&cmd.GitSSHSigningKey, names.GitSSHSigningKey, "", "Git SSH signing key"),
-		cliflags.Bool(&cmd.GPGAgentForwarding, names.SSHGPGForwarding, false, "Whether to forward the local GPG agent"),
+		cliflags.Bool(
+			&cmd.GPGAgentForwarding,
+			names.SSHGPGForwarding,
+			false,
+			"Whether to forward the local GPG agent",
+		),
 		cliflags.StringArray(
 			&cmd.InheritListeners,
 			names.InheritListener,

--- a/e2e/tests/ide/browser_returns.go
+++ b/e2e/tests/ide/browser_returns.go
@@ -507,7 +507,9 @@ func getTunnelLogs(combined string) (func() (string, error), error) {
 	start := idx + len("Logs: ")
 	end := strings.Index(combined[start:], ". Run 'devsy")
 	if end < 0 {
-		return nil, fmt.Errorf("failed to find '. Run 'devsy' marker after 'Logs: ' in combined output")
+		return nil, fmt.Errorf(
+			"failed to find '. Run 'devsy' marker after 'Logs: ' in combined output",
+		)
 	}
 	logPath := combined[start : start+end]
 	return func() (string, error) {

--- a/e2e/tests/ide/browser_returns.go
+++ b/e2e/tests/ide/browser_returns.go
@@ -353,7 +353,10 @@ var _ = ginkgo.Describe(
 				framework.ExpectNoError(err)
 
 				// After functional GPG forwarding succeeded, inspect both CLI and helper logs for issues.
-				tunnelLogs := getTunnelLogs(combined)()
+				getTunnelLogsFn, err := getTunnelLogs(combined)
+				framework.ExpectNoError(err)
+				tunnelLogs, err := getTunnelLogsFn()
+				framework.ExpectNoError(err)
 				allLogs := combined + "\n--- helper logs ---\n" + tunnelLogs
 
 				gomega.Expect(allLogs).NotTo(gomega.ContainSubstring("permission denied"),
@@ -431,7 +434,9 @@ var _ = ginkgo.Describe(
 						"expected browser IDE opener path to execute; got:\n%s", combined)
 
 				// Since forwarding runs asynchronously in the helper process, poll its logs for readiness.
-				gomega.Eventually(getTunnelLogs(combined)).
+				getTunnelLogsFn, err := getTunnelLogs(combined)
+				framework.ExpectNoError(err)
+				gomega.Eventually(getTunnelLogsFn).
 					WithTimeout(15*time.Second).
 					WithPolling(200*time.Millisecond).
 					Should(gomega.ContainSubstring("forwarding gpg-agent"),
@@ -442,7 +447,10 @@ var _ = ginkgo.Describe(
 				err = f.DevsySSHGpgSecretKeyForwarded(sshCtx, tempDir, gpgTestKeyFingerprint)
 				framework.ExpectNoError(err)
 
-				tunnelLogs := getTunnelLogs(combined)()
+				getTunnelLogsFn, err = getTunnelLogs(combined)
+				framework.ExpectNoError(err)
+				tunnelLogs, err := getTunnelLogsFn()
+				framework.ExpectNoError(err)
 				allLogs := combined + "\n--- helper logs ---\n" + tunnelLogs
 
 				gomega.Expect(allLogs).NotTo(gomega.ContainSubstring("continuing without it"),
@@ -489,22 +497,24 @@ var _ = ginkgo.Describe(
 
 // getTunnelLogs parses the log file location from the combined stdout/stderr output of the CLI,
 // and returns a function that dynamically reads and returns the contents of that log file when called.
-func getTunnelLogs(combined string) func() string {
+// Returns an error if the log path cannot be parsed from the combined output.
+// The returned closure propagates os.ReadFile errors instead of swallowing them.
+func getTunnelLogs(combined string) (func() (string, error), error) {
 	idx := strings.Index(combined, "Logs: ")
 	if idx < 0 {
-		return func() string { return "" }
+		return nil, fmt.Errorf("failed to find 'Logs: ' marker in combined output")
 	}
 	start := idx + len("Logs: ")
 	end := strings.Index(combined[start:], ". Run 'devsy")
 	if end < 0 {
-		return func() string { return "" }
+		return nil, fmt.Errorf("failed to find '. Run 'devsy' marker after 'Logs: ' in combined output")
 	}
 	logPath := combined[start : start+end]
-	return func() string {
+	return func() (string, error) {
 		data, err := os.ReadFile(logPath) // #nosec G304: path derived from test workspace
 		if err != nil {
-			return ""
+			return "", err
 		}
-		return string(data)
-	}
+		return string(data), nil
+	}, nil
 }

--- a/e2e/tests/ide/browser_returns.go
+++ b/e2e/tests/ide/browser_returns.go
@@ -347,20 +347,24 @@ var _ = ginkgo.Describe(
 				framework.ExpectNoError(err)
 				combined := stdout + stderr
 
-				gomega.Expect(combined).NotTo(gomega.ContainSubstring("permission denied"),
-					"root and vscode sessions must not collide on /tmp/devsy-gpg-setup.lock; "+
-						"got:\n%s", combined)
-				gomega.Expect(combined).NotTo(gomega.ContainSubstring("operation not permitted"),
-					"root and vscode sessions must not collide on /tmp/devsy.activity; "+
-						"got:\n%s", combined)
-				gomega.Expect(combined).NotTo(gomega.ContainSubstring("continuing without it"),
-					"GPG agent forwarding must succeed end-to-end for a non-root remoteUser "+
-						"browser IDE; got:\n%s", combined)
-
 				sshCtx, cancelSSH := context.WithDeadline(ctx, time.Now().Add(30*time.Second))
 				defer cancelSSH()
 				err = f.DevsySSHGpgSecretKeyForwarded(sshCtx, tempDir, gpgTestKeyFingerprint)
 				framework.ExpectNoError(err)
+
+				// After functional GPG forwarding succeeded, inspect both CLI and helper logs for issues.
+				tunnelLogs := getTunnelLogs(combined)()
+				allLogs := combined + "\n--- helper logs ---\n" + tunnelLogs
+
+				gomega.Expect(allLogs).NotTo(gomega.ContainSubstring("permission denied"),
+					"root and vscode sessions must not collide on /tmp/devsy-gpg-setup.lock; "+
+						"got:\n%s", allLogs)
+				gomega.Expect(allLogs).NotTo(gomega.ContainSubstring("operation not permitted"),
+					"root and vscode sessions must not collide on /tmp/devsy.activity; "+
+						"got:\n%s", allLogs)
+				gomega.Expect(allLogs).NotTo(gomega.ContainSubstring("continuing without it"),
+					"GPG agent forwarding must succeed end-to-end for a non-root remoteUser "+
+						"browser IDE; got:\n%s", allLogs)
 
 				framework.ExpectNoError(f.DevsyStop(ctx, tempDir))
 			},
@@ -423,16 +427,29 @@ var _ = ginkgo.Describe(
 				framework.ExpectNoError(err)
 				combined := stdout + stderr
 				gomega.Expect(combined).
-					To(gomega.ContainSubstring("Starting vscode in browser mode at"),
+					To(gomega.ContainSubstring("starting vscode in browser mode at"),
 						"expected browser IDE opener path to execute; got:\n%s", combined)
-				gomega.Expect(combined).To(gomega.ContainSubstring("forwarding gpg-agent"),
-					"expected browser IDE GPG forward bootstrap to run; got:\n%s", combined)
 
-				gomega.Expect(combined).NotTo(gomega.ContainSubstring("continuing without it"),
-					"GPG agent forwarding must succeed when enabled from context option only; got:\n%s", combined)
-				gomega.Expect(combined).NotTo(gomega.ContainSubstring(
+				// Since forwarding runs asynchronously in the helper process, poll its logs for readiness.
+				gomega.Eventually(getTunnelLogs(combined)).
+					WithTimeout(15*time.Second).
+					WithPolling(200*time.Millisecond).
+					Should(gomega.ContainSubstring("forwarding gpg-agent"),
+						"expected browser IDE GPG forward bootstrap to run; got:\n%s", combined)
+
+				sshCtx, cancelSSH := context.WithDeadline(ctx, time.Now().Add(30*time.Second))
+				defer cancelSSH()
+				err = f.DevsySSHGpgSecretKeyForwarded(sshCtx, tempDir, gpgTestKeyFingerprint)
+				framework.ExpectNoError(err)
+
+				tunnelLogs := getTunnelLogs(combined)()
+				allLogs := combined + "\n--- helper logs ---\n" + tunnelLogs
+
+				gomega.Expect(allLogs).NotTo(gomega.ContainSubstring("continuing without it"),
+					"GPG agent forwarding must succeed when enabled from context option only; got:\n%s", allLogs)
+				gomega.Expect(allLogs).NotTo(gomega.ContainSubstring(
 					"timed out waiting for gpg-agent forward to become ready",
-				), "GPG forward should be ready before handing off browser IDE session; got:\n%s", combined)
+				), "GPG forward should be ready before handing off browser IDE session; got:\n%s", allLogs)
 
 				ws, err := f.FindWorkspace(ctx, tempDir)
 				framework.ExpectNoError(err)
@@ -442,11 +459,6 @@ var _ = ginkgo.Describe(
 					"expected browser tunnel state to exist for IDE session")
 				gomega.Expect(state.PID).To(gomega.BeNumerically(">", 0),
 					"expected detached browser tunnel process to be running")
-
-				sshCtx, cancelSSH := context.WithDeadline(ctx, time.Now().Add(30*time.Second))
-				defer cancelSSH()
-				err = f.DevsySSHGpgSecretKeyForwarded(sshCtx, tempDir, gpgTestKeyFingerprint)
-				framework.ExpectNoError(err)
 
 				framework.ExpectNoError(f.DevsyStop(ctx, tempDir))
 			},
@@ -474,3 +486,25 @@ var _ = ginkgo.Describe(
 		)
 	},
 )
+
+// getTunnelLogs parses the log file location from the combined stdout/stderr output of the CLI,
+// and returns a function that dynamically reads and returns the contents of that log file when called.
+func getTunnelLogs(combined string) func() string {
+	idx := strings.Index(combined, "Logs: ")
+	if idx < 0 {
+		return func() string { return "" }
+	}
+	start := idx + len("Logs: ")
+	end := strings.Index(combined[start:], ". Run 'devsy")
+	if end < 0 {
+		return func() string { return "" }
+	}
+	logPath := combined[start : start+end]
+	return func() string {
+		data, err := os.ReadFile(logPath) // #nosec G304: path derived from test workspace
+		if err != nil {
+			return ""
+		}
+		return string(data)
+	}
+}

--- a/pkg/ide/opener/browser_tunnel.go
+++ b/pkg/ide/opener/browser_tunnel.go
@@ -382,6 +382,9 @@ func buildHelperArgs(
 		names.Flag(names.User), tunnelParams.User,
 		names.Flag(names.GitSSHSigningKey), tunnelParams.GitSSHSigningKey,
 	}
+	if tunnelParams.GPGAgentForwarding {
+		args = append(args, names.FlagTrue(names.SSHGPGForwarding))
+	}
 	if tunnelParams.ForwardPorts {
 		args = append(args, names.Flag(names.ForwardPorts))
 	}

--- a/pkg/ide/opener/browser_tunnel_test.go
+++ b/pkg/ide/opener/browser_tunnel_test.go
@@ -106,6 +106,24 @@ func TestBuildHelperArgs_OpenBrowser(t *testing.T) {
 	}
 }
 
+func TestBuildHelperArgs_GPGAgentForwarding(t *testing.T) {
+	withFlag := buildHelperArgs("ctx", "ws", tunnel.BrowserTunnelParams{
+		TargetURL:          "http://localhost:1234",
+		GPGAgentForwarding: true,
+	}, false)
+	if !containsArg(withFlag, "--ssh-gpg-forwarding=true") {
+		t.Errorf("expected --ssh-gpg-forwarding=true in %v", withFlag)
+	}
+
+	withoutFlag := buildHelperArgs("ctx", "ws", tunnel.BrowserTunnelParams{
+		TargetURL:          "http://localhost:1234",
+		GPGAgentForwarding: false,
+	}, false)
+	if containsArg(withoutFlag, "--ssh-gpg-forwarding=true") {
+		t.Errorf("did not expect --ssh-gpg-forwarding=true in %v", withoutFlag)
+	}
+}
+
 func TestBuildHelperArgs_IncludesResolvedUser(t *testing.T) {
 	args := buildHelperArgs("default", "my-workspace", tunnel.BrowserTunnelParams{
 		User:      "vscode",

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -15,7 +15,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/flags/names"
-	"github.com/devsy-org/devsy/pkg/gpg"
 	"github.com/devsy-org/devsy/pkg/ide/codeserver"
 	"github.com/devsy-org/devsy/pkg/ide/fleet"
 	"github.com/devsy-org/devsy/pkg/ide/jetbrains"
@@ -323,12 +322,6 @@ type browserIDESpec struct {
 }
 
 func openBrowserIDE(ctx context.Context, params IDEParams, spec browserIDESpec) (string, error) {
-	if params.GPGAgentForwarding {
-		if err := gpg.ForwardAgent(ctx, params.Client); err != nil {
-			return "", err
-		}
-	}
-
 	addr, port, err := ParseAddressAndPort(spec.BindAddrOption, spec.DefaultPort)
 	if err != nil {
 		return "", err
@@ -338,18 +331,19 @@ func openBrowserIDE(ctx context.Context, params IDEParams, spec browserIDESpec) 
 	targetURL := spec.TargetURLFn(port, folder)
 	openBrowser := params.Launch == LaunchAuto
 
-	pkglog.Infof("Starting %s in browser mode at %s", spec.LogName, targetURL)
+	pkglog.Infof("starting %s in browser mode at %s", spec.LogName, targetURL)
 	extraPorts := []string{fmt.Sprintf("%s:%d", addr, spec.DefaultPort)}
 	effectiveURL, err := startDetachedBrowserTunnel(ctx, params, tunnel.BrowserTunnelParams{
-		DevsyConfig:      params.DevsyConfig,
-		Client:           params.Client,
-		User:             params.User,
-		TargetURL:        targetURL,
-		ForwardPorts:     spec.ForwardPorts,
-		ExtraPorts:       extraPorts,
-		AuthSockID:       params.SSHAuthSockID,
-		GitSSHSigningKey: params.GitSSHSigningKey,
-		DaemonStartFunc:  makeDaemonStartFunc(params, spec.ForwardPorts, extraPorts),
+		DevsyConfig:        params.DevsyConfig,
+		Client:             params.Client,
+		User:               params.User,
+		TargetURL:          targetURL,
+		ForwardPorts:       spec.ForwardPorts,
+		ExtraPorts:         extraPorts,
+		AuthSockID:         params.SSHAuthSockID,
+		GitSSHSigningKey:   params.GitSSHSigningKey,
+		GPGAgentForwarding: params.GPGAgentForwarding,
+		DaemonStartFunc:    makeDaemonStartFunc(params, spec.ForwardPorts, extraPorts),
 	}, browserIDEInvocation{Label: spec.Label, OpenBrowser: openBrowser})
 	if err != nil {
 		return "", err

--- a/pkg/tunnel/browser.go
+++ b/pkg/tunnel/browser.go
@@ -22,14 +22,15 @@ import (
 
 // BrowserTunnelParams bundles the arguments for browser-based IDE tunnels.
 type BrowserTunnelParams struct {
-	DevsyConfig      *config.Config
-	Client           client2.BaseWorkspaceClient
-	User             string
-	TargetURL        string
-	ForwardPorts     bool
-	ExtraPorts       []string
-	AuthSockID       string
-	GitSSHSigningKey string
+	DevsyConfig        *config.Config
+	Client             client2.BaseWorkspaceClient
+	User               string
+	TargetURL          string
+	ForwardPorts       bool
+	ExtraPorts         []string
+	AuthSockID         string
+	GitSSHSigningKey   string
+	GPGAgentForwarding bool
 
 	// ExtraListeners holds pre-bound listeners for ExtraPorts entries,
 	// keyed by host addr (e.g. "localhost:10800"). Set by the parent so the


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional GPG agent forwarding for browser-based IDE tunnels.
  * Added a command-line option to enable GPG forwarding when starting a browser tunnel.

* **Bug Fixes**
  * Improved forwarding readiness handling and error reporting.
  * Updated tunnel logs and validation to better detect forwarding timeouts and startup issues.

* **Tests**
  * Added coverage confirming the GPG forwarding option is passed only when enabled.
  * Enhanced end-to-end checks for forwarding status and browser tunnel logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->