### PR TITLE
test(e2e): add debug flag to up stream

### DIFF
--- a/e2e/framework/command.go
+++ b/e2e/framework/command.go
@@ -80,7 +80,7 @@ func (f *Framework) DevsyUpStreams(
 	workspace string,
 	additionalArgs ...string,
 ) (string, string, error) {
-	upArgs := []string{cmdWorkspace, "up", flagIDE, ideNone, workspace}
+	upArgs := []string{cmdWorkspace, "up", flagDebug, flagIDE, ideNone, workspace}
 	upArgs = append(upArgs, additionalArgs...)
 
 	stdout, stderr, err := execWithDockerRetry(


### PR DESCRIPTION
Signed-off-by: Samuel K <skevetter@pm.me>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace startup commands now correctly preserve the debug setting while retaining the selected IDE and additional options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->