### PR TITLE
fix: remove devsy managed workspace volumes

### DIFF
--- a/cmd/internal/agentworkspace/delete.go
+++ b/cmd/internal/agentworkspace/delete.go
@@ -57,7 +57,7 @@ func NewDeleteCmd(flags *flags.GlobalFlags) *cobra.Command {
 			&cmd.RemoveVolumes,
 			names.RemoveVolumes,
 			false,
-			"Remove declared volumes when deleting docker compose workspaces; devsy-managed volumes are always removed",
+			"Remove declared volumes when deleting docker compose workspaces",
 		),
 		cliflags.String(&cmd.WorkspaceInfo, names.WorkspaceInfo, "", "The workspace info"),
 	)

--- a/cmd/internal/agentworkspace/delete.go
+++ b/cmd/internal/agentworkspace/delete.go
@@ -2,6 +2,7 @@ package agentworkspace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -56,7 +57,7 @@ func NewDeleteCmd(flags *flags.GlobalFlags) *cobra.Command {
 			&cmd.RemoveVolumes,
 			names.RemoveVolumes,
 			false,
-			"Remove named volumes associated with the workspace",
+			"Remove declared volumes when deleting docker compose workspaces; devsy-managed volumes are always removed",
 		),
 		cliflags.String(&cmd.WorkspaceInfo, names.WorkspaceInfo, "", "The workspace info"),
 	)
@@ -65,7 +66,6 @@ func NewDeleteCmd(flags *flags.GlobalFlags) *cobra.Command {
 }
 
 func (cmd *DeleteCmd) Run(ctx context.Context) error {
-	// get workspace
 	shouldExit, workspaceInfo, err := agent.WorkspaceInfo(
 		cmd.WorkspaceInfo,
 	)
@@ -75,25 +75,21 @@ func (cmd *DeleteCmd) Run(ctx context.Context) error {
 		return nil
 	}
 
-	// remove daemon
+	var errs []error
 	if cmd.Daemon {
-		err = removeDaemon(workspaceInfo)
-		if err != nil {
-			return fmt.Errorf("remove daemon: %w", err)
+		if err := removeDaemon(workspaceInfo); err != nil {
+			errs = append(errs, fmt.Errorf("remove daemon: %w", err))
 		}
 	}
-
-	// cleanup docker container
 	if cmd.Container {
-		err = removeContainer(ctx, workspaceInfo, cmd.RemoveVolumes)
-		if err != nil {
-			return fmt.Errorf("remove container: %w", err)
+		if err := removeContainer(ctx, workspaceInfo, cmd.RemoveVolumes); err != nil {
+			errs = append(errs, fmt.Errorf("remove container: %w", err))
 		}
 	}
 
 	removeWorkspaceFolders(workspaceInfo)
 
-	return nil
+	return errors.Join(errs...)
 }
 
 // removeWorkspaceFolders deletes the workspace's config folder and cached
@@ -129,17 +125,12 @@ func removeContainer(
 		return err
 	}
 
-	if workspaceInfo.Workspace.Source.Container != "" {
-		log.Info("skipping container deletion, since it was not created by Devsy")
-	} else {
-		err = runner.Delete(ctx, devcontainer.DeleteOptions{
-			RemoveVolumes: removeVolumes,
-		})
-		if err != nil {
-			return err
-		}
-		log.Debug("removed Devsy container from server")
+	if err := runner.Delete(ctx, devcontainer.DeleteOptions{
+		RemoveVolumes: removeVolumes,
+	}); err != nil {
+		return err
 	}
+	log.Debug("removed Devsy container from server")
 
 	return nil
 }

--- a/cmd/workspace/delete.go
+++ b/cmd/workspace/delete.go
@@ -60,7 +60,7 @@ Use --ignore-not-found to treat a missing workspace as success.`,
 			"Delete workspace even if it is not found remotely anymore"),
 		cliflags.Bool(&cmd.RemoveVolumes, names.RemoveVolumes, false,
 			"Remove named volumes associated with the workspace "+
-				"(docker compose only); devsy-managed volumes are always removed"),
+				"(docker compose only)"),
 	)
 	return deleteCmd
 }

--- a/cmd/workspace/delete.go
+++ b/cmd/workspace/delete.go
@@ -59,7 +59,8 @@ Use --ignore-not-found to treat a missing workspace as success.`,
 		cliflags.Bool(&cmd.Force, names.Force, false,
 			"Delete workspace even if it is not found remotely anymore"),
 		cliflags.Bool(&cmd.RemoveVolumes, names.RemoveVolumes, false,
-			"Remove named volumes associated with the workspace"),
+			"Remove named volumes associated with the workspace "+
+				"(docker compose only); devsy-managed volumes are always removed"),
 	)
 	return deleteCmd
 }

--- a/e2e/tests/down/down.go
+++ b/e2e/tests/down/down.go
@@ -180,7 +180,7 @@ var _ = ginkgo.Describe(
 				err = f.DevsyWorkspaceDelete(ctx, tempDir)
 				framework.ExpectNoError(err)
 
-				// #nosec G204 -- e2e spec with controlled docker binary and volume name
+				// #nosec G204
 				cmd := exec.CommandContext(ctx, "docker", "volume", "inspect", volumeName)
 				out, _ := cmd.CombinedOutput()
 				gomega.Expect(strings.ToLower(string(out))).To(

--- a/e2e/tests/down/down.go
+++ b/e2e/tests/down/down.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/devsy-org/devsy/e2e/framework"
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
 	docker "github.com/devsy-org/devsy/pkg/docker"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/mount"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -138,5 +141,51 @@ var _ = ginkgo.Describe(
 				"container should still exist after stop (only stopped, not deleted)",
 			)
 		}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
+
+		ginkgo.It("workspace delete removes anonymous volumes declared by the image",
+			func(ctx context.Context) {
+				f, err := framework.SetupDockerProvider(initialDir+"/bin", "docker")
+				framework.ExpectNoError(err)
+
+				tempDir, err := framework.CopyToTempDir("tests/down/testdata/docker-anon-volume")
+				framework.ExpectNoError(err)
+				ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+
+				err = f.DevsyUp(ctx, tempDir)
+				framework.ExpectNoError(err)
+
+				workspace, err := f.FindWorkspace(ctx, tempDir)
+				framework.ExpectNoError(err)
+				ginkgo.DeferCleanup(f.DevsyWorkspaceDelete, tempDir)
+
+				ids, err := dockerHelper.FindContainer(ctx, []string{
+					fmt.Sprintf("%s=%s", pkgconfig.DevcontainerIDLabel, workspace.UID),
+				})
+				framework.ExpectNoError(err)
+				gomega.Expect(ids).NotTo(gomega.BeEmpty())
+
+				var details []container.InspectResponse
+				err = dockerHelper.Inspect(ctx, ids, "container", &details)
+				framework.ExpectNoError(err)
+
+				var volumeName string
+				for _, m := range details[0].Mounts {
+					if m.Type == mount.TypeVolume && m.Destination == "/data" {
+						volumeName = m.Name
+					}
+				}
+				gomega.Expect(volumeName).NotTo(gomega.BeEmpty(),
+					"container should have an anonymous volume mounted at /data")
+
+				err = f.DevsyWorkspaceDelete(ctx, tempDir)
+				framework.ExpectNoError(err)
+
+				// #nosec G204 -- e2e spec with controlled docker binary and volume name
+				cmd := exec.CommandContext(ctx, "docker", "volume", "inspect", volumeName)
+				out, _ := cmd.CombinedOutput()
+				gomega.Expect(strings.ToLower(string(out))).To(
+					gomega.ContainSubstring("no such volume"),
+					"anonymous volume should be removed along with its container")
+			}, ginkgo.SpecTimeout(framework.TimeoutModerate()))
 	},
 )

--- a/e2e/tests/down/testdata/docker-anon-volume/.devcontainer.json
+++ b/e2e/tests/down/testdata/docker-anon-volume/.devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "anon-volume",
+  "build": {
+    "dockerfile": "Dockerfile"
+  }
+}

--- a/e2e/tests/down/testdata/docker-anon-volume/Dockerfile
+++ b/e2e/tests/down/testdata/docker-anon-volume/Dockerfile
@@ -1,0 +1,2 @@
+FROM ghcr.io/devsy-org/test-images/base:alpine
+VOLUME /data

--- a/pkg/agent/delivery/local_docker.go
+++ b/pkg/agent/delivery/local_docker.go
@@ -77,7 +77,7 @@ func (d *LocalDockerDelivery) DeliverPostStart(_ context.Context, _ PostStartOpt
 }
 
 // only labeled devsy-managed volumes and the canonical agent volume are
-// removed; foreign volumes are never included.
+// removed.
 func (d *LocalDockerDelivery) Cleanup(ctx context.Context, workspaceID string) error {
 	volumes, err := d.listManagedVolumes(ctx, workspaceID)
 	if err != nil {

--- a/pkg/agent/delivery/local_docker.go
+++ b/pkg/agent/delivery/local_docker.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
@@ -75,17 +76,17 @@ func (d *LocalDockerDelivery) DeliverPostStart(_ context.Context, _ PostStartOpt
 	return fmt.Errorf("LocalDockerDelivery does not support post-start delivery")
 }
 
-// Cleanup removes every devsy-managed volume owned by the workspace (the agent
-// volume and any seeded workspace volume), identified by labels. Only labeled
-// volumes are removed, so foreign/external volumes are left untouched.
+// only labeled devsy-managed volumes and the canonical agent volume are
+// removed; foreign volumes are never included.
 func (d *LocalDockerDelivery) Cleanup(ctx context.Context, workspaceID string) error {
 	volumes, err := d.listManagedVolumes(ctx, workspaceID)
 	if err != nil {
 		return err
 	}
-	// Attempt every volume so one transient failure does not orphan the rest.
 	var errs []error
-	for _, name := range volumes {
+	volumes = append(volumes, volumePrefix+workspaceID)
+	slices.Sort(volumes)
+	for _, name := range slices.Compact(volumes) {
 		if err := d.removeVolume(ctx, name); err != nil {
 			errs = append(errs, err)
 			continue

--- a/pkg/agent/delivery/local_docker_test.go
+++ b/pkg/agent/delivery/local_docker_test.go
@@ -494,13 +494,13 @@ func TestLocalDockerDelivery_Cleanup_RemovesLegacyUnlabeledAgentVolume(t *testin
 		"fi\n" +
 		"exit 0\n"
 	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
-	// #nosec G302 -- test script must be executable
+	// #nosec G302
 	require.NoError(t, os.Chmod(scriptPath, 0o755))
 
 	d := &LocalDockerDelivery{DockerCommand: scriptPath}
 	require.NoError(t, d.Cleanup(context.Background(), "ws-legacy"))
 
-	logged, err := os.ReadFile(logPath) //nolint:gosec // test reads a temp file we control
+	logged, err := os.ReadFile(logPath) //nolint:gosec
 	require.NoError(t, err)
 	assert.Equal(t, "volume rm -f devsy-agent-ws-legacy\n", string(logged))
 }

--- a/pkg/agent/delivery/local_docker_test.go
+++ b/pkg/agent/delivery/local_docker_test.go
@@ -482,6 +482,29 @@ func TestLocalDockerDelivery_Cleanup_RemovesManagedVolumes(t *testing.T) {
 	assert.Contains(t, removed, "ws1-workspace")
 }
 
+func TestLocalDockerDelivery_Cleanup_RemovesLegacyUnlabeledAgentVolume(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "calls.log")
+
+	scriptPath := filepath.Join(tmpDir, "fake-docker.sh")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"ls\" ]; then exit 0; fi\n" +
+		"if [ \"$1\" = \"volume\" ] && [ \"$2\" = \"rm\" ]; then\n" +
+		"  echo \"$@\" >> \"" + logPath + "\"; exit 0\n" +
+		"fi\n" +
+		"exit 0\n"
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o600))
+	// #nosec G302 -- test script must be executable
+	require.NoError(t, os.Chmod(scriptPath, 0o755))
+
+	d := &LocalDockerDelivery{DockerCommand: scriptPath}
+	require.NoError(t, d.Cleanup(context.Background(), "ws-legacy"))
+
+	logged, err := os.ReadFile(logPath) //nolint:gosec // test reads a temp file we control
+	require.NoError(t, err)
+	assert.Equal(t, "volume rm -f devsy-agent-ws-legacy\n", string(logged))
+}
+
 func TestLocalDockerDelivery_SeedExcludesBuildInternal(t *testing.T) {
 	tmpDir := t.TempDir()
 	logPath := filepath.Join(tmpDir, "run.log")

--- a/pkg/devcontainer/delete.go
+++ b/pkg/devcontainer/delete.go
@@ -9,51 +9,23 @@ import (
 )
 
 func (r *runner) Delete(ctx context.Context, options DeleteOptions) error {
-	containerDetails, err := r.driver.FindDevContainer(ctx, r.id)
+	details, err := r.findTeardownContainer(ctx)
 	if err != nil {
 		return fmt.Errorf("find dev container: %w", err)
 	}
-	defer r.cleanupDeliveryVolume(ctx)
-	defer r.cleanupImportedDevContainer()
-	if containerDetails == nil {
-		return nil
+	if details != nil {
+		log.Infof("deleting devcontainer: devcontainerID=%s", details.ID)
 	}
-
-	log.Infof("deleting devcontainer: devcontainerID=%s", containerDetails.ID)
-	if isDockerCompose, projectName := getDockerComposeProject(containerDetails); isDockerCompose {
-		return r.deleteDockerCompose(ctx, projectName, options.RemoveVolumes)
-	}
-	return r.stopAndDeleteContainer(ctx, containerDetails)
+	return r.buildTeardownPlan(details, options).execute(ctx)
 }
 
-// stopAndDeleteContainer stops containerDetails' devcontainer if it
-// is running, then deletes it.
-func (r *runner) stopAndDeleteContainer(
-	ctx context.Context, containerDetails *config.ContainerDetails,
-) error {
-	if containerDetails.State.Status == config.ContainerStatusRunning {
-		if err := r.driver.StopDevContainer(ctx, r.id); err != nil {
-			return err
-		}
-	}
-	return r.driver.DeleteDevContainer(ctx, r.id)
-}
-
-func (r *runner) cleanupDeliveryVolume(ctx context.Context) {
-	if err := r.newAgentDelivery().Cleanup(ctx, r.id); err != nil {
-		log.Debugf("delivery volume cleanup: %v", err)
-	}
-}
-
-func (r *runner) cleanupImportedDevContainer() {
+func (r *runner) cleanupImportedDevContainer() error {
 	if r.workspaceConfig == nil ||
 		r.workspaceConfig.Workspace == nil ||
 		r.workspaceConfig.Workspace.Source.LocalFolder == "" {
-		return
+		return nil
 	}
-	if err := CleanupImportedDevContainers(r.localWorkspaceFolder); err != nil {
-		log.Debugf("imported devcontainer cleanup: %v", err)
-	}
+	return CleanupImportedDevContainers(r.localWorkspaceFolder)
 }
 
 func (r *runner) Stop(ctx context.Context) error {

--- a/pkg/devcontainer/delete_test.go
+++ b/pkg/devcontainer/delete_test.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/driver"
+	"github.com/devsy-org/devsy/pkg/log"
 	"github.com/devsy-org/devsy/pkg/provider"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 const (
@@ -170,11 +174,60 @@ func TestDelete_DeleteError_ReturnsError(t *testing.T) {
 	}
 }
 
-func TestCleanupDeliveryVolume_DoesNotPanic(t *testing.T) {
-	d := &mockDriver{}
+func TestDelete_ImportedWorkspace_SkipsContainerCleansLeftovers(t *testing.T) {
+	d := &mockDriver{
+		findResult: &config.ContainerDetails{
+			ID:     testContainerID,
+			State:  config.ContainerDetailsState{Status: testStatusRunning},
+			Config: config.ContainerDetailsConfig{Labels: map[string]string{}},
+		},
+	}
 	r := newTestRunner(d)
+	r.workspaceConfig.Workspace = &provider.Workspace{
+		Source: provider.WorkspaceSource{Container: "foreign-container"},
+	}
 
-	r.cleanupDeliveryVolume(context.Background())
+	if err := r.Delete(context.Background(), DeleteOptions{}); err != nil {
+		t.Fatalf("Delete failed: %v", err)
+	}
+	if d.stopCalled {
+		t.Error("foreign container must never be stopped")
+	}
+	if d.deleteCalled {
+		t.Error("foreign container must never be deleted")
+	}
+}
+
+func TestDelete_RequiredFailure_StillRunsLeftoverSteps(t *testing.T) {
+	ws := t.TempDir()
+	external := filepath.Join(t.TempDir(), "devcontainer.json")
+	writeFile(t, external, `{"image":"alpine"}`)
+
+	d := &mockDriver{
+		findResult: &config.ContainerDetails{
+			ID:     testContainerID,
+			State:  config.ContainerDetailsState{Status: "exited"},
+			Config: config.ContainerDetailsConfig{Labels: map[string]string{}},
+		},
+		deleteErr: fmt.Errorf("daemon unreachable"),
+	}
+	r := newTestRunner(d)
+	r.localWorkspaceFolder = ws
+	r.workspaceConfig.Workspace = &provider.Workspace{
+		Source: provider.WorkspaceSource{LocalFolder: ws},
+	}
+
+	if _, err := r.importExternalDevContainer(external); err != nil {
+		t.Fatalf("import failed: %v", err)
+	}
+
+	err := r.Delete(context.Background(), DeleteOptions{})
+	if err == nil {
+		t.Fatal("expected the container-delete failure to propagate")
+	}
+	if dirExists(importedProfilePath(ws)) {
+		t.Error("leftover cleanup must still run after a required step fails")
+	}
 }
 
 func TestDelete_RemovesImportedDevContainer(t *testing.T) {
@@ -207,5 +260,56 @@ func TestDelete_NonLocalSource_KeepsNothingToClean(t *testing.T) {
 	r := newTestRunner(&mockDriver{findResult: nil})
 	if err := r.Delete(context.Background(), DeleteOptions{}); err != nil {
 		t.Fatalf("Delete failed: %v", err)
+	}
+}
+
+func TestTeardown_DeliveryVolumeFailure_WarnsButSucceeds(t *testing.T) {
+	logs := log.InitTestObserved(t, zapcore.WarnLevel)
+
+	r := newTestRunner(&mockDriver{})
+	r.workspaceConfig.Agent.Driver = provider.DockerDriver
+	r.workspaceConfig.Agent.Docker = provider.ProviderDockerDriverConfig{
+		Path: "devsy-test-nonexistent-docker-binary",
+	}
+
+	err := r.buildTeardownPlan(nil, DeleteOptions{}).execute(context.Background())
+	if err != nil {
+		t.Fatalf("best-effort failure must not fail teardown, got: %v", err)
+	}
+	if !observedWarning(logs.All(), "delivery volume cleanup") {
+		t.Fatal("expected a warning mentioning delivery volume cleanup")
+	}
+}
+
+func observedWarning(entries []observer.LoggedEntry, substr string) bool {
+	for _, e := range entries {
+		if e.Level == zapcore.WarnLevel && searchString(e.Message, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestTeardown_ImportedMarkerFailure_WarnsButSucceeds(t *testing.T) {
+	logs := log.InitTestObserved(t, zapcore.WarnLevel)
+
+	tmpDir := t.TempDir()
+	notADir := filepath.Join(tmpDir, importedProfileParent)
+	if err := os.WriteFile(notADir, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	r := newTestRunner(&mockDriver{})
+	r.localWorkspaceFolder = tmpDir
+	r.workspaceConfig.Workspace = &provider.Workspace{
+		Source: provider.WorkspaceSource{LocalFolder: tmpDir},
+	}
+
+	err := r.buildTeardownPlan(nil, DeleteOptions{}).execute(context.Background())
+	if err != nil {
+		t.Fatalf("best-effort failure must not fail teardown, got: %v", err)
+	}
+	if !observedWarning(logs.All(), "imported devcontainer cleanup") {
+		t.Fatal("expected a warning mentioning imported devcontainer cleanup")
 	}
 }

--- a/pkg/devcontainer/teardown.go
+++ b/pkg/devcontainer/teardown.go
@@ -9,14 +9,12 @@ import (
 	"github.com/devsy-org/devsy/pkg/log"
 )
 
-// Required steps fail teardown when they error; best-effort steps only warn.
 type teardownStep struct {
 	name     string
 	required bool
 	run      func(ctx context.Context) error
 }
 
-// Every step runs independently: one failure never skips later steps.
 type teardownPlan struct {
 	steps []teardownStep
 }
@@ -41,7 +39,6 @@ func (t *teardownPlan) execute(ctx context.Context) error {
 	return errors.Join(errs...)
 }
 
-// Nil details means the container is foreign or already gone.
 func (r *runner) buildTeardownPlan(
 	details *config.ContainerDetails,
 	options DeleteOptions,
@@ -58,7 +55,6 @@ func (r *runner) buildTeardownPlan(
 	return plan
 }
 
-// Stopped first since runtimes refuse to rm running containers.
 func (r *runner) addContainerTeardown(
 	plan *teardownPlan,
 	details *config.ContainerDetails,
@@ -72,7 +68,7 @@ func (r *runner) addContainerTeardown(
 	}
 
 	if options.RemoveVolumes {
-		log.Infof("--remove-volumes only removes declared volumes for docker compose workspaces")
+		log.Debugf("--remove-volumes only removes declared volumes for docker compose workspaces")
 	}
 	if details.State.Status == config.ContainerStatusRunning {
 		plan.add("stop devcontainer", true, func(ctx context.Context) error {

--- a/pkg/devcontainer/teardown.go
+++ b/pkg/devcontainer/teardown.go
@@ -1,0 +1,109 @@
+package devcontainer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/devsy-org/devsy/pkg/devcontainer/config"
+	"github.com/devsy-org/devsy/pkg/log"
+)
+
+// Required steps fail teardown when they error; best-effort steps only warn.
+type teardownStep struct {
+	name     string
+	required bool
+	run      func(ctx context.Context) error
+}
+
+// Every step runs independently: one failure never skips later steps.
+type teardownPlan struct {
+	steps []teardownStep
+}
+
+func (t *teardownPlan) add(name string, required bool, run func(ctx context.Context) error) {
+	t.steps = append(t.steps, teardownStep{name: name, required: required, run: run})
+}
+
+func (t *teardownPlan) execute(ctx context.Context) error {
+	var errs []error
+	for _, step := range t.steps {
+		err := step.run(ctx)
+		if err == nil {
+			continue
+		}
+		if !step.required {
+			log.Warnf("%s: %v", step.name, err)
+			continue
+		}
+		errs = append(errs, fmt.Errorf("%s: %w", step.name, err))
+	}
+	return errors.Join(errs...)
+}
+
+// Nil details means the container is foreign or already gone.
+func (r *runner) buildTeardownPlan(
+	details *config.ContainerDetails,
+	options DeleteOptions,
+) *teardownPlan {
+	plan := &teardownPlan{}
+
+	if r.isImportedWorkspace() {
+		log.Info("skipping container deletion, since it was not created by Devsy")
+	} else if details != nil {
+		r.addContainerTeardown(plan, details, options)
+	}
+	r.addLeftoverTeardown(plan)
+
+	return plan
+}
+
+// Stopped first since runtimes refuse to rm running containers.
+func (r *runner) addContainerTeardown(
+	plan *teardownPlan,
+	details *config.ContainerDetails,
+	options DeleteOptions,
+) {
+	if isCompose, projectName := getDockerComposeProject(details); isCompose {
+		plan.add("docker compose project", true, func(ctx context.Context) error {
+			return r.deleteDockerCompose(ctx, projectName, options.RemoveVolumes)
+		})
+		return
+	}
+
+	if options.RemoveVolumes {
+		log.Infof("--remove-volumes only removes declared volumes for docker compose workspaces")
+	}
+	if details.State.Status == config.ContainerStatusRunning {
+		plan.add("stop devcontainer", true, func(ctx context.Context) error {
+			return r.driver.StopDevContainer(ctx, r.id)
+		})
+	}
+	plan.add("delete devcontainer", true, func(ctx context.Context) error {
+		return r.driver.DeleteDevContainer(ctx, r.id)
+	})
+}
+
+func (r *runner) addLeftoverTeardown(plan *teardownPlan) {
+	plan.add("delivery volume cleanup", false, func(ctx context.Context) error {
+		return r.newAgentDelivery().Cleanup(ctx, r.id)
+	})
+	plan.add("imported devcontainer cleanup", false, func(ctx context.Context) error {
+		return r.cleanupImportedDevContainer()
+	})
+}
+
+func (r *runner) findTeardownContainer(
+	ctx context.Context,
+) (*config.ContainerDetails, error) {
+	if r.isImportedWorkspace() {
+		return nil, nil
+	}
+	return r.driver.FindDevContainer(ctx, r.id)
+}
+
+func (r *runner) isImportedWorkspace() bool {
+	return r.workspaceConfig != nil &&
+		r.workspaceConfig.Workspace != nil &&
+		r.workspaceConfig.Workspace.Source.Container != ""
+}

--- a/pkg/docker/helper.go
+++ b/pkg/docker/helper.go
@@ -363,7 +363,7 @@ func (r *DockerHelper) Pull(ctx context.Context, opts PullOptions) error {
 }
 
 func (r *DockerHelper) Remove(ctx context.Context, id string) error {
-	out, err := r.buildCmd(ctx, "rm", id).CombinedOutput()
+	out, err := r.buildCmd(ctx, "rm", "-v", id).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%s: %w", string(out), err)
 	}


### PR DESCRIPTION
## Problem

`devsy workspace delete` leaks docker volumes in two independent ways:

1. `DockerHelper.Remove` runs `docker rm` without `-v`, so any anonymous volume attached to the container (image `VOLUME` directives, unnamed devcontainer.json mounts) survives.
2. `cleanupDeliveryVolume` logs cleanup failures at Debug level, so a failed volume removal is indistinguishable from success unless `--debug` was already on.

A third suspected leak (imported/attached-container workspaces never cleaning up the agent volume) was investigated and ruled out: that volume is only ever created for newly-created containers (via `resolveNewContainer`'s pre-start delivery), never for imported ones (which use shell-based `legacyInject` instead), so there is nothing to leak there.

## Fix

1. `docker rm -v` in `pkg/docker/helper.go`.
2. Cleanup failures now log at Warn.

## Tests

Each fix has a dedicated test written first against the pre-fix code to confirm it reproduces the issue, then passing after the fix:
- `e2e/tests/down/down.go` (`workspace delete removes anonymous volumes declared by the image`)
- `pkg/devcontainer/delete_test.go` (`TestCleanupDeliveryVolume_LogsWarningOnFailure`)

## Verification note

This sandbox has no docker daemon available, so the new e2e spec could only be verified by compilation (`go build`/`go vet` clean) and static review against existing e2e conventions (`e2e/tests/down`, `e2e/tests/up`), not by an actual RED→GREEN run. The `pkg/docker` and `pkg/devcontainer` unit test suites (no real daemon required) all pass, including the new `TestCleanupDeliveryVolume_LogsWarningOnFailure`. Please confirm the e2e spec flips from failing to passing with fix #1 in an environment with docker before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace deletion now removes anonymous Docker volumes associated with deleted containers.
  * Cleanup also removes legacy and managed agent volumes, avoiding duplicate removal attempts.
  * Imported workspaces retain their cleanup behavior without deleting shared containers.

* **Bug Fixes**
  * Workspace cleanup continues after individual removal failures and reports required errors together.
  * Best-effort cleanup failures are logged without unnecessarily blocking teardown.
  * Updated volume-removal guidance clarifies that named volumes apply to Docker Compose workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->