### PR TITLE
docs(site): update landing page

### DIFF
--- a/sites/docs-devsy-sh/app/(home)/layout.tsx
+++ b/sites/docs-devsy-sh/app/(home)/layout.tsx
@@ -3,23 +3,23 @@ import { HomeLayout } from 'fumadocs-ui/layouts/home';
 import { baseOptions } from '@/lib/layout.shared';
 
 export const metadata: Metadata = {
-  title: 'Devsy: Standardized development workspaces, engineering at scale',
+  title: 'Devsy: Devcontainer Workspaces, Any Backend, No Lock-In',
   description:
-    'Devsy gives teams and AI coding agents standardized, isolated workspaces that cut hardware cost, shorten onboarding, and contain agent risk. Deploy across Docker, Kubernetes, cloud providers, and SSH hosts.',
+    'Devsy runs devcontainer-based developer workspaces as Docker containers, Kubernetes pods, or microVMs, for engineers and their AI agents.',
   openGraph: {
     type: 'website',
     siteName: 'Devsy',
-    title: 'Devsy: Engineering at scale',
+    title: 'Devsy: Devcontainer Workspaces, Any Backend',
     description:
-      'Standardized, reproducible development workspaces that run anywhere: local, cloud, Kubernetes, or remote SSH.',
+      'Developer workspaces built from your devcontainer.json, portable across Docker, Kubernetes, microVMs, cloud, and SSH.',
     url: 'https://www.devsy.sh/',
     images: 'https://www.devsy.sh/docs/media/devsy.png',
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Devsy: Engineering at scale',
+    title: 'Devsy: Devcontainer Workspaces, Any Backend',
     description:
-      'Standardized, reproducible development workspaces that run anywhere: local, cloud, Kubernetes, or remote SSH.',
+      'Developer workspaces built from your devcontainer.json, portable across Docker, Kubernetes, microVMs, cloud, and SSH.',
     images: 'https://www.devsy.sh/docs/media/devsy.png',
   },
 };

--- a/sites/docs-devsy-sh/app/(home)/page.tsx
+++ b/sites/docs-devsy-sh/app/(home)/page.tsx
@@ -131,7 +131,7 @@ export default function HomePage() {
               Secure workspaces, built using a devcontainer.json, for developers and agents.
             </p>
             <p className="lede">
-              Devsy runs the same developer environment in a Docker container, a Kubernetes pod, microVM, 
+              Devsy runs the same developer environment in a Docker container, a Kubernetes pod, microVM,
               on a laptop, in the cloud, or on a shared host. Switch backends with one command. No
               rewrite, and no lock-in.
             </p>

--- a/sites/docs-devsy-sh/app/(home)/page.tsx
+++ b/sites/docs-devsy-sh/app/(home)/page.tsx
@@ -128,12 +128,12 @@ export default function HomePage() {
               Ship from <span className="grad">day zero</span>.
             </h1>
             <p className="hero-sub">
-              Developer workspaces, built from your devcontainer.json, for engineers and their AI agents.
+              Secure workspaces, built using a devcontainer.json, for developers and agents.
             </p>
             <p className="lede">
-              Devsy runs the same devcontainer.json as a Docker container, a Kubernetes pod, or a hardware-isolated
-              microVM, on a laptop, in the cloud, or on a shared host. Switch backends with one command. No
-              rewrite, no lock-in, and the isolation that protects your engineers protects every agent too.
+              Devsy runs the same developer environment in a Docker container, a Kubernetes pod, microVM, 
+              on a laptop, in the cloud, or on a shared host. Switch backends with one command. No
+              rewrite, and no lock-in.
             </p>
             <div className="hero-cta">
               <a className="btn btn-primary" href="/docs/getting-started/install">

--- a/sites/docs-devsy-sh/app/(home)/page.tsx
+++ b/sites/docs-devsy-sh/app/(home)/page.tsx
@@ -131,9 +131,9 @@ export default function HomePage() {
               Secure workspaces, at scale, for developers and agents.
             </p>
             <p className="lede">
-              Devsy runs the same developer environment in a Docker container, a Kubernetes pod, microVM,
-              on a laptop, in the cloud, or on a shared host. Switch backends with one command. No
-              rewrite and no lock-in.
+              Devsy runs the same developer environment in a Docker container, a Kubernetes pod, or a microVM,
+              whether it runs on a laptop, in the cloud, or on a shared host. Switch backends with one command.
+              No rewrite and no lock-in.
             </p>
             <div className="hero-cta">
               <a className="btn btn-primary" href="/docs/getting-started/install">

--- a/sites/docs-devsy-sh/app/(home)/page.tsx
+++ b/sites/docs-devsy-sh/app/(home)/page.tsx
@@ -127,10 +127,13 @@ export default function HomePage() {
             <h1>
               Ship from <span className="grad">day zero</span>.
             </h1>
-            <p className="hero-sub">Standardized workspaces, engineering at scale.</p>
+            <p className="hero-sub">
+              Developer workspaces, built from your devcontainer.json, for engineers and their AI agents.
+            </p>
             <p className="lede">
-              Devsy gives every engineer the same environment. Cut hardware cost, shorten onboarding, and raise
-              developer productivity. Deploy across Docker, Kubernetes, cloud providers, and SSH hosts.
+              Devsy runs the same devcontainer.json as a Docker container, a Kubernetes pod, or a hardware-isolated
+              microVM, on a laptop, in the cloud, or on a shared host. Switch backends with one command. No
+              rewrite, no lock-in, and the isolation that protects your engineers protects every agent too.
             </p>
             <div className="hero-cta">
               <a className="btn btn-primary" href="/docs/getting-started/install">

--- a/sites/docs-devsy-sh/app/(home)/page.tsx
+++ b/sites/docs-devsy-sh/app/(home)/page.tsx
@@ -128,12 +128,12 @@ export default function HomePage() {
               Ship from <span className="grad">day zero</span>.
             </h1>
             <p className="hero-sub">
-              Secure workspaces, built using a devcontainer.json, for developers and agents.
+              Secure workspaces, at scale, for developers and agents.
             </p>
             <p className="lede">
               Devsy runs the same developer environment in a Docker container, a Kubernetes pod, microVM,
               on a laptop, in the cloud, or on a shared host. Switch backends with one command. No
-              rewrite, and no lock-in.
+              rewrite and no lock-in.
             </p>
             <div className="hero-cta">
               <a className="btn btn-primary" href="/docs/getting-started/install">

--- a/sites/docs-devsy-sh/content/docs/what-is-devsy.mdx
+++ b/sites/docs-devsy-sh/content/docs/what-is-devsy.mdx
@@ -1,9 +1,10 @@
 ---
-title: What is Devsy?
+title: What is Devsy? Devcontainer Workspaces for Any Backend
 sidebar_label: What is Devsy?
+description: Devsy runs devcontainer-based developer workspaces as Docker containers, Kubernetes pods, or microVMs, on any machine, cloud, or SSH host.
 ---
 
-Devsy helps organizations scale their engineering operations with standardized, reproducible development environments. Each environment runs in its own container, defined by a [devcontainer.json](https://containers.dev/) that lives alongside your source. [Devsy providers](./managing-providers/what-are-providers) provision those containers on a developer's machine, any reachable remote host, or in a public or private cloud — and you can extend Devsy with your own custom providers.
+Devsy helps organizations scale their engineering operations with standardized, reproducible development environments. Each environment runs as a container, a Kubernetes pod, or a hardware-isolated microVM, defined by a [devcontainer.json](https://containers.dev/) that lives alongside your source. [Devsy providers](./managing-providers/what-are-providers) provision those environments on a developer's machine, any reachable remote host, or in a public or private cloud, and you can extend Devsy with your own custom providers.
 
 <figure>
   <img src="/docs/media/devsy-flow.gif" alt="Animated demo of launching Devsy, connecting to a workspace, and opening it in an IDE" />

--- a/sites/docs-devsy-sh/content/docs/what-is-devsy.mdx
+++ b/sites/docs-devsy-sh/content/docs/what-is-devsy.mdx
@@ -1,7 +1,7 @@
 ---
 title: What is Devsy?
 sidebar_label: What is Devsy?
-description: Devsy runs devcontainer-based developer workspaces as Docker containers, Kubernetes pods, or microVMs, on any machine, cloud, or SSH host.
+description: Devsy runs devcontainer-based developer workspaces as Docker containers, Kubernetes pods, or microVMs on local machines, remote SSH hosts, or public and private clouds.
 ---
 
 Devsy enables organizations to scale their engineering operations through standardized, trusted development environments. Environments run as containers, Kubernetes pods, or hardware-isolated microVMs, defined by a [devcontainer.json](https://containers.dev/) that lives alongside your source. [Devsy providers](./managing-providers/what-are-providers) provision those environments on a developer's machine, any reachable remote host, or in a public or private cloud, and you can extend Devsy with your own custom providers.

--- a/sites/docs-devsy-sh/content/docs/what-is-devsy.mdx
+++ b/sites/docs-devsy-sh/content/docs/what-is-devsy.mdx
@@ -4,7 +4,7 @@ sidebar_label: What is Devsy?
 description: Devsy runs devcontainer-based developer workspaces as Docker containers, Kubernetes pods, or microVMs, on any machine, cloud, or SSH host.
 ---
 
-Devsy helps organizations scale their engineering operations with standardized, reproducible development environments. Environments run as containers, Kubernetes pods, or hardware-isolated microVMs, defined by a [devcontainer.json](https://containers.dev/) that lives alongside your source. [Devsy providers](./managing-providers/what-are-providers) provision those environments on a developer's machine, any reachable remote host, or in a public or private cloud, and you can extend Devsy with your own custom providers.
+Devsy enables organizations to scale their engineering operations through standardized, trusted development environments. Environments run as containers, Kubernetes pods, or hardware-isolated microVMs, defined by a [devcontainer.json](https://containers.dev/) that lives alongside your source. [Devsy providers](./managing-providers/what-are-providers) provision those environments on a developer's machine, any reachable remote host, or in a public or private cloud, and you can extend Devsy with your own custom providers.
 
 <figure>
   <img src="/docs/media/devsy-flow.gif" alt="Animated demo of launching Devsy, connecting to a workspace, and opening it in an IDE" />

--- a/sites/docs-devsy-sh/content/docs/what-is-devsy.mdx
+++ b/sites/docs-devsy-sh/content/docs/what-is-devsy.mdx
@@ -1,10 +1,10 @@
 ---
-title: What is Devsy? Devcontainer Workspaces for Any Backend
+title: What is Devsy?
 sidebar_label: What is Devsy?
 description: Devsy runs devcontainer-based developer workspaces as Docker containers, Kubernetes pods, or microVMs, on any machine, cloud, or SSH host.
 ---
 
-Devsy helps organizations scale their engineering operations with standardized, reproducible development environments. Each environment runs as a container, a Kubernetes pod, or a hardware-isolated microVM, defined by a [devcontainer.json](https://containers.dev/) that lives alongside your source. [Devsy providers](./managing-providers/what-are-providers) provision those environments on a developer's machine, any reachable remote host, or in a public or private cloud, and you can extend Devsy with your own custom providers.
+Devsy helps organizations scale their engineering operations with standardized, reproducible development environments. Environments run as containers, Kubernetes pods, or hardware-isolated microVMs, defined by a [devcontainer.json](https://containers.dev/) that lives alongside your source. [Devsy providers](./managing-providers/what-are-providers) provision those environments on a developer's machine, any reachable remote host, or in a public or private cloud, and you can extend Devsy with your own custom providers.
 
 <figure>
   <img src="/docs/media/devsy-flow.gif" alt="Animated demo of launching Devsy, connecting to a workspace, and opening it in an IDE" />


### PR DESCRIPTION
## Summary

Repositions the devsy.sh landing hero, home page metadata, and the
`what-is-devsy` docs intro so devcontainer terminology and the
backend-agnostic value prop are explicit and indexable, instead of a
generic "cut onboarding cost" claim shared by every competing
dev-environment tool.

- Hero sub/lede now name `devcontainer.json` explicitly and tie together
  the two audiences the page already serves structurally (engineers and
  their AI agents), via the backend-agnostic mechanic: same
  `devcontainer.json` runs as a Docker container, Kubernetes pod, or
  hardware-isolated microVM, switchable with one command.
- Home page `<title>`, `<meta description>`, OpenGraph, and Twitter tags
  updated to match.
- `content/docs/what-is-devsy.mdx` gets a keyword-rich title, a new
  `description` frontmatter field (schema already supported it, unused
  until now), and its opening paragraph now names Kubernetes pods and
  microVMs alongside plain containers.

No em dashes, no adverbs, per stakeholder style preference.

## Scope

Three files only: `app/(home)/page.tsx`, `app/(home)/layout.tsx`,
`content/docs/what-is-devsy.mdx`. Nav copy, other landing sections
(FEATURES/AGENTS/DEPLOY ANYWHERE), other docs pages, `dl-devsy-sh`, and
`images-devsy-sh` are untouched.

## Verification

`npm run build` in `sites/docs-devsy-sh` succeeds. Static export HTML
confirmed the new `<title>`, `<meta description>`, `og:title`,
`og:description`, `twitter:title`, `twitter:description`, hero copy, and
docs page title/description all render correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated homepage messaging to highlight secure, scalable workspaces for developers and AI agents.
  * Clarified support for Docker, Kubernetes, microVMs, local and cloud infrastructure, and flexible execution backends.
  * Refreshed page titles, descriptions, and social sharing metadata to reflect portability and provider flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->