### PR TITLE
feat: breadcrumbs navigation accessibility

### DIFF
--- a/desktop/src/renderer/src/lib/components/layout/Breadcrumbs.svelte
+++ b/desktop/src/renderer/src/lib/components/layout/Breadcrumbs.svelte
@@ -40,15 +40,21 @@ let crumbs = $derived.by(() => {
 </script>
 
 {#if crumbs.length > 0}
-  <nav class="flex items-center gap-1 text-sm text-muted-foreground">
-    <a href="#/" class="hover:text-foreground transition-colors">Home</a>
-    {#each crumbs as crumb}
-      <ChevronRight class="h-3 w-3" />
-      {#if crumb.href}
-        <a href={crumb.href} class="hover:text-foreground transition-colors">{crumb.label}</a>
-      {:else}
-        <span class="text-foreground font-medium">{crumb.label}</span>
-      {/if}
-    {/each}
+  <nav aria-label="Breadcrumb" class="flex items-center gap-1 text-sm text-muted-foreground">
+    <ol class="flex items-center gap-1">
+      <li class="flex items-center gap-1">
+        <a href="#/" class="hover:text-foreground transition-colors">Home</a>
+      </li>
+      {#each crumbs as crumb}
+        <li class="flex items-center gap-1">
+          <ChevronRight class="h-3 w-3" aria-hidden="true" />
+          {#if crumb.href}
+            <a href={crumb.href} class="hover:text-foreground transition-colors">{crumb.label}</a>
+          {:else}
+            <span class="text-foreground font-medium" aria-current="page">{crumb.label}</span>
+          {/if}
+        </li>
+      {/each}
+    </ol>
   </nav>
 {/if}


### PR DESCRIPTION
What: Standardized the Breadcrumbs component using semantic `<nav aria-label="Breadcrumb">` and `<ol>` list structure with `aria-current="page"` for the current active page crumb and `aria-hidden="true"` on separator icons.

Why: Screen readers previously lacked structured navigation semantics and landmark identification when navigating header breadcrumbs.

Accessibility: Added `aria-label="Breadcrumb"`, `<ol>` list markup, `aria-hidden="true"` for decorative Chevron icons, and `aria-current="page"` attribute for the current page item.

---
*PR created automatically by Jules for task [8636199951307305833](https://jules.google.com/task/8636199951307305833) started by @skevetter*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility Improvements**
  - Improved breadcrumb navigation semantics for assistive technologies.
  - Added a clear navigation label and structured breadcrumb list.
  - Identified the current page and hid decorative chevron icons from screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->