### PR TITLE
fix(ci): stabilize flaky up-docker-wsl on windows-latest

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -571,9 +571,59 @@ jobs:
           echo "$installDir" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
           wsl --set-default-version 2
-          & "$installDir\podman.exe" machine init
-          & "$installDir\podman.exe" machine set --rootful
-          & "$installDir\podman.exe" machine start
+
+          # podman machine start can return before the WSL VM and its API socket
+          # are fully ready, leaving a window where containers created immediately
+          # afterwards get SIGTERM'd mid-startup (the flaky "container exited
+          # (exit code 0)" + "[inject] EOF" cascade). Retry init/start a few
+          # times, then gate the e2e suite behind a readiness probe + a throwaway
+          # preflight container, mirroring the Linux rootful setup below.
+          $busybox = "busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d"
+          $machineReady = $false
+          for ($attempt = 1; $attempt -le 3; $attempt++) {
+            if ($attempt -gt 1) {
+              Write-Host "--- retrying podman machine start (attempt $attempt/3) ---"
+              & "$installDir\podman.exe" machine stop 2>$null
+              Start-Sleep -Seconds 3
+            } else {
+              # machine init is not idempotent (errors if the machine already
+              # exists), so only create it on the first attempt; later attempts
+              # reuse the existing machine and just restart it.
+              & "$installDir\podman.exe" machine init
+              & "$installDir\podman.exe" machine set --rootful
+            }
+            & "$installDir\podman.exe" machine start
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "podman machine start exited $LASTEXITCODE on attempt $attempt"
+              continue
+            }
+
+            $ready = $false
+            $deadline = (Get-Date).AddSeconds(60)
+            while ((Get-Date) -lt $deadline) {
+              & "$installDir\podman.exe" info *> $null
+              if ($LASTEXITCODE -eq 0) { $ready = $true; break }
+              Start-Sleep -Seconds 2
+            }
+            if (-not $ready) {
+              Write-Host "::warning::podman info did not succeed within 60s on attempt $attempt"
+              & "$installDir\podman.exe" machine list
+              continue
+            }
+
+            Write-Host "Running podman runtime preflight..."
+            & "$installDir\podman.exe" run --rm $busybox echo "podman runtime preflight OK"
+            if ($LASTEXITCODE -eq 0) {
+              $machineReady = $true
+              break
+            }
+            Write-Host "podman preflight container failed (exit $LASTEXITCODE) on attempt $attempt"
+          }
+          if (-not $machineReady) {
+            & "$installDir\podman.exe" machine list
+            & "$installDir\podman.exe" info
+            throw "podman machine did not become ready after 3 attempts"
+          }
 
       - name: cache kind.exe (Windows)
         if: matrix.install-kind == true && runner.os == 'Windows' && (matrix.requires-secret == false || needs.can-read-secret.outputs.secret-set == 'true')

--- a/pkg/agent/delivery/local_docker.go
+++ b/pkg/agent/delivery/local_docker.go
@@ -66,7 +66,7 @@ func (d *LocalDockerDelivery) DeliverPreStart(ctx context.Context, opts PreStart
 	if opts.RunOptions.Env == nil {
 		opts.RunOptions.Env = make(map[string]string)
 	}
-	opts.RunOptions.Env["DEVSY_AGENT_PATH"] = volumeMountPath + "/" + binaryName()
+	opts.RunOptions.Env[pkgconfig.EnvAgentPath] = volumeMountPath + "/" + binaryName()
 
 	return nil
 }

--- a/pkg/config/env.go
+++ b/pkg/config/env.go
@@ -60,6 +60,13 @@ const (
 	// EnvAgentPreferDownload forces agent binary download even if a local copy exists.
 	EnvAgentPreferDownload = "DEVSY_AGENT_PREFER_DOWNLOAD"
 
+	// EnvAgentPath is set by pre-start delivery strategies (e.g.
+	// LocalDockerDelivery) to the in-container path of the volume-mounted agent
+	// binary. The container entrypoint honors it to exec the daemon directly
+	// from the delivered binary, decoupling daemon startup from post-start
+	// shell injection.
+	EnvAgentPath = "DEVSY_AGENT_PATH"
+
 	// EnvOS is set to the host operating system (runtime.GOOS).
 	EnvOS = "DEVSY_OS"
 

--- a/pkg/devcontainer/single.go
+++ b/pkg/devcontainer/single.go
@@ -31,11 +31,12 @@ const (
 	RemoteContainersExtraEnvVar = "REMOTE_CONTAINERS"
 
 	DefaultEntrypoint = `
-while ! command -v /usr/local/bin/devsy >/dev/null 2>&1; do
+DEVSYPATH="${DEVSY_AGENT_PATH:-/usr/local/bin/devsy}"
+while ! command -v "$DEVSYPATH" >/dev/null 2>&1; do
   echo "waiting for devsy agent to be available"
   sleep 1
 done
-exec /usr/local/bin/devsy internal agent container daemon
+exec "$DEVSYPATH" internal agent container daemon
 `
 )
 

--- a/pkg/driver/docker/lifecycle.go
+++ b/pkg/driver/docker/lifecycle.go
@@ -92,7 +92,12 @@ func (d *dockerDriver) ensureContainerRunning(
 			return err
 		}
 		lastErr = err
-		log.Debugf("container %s restart attempt %d failed: %v", container.ID, attempt, err)
+		// Surface restart failures at warn (not debug) so the container's exit
+		// code and tail logs are visible without --debug. An exit code 0 here
+		// usually means PID 1 caught a SIGTERM mid-startup (e.g. an unstable
+		// Podman/WSL machine), which is otherwise indistinguishable from a
+		// clean shutdown in the debug output.
+		log.Warnf("container %s restart attempt %d failed: %v", container.ID, attempt, err)
 	}
 
 	return fmt.Errorf(


### PR DESCRIPTION
## Summary

The `up-docker-wsl` job (`windows-latest`) was intermittently failing with the container exiting (exit code 0) right after start, followed by `[inject] EOF` and 3 failed restart attempts. The rerun of the same job with identical code passed, confirming an environmental flake.

Repro log: [run 31775426829 / job 94693528470](https://github.com/devsy-org/devsy/actions/runs/31775426829/job/94693528470) (failed) → rerun job `94699202314` (succeeded, same code).

## Root cause

`podman machine start` returns before the WSL VM and its API socket are fully ready. Containers created in that window get SIGTERM'd mid-startup. The daemon (PID 1, after the entrypoint's `exec`) catches SIGTERM via `signal.NotifyContext(..., os.Interrupt, syscall.SIGTERM)` and exits `0`, which cascades into the inject `EOF` and the 3-restart loop (each restart re-`exec`s the daemon, which gets SIGTERM'd again).

This is the **Windows analogue** of the Linux Podman-machine flakiness PR #1039 addresses — but #1039 is gated `runtime.GOOS == linux` and doesn't touch the Windows WSL path.

> Note: the quadrupled backslashes in the SSH-tunnel DEBUG logs (`"\"D:\\\\a\\\\..."`) are just nested-`%q` log noise (`agent.go` builds the command with `%q`, `sshtunnel.go` logs it again with `%q`) — cosmetic, not a cause.

## Changes

**Primary fix — gate the e2e suite behind Podman readiness (`.github/workflows/pr-ci.yml`):**
Mirrors the Linux rootful setup for the Windows Podman step:
- Retry `machine init`/`start` up to 3× (init is not idempotent, so only on the first attempt; later attempts stop + restart the existing machine).
- Readiness probe: poll `podman info` for up to 60s.
- Preflight: run a throwaway `busybox` container before the suite starts.

**Secondary fix — wire the pre-start volume binary into the entrypoint (`pkg/devcontainer/single.go`, `pkg/config/env.go`, `pkg/agent/delivery/local_docker.go`):**

Latent bug found during the investigation: `LocalDockerDelivery.DeliverPreStart` mounts the agent binary at `/opt/devsy/devsy` and sets `DEVSY_AGENT_PATH=/opt/devsy/devsy`, but `DEVSY_AGENT_PATH` had **zero readers** anywhere in the codebase — the entrypoint waited for and `exec`'d `/usr/local/bin/devsy` (placed later by the post-start legacy `inject.sh`). So the pre-start volume binary was effectively dead weight, and daemon startup was coupled to the post-start inject (where the `EOF` happens).

`DefaultEntrypoint` now `exec`s the daemon from `/usr/local/bin/devsy`, so the daemon arms **immediately** from the pre-start volume binary, decoupling it from the post-start inject.sh. The legacy inject.sh still runs to provision `/usr/local/bin/devsy` for the setup execs (`docker exec /usr/local/bin/devsy ...`), so no call sites needed changing. This shrinks the startup race window that contributes to the flake. Added the `EnvAgentPath` constant.

**Diagnostics (`pkg/driver/docker/lifecycle.go`):**
Surface per-restart-attempt failures at `warn` instead of `debug` so the container's exit code + tail logs are visible without `--debug` (an exit code 0 here typically means PID 1 caught a SIGTERM).

## Verification

- `go build ./...` ✅
- `go vet` on all changed packages ✅
- `go test ./pkg/devcontainer/... ./pkg/agent/... ./pkg/config/... ./pkg/driver/docker/...` ✅ (all pass)
- Full `go test ./pkg/... ./cmd/...`: the only failure is `pkg/git/TestRepoCloneFromInfoHelper`, which is **pre-existing and environmental** (no `git-lfs` in the test sandbox — fails identically on the unmodified `main` tree). Unrelated to this change.
- Workflow YAML validated.

This PR was created by an AI agent (OpenHands) on behalf of the user.

@skevetter can click here to [continue refining the PR](https://app.all-hands.dev/conversations/226c6e43-4b59-486f-bdf4-b24543d1f185)