### PR TITLE
chore: configure git allowed_signers in agent setup

### DIFF
--- a/mise.agent.toml
+++ b/mise.agent.toml
@@ -34,4 +34,10 @@ git config --global commit.gpgsign true
 git config --global tag.gpgsign true
 git config --global user.name "$DEVSY_GIT_AUTHOR_NAME"
 git config --global user.email "$DEVSY_GIT_AUTHOR_EMAIL"
+
+mkdir -p "$HOME/.ssh"
+chmod 700 "$HOME/.ssh"
+echo "$DEVSY_GIT_AUTHOR_EMAIL $(cat $SIGNING_PUBLIC_KEY)" > "$HOME/.ssh/allowed_signers"
+chmod 600 "$HOME/.ssh/allowed_signers"
+git config --global gpg.ssh.allowedSignersFile "$HOME/.ssh/allowed_signers"
 '''


### PR DESCRIPTION
Configures the SSH `allowed_signers` file in `mise.agent.toml` so that `git log --show-signature` and git verification tools can verify SSH-signed commits made within the agent environment without encountering missing file errors (`gpg.ssh.allowedSignersFile`).

### Changes
- Updated the `setup:agent` task in `mise.agent.toml`:
  - Creates `~/.ssh` with permissions `700`.
  - Writes `$DEVSY_GIT_AUTHOR_EMAIL $(cat $SIGNING_PUBLIC_KEY)` to `~/.ssh/allowed_signers` with permissions `600`.
  - Configures `gpg.ssh.allowedSignersFile` globally to `$HOME/.ssh/allowed_signers`.
