### PR TITLE
fix: tighten gosec file/dir permission findings

### DIFF
--- a/pkg/devcontainer/config/prebuild.go
+++ b/pkg/devcontainer/config/prebuild.go
@@ -124,16 +124,16 @@ func readDockerignore(contextDir string, dockerfile string) ([]string, error) {
 	)
 
 	dockerignorefilepath := dockerfile + ".dockerignore"
-	if filepath.IsAbs(dockerignorefilepath) {
-		f, err = os.Open(dockerignorefilepath)
-	} else {
-		f, err = os.Open(filepath.Join(contextDir, dockerignorefilepath))
+	dockerignorepath := dockerignorefilepath
+	if !filepath.IsAbs(dockerignorepath) {
+		dockerignorepath = filepath.Join(contextDir, dockerignorepath)
 	}
+	f, err = os.Open(dockerignorepath) // #nosec G304 -- internal build path
 	if os.IsNotExist(err) {
-		dockerignorefilepath = ".dockerignore"
-		f, err = os.Open(filepath.Join(contextDir, dockerignorefilepath))
+		dockerignorepath = filepath.Join(contextDir, ".dockerignore")
+		f, err = os.Open(dockerignorepath) // #nosec G304 -- internal build path
 		if os.IsNotExist(err) {
-			return ensureDockerIgnoreAndDockerFile(excludes, dockerfile, dockerignorefilepath), nil
+			return ensureDockerIgnoreAndDockerFile(excludes, dockerfile, ".dockerignore"), nil
 		} else if err != nil {
 			return nil, err
 		}

--- a/pkg/ide/jetbrains/generic.go
+++ b/pkg/ide/jetbrains/generic.go
@@ -227,7 +227,7 @@ func (o *GenericJetBrainsServer) getDirectory(baseFolder string) string {
 }
 
 func (o *GenericJetBrainsServer) extractArchive(fromPath string, toPath string) error {
-	file, err := os.Open(fromPath)
+	file, err := os.Open(fromPath) // #nosec G304 -- internal install path
 	if err != nil {
 		return err
 	}
@@ -237,7 +237,7 @@ func (o *GenericJetBrainsServer) extractArchive(fromPath string, toPath string) 
 }
 
 func (o *GenericJetBrainsServer) download(targetFolder string) (string, error) {
-	err := os.MkdirAll(targetFolder, os.ModePerm)
+	err := os.MkdirAll(targetFolder, 0o750)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ide/rstudio/rstudio.go
+++ b/pkg/ide/rstudio/rstudio.go
@@ -270,7 +270,7 @@ func installDeb(debPath string) error {
 }
 
 func ensureConfigFolder(userName string) error {
-	err := os.MkdirAll(dataFolder, os.ModePerm)
+	err := os.MkdirAll(dataFolder, 0o750)
 	if err != nil {
 		return err
 	}
@@ -288,9 +288,13 @@ func setupSingleUserMode(configFolder, userName string) error {
 	dbConf := fmt.Sprintf(`provider=sqlite
 directory=%s`, configFolder)
 	dbConfPath := filepath.Join(configFolder, "dbconf.conf")
-	err := os.WriteFile(dbConfPath, []byte(dbConf), os.ModePerm)
+	err := os.WriteFile(dbConfPath, []byte(dbConf), 0o600)
 	if err != nil {
 		return fmt.Errorf("save db conf: %w", err)
+	}
+	err = copypkg.Chown(dbConfPath, userName)
+	if err != nil {
+		return fmt.Errorf("chown db conf: %w", err)
 	}
 
 	rServerConf := fmt.Sprintf(
@@ -309,9 +313,13 @@ database-config-file=%s/dbconf.conf
 	serverConfPath := filepath.Join(rstudioConfigFolder, "rserver.conf")
 	// The RStudio installer automatically creates an empty file at destConfPath, let's try to remove that first
 	_ = os.Remove(serverConfPath)
-	err = os.WriteFile(serverConfPath, []byte(rServerConf), os.ModePerm)
+	err = os.WriteFile(serverConfPath, []byte(rServerConf), 0o600)
 	if err != nil {
 		return fmt.Errorf("save rserver conf: %w", err)
+	}
+	err = copypkg.Chown(serverConfPath, userName)
+	if err != nil {
+		return fmt.Errorf("chown rserver conf: %w", err)
 	}
 
 	return nil
@@ -335,7 +343,7 @@ func setupPreferences(workspaceFolder, userName string) error {
 	}
 
 	prefsPath := filepath.Join(prefsDir, preferencesFile)
-	err = os.WriteFile(prefsPath, outPrefs, os.ModePerm)
+	err = os.WriteFile(prefsPath, outPrefs, 0o600)
 	if err != nil {
 		return fmt.Errorf("save preferences: %w", err)
 	}

--- a/pkg/platform/client/client.go
+++ b/pkg/platform/client/client.go
@@ -194,7 +194,7 @@ func (c *client) Save() error {
 		c.config.APIVersion = "storage.devsy.sh/v1"
 	}
 
-	err := os.MkdirAll(filepath.Dir(c.configPath), 0o755)
+	err := os.MkdirAll(filepath.Dir(c.configPath), 0o750)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func (c *client) Save() error {
 		return err
 	}
 
-	return os.WriteFile(c.configPath, out, 0o660)
+	return os.WriteFile(c.configPath, out, 0o600)
 }
 
 func (c *client) ManagementConfig() (*rest.Config, error) {


### PR DESCRIPTION
Task 2d3b5743-e3a5-4013-bc87-154fe3e07b1a.

## Summary
- Fix gosec G301: `MkdirAll` dirs now created with `0o750` (rstudio data folder, jetbrains download folder, platform client config dir)
- Fix gosec G306: config files written with `0o600`; rstudio db/server confs chowned to the server user so rserver (running via `su <user>`) keeps read access
- Annotate internal-path `os.Open` calls with `#nosec G304` where paths derive from the build context or install options; hoisted dockerignore path construction so suppression stays on a single line

## Verification
- `golangci-lint run` on all four touched packages: zero G301/G304/G306 findings remain (was 9); remaining scoped findings pre-exist on main
- `go test ./pkg/devcontainer/config/... ./pkg/copy/...` pass; touched packages have no other test files
- Full `go test ./...` failures (pkg/git, hack/sign_commit, e2e) reproduce identically on clean main — environmental, unrelated to this diff
- `task cli:format` applied (golines stable)