### PR TITLE
fix: suppress gosec G117 on credential marshals

### DIFF
--- a/cmd/internal/git_credentials.go
+++ b/cmd/internal/git_credentials.go
@@ -148,6 +148,7 @@ func doRequest(
 	credentials *gitcredentials.GitCredentials,
 	url string,
 ) (*gitcredentials.GitCredentials, error) {
+	// #nosec G117 -- credentials request legitimately carries the password.
 	rawJSON, err := json.Marshal(credentials)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling credentials: %w", err)

--- a/pkg/agent/tunnelserver/tunnelserver.go
+++ b/pkg/agent/tunnelserver/tunnelserver.go
@@ -222,6 +222,7 @@ func (t *tunnelServer) DockerCredentials(
 			return nil, err
 		}
 
+		// #nosec G117 -- docker credential response legitimately carries the secret.
 		out, err := json.Marshal(credentials)
 		if err != nil {
 			return nil, err
@@ -299,6 +300,7 @@ func (t *tunnelServer) GitCredentials(
 		return nil, err
 	}
 
+	// #nosec G117 -- git credential response legitimately carries the password.
 	out, err := json.Marshal(credentials)
 	if err != nil {
 		return nil, err

--- a/pkg/dockercredentials/helper_test.go
+++ b/pkg/dockercredentials/helper_test.go
@@ -30,6 +30,7 @@ func (s *HelperTestSuite) TestGet_Success() {
 		s.NoError(err)
 		s.Equal("docker.io", request.ServerURL)
 
+		// #nosec G117 -- test fixture credentials.
 		_ = json.NewEncoder(w).Encode(&Credentials{
 			ServerURL: "docker.io",
 			Username:  "testuser",
@@ -92,6 +93,7 @@ func (s *HelperTestSuite) TestGet_WorkspaceServerFallback() {
 			s.NoError(err)
 			s.Equal("docker.io", request.ServerURL)
 
+			// #nosec G117 -- test fixture credentials.
 			_ = json.NewEncoder(w).Encode(&Credentials{
 				ServerURL: "docker.io",
 				Username:  "workspaceuser",

--- a/pkg/platform/client/client.go
+++ b/pkg/platform/client/client.go
@@ -199,6 +199,7 @@ func (c *client) Save() error {
 		return err
 	}
 
+	// #nosec G117 -- persisted client config legitimately carries the access key.
 	out, err := json.Marshal(c.config)
 	if err != nil {
 		return err


### PR DESCRIPTION
Task 3de21e14-e6bf-4178-ac2a-f6ad57c53002. Adds `// #nosec G117` annotations where JSON marshaling legitimately carries secret fields (G117): docker/git credential tunnel responses in pkg/agent/tunnelserver, the localhost git credentials request in cmd/internal, persisted client config access key in pkg/platform/client, and test fixture credentials in pkg/dockercredentials.

Verification: golangci-lint gosec run over all four packages shows 0 remaining G117 findings; scoped `go test` for ./pkg/agent/tunnelserver/... ./pkg/dockercredentials/... ./cmd/internal/... ./pkg/platform/client/... all pass.