### PR TITLE
fix: gpg forwarding integration test assertion and style case

### DIFF
--- a/cmd/internal/browser_tunnel.go
+++ b/cmd/internal/browser_tunnel.go
@@ -14,6 +14,7 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	cliflags "github.com/devsy-org/devsy/pkg/flags"
 	"github.com/devsy-org/devsy/pkg/flags/names"
+	"github.com/devsy-org/devsy/pkg/gpg"
 	"github.com/devsy-org/devsy/pkg/ide/opener"
 	pkglog "github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/tunnel"
@@ -25,14 +26,15 @@ import (
 type BrowserTunnelCmd struct {
 	*flags.GlobalFlags
 
-	Workspace        string
-	TargetURL        string
-	AuthSockID       string
-	ForwardPorts     bool
-	ExtraPorts       []string
-	User             string
-	GitSSHSigningKey string
-	InheritListeners []string
+	Workspace          string
+	TargetURL          string
+	AuthSockID         string
+	ForwardPorts       bool
+	ExtraPorts         []string
+	User               string
+	GitSSHSigningKey   string
+	GPGAgentForwarding bool
+	InheritListeners   []string
 	// OpenBrowser tells the helper to probe TargetURL and open the host
 	// browser once the listener accepts. The parent CLI exits in
 	// milliseconds after spawning the helper, so the auto-open must be
@@ -61,6 +63,12 @@ func NewBrowserTunnelCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 		cliflags.StringArray(&cmd.ExtraPorts, names.ExtraPorts, nil, "Extra ports to forward"),
 		cliflags.String(&cmd.User, names.User, "", "Remote user"),
 		cliflags.String(&cmd.GitSSHSigningKey, names.GitSSHSigningKey, "", "Git SSH signing key"),
+		cliflags.Bool(
+			&cmd.GPGAgentForwarding,
+			names.SSHGPGForwarding,
+			false,
+			"Whether to forward the local GPG agent",
+		),
 		cliflags.StringArray(
 			&cmd.InheritListeners,
 			names.InheritListener,
@@ -181,6 +189,12 @@ func (cmd *BrowserTunnelCmd) Run(ctx context.Context) error {
 		return fmt.Errorf("parse inherited listeners: %w", err)
 	}
 
+	if cmd.GPGAgentForwarding {
+		if err := gpg.ForwardAgent(ctx, client); err != nil {
+			return fmt.Errorf("forward gpg agent: %w", err)
+		}
+	}
+
 	// Launch the probe-then-open goroutine before the blocking
 	// StartBrowserTunnel call so the TCP probe runs concurrently with
 	// SSH dial + listener bind. The probe observes ctx so it unwinds
@@ -190,15 +204,16 @@ func (cmd *BrowserTunnelCmd) Run(ctx context.Context) error {
 	}
 
 	return tunnel.StartBrowserTunnel(ctx, tunnel.BrowserTunnelParams{
-		DevsyConfig:      devsyConfig,
-		Client:           client,
-		User:             cmd.User,
-		TargetURL:        cmd.TargetURL,
-		ForwardPorts:     cmd.ForwardPorts,
-		ExtraPorts:       cmd.ExtraPorts,
-		AuthSockID:       cmd.AuthSockID,
-		GitSSHSigningKey: cmd.GitSSHSigningKey,
-		ExtraListeners:   extraListeners,
+		DevsyConfig:        devsyConfig,
+		Client:             client,
+		User:               cmd.User,
+		TargetURL:          cmd.TargetURL,
+		ForwardPorts:       cmd.ForwardPorts,
+		ExtraPorts:         cmd.ExtraPorts,
+		AuthSockID:         cmd.AuthSockID,
+		GitSSHSigningKey:   cmd.GitSSHSigningKey,
+		GPGAgentForwarding: cmd.GPGAgentForwarding,
+		ExtraListeners:     extraListeners,
 		// Helper lifecycle is owned by opener.KillBrowserTunnel and
 		// devsy stop/delete; the EXIT_AFTER_TIMEOUT idle shutdown
 		// would otherwise close the port-forward shortly after the

--- a/community.yaml
+++ b/community.yaml
@@ -1,2 +1,12 @@
 providers:
-  - repository: https://github.com/devsy-example/devsy-example
+  - repository: https://github.com/alexandrevilain/devsy-provider-ovhcloud
+  - repository: https://github.com/dirien/devsy-provider-exoscale
+  - repository: https://github.com/dirien/devsy-provider-scaleway
+  - repository: https://github.com/mrsimonemms/devsy-provider-hetzner
+  - repository: https://github.com/cloudbit-ch/devsy-provider-cloudbit
+  - repository: https://github.com/flowswiss/devsy-provider-flow
+  - repository: https://github.com/navaneeth-dev/devsy-provider-vultr
+  - repository: https://github.com/minhio/devsy-provider-multipass
+  - repository: https://github.com/akyriako/devsy-provider-opentelekomcloud
+  - repository: https://github.com/stackitcloud/devsy-provider-stackit
+  - repository: https://github.com/kuju63/devsy-provider-podman

--- a/e2e/tests/ide/browser_returns.go
+++ b/e2e/tests/ide/browser_returns.go
@@ -347,20 +347,24 @@ var _ = ginkgo.Describe(
 				framework.ExpectNoError(err)
 				combined := stdout + stderr
 
-				gomega.Expect(combined).NotTo(gomega.ContainSubstring("permission denied"),
-					"root and vscode sessions must not collide on /tmp/devsy-gpg-setup.lock; "+
-						"got:\n%s", combined)
-				gomega.Expect(combined).NotTo(gomega.ContainSubstring("operation not permitted"),
-					"root and vscode sessions must not collide on /tmp/devsy.activity; "+
-						"got:\n%s", combined)
-				gomega.Expect(combined).NotTo(gomega.ContainSubstring("continuing without it"),
-					"GPG agent forwarding must succeed end-to-end for a non-root remoteUser "+
-						"browser IDE; got:\n%s", combined)
-
 				sshCtx, cancelSSH := context.WithDeadline(ctx, time.Now().Add(30*time.Second))
 				defer cancelSSH()
 				err = f.DevsySSHGpgSecretKeyForwarded(sshCtx, tempDir, gpgTestKeyFingerprint)
 				framework.ExpectNoError(err)
+
+				// After functional GPG forwarding succeeded, inspect both CLI and helper logs for issues.
+				tunnelLogs := getTunnelLogs(combined)()
+				allLogs := combined + "\n--- helper logs ---\n" + tunnelLogs
+
+				gomega.Expect(allLogs).NotTo(gomega.ContainSubstring("permission denied"),
+					"root and vscode sessions must not collide on /tmp/devsy-gpg-setup.lock; "+
+						"got:\n%s", allLogs)
+				gomega.Expect(allLogs).NotTo(gomega.ContainSubstring("operation not permitted"),
+					"root and vscode sessions must not collide on /tmp/devsy.activity; "+
+						"got:\n%s", allLogs)
+				gomega.Expect(allLogs).NotTo(gomega.ContainSubstring("continuing without it"),
+					"GPG agent forwarding must succeed end-to-end for a non-root remoteUser "+
+						"browser IDE; got:\n%s", allLogs)
 
 				framework.ExpectNoError(f.DevsyStop(ctx, tempDir))
 			},
@@ -423,16 +427,29 @@ var _ = ginkgo.Describe(
 				framework.ExpectNoError(err)
 				combined := stdout + stderr
 				gomega.Expect(combined).
-					To(gomega.ContainSubstring("Starting vscode in browser mode at"),
+					To(gomega.ContainSubstring("starting vscode in browser mode at"),
 						"expected browser IDE opener path to execute; got:\n%s", combined)
-				gomega.Expect(combined).To(gomega.ContainSubstring("forwarding gpg-agent"),
-					"expected browser IDE GPG forward bootstrap to run; got:\n%s", combined)
 
-				gomega.Expect(combined).NotTo(gomega.ContainSubstring("continuing without it"),
-					"GPG agent forwarding must succeed when enabled from context option only; got:\n%s", combined)
-				gomega.Expect(combined).NotTo(gomega.ContainSubstring(
+				// Since forwarding runs asynchronously in the helper process, poll its logs for readiness.
+				gomega.Eventually(getTunnelLogs(combined)).
+					WithTimeout(15 * time.Second).
+					WithPolling(200 * time.Millisecond).
+					Should(gomega.ContainSubstring("forwarding gpg-agent"),
+						"expected browser IDE GPG forward bootstrap to run; got:\n%s", combined)
+
+				sshCtx, cancelSSH := context.WithDeadline(ctx, time.Now().Add(30*time.Second))
+				defer cancelSSH()
+				err = f.DevsySSHGpgSecretKeyForwarded(sshCtx, tempDir, gpgTestKeyFingerprint)
+				framework.ExpectNoError(err)
+
+				tunnelLogs := getTunnelLogs(combined)()
+				allLogs := combined + "\n--- helper logs ---\n" + tunnelLogs
+
+				gomega.Expect(allLogs).NotTo(gomega.ContainSubstring("continuing without it"),
+					"GPG agent forwarding must succeed when enabled from context option only; got:\n%s", allLogs)
+				gomega.Expect(allLogs).NotTo(gomega.ContainSubstring(
 					"timed out waiting for gpg-agent forward to become ready",
-				), "GPG forward should be ready before handing off browser IDE session; got:\n%s", combined)
+				), "GPG forward should be ready before handing off browser IDE session; got:\n%s", allLogs)
 
 				ws, err := f.FindWorkspace(ctx, tempDir)
 				framework.ExpectNoError(err)
@@ -442,11 +459,6 @@ var _ = ginkgo.Describe(
 					"expected browser tunnel state to exist for IDE session")
 				gomega.Expect(state.PID).To(gomega.BeNumerically(">", 0),
 					"expected detached browser tunnel process to be running")
-
-				sshCtx, cancelSSH := context.WithDeadline(ctx, time.Now().Add(30*time.Second))
-				defer cancelSSH()
-				err = f.DevsySSHGpgSecretKeyForwarded(sshCtx, tempDir, gpgTestKeyFingerprint)
-				framework.ExpectNoError(err)
 
 				framework.ExpectNoError(f.DevsyStop(ctx, tempDir))
 			},
@@ -474,3 +486,25 @@ var _ = ginkgo.Describe(
 		)
 	},
 )
+
+// getTunnelLogs parses the log file location from the combined stdout/stderr output of the CLI,
+// and returns a function that dynamically reads and returns the contents of that log file when called.
+func getTunnelLogs(combined string) func() string {
+	idx := strings.Index(combined, "Logs: ")
+	if idx < 0 {
+		return func() string { return "" }
+	}
+	start := idx + len("Logs: ")
+	end := strings.Index(combined[start:], ". Run 'devsy")
+	if end < 0 {
+		return func() string { return "" }
+	}
+	logPath := combined[start : start+end]
+	return func() string {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			return ""
+		}
+		return string(data)
+	}
+}

--- a/e2e/tests/ide/browser_returns.go
+++ b/e2e/tests/ide/browser_returns.go
@@ -432,8 +432,8 @@ var _ = ginkgo.Describe(
 
 				// Since forwarding runs asynchronously in the helper process, poll its logs for readiness.
 				gomega.Eventually(getTunnelLogs(combined)).
-					WithTimeout(15 * time.Second).
-					WithPolling(200 * time.Millisecond).
+					WithTimeout(15*time.Second).
+					WithPolling(200*time.Millisecond).
 					Should(gomega.ContainSubstring("forwarding gpg-agent"),
 						"expected browser IDE GPG forward bootstrap to run; got:\n%s", combined)
 
@@ -501,7 +501,7 @@ func getTunnelLogs(combined string) func() string {
 	}
 	logPath := combined[start : start+end]
 	return func() string {
-		data, err := os.ReadFile(logPath)
+		data, err := os.ReadFile(logPath) // #nosec G304: path derived from test workspace
 		if err != nil {
 			return ""
 		}

--- a/pkg/ide/opener/browser_tunnel.go
+++ b/pkg/ide/opener/browser_tunnel.go
@@ -382,6 +382,9 @@ func buildHelperArgs(
 		names.Flag(names.User), tunnelParams.User,
 		names.Flag(names.GitSSHSigningKey), tunnelParams.GitSSHSigningKey,
 	}
+	if tunnelParams.GPGAgentForwarding {
+		args = append(args, names.FlagTrue(names.SSHGPGForwarding))
+	}
 	if tunnelParams.ForwardPorts {
 		args = append(args, names.Flag(names.ForwardPorts))
 	}

--- a/pkg/ide/opener/browser_tunnel_test.go
+++ b/pkg/ide/opener/browser_tunnel_test.go
@@ -106,6 +106,24 @@ func TestBuildHelperArgs_OpenBrowser(t *testing.T) {
 	}
 }
 
+func TestBuildHelperArgs_GPGAgentForwarding(t *testing.T) {
+	withFlag := buildHelperArgs("ctx", "ws", tunnel.BrowserTunnelParams{
+		TargetURL:          "http://localhost:1234",
+		GPGAgentForwarding: true,
+	}, false)
+	if !containsArg(withFlag, "--ssh-gpg-forwarding=true") {
+		t.Errorf("expected --ssh-gpg-forwarding=true in %v", withFlag)
+	}
+
+	withoutFlag := buildHelperArgs("ctx", "ws", tunnel.BrowserTunnelParams{
+		TargetURL:          "http://localhost:1234",
+		GPGAgentForwarding: false,
+	}, false)
+	if containsArg(withoutFlag, "--ssh-gpg-forwarding=true") {
+		t.Errorf("did not expect --ssh-gpg-forwarding=true in %v", withoutFlag)
+	}
+}
+
 func TestBuildHelperArgs_IncludesResolvedUser(t *testing.T) {
 	args := buildHelperArgs("default", "my-workspace", tunnel.BrowserTunnelParams{
 		User:      "vscode",

--- a/pkg/ide/opener/opener.go
+++ b/pkg/ide/opener/opener.go
@@ -15,7 +15,6 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	config2 "github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/flags/names"
-	"github.com/devsy-org/devsy/pkg/gpg"
 	"github.com/devsy-org/devsy/pkg/ide/codeserver"
 	"github.com/devsy-org/devsy/pkg/ide/fleet"
 	"github.com/devsy-org/devsy/pkg/ide/jetbrains"
@@ -323,12 +322,6 @@ type browserIDESpec struct {
 }
 
 func openBrowserIDE(ctx context.Context, params IDEParams, spec browserIDESpec) (string, error) {
-	if params.GPGAgentForwarding {
-		if err := gpg.ForwardAgent(ctx, params.Client); err != nil {
-			return "", err
-		}
-	}
-
 	addr, port, err := ParseAddressAndPort(spec.BindAddrOption, spec.DefaultPort)
 	if err != nil {
 		return "", err
@@ -338,18 +331,19 @@ func openBrowserIDE(ctx context.Context, params IDEParams, spec browserIDESpec) 
 	targetURL := spec.TargetURLFn(port, folder)
 	openBrowser := params.Launch == LaunchAuto
 
-	pkglog.Infof("Starting %s in browser mode at %s", spec.LogName, targetURL)
+	pkglog.Infof("starting %s in browser mode at %s", spec.LogName, targetURL)
 	extraPorts := []string{fmt.Sprintf("%s:%d", addr, spec.DefaultPort)}
 	effectiveURL, err := startDetachedBrowserTunnel(ctx, params, tunnel.BrowserTunnelParams{
-		DevsyConfig:      params.DevsyConfig,
-		Client:           params.Client,
-		User:             params.User,
-		TargetURL:        targetURL,
-		ForwardPorts:     spec.ForwardPorts,
-		ExtraPorts:       extraPorts,
-		AuthSockID:       params.SSHAuthSockID,
-		GitSSHSigningKey: params.GitSSHSigningKey,
-		DaemonStartFunc:  makeDaemonStartFunc(params, spec.ForwardPorts, extraPorts),
+		DevsyConfig:        params.DevsyConfig,
+		Client:             params.Client,
+		User:               params.User,
+		TargetURL:          targetURL,
+		ForwardPorts:       spec.ForwardPorts,
+		ExtraPorts:         extraPorts,
+		AuthSockID:         params.SSHAuthSockID,
+		GitSSHSigningKey:   params.GitSSHSigningKey,
+		GPGAgentForwarding: params.GPGAgentForwarding,
+		DaemonStartFunc:    makeDaemonStartFunc(params, spec.ForwardPorts, extraPorts),
 	}, browserIDEInvocation{Label: spec.Label, OpenBrowser: openBrowser})
 	if err != nil {
 		return "", err

--- a/pkg/tunnel/browser.go
+++ b/pkg/tunnel/browser.go
@@ -22,14 +22,15 @@ import (
 
 // BrowserTunnelParams bundles the arguments for browser-based IDE tunnels.
 type BrowserTunnelParams struct {
-	DevsyConfig      *config.Config
-	Client           client2.BaseWorkspaceClient
-	User             string
-	TargetURL        string
-	ForwardPorts     bool
-	ExtraPorts       []string
-	AuthSockID       string
-	GitSSHSigningKey string
+	DevsyConfig        *config.Config
+	Client             client2.BaseWorkspaceClient
+	User               string
+	TargetURL          string
+	ForwardPorts       bool
+	ExtraPorts         []string
+	AuthSockID         string
+	GitSSHSigningKey   string
+	GPGAgentForwarding bool
 
 	// ExtraListeners holds pre-bound listeners for ExtraPorts entries,
 	// keyed by host addr (e.g. "localhost:10800"). Set by the parent so the

--- a/sites/docs-devsy-sh/content/docs/managing-providers/manage-providers.mdx
+++ b/sites/docs-devsy-sh/content/docs/managing-providers/manage-providers.mdx
@@ -3,7 +3,7 @@ title: Manage Providers
 sidebar_label: Manage Providers
 ---
 
-Devsy providers include:
+The Devsy team maintains providers for popular services such as:
 
 - [Docker (docker)](https://github.com/devsy-org/devsy/tree/main/providers/docker)
 - [Podman (podman)](https://github.com/devsy-org/devsy/tree/main/providers/podman)
@@ -19,12 +19,11 @@ Devsy providers include:
 - [Digital Ocean (digitalocean)](https://github.com/devsy-org/devsy-provider-digitalocean)
 
 Install these providers with the Devsy CLI:
-
 ```
 devsy provider add docker
 ```
 
-List available providers using the command:
+You can get a list of available 1st party providers by using the command:
 
 ```
 devsy provider list --available
@@ -44,7 +43,7 @@ Open the Providers view and click **Add**. The provider wizard has four steps:
 The ProviderSheet (click any provider in the list) exposes edit settings, switch version, update, delete, rename, set as default, and re-initialize.
 
 <Callout>
-  The Desktop Application calls `devsy provider add PROVIDER` under the hood.
+The Desktop Application calls `devsy provider add PROVIDER` under the hood.
 </Callout>
 
 #### Custom Providers
@@ -56,7 +55,6 @@ In the Select step, type one of the following into the **Provider Source** field
 - A file path to a `provider.yaml`
 
 ### Devsy CLI
-
 Install any provider from the list with:
 
 ```sh
@@ -75,9 +73,7 @@ devsy provider add digitalocean
 ```
 
 <Callout title="Multiple providers at the same time">
-  You can use the `--name` flag to add multiple providers of the same type with
-  different options, for example `devsy provider add aws --name aws-gpu -o
-  AWS_INSTANCE_TYPE=p3.8xlarge`
+You can use the `--name` flag to add multiple providers of the same type with different options, for example `devsy provider add aws --name aws-gpu -o AWS_INSTANCE_TYPE=p3.8xlarge`
 </Callout>
 
 #### From GitHub
@@ -92,7 +88,6 @@ devsy provider add devsy-org/devsy-provider-terraform
 Devsy will search the latest release for a `provider.yaml` and download that automatically. This should work for private GitHub repositories where Devsy will use the local https credentials to connect to the GitHub repository.
 
 If you want to install the provider from a different release, you can do the following:
-
 ```sh
 devsy provider add my-org/my-repo@v0.0.1
 ```
@@ -136,6 +131,7 @@ or
 ```sh
 devsy provider init <provider-name> -o KEY=value
 ```
+
 
 To manage options later, list the current values with:
 
@@ -279,9 +275,10 @@ devsy provider delete <provider name>
 ```
 
 <Callout type="warn">
-  Remember first to delete any workspace related to this provider first, or move
-  them to another provider, else you'll not be able to interact with the
-  workspace until you re-install the provider used.
+⚠️ **BE CAREFUL**:⚠️
+Remember first to delete any workspace related to this provider first, or move
+them to another provider, else you'll not be able to interact with the workspace
+until you re-install the provider used.
 </Callout>
 
 ## Renaming a Provider
@@ -322,3 +319,23 @@ devsy provider rename my-docker local-docker
 4. Click **Update Options** to save.
 
 Devsy will update the provider and all associated workspaces automatically.
+
+## Community Providers
+
+The community maintains providers for additional services.
+
+- [Cloudbit (cloudbit-ch/devsy-provider-cloudbit)](https://github.com/cloudbit-ch/devsy-provider-cloudbit)
+- [Flow (flowswiss/devsy-provider-flow)](https://github.com/flowswiss/devsy-provider-flow)
+- [Hetzner (mrsimonemms/devsy-provider-hetzner)](https://github.com/mrsimonemms/devsy-provider-hetzner)
+- [OVHcloud (alexandrevilain/devsy-provider-ovhcloud)](https://github.com/alexandrevilain/devsy-provider-ovhcloud)
+- [Scaleway (dirien/devsy-provider-scaleway)](https://github.com/dirien/devsy-provider-scaleway)
+- [Exoscale (dirien/devsy-provider-exoscale)](https://github.com/dirien/devsy-provider-exoscale)
+- [Multipass (minhio/devsy-provider-multipass)](https://github.com/minhio/devsy-provider-multipass)
+- [Open Telekom Cloud (akyriako/devsy-provider-opentelekomcloud)](https://github.com/akyriako/devsy-provider-opentelekomcloud)
+- [Vultr (navaneeth-dev/devsy-provider-vultr)](https://github.com/navaneeth-dev/devsy-provider-vultr)
+- [STACKIT (stackitcloud/devsy-provider-stackit)](https://github.com/stackitcloud/devsy-provider-stackit)
+
+Install these providers with the Devsy CLI:
+```
+devsy provider add <user/repository>
+```


### PR DESCRIPTION
Fixed the failing GPG agent forwarding integration test assertion by waiting for GPG forward events in the background helper's 'tunnel.log' instead of the short-lived main CLI process output. This matches the PR's architectural improvement of delegating GPG forwarding to the persistent browser-tunnel helper. Also corrected the log case assertion to support the new lowercase logging style.

---
*PR created automatically by Jules for task [16686981330832865040](https://jules.google.com/task/16686981330832865040) started by @skevetter*