### PR TITLE
fix(microsandbox): use new cli semantics to start vm

### DIFF
--- a/pkg/driver/microsandbox/cliclient.go
+++ b/pkg/driver/microsandbox/cliclient.go
@@ -57,7 +57,15 @@ func (c cliClient) Create(ctx context.Context, sandbox string, spec sandboxSpec)
 	if err := c.ensureVolumes(ctx, spec.Mounts); err != nil {
 		return err
 	}
-	return msbRun(ctx, createArgs(sandbox, spec)...)
+	return msbRun(ctx, runArgs(sandbox, spec)...)
+}
+
+func runArgs(sandbox string, spec sandboxSpec) []string {
+	args := []string{"run", "--detach", names.Flag(names.Name), sandbox}
+	args = append(args, runtimeArgs(spec)...)
+	args = append(args, resourceArgs(spec)...)
+	args = append(args, mountArgs(spec.Mounts)...)
+	return append(args, spec.Image)
 }
 
 func (cliClient) Find(ctx context.Context, sandbox string) (*sandboxInfo, error) {
@@ -158,10 +166,30 @@ func createArgs(sandbox string, spec sandboxSpec) []string {
 	return append(args, spec.Image)
 }
 
+func shellScriptEntrypoint(argv []string) (string, bool) {
+	if len(argv) != 4 ||
+		argv[0] != "/bin/sh" ||
+		argv[1] != "-c" ||
+		argv[3] != "-" {
+		return "", false
+	}
+
+	return "#!/bin/sh\n" + argv[2], true
+}
+
 func runtimeArgs(spec sandboxSpec) []string {
 	var args []string
+
 	if len(spec.Entrypoint) > 0 {
-		args = append(args, "--entrypoint", strings.Join(spec.Entrypoint, " "))
+		if script, ok := shellScriptEntrypoint(spec.Entrypoint); ok {
+			args = append(
+				args,
+				"--script-raw", "devsy-entrypoint="+script,
+				"--entrypoint", "/.msb/scripts/devsy-entrypoint",
+			)
+		} else if len(spec.Entrypoint) == 1 {
+			args = append(args, "--entrypoint", spec.Entrypoint[0])
+		}
 	}
 	for k, v := range spec.Env {
 		args = append(args, names.Flag(names.Env), k+"="+v)

--- a/pkg/driver/microsandbox/cliclient_test.go
+++ b/pkg/driver/microsandbox/cliclient_test.go
@@ -9,10 +9,15 @@ import (
 	"github.com/devsy-org/devsy/pkg/flags/names"
 )
 
-func TestCreateArgsFull(t *testing.T) {
+func TestRunArgsFull(t *testing.T) {
 	spec := sandboxSpec{
-		Image:       testImg,
-		Entrypoint:  []string{shPath, "-c", "sleep infinity"},
+		Image: testImg,
+		Entrypoint: []string{
+			shPath,
+			"-c",
+			"sleep infinity",
+			"-",
+		},
 		Env:         map[string]string{"K": "v"},
 		Labels:      map[string]string{"devsy.sh/user": "vscode"},
 		IdleTimeout: 90 * time.Second,
@@ -26,18 +31,25 @@ func TestCreateArgsFull(t *testing.T) {
 			{Target: "/tmp", Tmpfs: true},
 		},
 	}
-	args := createArgs(wsName, spec)
 
-	// name comes first, image last.
-	if args[0] != names.Create || args[1] != names.Flag(names.Name) || args[2] != wsName {
-		t.Errorf("prefix = %v", args[:3])
+	args := runArgs(wsName, spec)
+
+	// "run --detach --name <name>" comes first, image last.
+	if len(args) < 4 ||
+		args[0] != "run" ||
+		args[1] != "--detach" ||
+		args[2] != names.Flag(names.Name) ||
+		args[3] != wsName {
+		t.Errorf("prefix = %v", args[:min(4, len(args))])
 	}
+
 	if args[len(args)-1] != testImg {
 		t.Errorf("image should be the final arg, got %q", args[len(args)-1])
 	}
 
 	want := [][2]string{
-		{"--entrypoint", "/bin/sh -c sleep infinity"},
+		{"--script-raw", "devsy-entrypoint=#!/bin/sh\nsleep infinity"},
+		{"--entrypoint", "/.msb/scripts/devsy-entrypoint"},
 		{names.Flag(names.Env), "K=v"},
 		{"--label", "devsy.sh/user=vscode"},
 		{"--idle-timeout", "1m30s"},
@@ -48,20 +60,30 @@ func TestCreateArgsFull(t *testing.T) {
 		{"--mount-named", "cache-vol:/cache"},
 		{"--tmpfs", "/tmp"},
 	}
+
 	for _, kv := range want {
 		if !hasFlagValue(args, kv[0], kv[1]) {
 			t.Errorf("missing %s %q in %v", kv[0], kv[1], args)
 		}
 	}
-	if hasFlag(args, "--net-default-egress") == false {
+
+	if !hasFlag(args, "--net-default-egress") {
 		t.Errorf("expected egress deny flag in %v", args)
 	}
 }
 
-func TestCreateArgsMinimal(t *testing.T) {
-	args := createArgs(wsName, sandboxSpec{Image: testImg})
-	// Only name + image; no sizing/runtime flags for a bare spec.
-	want := []string{names.Create, names.Flag(names.Name), wsName, testImg}
+func TestRunArgsMinimal(t *testing.T) {
+	args := runArgs(wsName, sandboxSpec{Image: testImg})
+
+	// Only run/detach + name + image; no sizing/runtime flags for a bare spec.
+	want := []string{
+		"run",
+		"--detach",
+		names.Flag(names.Name),
+		wsName,
+		testImg,
+	}
+
 	if !slices.Equal(args, want) {
 		t.Errorf("args = %v, want %v", args, want)
 	}
@@ -75,9 +97,11 @@ func TestMountArgsAndNamedVolumes(t *testing.T) {
 		{Target: testBindDst, Source: testBindSrc},
 		{Target: "/ro", Source: "/host/ro", ReadOnly: true},
 	}
+
 	if got := namedVolumes(mounts); !slices.Equal(got, []string{"vol-a", "vol-c"}) {
 		t.Errorf("namedVolumes = %v, want [vol-a vol-c]", got)
 	}
+
 	args := mountArgs(mounts)
 	if !hasFlagValue(args, "--mount-named", "vol-a:/a") ||
 		!hasFlagValue(args, "--tmpfs", "/b") ||
@@ -92,6 +116,7 @@ func TestResourceArgsOmitsZero(t *testing.T) {
 	if got := resourceArgs(sandboxSpec{}); len(got) != 0 {
 		t.Errorf("zero spec should produce no resource args, got %v", got)
 	}
+
 	if got := resourceArgs(
 		sandboxSpec{Memory: 512},
 	); !slices.Equal(
@@ -112,13 +137,18 @@ func TestRedactArgsMasksEnvValues(t *testing.T) {
 		names.Flag(names.Env),
 		"PLAIN=ok",
 	}
+
 	got := redactArgs(args)
+
 	if strings.Contains(got, "s3cret") || strings.Contains(got, "ok") {
 		t.Errorf("env values leaked: %q", got)
 	}
-	if !strings.Contains(got, "TOKEN=***") || !strings.Contains(got, "PLAIN=***") {
+
+	if !strings.Contains(got, "TOKEN=***") ||
+		!strings.Contains(got, "PLAIN=***") {
 		t.Errorf("env keys should be preserved with masked values: %q", got)
 	}
+
 	if !strings.Contains(got, "--label k=v") {
 		t.Errorf("non-env args should be untouched: %q", got)
 	}


### PR DESCRIPTION
Addresses issue: #1035

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox launches now use detached execution, allowing them to run independently after startup.
  * Shell script entrypoints using `/bin/sh -c` are now recognized and executed correctly.
  * Single-command entrypoints continue to be supported.

* **Bug Fixes**
  * Improved handling of complex entrypoints to prevent incorrect command construction.
  * Preserved existing support for mounts, resource settings, and environment-variable masking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->