### PR TITLE
ci: disable free-disk-space for up-features job

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -503,7 +503,7 @@ jobs:
 
           - label: up-features
             runner: ubuntu-latest
-            free-disk-space: true
+            free-disk-space: false
             install-kind: true
             requires-secret: false
 


### PR DESCRIPTION
## Problem

`Test up-features on ubuntu-latest` failed with:

```
inspect image temp-2086554238-ccd77:devsy-82658532b00e76c6eb8cfb6b10913fb8: image not found
```

https://github.com/devsy-org/devsy/actions/runs/32018882285/job/95361185253

## Root cause

The full job log (fetched via `gh api .../actions/jobs/95361185253/logs`) shows the build succeeding and the image being verified present, then ~14–25s later, while the `jlumbroso/free-disk-space` step (running with `background: true`) was still pruning Docker images concurrently:

```
10:44:05.563  #12 naming to docker.io/library/temp-2086554238-ccd77:devsy-8265...  done
10:44:31.295  INFO inspecting image: image=temp-2086554238-ccd77:devsy-8265...
10:44:31.299  Deleted Images: untagged: ghcr.io/github/github-mcp-server:latest ...
10:44:41.298  ERROR ... image not found
```

The freshly built, not-yet-referenced-by-a-container image got swept up by the background disk-cleanup's `docker image prune` before the container could start. This is a CI workflow race, not an application bug.

## Fix

Set `free-disk-space: false` for the `up-features` (ubuntu-latest) matrix entry so the background image-prune step no longer runs for this job. This job doesn't need the extra disk headroom badly enough to risk racing its own devcontainer builds.

Other `free-disk-space: true` matrix entries (`provider`, `up-workspaces`, `up-handle-errors`, `up-provider-kubernetes`) are unchanged.