### PR TITLE
Fix workspace stop button race condition and deadlock bugs

### DIFF
--- a/desktop/src/main/cli.ts
+++ b/desktop/src/main/cli.ts
@@ -347,11 +347,23 @@ export class CliRunner {
     for (const child of bucket) {
       waits.push(
         new Promise<void>((resolve) => {
+          let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+            timer = null
+            resolve()
+          }, 2000)
+
           if (child.exitCode !== null || child.signalCode !== null) {
+            if (timer) clearTimeout(timer)
             resolve()
             return
           }
-          child.once("close", () => resolve())
+          child.once("close", () => {
+            if (timer) {
+              clearTimeout(timer)
+              timer = null
+            }
+            resolve()
+          })
         }),
       )
       child.kill("SIGTERM")

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -229,11 +229,23 @@ export function registerIpcHandlers(deps: IpcDependencies): {
     if (tunnelProc) {
       tunnelProcesses.delete(workspaceId)
       const tunnelExit = new Promise<void>((resolve) => {
+        let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+          timer = null
+          resolve()
+        }, 2000)
+
         if (tunnelProc.exitCode !== null || tunnelProc.signalCode !== null) {
+          if (timer) clearTimeout(timer)
           resolve()
           return
         }
-        tunnelProc.once("close", () => resolve())
+        tunnelProc.once("close", () => {
+          if (timer) {
+            clearTimeout(timer)
+            timer = null
+          }
+          resolve()
+        })
       })
       tunnelProc.kill("SIGTERM")
       await tunnelExit
@@ -908,6 +920,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
         prebuildRepository?: string
         platform?: string
         recovery?: boolean
+        commandId?: string
       },
     ) => {
       trackEvent("workspace_create", {
@@ -929,7 +942,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
       if (args.recovery) cliArgs.push("--recovery")
 
       const wsId = args.workspaceId ?? args.source
-      const cmdId = crypto.randomUUID()
+      const cmdId = args.commandId ?? crypto.randomUUID()
       const logPath = logStore.createLogFile(state.workspaceContext(wsId), wsId)
       const sink = createLogSink(
         deps.getMainWindow,
@@ -1064,12 +1077,12 @@ export function registerIpcHandlers(deps: IpcDependencies): {
 
   ipcMain.handle(
     "workspace_stop",
-    async (_event, args: { workspaceId: string; debug?: boolean }) => {
+    async (_event, args: { workspaceId: string; debug?: boolean; commandId?: string }) => {
       trackEvent("workspace_stop", {
         workspace_ref: hashWorkspaceRef(args.workspaceId),
       })
       await quiesceWorkspace(args.workspaceId)
-      const cmdId = crypto.randomUUID()
+      const cmdId = args.commandId ?? crypto.randomUUID()
       const logPath = logStore.createLogFile(
         state.workspaceContext(args.workspaceId),
         args.workspaceId,
@@ -1104,7 +1117,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
 
   ipcMain.handle(
     "workspace_delete",
-    async (_event, args: { workspaceId: string; debug?: boolean }) => {
+    async (_event, args: { workspaceId: string; debug?: boolean; commandId?: string }) => {
       trackEvent("workspace_delete", {
         workspace_ref: hashWorkspaceRef(args.workspaceId),
       })
@@ -1114,7 +1127,7 @@ export function registerIpcHandlers(deps: IpcDependencies): {
       // stdout/stderr lands on a log file the CLI is about to unlink, causing
       // an ENOENT crash in the main process.
       await quiesceWorkspace(args.workspaceId)
-      const cmdId = crypto.randomUUID()
+      const cmdId = args.commandId ?? crypto.randomUUID()
       const logPath = logStore.createLogFile(
         state.workspaceContext(args.workspaceId),
         args.workspaceId,
@@ -1160,11 +1173,11 @@ export function registerIpcHandlers(deps: IpcDependencies): {
 
   ipcMain.handle(
     "workspace_rebuild",
-    async (_event, args: { workspaceId: string; debug?: boolean }) => {
+    async (_event, args: { workspaceId: string; debug?: boolean; commandId?: string }) => {
       trackEvent("workspace_rebuild", {
         workspace_ref: hashWorkspaceRef(args.workspaceId),
       })
-      const cmdId = crypto.randomUUID()
+      const cmdId = args.commandId ?? crypto.randomUUID()
       const logPath = logStore.createLogFile(
         state.workspaceContext(args.workspaceId),
         args.workspaceId,
@@ -1201,11 +1214,11 @@ export function registerIpcHandlers(deps: IpcDependencies): {
 
   ipcMain.handle(
     "workspace_reset",
-    async (_event, args: { workspaceId: string; debug?: boolean }) => {
+    async (_event, args: { workspaceId: string; debug?: boolean; commandId?: string }) => {
       trackEvent("workspace_reset", {
         workspace_ref: hashWorkspaceRef(args.workspaceId),
       })
-      const cmdId = crypto.randomUUID()
+      const cmdId = args.commandId ?? crypto.randomUUID()
       const logPath = logStore.createLogFile(
         state.workspaceContext(args.workspaceId),
         args.workspaceId,

--- a/desktop/src/main/pty.ts
+++ b/desktop/src/main/pty.ts
@@ -104,7 +104,17 @@ export class PtyManager {
       if (!proc) continue
       waits.push(
         new Promise<void>((resolve) => {
+          let timer: ReturnType<typeof setTimeout> | null = setTimeout(() => {
+            timer = null
+            disposable.dispose()
+            resolve()
+          }, 2000)
+
           const disposable = proc.onExit(() => {
+            if (timer) {
+              clearTimeout(timer)
+              timer = null
+            }
             disposable.dispose()
             resolve()
           })

--- a/desktop/src/renderer/src/lib/ipc/commands.ts
+++ b/desktop/src/renderer/src/lib/ipc/commands.ts
@@ -47,6 +47,7 @@ export async function workspaceUp(params: {
   prebuildRepository?: string
   platform?: string
   recovery?: boolean
+  commandId?: string
 }): Promise<string> {
   return invoke<string>("workspace_up", params)
 }
@@ -54,29 +55,33 @@ export async function workspaceUp(params: {
 export async function workspaceStop(
   workspaceId: string,
   debug?: boolean,
+  commandId?: string,
 ): Promise<string> {
-  return invoke<string>("workspace_stop", { workspaceId, debug })
+  return invoke<string>("workspace_stop", { workspaceId, debug, commandId })
 }
 
 export async function workspaceDelete(
   workspaceId: string,
   debug?: boolean,
+  commandId?: string,
 ): Promise<string> {
-  return invoke<string>("workspace_delete", { workspaceId, debug })
+  return invoke<string>("workspace_delete", { workspaceId, debug, commandId })
 }
 
 export async function workspaceRebuild(
   workspaceId: string,
   debug?: boolean,
+  commandId?: string,
 ): Promise<string> {
-  return invoke<string>("workspace_rebuild", { workspaceId, debug })
+  return invoke<string>("workspace_rebuild", { workspaceId, debug, commandId })
 }
 
 export async function workspaceReset(
   workspaceId: string,
   debug?: boolean,
+  commandId?: string,
 ): Promise<string> {
-  return invoke<string>("workspace_reset", { workspaceId, debug })
+  return invoke<string>("workspace_reset", { workspaceId, debug, commandId })
 }
 
 export async function workspaceStatus(

--- a/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
+++ b/desktop/src/renderer/src/pages/WorkspaceDetailPage.svelte
@@ -410,7 +410,9 @@ function isDebug(): boolean {
   return loadLocalOptions().debugFlag
 }
 
-function startStreamingOp(label: string) {
+function startStreamingOp(label: string): string {
+  const newCmdId = crypto.randomUUID()
+  commandId = newCmdId
   operationLabel = label
   operationRunning = true
   buildFailed = false
@@ -422,18 +424,20 @@ function startStreamingOp(label: string) {
     flushHandle = null
   }
   activeTab = "logs"
+  return newCmdId
 }
 
 async function handleStart() {
   const ide = currentIde
   const folder = customFolder || undefined
-  startStreamingOp("Start")
+  const cmdId = startStreamingOp("Start")
   try {
-    commandId = await workspaceUp({
+    await workspaceUp({
       source: id,
       ide,
       debug: isDebug(),
       workspaceFolder: folder,
+      commandId: cmdId,
     })
   } catch (err) {
     operationRunning = false
@@ -463,14 +467,15 @@ function handleBuildFailure(progress: CommandProgress) {
 async function handleRecovery() {
   const ide = currentIde
   const folder = customFolder || undefined
-  startStreamingOp("Recovery")
+  const cmdId = startStreamingOp("Recovery")
   try {
-    commandId = await workspaceUp({
+    await workspaceUp({
       source: id,
       ide,
       recovery: true,
       debug: isDebug(),
       workspaceFolder: folder,
+      commandId: cmdId,
     })
   } catch (err) {
     operationRunning = false
@@ -484,14 +489,15 @@ async function handleOpenIde() {
   const ide = currentIde
   const folder = customFolder || undefined
   trackEngagement("ide_open", { ide })
-  startStreamingOp("Open IDE")
+  const cmdId = startStreamingOp("Open IDE")
   try {
-    commandId = await workspaceUp({
+    await workspaceUp({
       source: id,
       ide,
       ideLaunch: "auto",
       debug: isDebug(),
       workspaceFolder: folder,
+      commandId: cmdId,
     })
   } catch (err) {
     operationRunning = false
@@ -500,9 +506,9 @@ async function handleOpenIde() {
 }
 
 async function handleStop() {
-  startStreamingOp("Stop")
+  const cmdId = startStreamingOp("Stop")
   try {
-    commandId = await workspaceStop(id, isDebug())
+    await workspaceStop(id, isDebug(), cmdId)
   } catch (err) {
     operationRunning = false
     toasts.error(`Failed to stop: ${extractErrorMessage(err)}`)
@@ -511,9 +517,9 @@ async function handleStop() {
 
 async function handleRebuild() {
   confirmRebuildOpen = false
-  startStreamingOp("Rebuild")
+  const cmdId = startStreamingOp("Rebuild")
   try {
-    commandId = await workspaceRebuild(id, isDebug())
+    await workspaceRebuild(id, isDebug(), cmdId)
   } catch (err) {
     operationRunning = false
     toasts.error(`Failed to rebuild: ${extractErrorMessage(err)}`)
@@ -522,9 +528,9 @@ async function handleRebuild() {
 
 async function handleReset() {
   confirmResetOpen = false
-  startStreamingOp("Reset")
+  const cmdId = startStreamingOp("Reset")
   try {
-    commandId = await workspaceReset(id, isDebug())
+    await workspaceReset(id, isDebug(), cmdId)
   } catch (err) {
     operationRunning = false
     toasts.error(`Failed to reset: ${extractErrorMessage(err)}`)
@@ -533,10 +539,10 @@ async function handleReset() {
 
 async function handleDelete() {
   confirmDeleteOpen = false
-  startStreamingOp("Delete")
+  const cmdId = startStreamingOp("Delete")
   deleting = true
   try {
-    commandId = await workspaceDelete(id, isDebug())
+    await workspaceDelete(id, isDebug(), cmdId)
   } catch (err) {
     operationRunning = false
     deleting = false


### PR DESCRIPTION
This pull request resolves a critical race condition and process deadlock in the desktop workspace details page:

1. **Race Condition Fix**: The `commandId` is now generated on the Svelte/frontend layer (`WorkspaceDetailPage.svelte`) before making the IPC invocation. This ensures that the frontend is listening for the correct `commandId` before the backend begins streaming logs. This fixes the issue where the "Stop" and "Start" buttons get permanently disabled.
2. **Process Deadlock Fix**: A 2-second timeout has been introduced to process termination promises in `cancelActiveUp`, `cli.cancelFor`, and `pty.cancelFor`. This ensures that even if child processes hang, they will not block the main process or the serialization queue indefinitely. This fixes the issue where the first click on "Stop" on the workspaces list page fails to stop.

---
*PR created automatically by Jules for task [12595257464691527198](https://jules.google.com/task/12595257464691527198) started by @skevetter*