### PR TITLE
fix: silence gosec G204 on intentional exec calls

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -51,6 +51,13 @@ func ExistsForUser(cmd, user string) bool {
 		return Exists(cmd)
 	}
 
-	_, err = exec.Command("su", user, "-l", "-c", command).CombinedOutput()
+	_, err = exec.Command( // #nosec G204 -- runs the caller-provided command as the target workspace user
+		"su",
+		user,
+		"-l",
+		"-c",
+		command,
+	).
+		CombinedOutput()
 	return err == nil
 }

--- a/pkg/devsyconfig/config.go
+++ b/pkg/devsyconfig/config.go
@@ -44,7 +44,13 @@ func AuthVClusterCliToPlatform(config *client.Config) error {
 		return nil
 	}
 
-	cmd := exec.Command("vcluster", "login", "--access-key", config.AccessKey, config.Host)
+	cmd := exec.Command( // #nosec G204 -- vcluster resolved via LookPath above; args come from local config
+		"vcluster",
+		"login",
+		"--access-key",
+		config.AccessKey,
+		config.Host,
+	)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Debugf("Failed executing `vcluster login` : %v, output: %s", err, out)

--- a/pkg/ide/vscode/apk.go
+++ b/pkg/ide/vscode/apk.go
@@ -38,8 +38,9 @@ func InstallAPKRequirements() {
 		dependencies = append(dependencies, "curl")
 	}
 
-	out, err := exec.Command("sh", "-c", "apk update && apk add "+strings.Join(dependencies, " ")).
-		CombinedOutput()
+	out, err := exec.Command( // #nosec G204 -- package names come from a static list above
+		"sh", "-c", "apk update && apk add "+strings.Join(dependencies, " "),
+	).CombinedOutput()
 	if err != nil {
 		log.Errorf("Error updating apk dependencies: %v", command.WrapCommandError(out, err))
 	}

--- a/pkg/ide/vscode/open.go
+++ b/pkg/ide/vscode/open.go
@@ -172,7 +172,12 @@ func openViaCLI(ctx context.Context, params OpenParams) error {
 		cliPath,
 		strings.Join(args, " "),
 	)
-	out, err := exec.CommandContext(ctx, cliPath, args...).CombinedOutput()
+	out, err := exec.CommandContext( // #nosec G204 -- cliPath resolved by getCLIPath; args built internally
+		ctx,
+		cliPath,
+		args...,
+	).
+		CombinedOutput()
 	if err != nil {
 		return command.WrapCommandError(out, err)
 	}
@@ -209,7 +214,12 @@ func listInstalledExtensions(
 func ensureSSHExtension(ctx context.Context, cliPath, sshExtension string) error {
 	args := []string{"--install-extension", sshExtension}
 	log.Debugf("%s %s", cliPath, strings.Join(args, " "))
-	out, err := exec.CommandContext(ctx, cliPath, args...).CombinedOutput()
+	out, err := exec.CommandContext( // #nosec G204 -- cliPath resolved by getCLIPath; extension id from static config
+		ctx,
+		cliPath,
+		args...,
+	).
+		CombinedOutput()
 	if err != nil {
 		return command.WrapCommandError(out, err)
 	}

--- a/pkg/ide/vscode/vscode.go
+++ b/pkg/ide/vscode/vscode.go
@@ -208,9 +208,16 @@ func (o *VsCodeServer) buildExtensionCommand(binPath, extension string) *exec.Cm
 
 	if o.userName != "" {
 		cmd := shellescape.QuoteCommand(append([]string{binPath}, args...))
-		return exec.Command("su", o.userName, "-c", cmd)
+		return exec.Command(
+			"su",
+			o.userName,
+			"-c",
+			cmd,
+		) // #nosec G204 -- runs the workspace user's extension install by design
 	}
-	return exec.Command(binPath, args...)
+	return exec.Command(
+		binPath,
+		args...) // #nosec G204 -- binPath resolved from known server locations
 }
 
 func (o *VsCodeServer) findServerBinaryPath(location string) string {

--- a/pkg/ssh/server/ssh_container.go
+++ b/pkg/ssh/server/ssh_container.go
@@ -143,10 +143,14 @@ func (s *containerServer) getCommand(sess ssh.Session, isPty bool) (*exec.Cmd, e
 	}
 
 	if len(sess.RawCommand()) == 0 {
-		cmd = exec.Command(shell[0], args...)
+		cmd = exec.Command(
+			shell[0],
+			args...) // #nosec G204 -- ssh sessions run the user's login shell by design
 	} else {
 		args = append(args, "-c", sess.RawCommand())
-		cmd = exec.Command(shell[0], args...)
+		cmd = exec.Command(
+			shell[0],
+			args...) // #nosec G204 -- running the session's raw command is this server's purpose
 	}
 
 	err = config.PrepareCmdUser(cmd, user)


### PR DESCRIPTION
Task d18ab027-f8da-42f0-bf44-c2b41582dee3. Annotate intentionally dynamic subprocess invocations with `#nosec G204` justifications: su-based command execution (pkg/command), vcluster login (pkg/devsyconfig), vscode CLI wrappers and apk install (pkg/ide/vscode), ssh session shell execution (pkg/ssh/server). Clears all gosec G204 findings in those packages; no behavior change. Verification: golangci-lint run on pkg/command, pkg/devsyconfig, pkg/ide/vscode, pkg/ssh/server shows zero G204 (remaining findings pre-existing, out of scope); go test on the four packages passes; task cli:format applied.