### PR TITLE
fix(tunnel): stop double-wrapping credentials-server JSON logs

### DIFF
--- a/pkg/tunnel/services.go
+++ b/pkg/tunnel/services.go
@@ -209,8 +209,11 @@ func runServicesIteration(
 		errChan:      errChan,
 	})
 
-	writer := log.Writer(log.LevelDebug)
-	defer func() { _ = writer.Close() }()
+	writer, writerDone := log.PipeJSONStream()
+	defer func() {
+		_ = writer.Close()
+		<-writerDone
+	}()
 
 	command := buildCredentialsCommand(ctx, opts)
 


### PR DESCRIPTION
## Problem

The credentials-server SSH command's stderr showed nested log lines:

\`\`\`
2026-08-17T05:58:22.088Z	DEBUG	{"level":"debug","ts":"2026-08-17T05:58:22.087Z","msg":"Wrote docker credentials helper to /usr/local/bin/docker-credential-devsy"}
\`\`\`

\`devsy internal agent container credentials-server\` (run remotely over SSH,
see \`pkg/tunnel/services.go\`) always logs structured JSON on stderr, like every
\`devsy internal agent ...\` subcommand (\`cmd/internal/agent.go\` forces
\`Format: "json"\`). Its stderr was wired to \`log.Writer(log.LevelDebug)\`,
which treats each captured line as an opaque string and wraps it under the
local logger's own line — nesting one log record inside another.

## Fix

Switch \`runServicesIteration\`'s \`Stderr\` to \`log.PipeJSONStream()\`. This
already exists in \`pkg/log/jsonstream.go\` for exactly this shape of problem
(a devsy subprocess logging its own JSON) and is already used the same way
for \`ssh-server\` and \`container-tunnel\` (\`pkg/tunnel/container.go\`,
\`cmd/workspace/ssh.go\`). It parses each JSON line from the child process and
re-emits it at its original level and message instead of double-wrapping it.

No new logging component added — this is a one-caller fix to use the
existing pattern consistently.

## Verification

- \`go build ./...\` clean
- \`go vet ./pkg/tunnel/...\` clean
- \`go test ./pkg/tunnel/...\` passes