### PR TITLE
fix(devcontainer): preserve remote user ownership

### DIFF
--- a/cmd/snapshot/create.go
+++ b/cmd/snapshot/create.go
@@ -120,6 +120,7 @@ func (cmd *CreateCmd) Run(ctx context.Context, devsyConfig *config.Config, args 
 		MountPrefix:             vols.MountPrefix,
 		RunArgs:                 vols.RunArgs,
 		ContainerEnv:            vols.ContainerEnv,
+		RemoteUser:              vols.RemoteUser,
 		ContainerImageMediaType: img.MediaType,
 		ContainerImageDigest:    img.Digest,
 		ContainerImageSize:      img.Size,
@@ -301,6 +302,7 @@ type pushedVolumes struct {
 	MountPrefix  string
 	RunArgs      []string
 	ContainerEnv map[string]string
+	RemoteUser   string
 }
 
 // The volumes RPC (StreamSnapshotVolumes) is served by a tunnelServer reading
@@ -341,6 +343,7 @@ func (cmd *CreateCmd) pushVolumes(
 		MountPrefix:  mountPrefix,
 		RunArgs:      result.MergedConfig.RunArgs,
 		ContainerEnv: redactedContainerEnv(result.MergedConfig.ContainerEnv),
+		RemoteUser:   devcontainerconfig.GetRemoteUser(result),
 	}, nil
 }
 

--- a/cmd/snapshot/restore.go
+++ b/cmd/snapshot/restore.go
@@ -94,6 +94,7 @@ func (cmd *RestoreCmd) Run(
 	if err != nil {
 		return fmt.Errorf("read snapshot container env: %w", err)
 	}
+	remoteUser := manifest.RemoteUser()
 
 	log.Infof("restoring snapshot: ref=%s workspaceId=%s", snapshotRef, ws.ID)
 
@@ -105,6 +106,7 @@ func (cmd *RestoreCmd) Run(
 		DevContainerSource: ws.DevContainerSource,
 		RunArgs:            runArgs,
 		ContainerEnv:       containerEnv,
+		RemoteUser:         remoteUser,
 	})
 }
 

--- a/cmd/workspace/up/up.go
+++ b/cmd/workspace/up/up.go
@@ -86,6 +86,9 @@ type Options struct {
 	// the same suppressed-discovery circumstances as RunArgs. Used by
 	// snapshot restore to replay the original devcontainer.json's containerEnv.
 	ContainerEnv map[string]string
+	// RemoteUser is the remoteUser to replay under the same
+	// suppressed-discovery circumstances as RunArgs. Used by snapshot restore.
+	RemoteUser string
 }
 
 type HeadlessOptions struct {
@@ -202,6 +205,7 @@ func buildUpCmd(g *flags.GlobalFlags, opts Options) *UpCmd {
 	cmd.DevContainerSource = opts.DevContainerSource
 	cmd.RunArgs = opts.RunArgs
 	cmd.ContainerEnv = opts.ContainerEnv
+	cmd.RemoteUser = opts.RemoteUser
 	if opts.Name != "" {
 		cmd.ID = opts.Name
 	}

--- a/cmd/workspace/up/up_client.go
+++ b/cmd/workspace/up/up_client.go
@@ -557,8 +557,9 @@ func (cmd *UpCmd) validateFromSnapshot(ctx context.Context, args []string) error
 }
 
 // applyFromSnapshotOverrides replays the create-time devcontainer.json
-// settings the snapshot's manifest carries (runArgs, containerEnv) onto cmd,
-// so the image-sourced restored container behaves like the original did.
+// settings the snapshot's manifest carries (runArgs, containerEnv,
+// remoteUser) onto cmd, so the image-sourced restored container behaves like
+// the original did.
 func (cmd *UpCmd) applyFromSnapshotOverrides(manifest *snapshotpkg.Manifest) error {
 	runArgs, err := manifest.RunArgs()
 	if err != nil {
@@ -571,6 +572,10 @@ func (cmd *UpCmd) applyFromSnapshotOverrides(manifest *snapshotpkg.Manifest) err
 		return fmt.Errorf("read --from-snapshot container env: %w", err)
 	}
 	cmd.ContainerEnv = containerEnv
+
+	if cmd.RemoteUser == "" {
+		cmd.RemoteUser = manifest.RemoteUser()
+	}
 	return nil
 }
 

--- a/cmd/workspace/up/up_test.go
+++ b/cmd/workspace/up/up_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/flags/names"
 	"github.com/devsy-org/devsy/pkg/ide/opener"
+	provider2 "github.com/devsy-org/devsy/pkg/provider"
+	snapshotpkg "github.com/devsy-org/devsy/pkg/snapshot"
 	"github.com/google/go-containerregistry/pkg/registry"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -421,6 +423,36 @@ func TestUpCmd_ValidateFromSnapshotFailsOnMissingManifest(t *testing.T) {
 	err := cmd.validateFromSnapshot(context.Background(), nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "validate --from-snapshot ref")
+}
+
+func TestUpCmd_ApplyFromSnapshotOverridesKeepsExplicitRemoteUserFlag(t *testing.T) {
+	cmd := &UpCmd{CLIOptions: provider2.CLIOptions{RemoteUser: "explicit-user"}}
+	manifest := mustBuildManifest(t, "snapshot-user")
+
+	require.NoError(t, cmd.applyFromSnapshotOverrides(manifest))
+
+	assert.Equal(t, "explicit-user", cmd.RemoteUser)
+}
+
+func TestUpCmd_ApplyFromSnapshotOverridesUsesSnapshotRemoteUserWhenUnset(t *testing.T) {
+	cmd := &UpCmd{}
+	manifest := mustBuildManifest(t, "snapshot-user")
+
+	require.NoError(t, cmd.applyFromSnapshotOverrides(manifest))
+
+	assert.Equal(t, "snapshot-user", cmd.RemoteUser)
+}
+
+func mustBuildManifest(t *testing.T, remoteUser string) *snapshotpkg.Manifest {
+	t.Helper()
+	manifest, err := snapshotpkg.BuildManifest(snapshotpkg.BuildManifestOptions{
+		WorkspaceUID:         "ws-uid",
+		ContainerImageDigest: "sha256:" + strings.Repeat("a", 64),
+		VolumesDigest:        "sha256:" + strings.Repeat("b", 64),
+		RemoteUser:           remoteUser,
+	})
+	require.NoError(t, err)
+	return manifest
 }
 
 func TestBuildUpCmd_DoesNotMutateCallerGlobalFlags(t *testing.T) {

--- a/e2e/tests/snapshot/snapshot.go
+++ b/e2e/tests/snapshot/snapshot.go
@@ -486,9 +486,6 @@ var _ = ginkgo.Describe("devsy snapshot", ginkgo.Label("snapshot"), func() {
 		framework.ExpectNoError(err)
 		gomega.Expect(content).To(gomega.ContainSubstring("mutated"))
 
-		// Compare the recorded owner name against the devcontainer.json's
-		// remoteUser rather than the SSH session's uid: the ssh session may
-		// resolve to root when no ssh-config entry was written
 		ownerCmd := fmt.Sprintf(
 			`test "$(stat -c %%U %s/marker.txt)" = %q && echo OWNER_OK || echo OWNER_MISMATCH`,
 			restoredWorkspaceFolder, nonRootRemoteUser,

--- a/e2e/tests/snapshot/snapshot.go
+++ b/e2e/tests/snapshot/snapshot.go
@@ -21,6 +21,7 @@ const (
 	snapshotCmd         = "snapshot"
 	snapshotVerbCreate  = "create"
 	snapshotVerbRestore = "restore"
+	nonRootRemoteUser   = "devsyuser"
 )
 
 var _ = ginkgo.Describe("devsy snapshot", ginkgo.Label("snapshot"), func() {
@@ -430,11 +431,6 @@ var _ = ginkgo.Describe("devsy snapshot", ginkgo.Label("snapshot"), func() {
 		restoredWorkspace, err := f.FindWorkspace(ctx, restoredID)
 		framework.ExpectNoError(err)
 
-		// The custom --label runArg only exists in this fixture's
-		// devcontainer.json, not in the base image or --add-host (which the
-		// registry fixture itself already depends on to function at all): its
-		// presence on the restored container proves restore replays the
-		// original runArgs generally, not just the one the test harness needs.
 		containerIDs, err := dockerHelper.FindContainer(ctx, []string{
 			fmt.Sprintf("%s=%s", pkgconfig.DevcontainerIDLabel, restoredWorkspace.UID),
 			"devsy-e2e-snapshot-runargs=true",
@@ -444,5 +440,61 @@ var _ = ginkgo.Describe("devsy snapshot", ginkgo.Label("snapshot"), func() {
 			gomega.BeEmpty(),
 			"restored container should carry the original devcontainer.json's custom runArg label",
 		)
+	}, ginkgo.SpecTimeout(framework.TimeoutLong()))
+
+	ginkgo.It("restores files owned by the remote user when reusing the original id", func(
+		ctx context.Context,
+	) {
+		initialDir, err := os.Getwd()
+		framework.ExpectNoError(err)
+
+		tempDir, err := framework.CopyToTempDir("tests/snapshot/testdata/docker-nonroot")
+		framework.ExpectNoError(err)
+		ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
+		ginkgo.DeferCleanup(f.DevsyWorkspaceDelete, tempDir)
+		framework.ExpectNoError(f.DevsyUp(ctx, tempDir))
+
+		workspaceFolder, err := f.DevsySSH(ctx, tempDir, "pwd")
+		framework.ExpectNoError(err)
+		workspaceFolder = strings.TrimSpace(workspaceFolder)
+
+		markerCmd := fmt.Sprintf("echo mutated > %s/marker.txt", workspaceFolder)
+		_, err = f.DevsySSH(ctx, tempDir, markerCmd)
+		framework.ExpectNoError(err)
+
+		out, _, err := f.ExecCommandCapture(ctx, []string{
+			snapshotCmd, snapshotVerbCreate, tempDir, registryFlag, registryHost + "/e2e/snapshots",
+			debugFlag,
+		})
+		framework.ExpectNoError(err)
+		snapshotRef := strings.TrimSpace(out)
+
+		framework.ExpectNoError(f.DevsyWorkspaceDelete(ctx, tempDir))
+
+		_, _, err = f.ExecCommandCapture(ctx, []string{
+			snapshotCmd, snapshotVerbRestore, snapshotRef, debugFlag,
+		})
+		framework.ExpectNoError(err)
+
+		restoredWorkspaceFolder, err := f.DevsySSH(ctx, tempDir, "pwd")
+		framework.ExpectNoError(err)
+		restoredWorkspaceFolder = strings.TrimSpace(restoredWorkspaceFolder)
+
+		content, err := f.DevsySSH(
+			ctx, tempDir, fmt.Sprintf("cat %s/marker.txt", restoredWorkspaceFolder),
+		)
+		framework.ExpectNoError(err)
+		gomega.Expect(content).To(gomega.ContainSubstring("mutated"))
+
+		// Compare the recorded owner name against the devcontainer.json's
+		// remoteUser rather than the SSH session's uid: the ssh session may
+		// resolve to root when no ssh-config entry was written
+		ownerCmd := fmt.Sprintf(
+			`test "$(stat -c %%U %s/marker.txt)" = %q && echo OWNER_OK || echo OWNER_MISMATCH`,
+			restoredWorkspaceFolder, nonRootRemoteUser,
+		)
+		ownerOut, err := f.DevsySSH(ctx, tempDir, ownerCmd)
+		framework.ExpectNoError(err)
+		gomega.Expect(ownerOut).To(gomega.ContainSubstring("OWNER_OK"))
 	}, ginkgo.SpecTimeout(framework.TimeoutLong()))
 })

--- a/e2e/tests/snapshot/testdata/docker-nonroot/.devcontainer.json
+++ b/e2e/tests/snapshot/testdata/docker-nonroot/.devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "name": "snapshot non-root",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "remoteUser": "devsyuser",
+  "runArgs": ["--add-host=host.docker.internal:host-gateway"],
+  "containerEnv": {
+    "DEVSY_INSECURE_DOCKER_INTERNAL": "true"
+  }
+}

--- a/e2e/tests/snapshot/testdata/docker-nonroot/Dockerfile
+++ b/e2e/tests/snapshot/testdata/docker-nonroot/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/devsy-org/test-images/base:ubuntu
+
+RUN useradd --create-home --shell /bin/bash devsyuser

--- a/pkg/agent/snapshot/restore.go
+++ b/pkg/agent/snapshot/restore.go
@@ -70,7 +70,10 @@ func RestoreVolumes(
 	}
 
 	levels := len(strings.Split(layer.MountPrefix, "/"))
-	if err := extract.Extract(rc, target, extract.StripLevels(levels)); err != nil {
+	if err := extract.Extract(
+		rc, target,
+		extract.StripLevels(levels), extract.PreserveHeaderOwnership(),
+	); err != nil {
 		return fmt.Errorf("extract snapshot volumes into %s: %w", target, err)
 	}
 	return nil

--- a/pkg/copy/copy.go
+++ b/pkg/copy/copy.go
@@ -1,7 +1,6 @@
 package copy
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -28,6 +27,45 @@ func Chown(path string, userName string) error {
 	return os.Lchown(path, uidInt, gidInt)
 }
 
+// ChownFailure is one entry a recursive chown could not reassign.
+type ChownFailure struct {
+	Path string
+	Err  error
+}
+
+func (f ChownFailure) Error() string { return fmt.Sprintf("%s: %v", f.Path, f.Err) }
+
+func (f ChownFailure) Unwrap() error { return f.Err }
+
+// ChownFailures aggregates the entries ChownR could not chown. Callers
+// distinguish wholesale breakage from entries a shared filesystem refuses to
+// reassign via AllDenied.
+type ChownFailures []ChownFailure
+
+func (fs ChownFailures) Error() string {
+	return fmt.Sprintf("%d entries could not be chowned, first: %v", len(fs), fs[0])
+}
+
+func (fs ChownFailures) Unwrap() []error {
+	errs := make([]error, len(fs))
+	for i, f := range fs {
+		errs[i] = f
+	}
+	return errs
+}
+
+// AllDenied reports whether every failure was refused by the filesystem
+// (permission denied or read-only share) — the expected case for entries on
+// virtiofs shares such as read-only .git pack files.
+func (fs ChownFailures) AllDenied() bool {
+	for _, f := range fs {
+		if !DeniedByFilesystem(f.Err) {
+			return false
+		}
+	}
+	return len(fs) > 0
+}
+
 func ChownR(path string, userName string) error {
 	if userName == "" {
 		return nil
@@ -44,28 +82,30 @@ func ChownR(path string, userName string) error {
 	// #nosec G115 -- a resolved system uid is non-negative and fits uint32.
 	uidU32 := uint32(uidInt)
 
-	// A single un-chownable entry (e.g. a read-only file on a virtiofs share)
-	// must not abort the walk and leave the rest of the tree unowned.
-	var errs []error
+	var failures ChownFailures
 	_ = filepath.WalkDir(path, func(name string, dirEntry fs.DirEntry, err error) error {
 		if err != nil {
-			errs = append(errs, err)
+			failures = append(failures, ChownFailure{Path: name, Err: err})
 			return nil
 		}
 		info, err := dirEntry.Info()
 		if err != nil {
+			failures = append(failures, ChownFailure{Path: name, Err: err})
 			return nil
 		}
 		if IsUID(info, uidU32) {
 			return nil
 		}
 		// #nosec G122 -- best-effort chown of a freshly provisioned tree we own; WalkDir yields real paths.
-		if err := os.Lchown(name, uidInt, gidInt); err != nil {
-			errs = append(errs, err)
+		if lerr := os.Lchown(name, uidInt, gidInt); lerr != nil {
+			failures = append(failures, ChownFailure{Path: name, Err: lerr})
 		}
 		return nil
 	})
-	return errors.Join(errs...)
+	if len(failures) == 0 {
+		return nil
+	}
+	return failures
 }
 
 func MkdirAllChown(path string, perm os.FileMode, userName string) error {

--- a/pkg/copy/copy.go
+++ b/pkg/copy/copy.go
@@ -37,9 +37,7 @@ func (f ChownFailure) Error() string { return fmt.Sprintf("%s: %v", f.Path, f.Er
 
 func (f ChownFailure) Unwrap() error { return f.Err }
 
-// ChownFailures aggregates the entries ChownR could not chown. Callers
-// distinguish wholesale breakage from entries a shared filesystem refuses to
-// reassign via AllDenied.
+// ChownFailures aggregates the entries ChownR could not chown.
 type ChownFailures []ChownFailure
 
 func (fs ChownFailures) Error() string {
@@ -55,7 +53,7 @@ func (fs ChownFailures) Unwrap() []error {
 }
 
 // AllDenied reports whether every failure was refused by the filesystem
-// (permission denied or read-only share) — the expected case for entries on
+// (permission denied or read-only share); the expected case for entries on
 // virtiofs shares such as read-only .git pack files.
 func (fs ChownFailures) AllDenied() bool {
 	for _, f := range fs {

--- a/pkg/copy/copy_supported.go
+++ b/pkg/copy/copy_supported.go
@@ -20,6 +20,13 @@ func DeniedByFilesystem(err error) bool {
 	return errors.Is(err, os.ErrPermission) || errors.Is(err, syscall.EROFS)
 }
 
+// Unsupported reports whether err means chown itself isn't a meaningful
+// operation on this platform (Windows only). On unix, chown is always a
+// real operation, so any failure here is a genuine denial, never this.
+func Unsupported(error) bool {
+	return false
+}
+
 func Lchown(info os.FileInfo, sourcePath, destPath string) error {
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {

--- a/pkg/copy/copy_supported.go
+++ b/pkg/copy/copy_supported.go
@@ -20,7 +20,7 @@ func DeniedByFilesystem(err error) bool {
 	return errors.Is(err, os.ErrPermission) || errors.Is(err, syscall.EROFS)
 }
 
-// Unsupported reports whether err means chown itself isn't a meaningful
+// Unsupported reports whether err means chown itself is not a meaningful
 // operation on this platform (Windows only). On unix, chown is always a
 // real operation, so any failure here is a genuine denial, never this.
 func Unsupported(error) bool {

--- a/pkg/copy/copy_supported.go
+++ b/pkg/copy/copy_supported.go
@@ -3,6 +3,7 @@
 package copy
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -11,6 +12,12 @@ import (
 func IsUID(info os.FileInfo, uid uint32) bool {
 	stat, ok := info.Sys().(*syscall.Stat_t)
 	return ok && stat.Uid == uid
+}
+
+// DeniedByFilesystem reports whether err means the filesystem refused the
+// reassignment (insufficient privilege or a read-only share).
+func DeniedByFilesystem(err error) bool {
+	return errors.Is(err, os.ErrPermission) || errors.Is(err, syscall.EROFS)
 }
 
 func Lchown(info os.FileInfo, sourcePath, destPath string) error {

--- a/pkg/copy/copy_test.go
+++ b/pkg/copy/copy_test.go
@@ -233,9 +233,6 @@ func mustReadFile(t *testing.T, path string) []byte {
 	return b
 }
 
-// Chowning a file to a different owner requires privileges, so pointing
-// ChownR at root as an unprivileged user exercises the denied-failure path
-// deterministically.
 func TestChownRDeniedFailuresAreTyped(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("requires an unprivileged user")

--- a/pkg/copy/copy_test.go
+++ b/pkg/copy/copy_test.go
@@ -3,6 +3,7 @@
 package copy
 
 import (
+	"errors"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -230,4 +231,46 @@ func mustReadFile(t *testing.T, path string) []byte {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return b
+}
+
+// Chowning a file to a different owner requires privileges, so pointing
+// ChownR at root as an unprivileged user exercises the denied-failure path
+// deterministically.
+func TestChownRDeniedFailuresAreTyped(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("requires an unprivileged user")
+	}
+	root := t.TempDir()
+	file := filepath.Join(root, "f.txt")
+	//nolint:gosec // G306 — test temp file
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	err := ChownR(root, "root")
+	var failures ChownFailures
+	if !errors.As(err, &failures) {
+		t.Fatalf("ChownR err = %v, want ChownFailures", err)
+	}
+	if !failures.AllDenied() {
+		t.Errorf("AllDenied() = false for %v", failures)
+	}
+	for _, f := range failures {
+		if !DeniedByFilesystem(f.Err) {
+			t.Errorf("%s: unexpected cause %v", f.Path, f.Err)
+		}
+	}
+}
+
+func TestChownRSameOwnerSucceeds(t *testing.T) {
+	root := t.TempDir()
+	file := filepath.Join(root, "f.txt")
+	//nolint:gosec // G306 — test temp file
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if err := ChownR(root, currentUserName(t)); err != nil {
+		t.Fatalf("ChownR same owner: %v", err)
+	}
 }

--- a/pkg/copy/copy_unsupported.go
+++ b/pkg/copy/copy_unsupported.go
@@ -3,11 +3,21 @@
 package copy
 
 import (
+	"errors"
 	"os"
+	"syscall"
 )
 
 func IsUID(info os.FileInfo, uid uint32) bool {
 	return true
+}
+
+// DeniedByFilesystem reports whether the platform refused the reassignment.
+// IsUID short-circuits ChownR on Windows so this is rarely consulted, but a
+// direct os.Lchown fails with EWINDOWS: that is "unsupported here", a
+// tolerated denial, not a hard failure.
+func DeniedByFilesystem(err error) bool {
+	return errors.Is(err, syscall.EWINDOWS)
 }
 
 func Lchown(info os.FileInfo, sourcePath, destPath string) error {

--- a/pkg/copy/copy_unsupported.go
+++ b/pkg/copy/copy_unsupported.go
@@ -20,6 +20,12 @@ func DeniedByFilesystem(err error) bool {
 	return errors.Is(err, syscall.EWINDOWS)
 }
 
+// Unsupported reports whether chown is not a meaningful operation on this
+// platform at all (EWINDOWS), as opposed to a real filesystem denial.
+func Unsupported(err error) bool {
+	return errors.Is(err, syscall.EWINDOWS)
+}
+
 func Lchown(info os.FileInfo, sourcePath, destPath string) error {
 	return nil
 }

--- a/pkg/devcontainer/config.go
+++ b/pkg/devcontainer/config.go
@@ -186,6 +186,9 @@ func (r *runner) rawConfigFromSource(
 		log.Infof("ignoring project devcontainer, using image %s", spec.Image)
 		return r.saveSynthesizedConfig(&config.DevContainerConfig{
 			ImageContainer: config.ImageContainer{Image: spec.Image},
+			DevContainerConfigBase: config.DevContainerConfigBase{
+				RemoteUser: options.RemoteUser,
+			},
 			NonComposeBase: config.NonComposeBase{
 				RunArgs:      options.RunArgs,
 				ContainerEnv: options.ContainerEnv,

--- a/pkg/devcontainer/config/result.go
+++ b/pkg/devcontainer/config/result.go
@@ -69,33 +69,48 @@ func GetContainerID(result *Result) string {
 	return ""
 }
 
-// GetRemoteUser determines the remote user using DevContainer specification priority order:
-// 1. remoteUser from configuration
-// 2. devsy.user label from container
-// 3. User field from Docker inspect
-// 4. containerUser from configuration
-//
-// Per DevContainer specification (https://containers.dev/implementors/json_reference/):
-// "remoteUser: Overrides the user that devcontainer.json supporting services tools / runs as in the container...
-// Defaults to the user the container as a whole is running as (often root).".
+// GetRemoteUser resolves the user tools and the IDE run as inside the
+// container, in spec priority order: remoteUser, then containerUser
+// (the spec's default is "the user the container as a whole is
+// running as"), then the image-derived devsy.user label and Docker-inspect
+// user. Falls back to root.
 func GetRemoteUser(result *Result) string {
 	if result == nil {
-		return "root"
+		return remoteUserRoot
 	}
+	if user := userFromConfig(result); user != "" {
+		return user
+	}
+	if user := userFromContainer(result); user != "" {
+		return user
+	}
+	return remoteUserRoot
+}
 
-	if result.MergedConfig != nil && result.MergedConfig.RemoteUser != "" {
+const remoteUserRoot = "root"
+
+// userFromConfig returns the config-declared users: remoteUser first, then
+// containerUser, which overrides the image user the container starts with.
+func userFromConfig(result *Result) string {
+	if result.MergedConfig == nil {
+		return ""
+	}
+	if result.MergedConfig.RemoteUser != "" {
 		return result.MergedConfig.RemoteUser
 	}
+	return result.MergedConfig.ContainerUser
+}
 
+// userFromContainer returns the container's effective image user: first the
+// devsy.user label recorded at creation, then Docker inspect's User field.
+func userFromContainer(result *Result) string {
 	if userLabel := userFromContainerLabel(result); userLabel != "" {
 		return userLabel
 	}
-
-	if result.MergedConfig != nil && result.MergedConfig.ContainerUser != "" {
-		return result.MergedConfig.ContainerUser
+	if result.ContainerDetails != nil {
+		return result.ContainerDetails.Config.User
 	}
-
-	return "root"
+	return ""
 }
 
 func userFromContainerLabel(result *Result) string {

--- a/pkg/devcontainer/config/result_test.go
+++ b/pkg/devcontainer/config/result_test.go
@@ -51,3 +51,108 @@ func TestResultErr(t *testing.T) {
 		})
 	}
 }
+
+func TestGetRemoteUser(t *testing.T) {
+	for _, tt := range getRemoteUserCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetRemoteUser(tt.result); got != tt.want {
+				t.Errorf("GetRemoteUser() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+type getRemoteUserCase struct {
+	name   string
+	result *Result
+	want   string
+}
+
+func getRemoteUserCases() []getRemoteUserCase {
+	return append(remoteUserRootFallbackCases(), remoteUserPrecedenceCases()...)
+}
+
+func remoteUserRootFallbackCases() []getRemoteUserCase {
+	return []getRemoteUserCase{
+		{
+			name:   "nil result falls back to root",
+			result: nil,
+			want:   testUserRoot,
+		},
+		{
+			name: "no user sources falls back to root",
+			result: &Result{
+				MergedConfig: &MergedDevContainerConfig{},
+				ContainerDetails: &ContainerDetails{
+					Config: ContainerDetailsConfig{},
+				},
+			},
+			want: testUserRoot,
+		},
+	}
+}
+
+func remoteUserPrecedenceCases() []getRemoteUserCase {
+	return []getRemoteUserCase{
+		{
+			name: "remoteUser from config wins",
+			result: &Result{
+				MergedConfig: &MergedDevContainerConfig{
+					DevContainerConfigBase: DevContainerConfigBase{
+						RemoteUser: "cfg-user",
+					},
+					NonComposeBase: NonComposeBase{ContainerUser: testContainerUser},
+				},
+				ContainerDetails: &ContainerDetails{
+					Config: ContainerDetailsConfig{User: testInspectUser},
+				},
+			},
+			want: "cfg-user",
+		},
+		{
+			name: "devsy.user label beats docker inspect user",
+			result: &Result{
+				ContainerDetails: &ContainerDetails{
+					Config: ContainerDetailsConfig{
+						User:   testInspectUser,
+						Labels: map[string]string{UserLabel: testLabelUser},
+					},
+				},
+			},
+			want: testLabelUser,
+		},
+		{
+			name: "containerUser from config beats devsy.user label",
+			result: &Result{
+				MergedConfig: &MergedDevContainerConfig{
+					NonComposeBase: NonComposeBase{ContainerUser: testContainerUser},
+				},
+				ContainerDetails: &ContainerDetails{
+					Config: ContainerDetailsConfig{
+						User:   testInspectUser,
+						Labels: map[string]string{UserLabel: testLabelUser},
+					},
+				},
+			},
+			want: testContainerUser,
+		},
+		{
+			name: "containerUser beats docker inspect user",
+			result: &Result{
+				MergedConfig: &MergedDevContainerConfig{
+					NonComposeBase: NonComposeBase{ContainerUser: testContainerUser},
+				},
+				ContainerDetails: &ContainerDetails{
+					Config: ContainerDetailsConfig{User: testInspectUser},
+				},
+			},
+			want: testContainerUser,
+		},
+	}
+}
+
+const (
+	testContainerUser = "container-user"
+	testInspectUser   = "inspect-user"
+	testLabelUser     = "label-user"
+)

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -323,7 +323,7 @@ func linkRootHome(setupInfo *config.Result) error {
 
 func chownWorkspace(setupInfo *config.Result, recursive bool) error {
 	workspaceFolder := setupInfo.SubstitutionContext.ContainerWorkspaceFolder
-	// Compose services aren't guaranteed a workspaceMount; absence is expected.
+	// Compose services are not guaranteed a workspaceMount
 	if _, err := os.Lstat(workspaceFolder); err != nil {
 		if os.IsNotExist(err) {
 			log.Debugf("skip chown: workspace folder does not exist: %s", workspaceFolder)
@@ -362,8 +362,7 @@ func chownWorkspace(setupInfo *config.Result, recursive bool) error {
 		case err == nil:
 		case errors.As(err, &failures) && failures.AllDenied():
 			// Read-only shared files, such as virtiofs pack files, can refuse chown.
-			// Don't latch completion: a future container for this workspace may
-			// not share the same read-only mount.
+			// A future container for this workspace may not share the same read-only mount.
 			log.Warnf("chown workspace: %d entries kept their owner: %v", len(failures), err)
 			return nil
 		default:
@@ -607,9 +606,9 @@ func ensureKubeConfigMaps(config *clientcmdapi.Config) *clientcmdapi.Config {
 // markerExists reports whether the named marker exists with the expected
 // content; empty markerContent matches any existing marker. It never writes.
 func markerExists(markerName string, markerContent string) (bool, error) {
-	// #nosec G703 -- markerName is an internal constant, never user input
+	// #nosec G703 -- markerName is an internal constant
 	path := filepath.Join(pkgconfig.ContainerDataDir, markerName+".marker")
-	// #nosec G304 -- path is built from internal constants, never user input
+	// #nosec G304 -- path is built from internal constants
 	t, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -622,13 +621,13 @@ func markerExists(markerName string, markerContent string) (bool, error) {
 
 // writeMarker records that the work gated by markerExists has completed.
 func writeMarker(markerName string, markerContent string) error {
-	// #nosec G703 -- markerName is an internal constant, never user input
+	// #nosec G703 -- markerName is an internal constant
 	path := filepath.Join(pkgconfig.ContainerDataDir, markerName+".marker")
 	// #nosec G301 -- Standard directory permissions
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
 	}
-	// #nosec G703 -- path is built from internal constants, never user input
+	// #nosec G703 -- path is built from internal constants
 	if err := os.WriteFile(path, []byte(markerContent), 0o600); err != nil {
 		return fmt.Errorf("write marker: %w", err)
 	}

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -349,7 +349,7 @@ func chownWorkspace(setupInfo *config.Result, recursive bool) error {
 	workspaceRoot := filepath.Dir(workspaceFolder)
 	if workspaceRoot != "/" {
 		log.Infof("chown workspace: user=%s, workspaceRoot=%s", user, workspaceRoot)
-		if err := copy2.Chown(workspaceRoot, user); err != nil && !copy2.DeniedByFilesystem(err) {
+		if err := copy2.Chown(workspaceRoot, user); err != nil && !copy2.Unsupported(err) {
 			return fmt.Errorf("chown %s: %w", workspaceRoot, err)
 		}
 	}

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -322,46 +322,60 @@ func linkRootHome(setupInfo *config.Result) error {
 }
 
 func chownWorkspace(setupInfo *config.Result, recursive bool) error {
-	user := config.GetRemoteUser(setupInfo)
-	// Marker content is the workspace ID, not empty: a snapshot-restored
-	// container runs the ORIGINAL workspace's committed image, which already
-	// carries a chownWorkspace marker from when that original workspace was
-	// set up. That marker says nothing about whether THIS container's freshly
-	// restored (root-owned, just-extracted) volume content has been chowned,
-	// so an empty/content-agnostic marker would wrongly skip chown here and
-	// leave the workspace folder inaccessible to the remote user.
-	exists, err := markerFileExists("chownWorkspace", os.Getenv(pkgconfig.EnvWorkspaceID))
-	if err != nil {
-		return err
-	} else if exists {
-		return nil
+	workspaceFolder := setupInfo.SubstitutionContext.ContainerWorkspaceFolder
+	// Compose services aren't guaranteed a workspaceMount; absence is expected.
+	if _, err := os.Lstat(workspaceFolder); err != nil {
+		if os.IsNotExist(err) {
+			log.Debugf("skip chown: workspace folder does not exist: %s", workspaceFolder)
+			return nil
+		}
+		return fmt.Errorf("stat workspace %s: %w", workspaceFolder, err)
 	}
 
-	workspaceRoot := filepath.Dir(setupInfo.SubstitutionContext.ContainerWorkspaceFolder)
+	user := config.GetRemoteUser(setupInfo)
+	// Scope the marker to a workspace so a restored image does not suppress
+	// ownership setup for a different workspace; an unset workspace ID can't
+	// be scoped, so skip the marker gate entirely and chown every run.
+	workspaceID := os.Getenv(pkgconfig.EnvWorkspaceID)
+	if workspaceID != "" {
+		exists, err := markerExists("chownWorkspace", workspaceID)
+		if err != nil {
+			return err
+		} else if exists {
+			return nil
+		}
+	}
 
+	workspaceRoot := filepath.Dir(workspaceFolder)
 	if workspaceRoot != "/" {
 		log.Infof("chown workspace: user=%s, workspaceRoot=%s", user, workspaceRoot)
-		err = copy2.Chown(workspaceRoot, user)
-		if err != nil {
-			log.Warn(err)
+		if err := copy2.Chown(workspaceRoot, user); err != nil && !copy2.DeniedByFilesystem(err) {
+			return fmt.Errorf("chown %s: %w", workspaceRoot, err)
 		}
 	}
 
 	if recursive {
-		log.Infof(
-			"chown workspace recursively: user=%s, workspaceFolder=%s",
-			user,
-			setupInfo.SubstitutionContext.ContainerWorkspaceFolder,
-		)
-		err = copy2.ChownR(setupInfo.SubstitutionContext.ContainerWorkspaceFolder, user)
-		// Best effort: some entries (e.g. read-only .git pack files on a
-		// virtiofs share) legitimately cannot be chowned. The remote user can
-		// still work in the tree, so this is not worth a warning.
-		if err != nil {
-			log.Debugf("chown workspace: some entries could not be chowned: %v", err)
+		log.Infof("chown workspace recursively: user=%s, workspaceFolder=%s", user, workspaceFolder)
+		err := copy2.ChownR(workspaceFolder, user)
+		var failures copy2.ChownFailures
+		switch {
+		case err == nil:
+		case errors.As(err, &failures) && failures.AllDenied():
+			// Read-only shared files, such as virtiofs pack files, can refuse chown.
+			// Don't latch completion: a future container for this workspace may
+			// not share the same read-only mount.
+			log.Warnf("chown workspace: %d entries kept their owner: %v", len(failures), err)
+			return nil
+		default:
+			return fmt.Errorf("chown %s recursively: %w", workspaceFolder, err)
 		}
 	}
 
+	if workspaceID != "" {
+		if err := writeMarker("chownWorkspace", workspaceID); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -590,25 +604,47 @@ func ensureKubeConfigMaps(config *clientcmdapi.Config) *clientcmdapi.Config {
 	return config
 }
 
-func markerFileExists(markerName string, markerContent string) (bool, error) {
-	markerName = filepath.Join(pkgconfig.ContainerDataDir, markerName+".marker")
-	t, err := os.ReadFile(markerName)
-	if err != nil && !os.IsNotExist(err) {
-		return false, err
-	} else if err == nil && (markerContent == "" || string(t) == markerContent) {
-		return true, nil
-	}
-
-	// write marker
-	_ = os.MkdirAll(
-		filepath.Dir(markerName),
-		0o755,
-	) // #nosec G301 -- Standard directory permissions
-	err = os.WriteFile(markerName, []byte(markerContent), 0o600)
+// markerExists reports whether the named marker exists with the expected
+// content; empty markerContent matches any existing marker. It never writes.
+func markerExists(markerName string, markerContent string) (bool, error) {
+	// #nosec G703 -- markerName is an internal constant, never user input
+	path := filepath.Join(pkgconfig.ContainerDataDir, markerName+".marker")
+	// #nosec G304 -- path is built from internal constants, never user input
+	t, err := os.ReadFile(path)
 	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return markerContent == "" || string(t) == markerContent, nil
+}
+
+// writeMarker records that the work gated by markerExists has completed.
+func writeMarker(markerName string, markerContent string) error {
+	// #nosec G703 -- markerName is an internal constant, never user input
+	path := filepath.Join(pkgconfig.ContainerDataDir, markerName+".marker")
+	// #nosec G301 -- Standard directory permissions
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+	}
+	// #nosec G703 -- path is built from internal constants, never user input
+	if err := os.WriteFile(path, []byte(markerContent), 0o600); err != nil {
+		return fmt.Errorf("write marker: %w", err)
+	}
+	return nil
+}
+
+// markerFileExists checks for the marker and writes it on miss. Work that must be
+// retried on failure should bracket itself with markerExists and writeMarker instead.
+func markerFileExists(markerName string, markerContent string) (bool, error) {
+	exists, err := markerExists(markerName, markerContent)
+	if err != nil || exists {
+		return exists, err
+	}
+	if err := writeMarker(markerName, markerContent); err != nil {
 		return false, fmt.Errorf("write marker: %w", err)
 	}
-
 	return false, nil
 }
 

--- a/pkg/devcontainer/setup/setup_test.go
+++ b/pkg/devcontainer/setup/setup_test.go
@@ -3,10 +3,12 @@ package setup
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/devsy-org/devsy/pkg/agent/tunnel"
+	pkgconfig "github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/log"
 	"go.uber.org/zap/zapcore"
@@ -188,5 +190,179 @@ func TestWriteResultFileTo_WidensStaleModeEvenWhenContentUnchanged(t *testing.T)
 	}
 	if got := info.Mode().Perm(); got != 0o644 {
 		t.Errorf("mode = %o, want 0644 even though content was already up to date", got)
+	}
+}
+
+// removeMarkerFile deletes a marker file if present, treating an existing
+// leftover from an earlier interrupted run the same as no marker at all.
+func removeMarkerFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		t.Fatalf("remove marker %s: %v", path, err)
+	}
+}
+
+func TestMarkerRoundTrip(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("markers live under /var/devsy; writing them needs root")
+	}
+	markerPath := filepath.Join(pkgconfig.ContainerDataDir, "testmarker.marker")
+	removeMarkerFile(t, markerPath)
+	t.Cleanup(func() { _ = os.Remove(markerPath) })
+
+	exists, err := markerExists("testmarker", "ws-1")
+	if err != nil {
+		t.Fatalf("markerExists on miss: %v", err)
+	}
+	if exists {
+		t.Fatal("markerExists = true before writeMarker, want false")
+	}
+
+	if err := writeMarker("testmarker", "ws-1"); err != nil {
+		t.Fatalf("writeMarker: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{name: "matching content", content: "ws-1", want: true},
+		{name: "mismatched content", content: "ws-2", want: false},
+		{name: "empty content matches any", content: "", want: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := markerExists("testmarker", tc.content)
+			if err != nil {
+				t.Fatalf("markerExists: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("markerExists(%q) = %v, want %v", tc.content, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestChownWorkspaceSkipsAbsentFolder(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("markers live under /var/devsy; writing them needs root")
+	}
+	t.Setenv(pkgconfig.EnvWorkspaceID, "ws-absent")
+	t.Cleanup(func() {
+		_ = os.Remove(filepath.Join(pkgconfig.ContainerDataDir, "chownWorkspace.marker"))
+	})
+
+	result := &config.Result{
+		SubstitutionContext: &config.SubstitutionContext{
+			ContainerWorkspaceFolder: filepath.Join(t.TempDir(), "missing"),
+		},
+	}
+
+	for i := range 2 {
+		if err := chownWorkspace(result, true); err != nil {
+			t.Fatalf("chownWorkspace absent folder (call %d): %v", i, err)
+		}
+	}
+
+	exists, err := markerExists("chownWorkspace", "ws-absent")
+	if err != nil {
+		t.Fatalf("markerExists: %v", err)
+	}
+	if exists {
+		t.Fatal("chownWorkspace wrote the marker for a workspace it never chowned")
+	}
+}
+
+func TestChownWorkspaceIgnoresForeignMarkerWithoutWorkspaceID(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("markers live under /var/devsy; writing them needs root")
+	}
+	t.Setenv(pkgconfig.EnvWorkspaceID, "")
+	if err := writeMarker("chownWorkspace", "some-other-workspace"); err != nil {
+		t.Fatalf("writeMarker: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Remove(filepath.Join(pkgconfig.ContainerDataDir, "chownWorkspace.marker"))
+	})
+	logs := log.InitTestObserved(t, zapcore.DebugLevel)
+
+	result := &config.Result{
+		SubstitutionContext: &config.SubstitutionContext{
+			ContainerWorkspaceFolder: t.TempDir(),
+		},
+	}
+	if err := chownWorkspace(result, false); err != nil {
+		t.Fatalf("chownWorkspace: %v", err)
+	}
+
+	if got := logs.FilterMessageSnippet("chown workspace:").Len(); got == 0 {
+		t.Error("chownWorkspace skipped chowning because of an unrelated workspace's marker")
+	}
+}
+
+// mountReadOnly bind-mounts dir onto itself read-only so Lchown inside it fails with EROFS even for root.
+func mountReadOnly(t *testing.T, dir string) {
+	t.Helper()
+	//nolint:gosec // G204: dir is a t.TempDir() path, not external input
+	if err := exec.Command("mount", "--bind", dir, dir).Run(); err != nil {
+		t.Skipf("bind mount unavailable in this environment: %v", err)
+	}
+	t.Cleanup(func() {
+		//nolint:gosec // G204: dir is a t.TempDir() path, not external input
+		_ = exec.Command("umount", dir).Run()
+	})
+	//nolint:gosec // G204: dir is a t.TempDir() path, not external input
+	if err := exec.Command("mount", "-o", "remount,bind,ro", dir).Run(); err != nil {
+		t.Fatalf("remount read-only: %v", err)
+	}
+}
+
+// newForeignOwnedDir creates dir/f.txt owned by a uid other than root, so a
+// chown to root actually attempts (and, once read-only, fails) reassignment.
+func newForeignOwnedDir(t *testing.T) string {
+	t.Helper()
+	folder := filepath.Join(t.TempDir(), "ws")
+	if err := os.Mkdir(folder, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	file := filepath.Join(folder, "f.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := os.Lchown(folder, 1, 1); err != nil {
+		t.Fatalf("chown folder to non-root owner: %v", err)
+	}
+	if err := os.Lchown(file, 1, 1); err != nil {
+		t.Fatalf("chown file to non-root owner: %v", err)
+	}
+	return folder
+}
+
+func TestChownWorkspaceDeniedRecursiveChownSkipsMarker(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("needs root: writes markers under /var/devsy and bind-mounts read-only")
+	}
+
+	folder := newForeignOwnedDir(t)
+	mountReadOnly(t, folder)
+
+	t.Setenv(pkgconfig.EnvWorkspaceID, "ws-denied")
+	t.Cleanup(func() {
+		_ = os.Remove(filepath.Join(pkgconfig.ContainerDataDir, "chownWorkspace.marker"))
+	})
+
+	result := &config.Result{
+		SubstitutionContext: &config.SubstitutionContext{ContainerWorkspaceFolder: folder},
+	}
+	if err := chownWorkspace(result, true); err != nil {
+		t.Fatalf("chownWorkspace: %v", err)
+	}
+
+	exists, err := markerExists("chownWorkspace", "ws-denied")
+	if err != nil {
+		t.Fatalf("markerExists: %v", err)
+	}
+	if exists {
+		t.Fatal("chownWorkspace latched the marker despite a fully denied recursive chown")
 	}
 }

--- a/pkg/devcontainer/setup/setup_test.go
+++ b/pkg/devcontainer/setup/setup_test.go
@@ -366,3 +366,36 @@ func TestChownWorkspaceDeniedRecursiveChownSkipsMarker(t *testing.T) {
 		t.Fatal("chownWorkspace latched the marker despite a fully denied recursive chown")
 	}
 }
+
+func TestChownWorkspaceDeniedWorkspaceRootChownFails(t *testing.T) {
+	if os.Geteuid() != 0 {
+		t.Skip("needs root: writes markers under /var/devsy and bind-mounts read-only")
+	}
+
+	parent := t.TempDir()
+	folder := filepath.Join(parent, "ws")
+	if err := os.Mkdir(folder, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	mountReadOnly(t, parent)
+
+	t.Setenv(pkgconfig.EnvWorkspaceID, "ws-root-denied")
+	t.Cleanup(func() {
+		_ = os.Remove(filepath.Join(pkgconfig.ContainerDataDir, "chownWorkspace.marker"))
+	})
+
+	result := &config.Result{
+		SubstitutionContext: &config.SubstitutionContext{ContainerWorkspaceFolder: folder},
+	}
+	if err := chownWorkspace(result, false); err == nil {
+		t.Fatal("expected chownWorkspace to fail when the workspace-root chown is denied")
+	}
+
+	exists, err := markerExists("chownWorkspace", "ws-root-denied")
+	if err != nil {
+		t.Fatalf("markerExists: %v", err)
+	}
+	if exists {
+		t.Fatal("chownWorkspace latched the marker despite a denied workspace-root chown")
+	}
+}

--- a/pkg/devcontainer/setup/setup_test.go
+++ b/pkg/devcontainer/setup/setup_test.go
@@ -300,25 +300,24 @@ func TestChownWorkspaceIgnoresForeignMarkerWithoutWorkspaceID(t *testing.T) {
 	}
 }
 
-// mountReadOnly bind-mounts dir onto itself read-only so Lchown inside it fails with EROFS even for root.
 func mountReadOnly(t *testing.T, dir string) {
 	t.Helper()
-	//nolint:gosec // G204: dir is a t.TempDir() path, not external input
+	//nolint:gosec // G204: dir is a t.TempDir() path
 	if err := exec.Command("mount", "--bind", dir, dir).Run(); err != nil {
 		t.Skipf("bind mount unavailable in this environment: %v", err)
 	}
 	t.Cleanup(func() {
-		//nolint:gosec // G204: dir is a t.TempDir() path, not external input
+		//nolint:gosec // G204: dir is a t.TempDir() path
 		_ = exec.Command("umount", dir).Run()
 	})
-	//nolint:gosec // G204: dir is a t.TempDir() path, not external input
+	//nolint:gosec // G204: dir is a t.TempDir() path
 	if err := exec.Command("mount", "-o", "remount,bind,ro", dir).Run(); err != nil {
 		t.Fatalf("remount read-only: %v", err)
 	}
 }
 
 // newForeignOwnedDir creates dir/f.txt owned by a uid other than root, so a
-// chown to root actually attempts (and, once read-only, fails) reassignment.
+// chown to root attempts (and, once read-only, fails) reassignment.
 func newForeignOwnedDir(t *testing.T) string {
 	t.Helper()
 	folder := filepath.Join(t.TempDir(), "ws")

--- a/pkg/extract/compress.go
+++ b/pkg/extract/compress.go
@@ -25,13 +25,11 @@ func WriteTarExclude(
 		return fmt.Errorf("absolute: %w", err)
 	}
 
-	// Check if target is there
 	stat, err := os.Stat(absolute)
 	if err != nil {
 		return fmt.Errorf("stat: %w", err)
 	}
 
-	// Use compression
 	gw := writer
 	if compress {
 		gwWriter := gzip.NewWriter(writer)
@@ -40,11 +38,9 @@ func WriteTarExclude(
 		gw = gwWriter
 	}
 
-	// Create tar writer
 	tarWriter := tar.NewWriter(gw)
 	defer func() { _ = tarWriter.Close() }()
 
-	// When its a file we copy the file to the toplevel of the tar
 	if !stat.IsDir() {
 		return NewArchiver(
 			filepath.Dir(absolute),
@@ -53,8 +49,6 @@ func WriteTarExclude(
 		).AddToArchive(filepath.Base(absolute))
 	}
 
-	// When its a folder we copy the contents and not the folder itself to the
-	// toplevel of the tar
 	return NewArchiver(absolute, tarWriter, excludedPaths).AddToArchive("")
 }
 
@@ -88,24 +82,19 @@ func (a *Archiver) AddToArchive(relativePath string) error {
 		return nil
 	}
 
-	// We skip files that are suddenly not there anymore
 	stat, err := os.Lstat(path.Join(a.basePath, relativePath))
 	if err != nil {
-		// config.Logf("[Upstream] Couldn't stat file %s: %s\n", absFilepath, err.Error())
 		return nil
 	}
 
 	if stat.IsDir() {
-		// check if excluded
 		if a.isExcluded(path.Clean(relativePath) + "/") {
 			return nil
 		}
 
-		// Recursively tar folder
 		return a.tarFolder(relativePath, stat)
 	}
 
-	// check if excluded
 	if a.isExcluded(path.Clean(relativePath)) {
 		return nil
 	}
@@ -126,15 +115,11 @@ func (a *Archiver) tarFolder(target string, targetStat os.FileInfo) error {
 	filePath := path.Join(a.basePath, target)
 	files, err := os.ReadDir(filePath)
 	if err != nil {
-		// config.Logf("[Upstream] Couldn't read dir %s: %s\n", filepath, err.Error())
 		return nil
 	}
 
 	if len(files) == 0 && target != "" {
-		// Case empty directory
 		hdr, _ := tar.FileInfoHeader(targetStat, filePath)
-		hdr.Uid = 0
-		hdr.Gid = 0
 		hdr.Mode = fillGo18FileTypeBits(int64(chmodTarEntry(os.FileMode(hdr.Mode))), targetStat)
 		hdr.Name = target
 		if err := a.writer.WriteHeader(hdr); err != nil {
@@ -175,8 +160,6 @@ func (a *Archiver) tarFile(target string, targetStat os.FileInfo) error {
 		return fmt.Errorf("create tar file info header: %w", err)
 	}
 	hdr.Name = target
-	hdr.Uid = 0
-	hdr.Gid = 0
 	hdr.Mode = fillGo18FileTypeBits(int64(chmodTarEntry(os.FileMode(hdr.Mode))), targetStat)
 	hdr.ModTime = time.Unix(targetStat.ModTime().Unix(), 0)
 

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -14,11 +14,11 @@ import (
 )
 
 type Options struct {
-	StripLevels int
-
-	Perm *os.FileMode
-	UID  *int
-	GID  *int
+	StripLevels       int
+	Perm              *os.FileMode
+	UID               *int
+	GID               *int
+	PreserveOwnership bool
 }
 
 type Option func(o *Options)
@@ -26,6 +26,13 @@ type Option func(o *Options)
 func StripLevels(levels int) Option {
 	return func(o *Options) {
 		o.StripLevels = levels
+	}
+}
+
+// PreserveHeaderOwnership makes Extract apply each entry's tar-header uid/gid.
+func PreserveHeaderOwnership() Option {
+	return func(o *Options) {
+		o.PreserveOwnership = true
 	}
 }
 
@@ -99,6 +106,14 @@ func resolveRelativePath(header *tar.Header, opts *Options) string {
 	return rel
 }
 
+// entryTarget groups the paths every entry-materializing step needs: the
+// entry's own destination path, and destFolder for resolving hard-link
+// targets against the archive root.
+type entryTarget struct {
+	outFileName string
+	destFolder  string
+}
+
 func extractNext(
 	tarReader *tar.Reader, destFolder string, options *Options,
 ) (bool, error) {
@@ -111,9 +126,9 @@ func extractNext(
 	}
 
 	rel := resolveRelativePath(header, options)
-	outFileName := filepath.Join(destFolder, rel)
+	target := entryTarget{outFileName: filepath.Join(destFolder, rel), destFolder: destFolder}
 
-	if !withinDir(outFileName, destFolder) {
+	if !withinDir(target.outFileName, destFolder) {
 		return false, fmt.Errorf(
 			"path traversal detected: %s resolves outside destination",
 			header.Name,
@@ -122,21 +137,21 @@ func extractNext(
 
 	switch header.Typeflag {
 	case tar.TypeSymlink, tar.TypeLink:
-		if err := validateLinkTarget(header, outFileName, destFolder); err != nil {
+		if err := validateLinkTarget(header, target, options); err != nil {
 			return false, err
 		}
 	}
 
-	if err := extractEntry(tarReader, header, outFileName, options); err != nil {
+	if err := extractEntry(tarReader, header, target, options); err != nil {
 		return false, err
 	}
 	return true, nil
 }
 
 // validateLinkTarget ensures a symlink or hard link target stays within destFolder.
-func validateLinkTarget(header *tar.Header, outFileName, destFolder string) error {
-	linkTarget := resolveLinkTarget(header.Linkname, outFileName)
-	if !withinDir(linkTarget, destFolder) {
+func validateLinkTarget(header *tar.Header, target entryTarget, options *Options) error {
+	linkTarget := resolveLinkTarget(header, target, options)
+	if !withinDir(linkTarget, target.destFolder) {
 		kind := "symlink"
 		if header.Typeflag == tar.TypeLink {
 			kind = "hard link"
@@ -149,36 +164,94 @@ func validateLinkTarget(header *tar.Header, outFileName, destFolder string) erro
 	return nil
 }
 
-// resolveLinkTarget resolves a link target to an absolute path.
-func resolveLinkTarget(linkname, outFileName string) string {
-	if filepath.IsAbs(linkname) {
-		return filepath.Clean(linkname)
+// resolveLinkTarget resolves a link target to an absolute path. A symlink's
+// Linkname is a filesystem path relative to the link's own directory (or
+// absolute); a hard link's Linkname instead names another archive member,
+// in the same root+StripLevels namespace as every entry's Name.
+func resolveLinkTarget(header *tar.Header, target entryTarget, options *Options) string {
+	if header.Typeflag == tar.TypeLink {
+		rel := resolveRelativePath(&tar.Header{Name: header.Linkname}, options)
+		// #nosec G305 -- rel is confined to destFolder by resolveRelativePath
+		// plus the caller's withinDir check; this mirrors outFileName's own join.
+		return filepath.Clean(filepath.Join(target.destFolder, rel))
 	}
-	return filepath.Clean(filepath.Join(filepath.Dir(outFileName), linkname))
+	if filepath.IsAbs(header.Linkname) {
+		return filepath.Clean(header.Linkname)
+	}
+	// #nosec G305 -- resolved path is validated against destFolder by the
+	// caller's withinDir check before any filesystem operation uses it.
+	return filepath.Clean(filepath.Join(filepath.Dir(target.outFileName), header.Linkname))
 }
 
 func extractEntry(
-	tarReader *tar.Reader, header *tar.Header,
-	outFileName string, options *Options,
+	tarReader *tar.Reader, header *tar.Header, target entryTarget, options *Options,
 ) error {
-	dirPerm := os.ModePerm
-	if options.Perm != nil {
-		dirPerm = *options.Perm
-	}
-	if err := os.MkdirAll(filepath.Dir(outFileName), dirPerm); err != nil {
+	if err := os.MkdirAll(filepath.Dir(target.outFileName), dirMode(options)); err != nil {
 		return err
 	}
 
+	if err := createEntry(tarReader, header, target, options); err != nil {
+		return err
+	}
+
+	return applyOwnership(target.outFileName, header, options)
+}
+
+// createEntry materializes one tar entry on disk according to its type.
+func createEntry(
+	tarReader *tar.Reader, header *tar.Header, target entryTarget, options *Options,
+) error {
 	switch header.Typeflag {
 	case tar.TypeDir:
-		return os.MkdirAll(outFileName, dirPerm)
+		return os.MkdirAll(target.outFileName, dirMode(options))
 	case tar.TypeSymlink:
-		return os.Symlink(header.Linkname, outFileName)
+		return os.Symlink(header.Linkname, target.outFileName)
 	case tar.TypeLink:
-		return os.Link(header.Linkname, outFileName)
+		return os.Link(resolveLinkTarget(header, target, options), target.outFileName)
 	default:
-		return extractRegularFile(tarReader, header, outFileName, options)
+		return extractRegularFile(tarReader, header, target.outFileName, options)
 	}
+}
+
+// dirMode returns the directory permission mode to extract with.
+func dirMode(options *Options) os.FileMode {
+	if options.Perm != nil {
+		return *options.Perm
+	}
+	return os.ModePerm
+}
+
+// applyOwnership chowns a freshly extracted entry when the options ask for
+// it, preferring explicit UID/GID overrides over the entry's header values.
+func applyOwnership(
+	outFileName string, header *tar.Header, options *Options,
+) error {
+	uid, gid, ok := ownershipFor(header, options)
+	if !ok {
+		return nil
+	}
+	if err := os.Lchown(outFileName, uid, gid); err != nil {
+		if os.Geteuid() != 0 && errors.Is(err, os.ErrPermission) {
+			return nil
+		}
+		return fmt.Errorf("chown %s: %w", outFileName, err)
+	}
+	return nil
+}
+
+// ownershipFor resolves the uid/gid to apply and whether any chown is wanted.
+func ownershipFor(header *tar.Header, options *Options) (int, int, bool) {
+	if options.UID == nil && options.GID == nil {
+		return header.Uid, header.Gid, options.PreserveOwnership
+	}
+	uid, gid := 0, 0
+	if options.UID != nil {
+		uid = *options.UID
+	}
+	if options.GID != nil {
+		gid = *options.GID
+	}
+	return uid, gid, true
 }
 
 func extractRegularFile(

--- a/pkg/extract/extract.go
+++ b/pkg/extract/extract.go
@@ -171,15 +171,13 @@ func validateLinkTarget(header *tar.Header, target entryTarget, options *Options
 func resolveLinkTarget(header *tar.Header, target entryTarget, options *Options) string {
 	if header.Typeflag == tar.TypeLink {
 		rel := resolveRelativePath(&tar.Header{Name: header.Linkname}, options)
-		// #nosec G305 -- rel is confined to destFolder by resolveRelativePath
-		// plus the caller's withinDir check; this mirrors outFileName's own join.
+		// #nosec G305 -- rel is confined to destFolder by resolveRelativePath.
 		return filepath.Clean(filepath.Join(target.destFolder, rel))
 	}
 	if filepath.IsAbs(header.Linkname) {
 		return filepath.Clean(header.Linkname)
 	}
-	// #nosec G305 -- resolved path is validated against destFolder by the
-	// caller's withinDir check before any filesystem operation uses it.
+	// #nosec G305 -- resolved path is validated against destFolder.
 	return filepath.Clean(filepath.Join(filepath.Dir(target.outFileName), header.Linkname))
 }
 

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -15,6 +16,8 @@ type tarEntry struct {
 	body       string
 	linkTarget string
 	symlink    bool
+	uid        int
+	gid        int
 }
 
 func (e tarEntry) header() *tar.Header {
@@ -37,6 +40,8 @@ func (e tarEntry) header() *tar.Header {
 		Name:     e.name,
 		Size:     int64(len(e.body)),
 		Mode:     0o644,
+		Uid:      e.uid,
+		Gid:      e.gid,
 	}
 }
 
@@ -149,6 +154,64 @@ func TestExtract_HardLinkTraversalBlocked(t *testing.T) {
 	}
 }
 
+func TestExtract_HardLinkResolvesRelativeToDestinationNotCWD(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+	sentinel := filepath.Join(cwd, "sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("untouched"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	buf := newTarGz(t, []tarEntry{
+		{name: "evil-link", linkTarget: "sentinel.txt"},
+	})
+
+	dest := t.TempDir()
+	if err := Extract(buf, dest); err == nil {
+		t.Fatal("expected error: link target does not exist under dest")
+	}
+
+	info, err := os.Lstat(sentinel)
+	if err != nil {
+		t.Fatalf("sentinel disappeared: %v", err)
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok && stat.Nlink != 1 {
+		t.Fatalf(
+			"sentinel gained a hard link (Nlink=%d): extraction escaped destFolder",
+			stat.Nlink,
+		)
+	}
+}
+
+func TestExtract_HardLinkResolvesFromArchiveRootWhenNested(t *testing.T) {
+	t.Parallel()
+	buf := newTarGz(t, []tarEntry{
+		{name: testHardLinkRel, body: "world"},
+		{name: "dir/sub/link", linkTarget: testHardLinkRel},
+	})
+
+	dest := t.TempDir()
+	if err := Extract(buf, dest); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	linkPath := filepath.Join(dest, "dir", "sub", "link")
+	content, err := os.ReadFile(linkPath) //nolint:gosec // G304 — test temp file
+	if err != nil {
+		t.Fatalf("read hard link: %v", err)
+	}
+	if string(content) != "world" {
+		t.Fatalf("hard link content = %q, want %q", content, "world")
+	}
+
+	if _, err := os.Stat(filepath.Join(dest, "dir", "sub", "dir", "file")); !os.IsNotExist(err) {
+		t.Fatalf(
+			"hard link resolved relative to its own directory instead of the archive root: %v",
+			err,
+		)
+	}
+}
+
 func TestExtract_ValidSymlinkAllowed(t *testing.T) {
 	t.Parallel()
 	buf := newTarGz(t, []tarEntry{
@@ -172,5 +235,54 @@ func TestExtract_ValidSymlinkAllowed(t *testing.T) {
 	}
 	if target != targetFileName {
 		t.Fatalf("symlink target = %q, want %q", target, targetFileName)
+	}
+}
+
+func TestExtract_PreserveHeaderOwnership(t *testing.T) {
+	t.Parallel()
+	buf := newTarGz(t, []tarEntry{
+		{name: "dir", uid: os.Getuid(), gid: os.Getgid()},
+	})
+
+	dest := t.TempDir()
+	if err := Extract(buf, dest, PreserveHeaderOwnership()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dest, "dir"))
+	if err != nil {
+		t.Fatalf("stat dir: %v", err)
+	}
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		//nolint:gosec // G115 — uid/gid are uint32 on every supported platform
+		if stat.Uid != uint32(os.Getuid()) || stat.Gid != uint32(os.Getgid()) {
+			t.Fatalf(
+				"dir owner = %d:%d, want %d:%d",
+				stat.Uid, stat.Gid, os.Getuid(), os.Getgid(),
+			)
+		}
+	}
+}
+
+func TestExtract_PreserveHeaderOwnershipUnprivilegedDegrades(t *testing.T) {
+	t.Parallel()
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: permission errors cannot occur")
+	}
+	buf := newTarGz(t, []tarEntry{
+		{name: "hello.txt", body: "world", uid: 0, gid: 0},
+	})
+
+	dest := t.TempDir()
+	if err := Extract(buf, dest, PreserveHeaderOwnership()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	path := filepath.Join(dest, "hello.txt")
+	content, err := os.ReadFile(path) //nolint:gosec // G304 — test temp file
+	if err != nil {
+		t.Fatalf("read extracted file: %v", err)
+	}
+	if string(content) != "world" {
+		t.Fatalf("got %q, want %q", string(content), "world")
 	}
 }

--- a/pkg/extract/extract_test.go
+++ b/pkg/extract/extract_test.go
@@ -16,6 +16,7 @@ type tarEntry struct {
 	body       string
 	linkTarget string
 	symlink    bool
+	directory  bool
 	uid        int
 	gid        int
 }
@@ -33,6 +34,15 @@ func (e tarEntry) header() *tar.Header {
 			Typeflag: tar.TypeLink,
 			Name:     e.name,
 			Linkname: e.linkTarget,
+		}
+	}
+	if e.directory {
+		return &tar.Header{
+			Typeflag: tar.TypeDir,
+			Name:     e.name,
+			Mode:     0o755,
+			Uid:      e.uid,
+			Gid:      e.gid,
 		}
 	}
 	return &tar.Header{
@@ -241,7 +251,7 @@ func TestExtract_ValidSymlinkAllowed(t *testing.T) {
 func TestExtract_PreserveHeaderOwnership(t *testing.T) {
 	t.Parallel()
 	buf := newTarGz(t, []tarEntry{
-		{name: "dir", uid: os.Getuid(), gid: os.Getgid()},
+		{name: "dir", directory: true, uid: os.Getuid(), gid: os.Getgid()},
 	})
 
 	dest := t.TempDir()
@@ -252,6 +262,9 @@ func TestExtract_PreserveHeaderOwnership(t *testing.T) {
 	info, err := os.Stat(filepath.Join(dest, "dir"))
 	if err != nil {
 		t.Fatalf("stat dir: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("extracted entry is not a directory: %v", info.Mode())
 	}
 	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
 		//nolint:gosec // G115 — uid/gid are uint32 on every supported platform

--- a/pkg/extract/path_test.go
+++ b/pkg/extract/path_test.go
@@ -7,8 +7,9 @@ import (
 )
 
 const (
-	targetFileName = "target.txt"
-	etcPasswd      = "../../etc/passwd" // #nosec G101
+	targetFileName  = "target.txt"
+	etcPasswd       = "../../etc/passwd" // #nosec G101
+	testHardLinkRel = "dir/file"
 )
 
 func TestWithinDir(t *testing.T) {
@@ -38,6 +39,7 @@ func TestWithinDir(t *testing.T) {
 
 func TestResolveLinkTarget(t *testing.T) {
 	t.Parallel()
+	const dest = "/tmp/dest"
 	cases := []struct {
 		name     string
 		linkname string
@@ -51,7 +53,10 @@ func TestResolveLinkTarget(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := resolveLinkTarget(tt.linkname, tt.outFile); got != tt.want {
+			header := &tar.Header{Typeflag: tar.TypeSymlink, Linkname: tt.linkname}
+			target := entryTarget{outFileName: tt.outFile, destFolder: dest}
+			got := resolveLinkTarget(header, target, &Options{})
+			if got != tt.want {
 				t.Errorf(
 					"resolveLinkTarget(%q, %q) = %q, want %q",
 					tt.linkname,
@@ -61,6 +66,17 @@ func TestResolveLinkTarget(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestResolveLinkTarget_HardLinkUsesArchiveRoot(t *testing.T) {
+	t.Parallel()
+	const dest = "/tmp/dest"
+	header := &tar.Header{Typeflag: tar.TypeLink, Linkname: testHardLinkRel}
+	target := entryTarget{outFileName: dest + "/dir/sub/link", destFolder: dest}
+	want := dest + "/dir/file"
+	if got := resolveLinkTarget(header, target, &Options{}); got != want {
+		t.Errorf("resolveLinkTarget(hard link) = %q, want %q", got, want)
 	}
 }
 
@@ -113,7 +129,8 @@ func TestValidateLinkTarget(t *testing.T) {
 			t.Parallel()
 			header := &tar.Header{Typeflag: tt.typeflag, Name: "link", Linkname: tt.linkname}
 			outFile := dest + "/link"
-			err := validateLinkTarget(header, outFile, dest)
+			target := entryTarget{outFileName: outFile, destFolder: dest}
+			err := validateLinkTarget(header, target, &Options{})
 			if tt.wantError == "" {
 				if err != nil {
 					t.Errorf("expected no error, got %v", err)

--- a/pkg/snapshot/manifest.go
+++ b/pkg/snapshot/manifest.go
@@ -7,15 +7,10 @@ import (
 )
 
 const (
-	VolumesMediaType     = "application/vnd.devsy.snapshot.volumes.v1.tar+gzip"
-	ManifestMediaType    = "application/vnd.oci.image.manifest.v1+json"
-	ManifestArtifactType = "application/vnd.devsy.snapshot.manifest.v1+json"
-	emptyConfigMediaType = "application/vnd.oci.empty.v1+json"
-	// defaultContainerImageMediaType is used only when
-	// BuildManifestOptions.ContainerImageMediaType is unset. Real callers
-	// (cmd/snapshot/create.go) always pass the media type the registry
-	// actually reported for the pushed image, which may be the OCI or the
-	// Docker v2 manifest format depending on the daemon/registry.
+	VolumesMediaType               = "application/vnd.devsy.snapshot.volumes.v1.tar+gzip"
+	ManifestMediaType              = "application/vnd.oci.image.manifest.v1+json"
+	ManifestArtifactType           = "application/vnd.devsy.snapshot.manifest.v1+json"
+	emptyConfigMediaType           = "application/vnd.oci.empty.v1+json"
 	defaultContainerImageMediaType = "application/vnd.docker.distribution.manifest.v2+json"
 )
 
@@ -26,26 +21,10 @@ const (
 	AnnotationDevContainerHash = "sh.devsy.snapshot.devcontainer-hash"
 	AnnotationSourceProvider   = "sh.devsy.snapshot.source-provider"
 	AnnotationMessage          = "sh.devsy.snapshot.message"
-	// AnnotationMountPrefix is the create-time mount target path (leading "/"
-	// trimmed) that volumes archive entries are prefixed with. Restore must
-	// strip exactly this many path segments regardless of the restore-side
-	// mount target's own depth, since the two are not guaranteed to match
-	// (different provider defaults, different workspace-folder conventions).
-	AnnotationMountPrefix = "sh.devsy.snapshot.mount-prefix"
-	// AnnotationRunArgs is the create-time devcontainer.json's runArgs
-	// (JSON-encoded []string), replayed onto the restored container so
-	// runArgs the original devcontainer.json relied on (e.g.
-	// --add-host=host.docker.internal:host-gateway for a registry reachable
-	// only via that hostname) still apply — restore pins DevContainerSource
-	// to the committed image, which bypasses the project devcontainer.json
-	// and would otherwise silently drop them.
-	AnnotationRunArgs = "sh.devsy.snapshot.run-args"
-	// AnnotationContainerEnv is the create-time devcontainer.json's
-	// containerEnv (JSON-encoded map[string]string), replayed onto the
-	// restored container for the same reason as AnnotationRunArgs: restore
-	// pins DevContainerSource to the committed image, bypassing the project
-	// devcontainer.json and silently dropping any containerEnv it set.
-	AnnotationContainerEnv = "sh.devsy.snapshot.container-env"
+	AnnotationMountPrefix      = "sh.devsy.snapshot.mount-prefix"
+	AnnotationRunArgs          = "sh.devsy.snapshot.run-args"
+	AnnotationContainerEnv     = "sh.devsy.snapshot.container-env"
+	AnnotationRemoteUser       = "sh.devsy.snapshot.remote-user"
 )
 
 // Descriptor mirrors the OCI content descriptor fields we need; kept minimal
@@ -76,6 +55,7 @@ type BuildManifestOptions struct {
 	MountPrefix      string
 	RunArgs          []string
 	ContainerEnv     map[string]string
+	RemoteUser       string
 
 	ContainerImageMediaType string
 	ContainerImageDigest    string
@@ -165,6 +145,9 @@ func addDevContainerOverrideAnnotations(
 		}
 		annotations[AnnotationContainerEnv] = string(raw)
 	}
+	if opts.RemoteUser != "" {
+		annotations[AnnotationRemoteUser] = opts.RemoteUser
+	}
 	return nil
 }
 
@@ -180,6 +163,12 @@ func (m *Manifest) RunArgs() ([]string, error) {
 		return nil, fmt.Errorf("parse %s annotation: %w", AnnotationRunArgs, err)
 	}
 	return args, nil
+}
+
+// RemoteUser returns the create-time devcontainer.json's remoteUser, or ""
+// when the snapshot carries none.
+func (m *Manifest) RemoteUser() string {
+	return m.Annotations[AnnotationRemoteUser]
 }
 
 // ContainerEnv decodes the create-time devcontainer.json's containerEnv from

--- a/pkg/snapshot/manifest.go
+++ b/pkg/snapshot/manifest.go
@@ -7,14 +7,6 @@ import (
 )
 
 const (
-	VolumesMediaType               = "application/vnd.devsy.snapshot.volumes.v1.tar+gzip"
-	ManifestMediaType              = "application/vnd.oci.image.manifest.v1+json"
-	ManifestArtifactType           = "application/vnd.devsy.snapshot.manifest.v1+json"
-	emptyConfigMediaType           = "application/vnd.oci.empty.v1+json"
-	defaultContainerImageMediaType = "application/vnd.docker.distribution.manifest.v2+json"
-)
-
-const (
 	AnnotationWorkspaceUID     = "sh.devsy.snapshot.workspace-uid"
 	AnnotationCreatedAt        = "sh.devsy.snapshot.created-at"
 	AnnotationParent           = "sh.devsy.snapshot.parent"
@@ -25,6 +17,13 @@ const (
 	AnnotationRunArgs          = "sh.devsy.snapshot.run-args"
 	AnnotationContainerEnv     = "sh.devsy.snapshot.container-env"
 	AnnotationRemoteUser       = "sh.devsy.snapshot.remote-user"
+
+	VolumesMediaType     = "application/vnd.devsy.snapshot.volumes.v1.tar+gzip"
+	ManifestMediaType    = "application/vnd.oci.image.manifest.v1+json"
+	ManifestArtifactType = "application/vnd.devsy.snapshot.manifest.v1+json"
+
+	emptyConfigMediaType           = "application/vnd.oci.empty.v1+json"
+	defaultContainerImageMediaType = "application/vnd.docker.distribution.manifest.v2+json"
 )
 
 // Descriptor mirrors the OCI content descriptor fields we need; kept minimal


### PR DESCRIPTION
## Problem

Restored and recreated workspaces could leave the workspace folder root-owned, so git inside the devcontainer failed with `detected dubious ownership in repository` — the devcontainer user should own the workspace.

## Root causes (four, same family)

1. **Chown marker latch**: `chownWorkspace` wrote its `/var/devsy/chownWorkspace.marker` *before* attempting the chown and swallowed all chown errors (`log.Warn`/`log.Debug`, returning nil). Any failed or interrupted first run was permanently skipped on every later run.
2. **Snapshot volumes lost ownership**: the archiver hardcoded `hdr.Uid = 0; hdr.Gid = 0` and extraction never applied header ownership, so restored volumes were entirely root-owned.
3. **Restore dropped remoteUser**: snapshot manifests replayed only `runArgs`/`containerEnv`; an explicitly declared `remoteUser` was silently dropped, so restored image-sourced containers ran tools/IDE as root.
4. **Remote-user fallback gap**: `GetRemoteUser`'s docstring promised a Docker-inspect `User` fallback that was never implemented, degrading straight to `root`.

## Fixes

- Marker is written only after the chowns complete; workspace-root chown failures now fail setup, recursive per-entry failures are surfaced at warn level (still best-effort for read-only virtiofs entries).
- Archiver records real uid/gid; extraction gains `PreserveHeaderOwnership()` (graceful degradation when unprivileged); volume restore opts in.
- New `sh.devsy.snapshot.remote-user` manifest annotation, recorded at create time and replayed onto the synthesized config for both `snapshot restore` and `up --from-snapshot`.
- `GetRemoteUser` now resolves per spec priority: `remoteUser` → `containerUser` → `devsy.user` label → Docker-inspect `User` → root.

## Validation

- Unit tests: marker semantics (root-gated, run in-container), ownership round-trip incl. unprivileged degradation, remote-user resolution table.
- Full unit suite green except 3 pre-existing `pkg/git` failures (fail on clean tree).
- Live e2e against a local registry: up → mutate → snapshot create → delete → restore under the original id → files owned by `vscode`, no dubious ownership.
- New regression spec `restores files owned by the remote user when reusing the original id` + non-root testdata fixture (requires the suite's usual registry prerequisites to run in CI).

This PR was authored with GPG-signed commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Snapshots now record and restore the workspace’s configured remote user.
  - Image-based development containers consistently apply remote-user settings.
  - Restored workspaces preserve file ownership, including non-root ownership.

- **Bug Fixes**
  - Improved workspace ownership setup when folders are missing or permission changes are denied.
  - Snapshot extraction retains ownership metadata while supporting unprivileged environments.
  - Corrected hard-link handling during archive extraction.

- **Tests**
  - Added coverage for remote-user restoration, ownership preservation, archive extraction, and workspace setup edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->