### PR TITLE
fix: add ReadHeaderTimeout to http servers (G112)

### DIFF
--- a/pkg/daemon/platform/local_server.go
+++ b/pkg/daemon/platform/local_server.go
@@ -122,7 +122,7 @@ func newLocalServer(
 		handlers.PrintRecoveryStack(true),
 	)(mux)
 	handler = handlers.LoggingHandler(log.Writer(log.LevelDebug), handler)
-	l.httpServer = &http.Server{Handler: handler}
+	l.httpServer = &http.Server{Handler: handler, ReadHeaderTimeout: 5 * time.Second}
 
 	return l
 }

--- a/pkg/platform/client/client.go
+++ b/pkg/platform/client/client.go
@@ -533,7 +533,7 @@ func GetRestConfig(host, token string, insecure bool) (*rest.Config, error) {
 }
 
 func startServer(redirectURI string, keyChannel chan keyStruct) *http.Server {
-	srv := &http.Server{Addr: ":25843"}
+	srv := &http.Server{Addr: ":25843", ReadHeaderTimeout: 5 * time.Second}
 
 	http.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
 		keys, ok := r.URL.Query()["key"]


### PR DESCRIPTION
Task 8a520d85-d633-4122-8e05-8f6a1311d5b9. Set a 5s ReadHeaderTimeout on the daemon local server (`pkg/daemon/platform/local_server.go`) and the login callback server (`pkg/platform/client/client.go`), resolving gosec G112 (slowloris) findings. Verification: `go test ./pkg/daemon/platform/... ./pkg/platform/client/...` pass; golangci-lint shows no G112 on touched packages (remaining findings pre-exist on untouched code); full `task cli:test` failures in pkg/git and hack/sign_commit reproduce on a clean tree without this change.