### PR TITLE
fix(lint): audit gosec G703/G704 taint sinks

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -311,7 +311,7 @@ func CreateWorkspaceBusyFile(folder string) {
 
 func HasWorkspaceBusyFile(folder string) bool {
 	filePath := filepath.Join(folder, config.WorkspaceBusyFile)
-	_, err := os.Stat(filePath)
+	_, err := os.Stat(filePath) // #nosec G703 -- folder is the agent-resolved workspace dir, not user input
 	return err == nil
 }
 

--- a/pkg/agent/dockerless.go
+++ b/pkg/agent/dockerless.go
@@ -48,7 +48,7 @@ func GetDockerlessBuildContext() string {
 }
 
 func ImageConfigExists(path string) bool {
-	_, err := os.Stat(path)
+	_, err := os.Stat(path) // #nosec G703 -- path is the agent-written image config output, not user input
 	return err == nil
 }
 

--- a/pkg/devcontainer/setup/setup.go
+++ b/pkg/devcontainer/setup/setup.go
@@ -604,7 +604,7 @@ func markerFileExists(markerName string, markerContent string) (bool, error) {
 		filepath.Dir(markerName),
 		0o755,
 	) // #nosec G301 -- Standard directory permissions
-	err = os.WriteFile(markerName, []byte(markerContent), 0o600)
+	err = os.WriteFile(markerName, []byte(markerContent), 0o600) // #nosec G703 -- fixed caller-defined marker name under ContainerDataDir
 	if err != nil {
 		return false, fmt.Errorf("write marker: %w", err)
 	}

--- a/pkg/dockercredentials/helper.go
+++ b/pkg/dockercredentials/helper.go
@@ -137,6 +137,7 @@ func (h *Helper) getFromWorkspaceServer(serverURL string) (string, string, error
 
 	client := &http.Client{Timeout: credentialsTimeout}
 	endpoint := fmt.Sprintf("http://localhost:%s/docker-credentials", workspacePort)
+	// #nosec G704 -- endpoint is localhost with the workspace credentials port injected by the agent
 	resp, err := client.Post(endpoint, "application/json", bytes.NewReader(requestBody))
 	if err != nil {
 		return "", "", err

--- a/pkg/gpg/gpg_forwarding.go
+++ b/pkg/gpg/gpg_forwarding.go
@@ -169,7 +169,7 @@ func (g *GPGConf) SetupRemoteSocketLink(ctx context.Context) error {
 		if err := os.MkdirAll(filepath.Dir(link), 0o700); err != nil {
 			return err
 		}
-		_ = os.Remove(link)
+		_ = os.Remove(link) // #nosec G703 -- link derives from $HOME and the current uid, not user input
 		if err := os.Symlink(g.SocketPath, link); err != nil {
 			return err
 		}


### PR DESCRIPTION
Task 8a5eca13-1398-4a72-af1a-1be681421cf0. Annotate five gosec taint-analysis findings (G703 path traversal, G704 SSRF) where the tainted input is self-owned infrastructure: agent-resolved workspace busy-file paths (pkg/agent/agent.go), agent-written image config path (pkg/agent/dockerless.go), marker files under the fixed ContainerDataDir (pkg/devcontainer/setup/setup.go), GPG socket links derived from $HOME/uid (pkg/gpg/gpg_forwarding.go), and localhost credential posts on the agent-injected workspace port (pkg/dockercredentials/helper.go). Verification: golangci-lint run on all four touched package trees — zero remaining G703/G704 findings, no lll regressions; go test green on pkg/agent/..., pkg/gpg, pkg/devcontainer/setup, pkg/dockercredentials.