### PR TITLE
fix(agent): stop excluding .devsy-internal from streamed workspace mount

### DIFF
--- a/e2e/tests/build/build.go
+++ b/e2e/tests/build/build.go
@@ -383,6 +383,49 @@ var _ = ginkgo.Describe("devsy build test suite", ginkgo.Label("build"), ginkgo.
 				},
 			)
 		})
+
+	ginkgo.It(
+		"kubernetes dockerless build cleans up .devsy-internal after streaming",
+		ginkgo.SpecTimeout(framework.TimeoutShort()),
+		func(ctx context.Context) {
+			if runtime.GOOS == osWindows {
+				ginkgo.Skip("skipping on windows")
+			}
+
+			f := framework.NewDefaultFramework(initialDir + "/bin")
+			tempDir, err := framework.CopyToTempDir("tests/build/testdata/kubernetes")
+			framework.ExpectNoError(err)
+			ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+			_ = f.DevsyProviderDelete(ctx, "kubernetes")
+			err = f.DevsyProviderAdd(ctx, "kubernetes")
+			framework.ExpectNoError(err)
+			err = f.DevsyProviderUse(ctx, "kubernetes", "-o", "KUBERNETES_NAMESPACE=devsy")
+			framework.ExpectNoError(err)
+
+			ginkgo.DeferCleanup(f.DevsyWorkspaceDelete, tempDir)
+
+			err = f.DevsyUp(ctx, tempDir)
+			framework.ExpectNoError(err)
+
+			out, err := f.DevsySSH(ctx, tempDir, "echo -n $MY_TEST")
+			framework.ExpectNoError(err)
+			framework.ExpectEqual(out, "test456")
+
+			workspaceArtifact := "/workspaces/" + filepath.Base(tempDir) +
+				"/.devcontainer/" + config.DevsyContextFeatureFolder
+			_, err = f.DevsySSH(ctx, tempDir, "test -e "+workspaceArtifact)
+			framework.ExpectError(err)
+
+			hostArtifact := filepath.Join(
+				tempDir,
+				".devcontainer",
+				config.DevsyContextFeatureFolder,
+			)
+			_, statErr := os.Stat(hostArtifact)
+			framework.ExpectEqual(os.IsNotExist(statErr), true)
+		},
+	)
 })
 
 func validateKubernetesDeploymentWithoutDocker(

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -482,8 +482,6 @@ func (t *tunnelServer) StreamWorkspace(
 		}
 	}
 
-	excludes = append(excludes, config.BuildArtifactExcludes()...)
-
 	buf := bufio.NewWriterSize(NewStreamWriter(stream), 10*1024)
 	err = extract.WriteTarExclude(buf, t.workspace.Source.LocalFolder, false, excludes)
 	if err != nil {
@@ -516,7 +514,7 @@ func (t *tunnelServer) StreamMount(
 		return fmt.Errorf("mount %s is not allowed to download", message.Mount)
 	}
 
-	excludes := append(t.workspaceIgnoreExcludes(), config.BuildArtifactExcludes()...)
+	excludes := t.workspaceIgnoreExcludes()
 
 	buf := bufio.NewWriterSize(NewStreamWriter(stream), 10*1024)
 	err := extract.WriteTarExclude(buf, mount.Source, false, excludes)

--- a/pkg/agent/tunnelserver/tunnelserver_test.go
+++ b/pkg/agent/tunnelserver/tunnelserver_test.go
@@ -74,6 +74,105 @@ func TestStreamSnapshotVolumes_TarsMountTargets(t *testing.T) {
 	require.True(t, found, "expected tar entry %q not found", wantName)
 }
 
+type fakeStreamServer struct {
+	tunnel.Tunnel_StreamWorkspaceServer
+	chunks [][]byte
+}
+
+func (f *fakeStreamServer) Send(c *tunnel.Chunk) error {
+	f.chunks = append(f.chunks, c.Content)
+	return nil
+}
+
+func (f *fakeStreamServer) Context() context.Context { return context.Background() }
+
+func tarEntryNames(t *testing.T, chunks [][]byte) []string {
+	t.Helper()
+	var buf bytes.Buffer
+	for _, c := range chunks {
+		buf.Write(c)
+	}
+	var names []string
+	tr := tar.NewReader(&buf)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		names = append(names, hdr.Name)
+	}
+	return names
+}
+
+func TestStreamWorkspace_IncludesDevsyInternalBuildArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	internalDir := filepath.Join(dir, config.DevsyContextFeatureFolder)
+	require.NoError(t, os.MkdirAll(internalDir, 0o750))
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(internalDir, "Dockerfile-without-features"),
+			[]byte("FROM scratch"),
+			0o600,
+		),
+	)
+
+	srv := &tunnelServer{
+		workspace: &provider2.Workspace{Source: provider2.WorkspaceSource{LocalFolder: dir}},
+	}
+
+	fake := &fakeStreamServer{}
+	require.NoError(t, srv.StreamWorkspace(&tunnel.Empty{}, fake))
+
+	names := tarEntryNames(t, fake.chunks)
+	require.Contains(
+		t,
+		names,
+		filepath.ToSlash(filepath.Join(
+			config.DevsyContextFeatureFolder,
+			"Dockerfile-without-features",
+		)),
+	)
+}
+
+func TestStreamMount_IncludesDevsyInternalBuildArtifacts(t *testing.T) {
+	dir := t.TempDir()
+	mountSource := filepath.Join(dir, "mount")
+	internalDir := filepath.Join(mountSource, config.DevsyContextFeatureFolder)
+	require.NoError(t, os.MkdirAll(internalDir, 0o750))
+	require.NoError(
+		t,
+		os.WriteFile(
+			filepath.Join(internalDir, "Dockerfile-without-features"),
+			[]byte("FROM scratch"),
+			0o600,
+		),
+	)
+
+	srv := &tunnelServer{
+		mounts: []*config.Mount{
+			{Source: mountSource, Target: "/workspaces/e2e"},
+		},
+	}
+
+	fake := &fakeStreamServer{}
+	require.NoError(
+		t,
+		srv.StreamMount(&tunnel.StreamMountRequest{Mount: srv.mounts[0].String()}, fake),
+	)
+
+	names := tarEntryNames(t, fake.chunks)
+	require.Contains(
+		t,
+		names,
+		filepath.ToSlash(filepath.Join(
+			config.DevsyContextFeatureFolder,
+			"Dockerfile-without-features",
+		)),
+	)
+}
+
 func TestRunWithResult_CancelBeforeResult(t *testing.T) {
 	srv := New()
 


### PR DESCRIPTION
## Problem

Kubernetes-provider `workspace up` for a Dockerfile-backed devcontainer fails before the Dockerless build starts:

```
dockerless build: rename dir: open /workspaces/.dockerless/.devsy-internal: no such file or directory
```

## Root cause

The Kubernetes dockerless fallback (`dockerlessFallback` in `pkg/devcontainer/build.go`) generates `.devsy-internal/Dockerfile-without-features` on the host, inside the Dockerfile build context, before the pod exists. Since Kubernetes has no bind mount, the primary workspace content (including the build context) is delivered into the pod exclusively via the tunnel `StreamWorkspace`/`StreamMount` RPCs (`pkg/agent/tunnelserver/tunnelserver.go`).

Both of those RPCs appended `config.BuildArtifactExcludes()` (`.devsy-internal`) to their tar excludes, so the generated build context never reached the pod. In-pod, `prepareBuildDirectory` (`pkg/agent/dockerless.go`) then can't find it at either the primary location or the `/workspaces/.dockerless` fallback, producing the observed `rename dir` error.

The exclude was introduced in `8e32743af` (#615) to fix build-artifact leakage into `LocalDockerDelivery`'s docker-volume seeding (`pkg/agent/delivery/workspace_seed.go`), which has its own independent tar/exclude logic and is unaffected by this change — the tunnelserver changes in that commit were an unrelated, untested "also fix it here" that caused this regression.

## Fix

Remove `config.BuildArtifactExcludes()` from `StreamWorkspace` and `StreamMount`. Cleanup of `.devsy-internal` is unaffected: it still happens host-side (`cleanupBuildInformation` in `run.go`) and in-pod (`cleanupBuildDirectory` in `dockerless.go`) after the build.

## Testing

- `pkg/agent/tunnelserver/tunnelserver_test.go`: added `TestStreamWorkspace_IncludesDevsyInternalBuildArtifacts` and `TestStreamMount_IncludesDevsyInternalBuildArtifacts`, which seed a `.devsy-internal/Dockerfile-without-features` file and assert it survives the tar stream. Verified both fail against the pre-fix exclude and pass with the fix.
- `e2e/tests/build/build.go`: added `"kubernetes dockerless build cleans up .devsy-internal after streaming"`, exercising the exact repro (Dockerfile-backed devcontainer + Kubernetes provider + `up`), asserting the build actually ran with the transported Dockerfile and that `.devsy-internal` doesn't linger in the pod workspace or on the host afterward. Requires a kind cluster; not run locally in this sandbox.

Fixes #1108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace and mount streaming now preserves required internal build artifacts during transfers.
  * Improved dockerless Kubernetes builds by ensuring temporary build artifacts are properly removed after streaming completes.
* **Tests**
  * Added end-to-end coverage for dockerless Kubernetes builds.
  * Added validation for workspace and mount streaming contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->