### PR TITLE
fix(lint): audit gosec G106/G402 insecure TLS sites

### DIFF
--- a/cmd/pro/start.go
+++ b/cmd/pro/start.go
@@ -1260,7 +1260,7 @@ func (cmd *StartCmd) pingLoftRouter(ctx context.Context, loftPod *corev1.Pod) (s
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
+				InsecureSkipVerify: true, // #nosec G402 -- self-signed cert of the user's own pro instance
 			},
 		},
 	}
@@ -1378,7 +1378,9 @@ func (cmd *StartCmd) loginViaCLI(url string) error {
 	}
 	loginRequestBuf := bytes.NewBuffer(loginRequestBytes)
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, // #nosec G402 -- self-signed cert of the user's own pro instance
+		},
 	}
 	httpClient := &http.Client{Transport: tr}
 
@@ -1965,7 +1967,9 @@ func isHostReachable(ctx context.Context, host string) (bool, error) {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	// we disable http2 as Kubernetes has problems with this
 	transport.ForceAttemptHTTP2 = false
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true, // #nosec G402 -- self-signed cert of the user's own pro instance
+	}
 	// wait until loft is reachable at the given url
 	client := &http.Client{Transport: transport}
 	url := "https://" + host + "/version"

--- a/pkg/ssh/helper.go
+++ b/pkg/ssh/helper.go
@@ -13,7 +13,7 @@ import (
 func NewSSHPassClient(user, addr, password string) (*ssh.Client, error) {
 	clientConfig := &ssh.ClientConfig{
 		Auth:            []ssh.AuthMethod{},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // #nosec G106 -- agent-managed SSH server inside its own workspace
 	}
 
 	clientConfig.Auth = append(clientConfig.Auth, ssh.Password(password))
@@ -86,7 +86,7 @@ func StdioClientFromKeyBytesWithUser(
 func ConfigFromKeyBytes(keyBytes []byte) (*ssh.ClientConfig, error) {
 	clientConfig := &ssh.ClientConfig{
 		Auth:            []ssh.AuthMethod{},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // #nosec G106 -- agent-managed SSH server inside its own workspace
 	}
 
 	// key file authentication?

--- a/pkg/ts/derp.go
+++ b/pkg/ts/derp.go
@@ -17,7 +17,7 @@ type ConnTrackingFunc func(address string)
 func CheckDerpConnection(ctx context.Context, baseUrl *url.URL) error {
 	newTransport := http.DefaultTransport.(*http.Transport).Clone()
 	newTransport.TLSClientConfig = &tls.Config{
-		InsecureSkipVerify: true,
+		InsecureSkipVerify: true, // #nosec G402 -- reachability probe of our own coordinator; no data exchanged
 	}
 
 	client := &http.Client{

--- a/pkg/ts/ssh.go
+++ b/pkg/ts/ssh.go
@@ -56,8 +56,8 @@ func newSSHClient(
 
 	clientConfig := &ssh.ClientConfig{
 		User:            user,
-		Auth:            []ssh.AuthMethod{}, // The SSH server is only reachable through the tailnet
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Auth:            []ssh.AuthMethod{},          // The SSH server is only reachable through the tailnet
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(), // #nosec G106 -- workspace agent server reachable only through the encrypted tailnet
 	}
 
 	sshConn, channels, requests, err := ssh.NewClientConn(conn, address, clientConfig)


### PR DESCRIPTION
Task 8d85d5c3-0803-4be0-ac74-b562eea54c8c. Audit gosec G106/G402 findings in pkg/ts/ssh.go, pkg/ssh/helper.go, pkg/ts/derp.go, cmd/pro/start.go. All seven sites target self-owned infrastructure (agent-managed SSH servers reachable only through the tailnet/workspace; reachability probes and login flows against the user's own pro instance with a self-signed certificate), so real known-hosts/CA verification is not feasible without new infrastructure — each site now carries a documented `#nosec` rationale per the task note and the repo's existing convention.

Verification:
- `golangci-lint run ./pkg/ts/... ./pkg/ssh/... ./cmd/pro/...`: no G106/G402 findings remain (other pre-existing findings untouched).
- `go test ./pkg/ts/... ./pkg/ssh/... ./cmd/pro/...`: pass.
- Full `task cli:test` failures (e2e, pkg/git clone tests, hack/sign_commit) reproduced on clean tree — pre-existing/environmental.