### PR TITLE
fix: own persistent SSH transport lifecycle

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -757,7 +757,7 @@ jobs:
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/podman-linux-amd64.tar.gz
-          key: ${{ runner.os }}-${{ runner.arch }}-podman-static-v5.8.2
+          key: ${{ runner.os }}-${{ runner.arch }}-podman-static-v5.8.4
 
       - name: install podman (Linux)
         if: (matrix.install-podman == 'rootless' || matrix.install-podman == 'rootful') && runner.os == 'Linux'
@@ -766,10 +766,10 @@ jobs:
           archive="${{ runner.temp }}/podman-linux-amd64.tar.gz"
           if [ "${{ steps.podman-cache-linux.outputs.cache-hit }}" != "true" ]; then
             curl -fsSL -o "$archive" \
-              https://github.com/mgoltzsche/podman-static/releases/download/v5.8.2/podman-linux-amd64.tar.gz
+              https://github.com/mgoltzsche/podman-static/releases/download/v5.8.4/podman-linux-amd64.tar.gz
           fi
 
-          expectedHash="228b9adf1ba3585d1d72f0a4bb9a669de5ea806d13884b2c43b5e65601a1a580"
+          expectedHash="a58765fe8be6ab3fb79f892f1a027b4ce4a7e8eb589df1ef960c167cbde08d69"
           actualHash=$(sha256sum "$archive" | cut -d' ' -f1)
           if [ "$actualHash" != "$expectedHash" ]; then
             echo "::error::SHA256 mismatch for podman-static archive! Expected: $expectedHash, Got: $actualHash"

--- a/cmd/workspace/ssh.go
+++ b/cmd/workspace/ssh.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -354,7 +355,7 @@ func (cmd *SSHCmd) startProxyTunnel(
 	client client2.ProxyClient,
 ) error {
 	log.Debugf("start proxy tunnel")
-	return tunnel.NewTunnel(
+	return tunnel.NewTunnelWithMetadata(
 		ctx,
 		func(ctx context.Context, stdin io.Reader, stdout io.Writer) error {
 			return client.Ssh(ctx, client2.SshOptions{
@@ -365,6 +366,11 @@ func (cmd *SSHCmd) startProxyTunnel(
 		},
 		func(ctx context.Context, containerClient *ssh.Client) error {
 			return cmd.startTunnel(ctx, devsyConfig, containerClient, client)
+		},
+		tunnel.TransportLogMetadata{
+			Provider:  client.Provider(),
+			Mode:      "proxy",
+			Workspace: client.Workspace(),
 		},
 	)
 }
@@ -689,10 +695,20 @@ func startSSHKeepAlive(
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			_, _, err := client.SendRequest("keepalive@openssh.com", true, nil)
-			if err != nil {
+			ok, _, err := client.SendRequest("keepalive@openssh.com", true, nil)
+			if err := checkKeepAliveResponse(ok, err); err != nil {
 				log.Errorf("failed to send keepalive: %v", err)
 			}
 		}
 	}
+}
+
+func checkKeepAliveResponse(ok bool, err error) error {
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("keepalive request rejected")
+	}
+	return nil
 }

--- a/cmd/workspace/ssh_keepalive_test.go
+++ b/cmd/workspace/ssh_keepalive_test.go
@@ -1,0 +1,37 @@
+package workspace
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestCheckKeepAliveResponse(t *testing.T) {
+	t.Parallel()
+
+	transportErr := errors.New("connection closed")
+	tests := []struct {
+		name string
+		ok   bool
+		err  error
+		want error
+	}{
+		{name: "positive reply", ok: true},
+		{name: "negative reply", ok: false, want: errors.New("keepalive request rejected")},
+		{name: "transport error", ok: true, err: transportErr, want: transportErr},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := checkKeepAliveResponse(tt.ok, tt.err)
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("checkKeepAliveResponse() = %v, want nil", got)
+				}
+				return
+			}
+			if got == nil || got.Error() != tt.want.Error() {
+				t.Fatalf("checkKeepAliveResponse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/ssh/direct_tcpip_test.go
+++ b/pkg/ssh/direct_tcpip_test.go
@@ -1,0 +1,249 @@
+package ssh
+
+import (
+	"crypto/ed25519"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type directTCPIPChannelData struct {
+	DestAddr   string
+	DestPort   uint32
+	OriginAddr string
+	OriginPort uint32
+}
+
+func startDirectTCPIPSSHServer(t *testing.T) (*ssh.Client, string) {
+	t.Helper()
+
+	signer := newTestSSHSigner(t)
+	backend, backendAddr := startEchoBackend(t)
+	serverListener := startDirectTCPIPServer(t)
+	serverConnDone := serveDirectTCPIPConnection(serverListener, signer)
+
+	client, err := ssh.Dial("tcp", serverListener.Addr().String(), &ssh.ClientConfig{
+		User:            "test",
+		HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
+		Timeout:         2 * time.Second,
+	})
+	if err != nil {
+		_ = serverListener.Close()
+		_ = backend.Close()
+		t.Fatalf("dial SSH server: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = client.Close()
+		_ = serverListener.Close()
+		_ = backend.Close()
+		<-serverConnDone
+	})
+	return client, backendAddr
+}
+
+func newTestSSHSigner(t *testing.T) ssh.Signer {
+	t.Helper()
+
+	_, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("generate host key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatalf("create host signer: %v", err)
+	}
+	return signer
+}
+
+func startEchoBackend(t *testing.T) (net.Listener, string) {
+	t.Helper()
+
+	backend, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for backend: %v", err)
+	}
+	go serveEchoBackend(backend)
+	return backend, backend.Addr().String()
+}
+
+func serveEchoBackend(listener net.Listener) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		go func() {
+			defer func() { _ = conn.Close() }()
+			_, _ = io.Copy(conn, conn)
+		}()
+	}
+}
+
+func startDirectTCPIPServer(t *testing.T) net.Listener {
+	t.Helper()
+
+	serverListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for SSH server: %v", err)
+	}
+	return serverListener
+}
+
+func serveDirectTCPIPConnection(listener net.Listener, signer ssh.Signer) <-chan struct{} {
+	serverConfig := &ssh.ServerConfig{NoClientAuth: true}
+	serverConfig.AddHostKey(signer)
+	serverConnDone := make(chan struct{})
+	go func() {
+		defer close(serverConnDone)
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		serverConn, channels, requests, handshakeErr := ssh.NewServerConn(conn, serverConfig)
+		if handshakeErr != nil {
+			return
+		}
+		go ssh.DiscardRequests(requests)
+		for newChannel := range channels {
+			handleDirectTCPIPChannel(newChannel)
+		}
+		_ = serverConn.Close()
+	}()
+	return serverConnDone
+}
+
+func handleDirectTCPIPChannel(newChannel ssh.NewChannel) {
+	if newChannel.ChannelType() != "direct-tcpip" {
+		_ = newChannel.Reject(ssh.UnknownChannelType, "only direct-tcpip is supported")
+		return
+	}
+	var data directTCPIPChannelData
+	if err := ssh.Unmarshal(newChannel.ExtraData(), &data); err != nil {
+		_ = newChannel.Reject(ssh.ConnectionFailed, err.Error())
+		return
+	}
+	channel, channelRequests, err := newChannel.Accept()
+	if err != nil {
+		return
+	}
+	go ssh.DiscardRequests(channelRequests)
+	backendAddr := net.JoinHostPort(data.DestAddr, strconv.FormatUint(uint64(data.DestPort), 10))
+	backendConn, err := net.Dial("tcp", backendAddr)
+	if err != nil {
+		_ = channel.Close()
+		return
+	}
+	go bridgeDirectTCPIPChannel(channel, backendConn)
+}
+
+func bridgeDirectTCPIPChannel(channel ssh.Channel, backendConn net.Conn) {
+	defer func() { _ = channel.Close() }()
+	defer func() { _ = backendConn.Close() }()
+	go func() { _, _ = io.Copy(backendConn, channel) }()
+	_, _ = io.Copy(channel, backendConn)
+}
+
+func openDirectTCPIP(t *testing.T, client *ssh.Client, backendAddr string) ssh.Channel {
+	t.Helper()
+	host, portString, err := net.SplitHostPort(backendAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.ParseUint(portString, 10, 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	channel, _, err := client.OpenChannel("direct-tcpip", ssh.Marshal(&directTCPIPChannelData{
+		DestAddr:   host,
+		DestPort:   uint32(port),
+		OriginAddr: "127.0.0.1",
+		OriginPort: 0,
+	}))
+	if err != nil {
+		t.Fatalf("open direct-tcpip channel: %v", err)
+	}
+	return channel
+}
+
+func TestDirectTCPIPRepeatedChannelsKeepParentAlive(t *testing.T) {
+	client, backendAddr := startDirectTCPIPSSHServer(t)
+
+	for range 10 {
+		channel := openDirectTCPIP(t, client, backendAddr)
+		message := []byte("ping")
+		if _, err := channel.Write(message); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		response := make([]byte, len(message))
+		if _, err := io.ReadFull(channel, response); err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		if string(response) != string(message) {
+			t.Fatalf("response = %q, want %q", response, message)
+		}
+		_ = channel.Close()
+	}
+}
+
+func TestDirectTCPIPConcurrentChannelsAreIndependent(t *testing.T) {
+	client, backendAddr := startDirectTCPIPSSHServer(t)
+	channels := make([]ssh.Channel, 5)
+	for i := range channels {
+		channels[i] = openDirectTCPIP(t, client, backendAddr)
+	}
+
+	var wg sync.WaitGroup
+	for i, channel := range channels {
+		wg.Go(func() {
+			message := fmt.Appendf(nil, "channel-%d", i)
+			if err := exchangeDirectTCPIP(channel, message); err != nil {
+				t.Errorf("channel %d exchange: %v", i, err)
+			}
+		})
+	}
+	wg.Wait()
+
+	// Closing channels in non-FIFO order exercises parent/channel ownership.
+	for _, index := range []int{4, 1, 3, 0, 2} {
+		_ = channels[index].Close()
+	}
+
+	channel := openDirectTCPIP(t, client, backendAddr)
+	defer func() { _ = channel.Close() }()
+	message := []byte("still-alive")
+	if err := exchangeDirectTCPIP(channel, message); err != nil {
+		t.Fatalf("parent transport unusable after channel churn: %v", err)
+	}
+}
+
+func TestDirectTCPIPIdleParentAcceptsNewChannel(t *testing.T) {
+	client, backendAddr := startDirectTCPIPSSHServer(t)
+	time.Sleep(25 * time.Millisecond)
+	channel := openDirectTCPIP(t, client, backendAddr)
+	defer func() { _ = channel.Close() }()
+	message := []byte("after-idle")
+	if err := exchangeDirectTCPIP(channel, message); err != nil {
+		t.Fatalf("exchange after idle: %v", err)
+	}
+}
+
+func exchangeDirectTCPIP(channel ssh.Channel, message []byte) error {
+	if _, err := channel.Write(message); err != nil {
+		return fmt.Errorf("write: %w", err)
+	}
+	response := make([]byte, len(message))
+	if _, err := io.ReadFull(channel, response); err != nil {
+		return fmt.Errorf("read: %w", err)
+	}
+	if string(response) != string(message) {
+		return fmt.Errorf("response = %q, want %q", response, message)
+	}
+	return nil
+}

--- a/pkg/tunnel/container.go
+++ b/pkg/tunnel/container.go
@@ -59,7 +59,9 @@ func (c *ContainerTunnel) Run(
 	}
 	defer pb.Close()
 
-	return pb.RunPair(ctx,
+	info, err := runPersistentPair(
+		ctx,
+		pb,
 		func(ctx context.Context, stdin, stdout *os.File) error {
 			return c.runHostTunnel(ctx, stdin, stdout, timeout)
 		},
@@ -82,6 +84,12 @@ func (c *ContainerTunnel) Run(
 			return nil
 		},
 	)
+	LogTransportClose(info, TransportLogMetadata{
+		Provider:  c.client.Provider(),
+		Mode:      workspaceSubcommand,
+		Workspace: c.client.Workspace(),
+	})
+	return err
 }
 
 // runHostTunnel injects the devsy agent onto the host and starts the SSH server,

--- a/pkg/tunnel/direct.go
+++ b/pkg/tunnel/direct.go
@@ -13,17 +13,39 @@ type Tunnel func(ctx context.Context, stdin io.Reader, stdout io.Writer) error
 
 // NewTunnel creates a tunnel to the devcontainer using generic functions
 // to establish the "outer" and "inner" tunnel, used by proxy clients.
-// The tunnel will be an SSH connection with its STDIO as arguments and
-// the handler will be the function to execute the command using the
+// The tunnel will be an SSH connection with its STDIO as arguments and the
+// handler will be the function to execute the command using the
 // connected SSH client.
 func NewTunnel(ctx context.Context, tunnel Tunnel, handler Handler) error {
+	return newTunnel(ctx, tunnel, handler, TransportLogMetadata{})
+}
+
+// NewTunnelWithMetadata is NewTunnel with context for the canonical transport
+// close event.
+func NewTunnelWithMetadata(
+	ctx context.Context,
+	tunnel Tunnel,
+	handler Handler,
+	metadata TransportLogMetadata,
+) error {
+	return newTunnel(ctx, tunnel, handler, metadata)
+}
+
+func newTunnel(
+	ctx context.Context,
+	tunnel Tunnel,
+	handler Handler,
+	metadata TransportLogMetadata,
+) error {
 	pb, err := NewPipeBridge()
 	if err != nil {
 		return err
 	}
 	defer pb.Close()
 
-	return pb.RunPair(ctx,
+	info, err := runPersistentPair(
+		ctx,
+		pb,
 		func(ctx context.Context, stdin, stdout *os.File) error {
 			return tunnel(ctx, stdin, stdout)
 		},
@@ -36,4 +58,6 @@ func NewTunnel(ctx context.Context, tunnel Tunnel, handler Handler) error {
 			return handler(ctx, sshClient)
 		},
 	)
+	LogTransportClose(info, metadata)
+	return err
 }

--- a/pkg/tunnel/transport.go
+++ b/pkg/tunnel/transport.go
@@ -1,0 +1,208 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/devsy-org/devsy/pkg/log"
+)
+
+// TransportCloseReason describes why a persistent transport ended. The reason
+// is recorded by the transport owner before any shared-resource cleanup runs.
+type TransportCloseReason string
+
+const (
+	CloseUnknown           TransportCloseReason = "unknown"
+	ClosePeerEOF           TransportCloseReason = "peer_eof"
+	CloseContextCancelled  TransportCloseReason = "context_cancelled"
+	CloseLocalShutdown     TransportCloseReason = "local_shutdown"
+	CloseProviderExit      TransportCloseReason = "provider_exit"
+	CloseProviderError     TransportCloseReason = "provider_error"
+	CloseSSHTransportError TransportCloseReason = "ssh_transport_error"
+	CloseSessionExit       TransportCloseReason = "session_exit"
+	CloseKeepaliveTimeout  TransportCloseReason = "keepalive_timeout"
+)
+
+// TransportSide identifies the participant that first caused transport
+// shutdown.
+type TransportSide string
+
+const (
+	TransportSideUnknown  TransportSide = "unknown"
+	TransportSideProvider TransportSide = "provider"
+	TransportSideSSH      TransportSide = "ssh"
+	TransportSideParent   TransportSide = "parent"
+)
+
+// TransportCloseInfo is the immutable, first-close-wins result of a
+// persistent transport's lifecycle. Err is the initiating error, not a later
+// cleanup error caused by shutting down the other side.
+type TransportCloseInfo struct {
+	Reason TransportCloseReason
+	Err    error
+	Side   TransportSide
+}
+
+// PersistentTransport owns lifecycle state shared by a persistent transport.
+// It provides a transport-scoped context, a one-shot completion signal, and the
+// authoritative close reason. It deliberately does not own the underlying
+// sockets, subprocesses, or PipeBridge; the caller remains responsible for
+// those resources while using this object as the lifecycle owner.
+type PersistentTransport struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	done chan struct{}
+	once sync.Once
+
+	mu   sync.RWMutex
+	info TransportCloseInfo
+}
+
+// NewPersistentTransport creates a persistent transport whose context is a
+// child of parent. Parent cancellation propagates to Context immediately.
+func NewPersistentTransport(parent context.Context) *PersistentTransport {
+	ctx, cancel := context.WithCancel(parent)
+	return &PersistentTransport{
+		ctx:    ctx,
+		cancel: cancel,
+		done:   make(chan struct{}),
+		info:   TransportCloseInfo{Reason: CloseUnknown, Side: TransportSideUnknown},
+	}
+}
+
+// Context returns the context shared by persistent transport work.
+func (t *PersistentTransport) Context() context.Context {
+	return t.ctx
+}
+
+// Done is closed exactly once when Close records the transport's terminal
+// state.
+func (t *PersistentTransport) Done() <-chan struct{} {
+	return t.done
+}
+
+// Close records info and shuts down the transport. The first call wins;
+// repeated calls are safe and cannot replace CloseInfo or panic on Done.
+func (t *PersistentTransport) Close(info TransportCloseInfo) {
+	t.once.Do(func() {
+		t.mu.Lock()
+		t.info = info
+		t.mu.Unlock()
+
+		t.cancel()
+		close(t.done)
+	})
+}
+
+// CloseInfo returns the first recorded close information. Before Close it is
+// the zero value, whose Reason is CloseUnknown.
+func (t *PersistentTransport) CloseInfo() TransportCloseInfo {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.info
+}
+
+// classifyTransportError maps a side completion into the semantic close
+// reason for a persistent transport. Parent cancellation takes precedence over
+// side errors because cancellation is intentional caller shutdown.
+func classifyTransportError(
+	side TransportSide,
+	err error,
+	parentCtx context.Context,
+) TransportCloseInfo {
+	if parentCtx.Err() != nil {
+		return TransportCloseInfo{
+			Reason: CloseContextCancelled,
+			Side:   TransportSideParent,
+			Err:    parentCtx.Err(),
+		}
+	}
+
+	if err == nil {
+		return TransportCloseInfo{
+			Reason: CloseLocalShutdown,
+			Side:   side,
+		}
+	}
+
+	if errors.Is(err, io.EOF) {
+		return TransportCloseInfo{
+			Reason: ClosePeerEOF,
+			Side:   side,
+			Err:    err,
+		}
+	}
+
+	switch side {
+	case TransportSideProvider:
+		return TransportCloseInfo{Reason: CloseProviderError, Side: side, Err: err}
+	case TransportSideSSH:
+		return TransportCloseInfo{Reason: CloseSSHTransportError, Side: side, Err: err}
+	default:
+		return TransportCloseInfo{Reason: CloseUnknown, Side: side, Err: err}
+	}
+}
+
+// TransportLogMetadata supplies optional context for the canonical close log.
+type TransportLogMetadata struct {
+	Provider  string
+	Mode      string
+	Workspace string
+}
+
+// LogTransportClose emits the single canonical close event for a persistent
+// SSH transport. Cleanup diagnostics remain separate from this event.
+func LogTransportClose(info TransportCloseInfo, metadata TransportLogMetadata) {
+	log.Debugw("ssh transport closed",
+		"reason", info.Reason,
+		"side", info.Side,
+		"error", info.Err,
+		"provider", metadata.Provider,
+		"mode", metadata.Mode,
+		"workspace", metadata.Workspace,
+	)
+}
+
+// runPersistentPair gives a PipeBridge pair an explicit persistent lifecycle
+// owner without changing PipeBridge's byte movement or join semantics.
+func runPersistentPair(
+	parent context.Context,
+	pb *PipeBridge,
+	tunnelFn TunnelFunc,
+	handlerFn HandlerFunc,
+) (TransportCloseInfo, error) {
+	transport := NewPersistentTransport(parent)
+
+	go func() {
+		select {
+		case <-parent.Done():
+			transport.Close(classifyTransportError(TransportSideParent, parent.Err(), parent))
+		case <-transport.Done():
+		}
+	}()
+
+	err := pb.RunPair(
+		transport.Context(),
+		func(ctx context.Context, stdin, stdout *os.File) error {
+			err := tunnelFn(ctx, stdin, stdout)
+			transport.Close(classifyTransportError(TransportSideProvider, err, parent))
+			return err
+		},
+		func(ctx context.Context, stdout, stdin *os.File) error {
+			err := handlerFn(ctx, stdout, stdin)
+			transport.Close(classifyTransportError(TransportSideSSH, err, parent))
+			return err
+		},
+	)
+
+	select {
+	case <-transport.Done():
+	default:
+		transport.Close(classifyTransportError(TransportSideUnknown, err, parent))
+	}
+	return transport.CloseInfo(), err
+}

--- a/pkg/tunnel/transport_test.go
+++ b/pkg/tunnel/transport_test.go
@@ -1,0 +1,269 @@
+package tunnel
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestPersistentTransportStartsUnknown(t *testing.T) {
+	t.Parallel()
+
+	transport := NewPersistentTransport(context.Background())
+	info := transport.CloseInfo()
+	if info.Reason != CloseUnknown || info.Side != TransportSideUnknown || info.Err != nil {
+		t.Fatalf("initial CloseInfo() = %+v, want unknown", info)
+	}
+}
+
+func TestPersistentTransportFirstCloseWins(t *testing.T) {
+	t.Parallel()
+
+	transport := NewPersistentTransport(context.Background())
+	firstErr := errors.New("provider stopped")
+	transport.Close(TransportCloseInfo{
+		Reason: CloseProviderError,
+		Side:   TransportSideProvider,
+		Err:    firstErr,
+	})
+	transport.Close(TransportCloseInfo{
+		Reason: CloseSSHTransportError,
+		Side:   TransportSideSSH,
+		Err:    errors.New("ssh stopped"),
+	})
+
+	info := transport.CloseInfo()
+	if info.Reason != CloseProviderError ||
+		info.Side != TransportSideProvider ||
+		!errors.Is(info.Err, firstErr) {
+		t.Fatalf("CloseInfo() = %+v, want first close", info)
+	}
+	select {
+	case <-transport.Done():
+	default:
+		t.Fatal("Done() is still open after Close")
+	}
+	select {
+	case <-transport.Context().Done():
+	default:
+		t.Fatal("transport context is still active after Close")
+	}
+}
+
+func TestPersistentTransportCloseIsSafeConcurrently(t *testing.T) {
+	t.Parallel()
+
+	transport := NewPersistentTransport(context.Background())
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Go(func() {
+			transport.Close(TransportCloseInfo{Reason: CloseLocalShutdown, Side: TransportSideSSH})
+		})
+	}
+	wg.Wait()
+	select {
+	case <-transport.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Done() did not close")
+	}
+}
+
+func TestPersistentTransportParentCancellationPropagates(t *testing.T) {
+	t.Parallel()
+
+	parent, cancel := context.WithCancel(context.Background())
+	transport := NewPersistentTransport(parent)
+	cancel()
+
+	select {
+	case <-transport.Context().Done():
+	case <-time.After(time.Second):
+		t.Fatal("transport context did not inherit parent cancellation")
+	}
+	if !errors.Is(transport.Context().Err(), context.Canceled) {
+		t.Fatalf("transport context error = %v, want context.Canceled", transport.Context().Err())
+	}
+}
+
+func TestClassifyTransportError(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range transportErrorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			parentCtx := context.Background()
+			if tt.cancelParent {
+				var cancel context.CancelFunc
+				parentCtx, cancel = context.WithCancel(parentCtx)
+				cancel()
+			}
+			got := classifyTransportError(tt.side, tt.err, parentCtx)
+			if got.Reason != tt.wantReason || got.Side != tt.wantSide {
+				t.Fatalf(
+					"classifyTransportError() = %+v, want reason=%s side=%s",
+					got,
+					tt.wantReason,
+					tt.wantSide,
+				)
+			}
+			if tt.wantErr != nil && !errors.Is(got.Err, tt.wantErr) {
+				t.Fatalf("classified error = %v, want %v", got.Err, tt.wantErr)
+			}
+		})
+	}
+}
+
+type fmtWrappedEOF struct{}
+
+func (fmtWrappedEOF) Error() string { return "peer: EOF" }
+func (fmtWrappedEOF) Unwrap() error { return io.EOF }
+
+type transportErrorTest struct {
+	name         string
+	side         TransportSide
+	err          error
+	cancelParent bool
+	wantReason   TransportCloseReason
+	wantSide     TransportSide
+	wantErr      error
+}
+
+var (
+	errProviderExit     = errors.New("provider exited")
+	errSSHTransport     = errors.New("ssh failed")
+	transportErrorTests = []transportErrorTest{
+		{
+			name:       "nil provider completion",
+			side:       TransportSideProvider,
+			wantReason: CloseLocalShutdown,
+			wantSide:   TransportSideProvider,
+		},
+		{
+			name:       "peer eof",
+			side:       TransportSideSSH,
+			err:        fmtWrappedEOF{},
+			wantReason: ClosePeerEOF,
+			wantSide:   TransportSideSSH,
+		},
+		{
+			name:         "parent cancellation",
+			side:         TransportSideProvider,
+			err:          errProviderExit,
+			cancelParent: true,
+			wantReason:   CloseContextCancelled,
+			wantSide:     TransportSideParent,
+			wantErr:      context.Canceled,
+		},
+		{
+			name:       "provider error",
+			side:       TransportSideProvider,
+			err:        errProviderExit,
+			wantReason: CloseProviderError,
+			wantSide:   TransportSideProvider,
+			wantErr:    errProviderExit,
+		},
+		{
+			name:       "ssh error",
+			side:       TransportSideSSH,
+			err:        errSSHTransport,
+			wantReason: CloseSSHTransportError,
+			wantSide:   TransportSideSSH,
+			wantErr:    errSSHTransport,
+		},
+		{
+			name:       "unknown side",
+			side:       TransportSideUnknown,
+			err:        errSSHTransport,
+			wantReason: CloseUnknown,
+			wantSide:   TransportSideUnknown,
+			wantErr:    errSSHTransport,
+		},
+	}
+)
+
+func TestRunPersistentPairAttributesProviderFailure(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pb.Close()
+	providerErr := errors.New("provider failed")
+
+	info, _ := runPersistentPair(
+		context.Background(),
+		pb,
+		func(context.Context, *os.File, *os.File) error { return providerErr },
+		func(ctx context.Context, _ *os.File, _ *os.File) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	)
+	if info.Reason != CloseProviderError ||
+		info.Side != TransportSideProvider ||
+		!errors.Is(info.Err, providerErr) {
+		t.Fatalf("close info = %+v, want provider failure", info)
+	}
+}
+
+func TestRunPersistentPairAttributesSSHFailure(t *testing.T) {
+	t.Parallel()
+
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pb.Close()
+	sshErr := errors.New("ssh failed")
+
+	info, _ := runPersistentPair(
+		context.Background(),
+		pb,
+		func(ctx context.Context, _ *os.File, _ *os.File) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+		func(context.Context, *os.File, *os.File) error { return sshErr },
+	)
+	if info.Reason != CloseSSHTransportError ||
+		info.Side != TransportSideSSH ||
+		!errors.Is(info.Err, sshErr) {
+		t.Fatalf("close info = %+v, want ssh failure", info)
+	}
+}
+
+func TestRunPersistentPairAttributesParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	pb, err := NewPipeBridge()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pb.Close()
+
+	done := make(chan TransportCloseInfo, 1)
+	go func() {
+		info, _ := runPersistentPair(
+			ctx,
+			pb,
+			func(ctx context.Context, _ *os.File, _ *os.File) error { <-ctx.Done(); return ctx.Err() },
+			func(ctx context.Context, _ *os.File, _ *os.File) error { <-ctx.Done(); return ctx.Err() },
+		)
+		done <- info
+	}()
+	cancel()
+
+	select {
+	case info := <-done:
+		if info.Reason != CloseContextCancelled || info.Side != TransportSideParent {
+			t.Fatalf("close info = %+v, want parent cancellation", info)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("persistent pair did not stop after parent cancellation")
+	}
+}


### PR DESCRIPTION
- add first-close-wins lifecycle ownership and structured closure attribution for persistent proxy and workspace SSH transports
- log canonical transport closure metadata and reject negative SSH keepalive acknowledgements
- cover direct-tcpip reuse, concurrent channels, idle parent connections, lifecycle cancellation, and close attribution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SSH tunnel reliability when opening repeated, concurrent, or delayed forwarding channels.
  - SSH keepalive failures now report rejected requests as errors, making connection issues easier to identify.
  - Tunnel shutdowns are handled more consistently, including provider failures, SSH failures, and canceled connections.

- **Improvements**
  - Added more complete transport lifecycle tracking and close-event logging to improve tunnel diagnostics.
  - Enhanced tunnel metadata reporting for workspace connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->