### PR TITLE
ci: stabilize Linux Podman E2E setup

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -423,7 +423,7 @@ jobs:
             requires-secret: false
 
           - label: up-provider-podman-rootless-basic
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             free-disk-space: false
             install-kind: false
             requires-secret: false
@@ -433,7 +433,7 @@ jobs:
             flake-attempts: 2
 
           - label: up-provider-podman-rootless-exec
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             free-disk-space: false
             install-kind: false
             requires-secret: false
@@ -443,7 +443,7 @@ jobs:
             flake-attempts: 2
 
           - label: up-provider-podman-rootless-lifecycle
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             free-disk-space: false
             install-kind: false
             requires-secret: false
@@ -453,7 +453,7 @@ jobs:
             flake-attempts: 2
 
           - label: up-provider-podman-rootless-config
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             free-disk-space: false
             install-kind: false
             requires-secret: false
@@ -463,7 +463,7 @@ jobs:
             flake-attempts: 2
 
           - label: up-provider-podman-rootless-features
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             free-disk-space: false
             install-kind: false
             requires-secret: false
@@ -473,7 +473,7 @@ jobs:
             flake-attempts: 2
 
           - label: up-provider-podman-rootful-basic
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             free-disk-space: false
             install-kind: false
             requires-secret: false
@@ -483,7 +483,7 @@ jobs:
             flake-attempts: 2
 
           - label: up-provider-podman-rootful-lifecycle
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             free-disk-space: false
             install-kind: false
             requires-secret: false
@@ -493,7 +493,7 @@ jobs:
             flake-attempts: 2
 
           - label: up-provider-podman-rootful-lifecycle-2
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             free-disk-space: false
             install-kind: false
             requires-secret: false
@@ -503,7 +503,7 @@ jobs:
             flake-attempts: 2
 
           - label: up-provider-podman-rootful-config
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             free-disk-space: false
             install-kind: false
             requires-secret: false
@@ -513,7 +513,7 @@ jobs:
             flake-attempts: 2
 
           - label: up-provider-podman-rootful-features
-            runner: ubuntu-latest
+            runner: ubuntu-24.04
             free-disk-space: false
             install-kind: false
             requires-secret: false
@@ -781,26 +781,17 @@ jobs:
 
           command -v newuidmap >/dev/null || sudo apt-get install -y uidmap
 
-      - name: Install Podman (Linux rootless)
+      - name: Install Podman (Linux)
         if: matrix.install-podman == 'rootless' && runner.os == 'Linux'
+        shell: bash
         run: |
-          podman info
-          podman run --rm busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d echo "podman runtime preflight OK"
+          ./hack/ci/setup-podman-linux.sh rootless
 
       - name: Install Podman (Linux rootful)
         if: matrix.install-podman == 'rootful' && runner.os == 'Linux'
+        shell: bash
         run: |
-          sudo systemctl daemon-reload
-          sudo systemctl enable --now podman.socket
-          if ! timeout 30 bash -c 'until sudo podman --remote --url unix:///run/podman/podman.sock info >/dev/null 2>&1; do sleep 1; done'; then
-            echo "::error::podman service did not become ready within 30s"
-            sudo systemctl status podman.socket --no-pager || true
-            sudo journalctl -u podman.socket --no-pager -n 100 || true
-            exit 1
-          fi
-          echo "DOCKER_HOST=unix:///run/podman/podman.sock" >> "$GITHUB_ENV"
-          sudo podman --remote --url unix:///run/podman/podman.sock info
-          sudo podman run --rm busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d echo "podman runtime preflight OK"
+          ./hack/ci/setup-podman-linux.sh rootful
 
       - name: get microsandbox latest version
         if: matrix.install-microsandbox == true && runner.os == 'Linux'

--- a/hack/ci/setup-podman-linux.sh
+++ b/hack/ci/setup-podman-linux.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+mode="${1:-}"
+if [[ "$mode" != "rootless" && "$mode" != "rootful" ]]; then
+    echo "::error::usage: $0 <rootless|rootful>"
+    exit 2
+fi
+
+export PATH="/usr/local/bin:$PATH"
+
+if [[ ! -x /usr/local/bin/podman ]]; then
+    echo "::error::Expected Podman at /usr/local/bin/podman"
+    exit 1
+fi
+if [[ ! -x /usr/local/bin/crun ]]; then
+    echo "::error::Expected bundled crun at /usr/local/bin/crun"
+    exit 1
+fi
+
+sudo mkdir -p /etc/containers/containers.conf.d
+sudo tee /etc/containers/containers.conf.d/99-devsy-ci.conf >/dev/null <<'EOF'
+[engine]
+runtime = "crun"
+
+[engine.runtimes]
+crun = ["/usr/local/bin/crun"]
+EOF
+
+if [[ -f /etc/apparmor.d/podman ]]; then
+    sudo sed -Ei \
+        's!^profile podman /usr/bin/podman !profile podman /usr/{bin,local/bin}/podman !' \
+        /etc/apparmor.d/podman
+    sudo apparmor_parser -r /etc/apparmor.d/podman
+fi
+
+echo "Podman executable: $(command -v podman)"
+podman --version
+/usr/local/bin/crun --version
+cat /etc/os-release
+uname -a
+
+if [[ "$mode" == "rootful" ]]; then
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now podman.socket
+    if ! timeout 30 bash -c \
+        'until sudo podman --remote --url unix:///run/podman/podman.sock info >/dev/null 2>&1; do sleep 1; done'; then
+        echo "::error::podman service did not become ready within 30s"
+        sudo systemctl status podman.socket --no-pager || true
+        sudo systemctl status podman.service --no-pager || true
+        sudo journalctl -u podman.socket --no-pager -n 100 || true
+        sudo journalctl -u podman.service --no-pager -n 100 || true
+        exit 1
+    fi
+
+    runtime_path="$(
+        sudo podman --remote --url unix:///run/podman/podman.sock \
+            info --format '{{.Host.OCIRuntime.Path}}'
+    )"
+    echo "Podman OCI runtime: $runtime_path"
+    if [[ "$runtime_path" != "/usr/local/bin/crun" ]]; then
+        echo "::error::Unexpected Podman OCI runtime: $runtime_path"
+        exit 1
+    fi
+
+    echo "DOCKER_HOST=unix:///run/podman/podman.sock" >>"$GITHUB_ENV"
+    sudo podman --remote --url unix:///run/podman/podman.sock info
+    sudo podman --remote --url unix:///run/podman/podman.sock run --rm \
+        busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d \
+        true
+else
+    runtime_path="$(podman info --format '{{.Host.OCIRuntime.Path}}')"
+    echo "Podman OCI runtime: $runtime_path"
+    if [[ "$runtime_path" != "/usr/local/bin/crun" ]]; then
+        echo "::error::Unexpected Podman OCI runtime: $runtime_path"
+        exit 1
+    fi
+
+    podman info
+    podman run --rm \
+        busybox@sha256:fd8d9aa63ba2f0982b5304e1ee8d3b90a210bc1ffb5314d980eb6962f1a9715d \
+        true
+fi


### PR DESCRIPTION
## Summary

Extracted Podman CI setup improvements from PR #1179 to stabilize Linux Podman E2E workflow runs independently:

- Pin Podman E2E matrix runners to `ubuntu-24.04` in `.github/workflows/pr-ci.yml`
- Introduce `hack/ci/setup-podman-linux.sh` to configure and validate rootless and rootful Podman setups, enforce `crun` OCI runtime, and reload AppArmor profiles when required
- Refactor inline Podman setup steps in `.github/workflows/pr-ci.yml` to delegate to `hack/ci/setup-podman-linux.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated integration testing to run Podman-based checks on Ubuntu 24.04.
  - Standardized Podman setup across rootless and rootful test environments.
  - Added validation for the configured OCI runtime, socket readiness, and basic container execution before tests run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->