### PR TITLE
fix(client): stream internal subprocess logs through PipeJSONStream

### DIFF
--- a/pkg/client/clientimplementation/workspace_client.go
+++ b/pkg/client/clientimplementation/workspace_client.go
@@ -561,8 +561,11 @@ func (s *workspaceClient) deleteContainer(ctx context.Context, opt client.Delete
 		return nil
 	}
 
-	writer := log.Writer(log.LevelInfo)
-	defer func() { _ = writer.Close() }()
+	writer, done := log.PipeJSONStream()
+	defer func() {
+		_ = writer.Close()
+		<-done
+	}()
 
 	log.Info("deleting workspace container")
 	command, err := s.agentWorkspaceCommand("delete")
@@ -599,8 +602,11 @@ func (s *workspaceClient) deleteMachine(ctx context.Context, opt client.DeleteOp
 }
 
 func (s *workspaceClient) stopContainer(ctx context.Context) error {
-	writer := log.Writer(log.LevelInfo)
-	defer func() { _ = writer.Close() }()
+	writer, done := log.PipeJSONStream()
+	defer func() {
+		_ = writer.Close()
+		<-done
+	}()
 
 	log.Info("stopping container")
 	command, err := s.agentWorkspaceCommand("stop")


### PR DESCRIPTION
## Problem

Workspace stop/delete logs showed doubly nested JSON:

```
2026-08-21T00:06:18.836-0500    INFO    {"level":"debug","ts":"2026-08-21T00:06:18.836-0500","msg":"stopping Devsy container"}
```

## Root cause

`deleteContainer`/`stopContainer` in `workspace_client.go` run
`devsy internal agent workspace delete|stop` as a subprocess and capture
its stdout/stderr with `log.Writer(log.LevelInfo)`. `cmd/internal/agent.go`
always forces internal commands to `--log-output json`, so that subprocess
only ever emits structured JSON log lines. `log.Writer`'s `levelWriter` just
re-logs each captured line verbatim as a message — wrapping the child's
already-JSON line inside another log record.

## Fix

Use `log.PipeJSONStream()` instead, which parses each line and re-emits it
at its original level/message. This is the same pattern already used for
other internal JSON-emitting subprocesses (`cmd/workspace/ssh.go`,
`cmd/workspace/gpg_tunnel.go`, `pkg/client/clientimplementation/proxy_client.go`).
Close+drain moved to a `defer` so early-return paths (e.g. `agentWorkspaceCommand`
failing) still drain the pipe goroutine before returning.

## Verification

- `go build ./...`
- `go vet ./pkg/client/clientimplementation/...`
- `go test ./pkg/client/clientimplementation/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging during workspace container deletion and stop operations.
  * Ensured operation logs are fully processed before cleanup completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->