### PR TITLE
fix(docker): stop running container before removing it in DeleteDevContainer

### DIFF
--- a/pkg/driver/docker/lifecycle.go
+++ b/pkg/driver/docker/lifecycle.go
@@ -17,6 +17,8 @@ import (
 
 const containerRestartAttempts = 3
 
+const containerStatusRunning = "running"
+
 // snapshotImageLabel marks a committed image as a devsy workspace snapshot,
 // so it's identifiable via `docker inspect`/`docker images --filter` by
 // anyone who pulls or lists it outside `devsy snapshot` tooling — the
@@ -72,7 +74,7 @@ func (d *dockerDriver) ensureContainerRunning(
 			status,
 		)
 	}
-	if status == "running" {
+	if status == containerStatusRunning {
 		return nil
 	}
 
@@ -189,6 +191,8 @@ func (d *dockerDriver) CommitContainer(ctx context.Context, workspaceID, tag str
 	return nil
 }
 
+// DeleteDevContainer stops a still-running container before removing it,
+// since podman/docker refuse to `rm` a running container.
 func (d *dockerDriver) DeleteDevContainer(ctx context.Context, workspaceId string) error {
 	container, err := d.FindDevContainer(ctx, workspaceId)
 	if err != nil {
@@ -197,12 +201,13 @@ func (d *dockerDriver) DeleteDevContainer(ctx context.Context, workspaceId strin
 		return nil
 	}
 
-	err = d.Docker.Remove(ctx, container.ID)
-	if err != nil {
-		return err
+	if strings.ToLower(container.State.Status) == containerStatusRunning {
+		if err := d.Docker.Stop(ctx, container.ID); err != nil {
+			log.Warnf("stop before delete failed for %s: %v", container.ID, err)
+		}
 	}
 
-	return nil
+	return d.Docker.Remove(ctx, container.ID)
 }
 
 func (d *dockerDriver) StartDevContainer(ctx context.Context, workspaceId string) error {

--- a/pkg/driver/docker/lifecycle_test.go
+++ b/pkg/driver/docker/lifecycle_test.go
@@ -203,7 +203,7 @@ func TestEnsureContainerRunning_AlreadyRunning(t *testing.T) {
 	d := &dockerDriver{Docker: &docker.DockerHelper{DockerCommand: testDockerCmd}}
 	container := &config.ContainerDetails{
 		ID:    "c1",
-		State: config.ContainerDetailsState{Status: "running"},
+		State: config.ContainerDetailsState{Status: containerStatusRunning},
 	}
 
 	require.NoError(t, d.ensureContainerRunning(context.Background(), container))
@@ -325,4 +325,36 @@ esac
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestDeleteDevContainer_StopsRunningContainerBeforeRemove(t *testing.T) {
+	dir := t.TempDir()
+	calls := filepath.Join(dir, "calls")
+	script := `#!/bin/sh
+echo "$1" >> "` + calls + `"
+case "$1" in
+  inspect)
+    echo '[{"ID":"c1","State":{"Status":"running"}}]'
+    ;;
+  stop) ;;
+  rm)
+    if ! grep -q '^stop$' "` + calls + `"; then
+      echo "cannot remove running container" >&2
+      exit 1
+    fi
+    ;;
+esac
+`
+	bin := filepath.Join(dir, "docker-fake")
+	require.NoError(t, os.WriteFile(bin, []byte(script), 0o755)) //nolint:gosec
+
+	d := &dockerDriver{Docker: &docker.DockerHelper{DockerCommand: bin, ContainerID: "c1"}}
+
+	err := d.DeleteDevContainer(context.Background(), "ws1")
+	require.NoError(t, err)
+
+	logged, readErr := os.ReadFile(calls) //nolint:gosec // G304: test-controlled path
+	require.NoError(t, readErr)
+	assert.Contains(t, string(logged), "stop\n")
+	assert.Contains(t, string(logged), "rm\n")
 }


### PR DESCRIPTION
## Root cause

CI job `up-provider-podman-rootful-features (rootful)` failed ([run 32075302649](https://github.com/devsy-org/devsy/actions/runs/32075302649/job/95533405340)):

1. During the "should use custom image" spec, the container's SSH tunnel died abnormally mid-command (transient, expected occasionally on loaded CI runners).
2. The spec's `DeferCleanup` called `workspace delete` → `dockerDriver.DeleteDevContainer`, which called `podman rm <id>` **directly, without stopping the container first**. The container was still running (only the exec session into it had died), so `podman rm` (non-force) refused with "container is running" and cleanup failed.
3. Ginkgo retried the whole spec, but the container was never removed — it leaked, still running, consuming resources on the runner.
4. Every subsequent podman command in the same job (including an unrelated `sudo podman ps` in the next spec) then slowed dramatically under the resulting contention, blowing through spec timeouts, and the whole test binary eventually panicked with `test timed out after 10m0s`.

`pkg/driver/docker/lifecycle.go`'s `DeleteDevContainer` was the only driver skipping stop-before-remove — both `pkg/driver/apple/lifecycle.go` and `pkg/driver/microsandbox/microsandbox.go` already stop a running container before removing it.

## Fix

`DeleteDevContainer` now stops a running container before removing it, mirroring the Apple driver's pattern: a stop failure is logged but removal is still attempted.

## Verification

- Added `TestDeleteDevContainer_StopsRunningContainerBeforeRemove`, which fails against the pre-fix code with the exact error class seen in CI (`cannot remove running container`) and passes with the fix.
- `go build ./...` and `go test ./pkg/driver/docker/...` pass.
- `golangci-lint run ./pkg/driver/docker/...` clean (pre-existing, unrelated `cyclop` finding in `runPreflight` untouched).