### PR TITLE
fix: resolve gosec G404 and G101 findings

### DIFF
--- a/pkg/config/context.go
+++ b/pkg/config/context.go
@@ -10,8 +10,8 @@ const (
 	ContextOptionSSHAddPrivateKeys          = "SSH_ADD_PRIVATE_KEYS"
 	ContextOptionGPGAgentForwarding         = "GPG_AGENT_FORWARDING"
 	ContextOptionGitSSHSignatureForwarding  = "GIT_SSH_SIGNATURE_FORWARDING"
-	ContextOptionSSHInjectDockerCredentials = "SSH_INJECT_DOCKER_CREDENTIALS"
-	ContextOptionSSHInjectGitCredentials    = "SSH_INJECT_GIT_CREDENTIALS"
+	ContextOptionSSHInjectDockerCredentials = "SSH_INJECT_DOCKER_CREDENTIALS" //nolint:gosec // G101: context option name, not a credential
+	ContextOptionSSHInjectGitCredentials    = "SSH_INJECT_GIT_CREDENTIALS"    //nolint:gosec // G101: context option name, not a credential
 	ContextOptionExitAfterTimeout           = "EXIT_AFTER_TIMEOUT"
 	ContextOptionTelemetry                  = "TELEMETRY"
 	ContextOptionAgentURL                   = "AGENT_URL"

--- a/pkg/image/auth.go
+++ b/pkg/image/auth.go
@@ -24,7 +24,7 @@ var (
 	)
 )
 
-const tokenFileLocation = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+const tokenFileLocation = "/var/run/secrets/kubernetes.io/serviceaccount/token" //nolint:gosec // G101: projected service account token file path, not a credential
 
 // See https://github.com/kubernetes/kubernetes/blob/30ae12d018697d3c5f04e225b11f242f5310e097/pkg/serviceaccount/claims.go#L55
 type privateClaims struct {

--- a/pkg/random/random.go
+++ b/pkg/random/random.go
@@ -1,6 +1,9 @@
 package random
 
-import "math/rand"
+import (
+	"crypto/rand"
+	"math/big"
+)
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
 
@@ -8,7 +11,7 @@ var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz")
 func String(length int) string {
 	b := make([]rune, length)
 	for i := range b {
-		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+		b[i] = letterRunes[randInt(len(letterRunes))]
 	}
 	return string(b)
 }
@@ -17,5 +20,14 @@ func InRange(min, max int) int {
 	if max <= min {
 		return min
 	}
-	return rand.Intn(max-min) + min
+	return randInt(max-min) + min
+}
+
+// randInt returns a cryptographically secure random int in [0, max).
+func randInt(max int) int {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	return int(n.Int64())
 }

--- a/pkg/util/rand.go
+++ b/pkg/util/rand.go
@@ -1,7 +1,8 @@
 package util
 
 import (
-	"math/rand"
+	"crypto/rand"
+	"math/big"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -9,7 +10,16 @@ const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 func RandStringBytes(n int) string {
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+		b[i] = letterBytes[randInt(len(letterBytes))]
 	}
 	return string(b)
+}
+
+// randInt returns a cryptographically secure random int in [0, max).
+func randInt(max int) int {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		panic("crypto/rand failed: " + err.Error())
+	}
+	return int(n.Int64())
 }


### PR DESCRIPTION
Task 3ac782f8-eba2-48a7-b49c-70bd8d3e1476. Replace math/rand with crypto/rand-backed helpers in pkg/random and pkg/util/rand.go (G404 weak randomness); annotate non-credential constants in pkg/image/auth.go (service account token file path) and pkg/config/context.go (context option names) with justified //nolint:gosec for G101. Verification: gosec clean on pkg/random + pkg/util; golangci-lint run on all four touched packages shows no new findings (remaining are pre-existing on untouched lines); scoped go test of touched packages and all consumers passes; full task cli:test fails only in hack/sign_commit and pkg/git, confirmed pre-existing on base branch.