### PR TITLE
🧹 Code Health: wait for started event using `--wait` in docker-compose up

### DIFF
--- a/pkg/devcontainer/compose.go
+++ b/pkg/devcontainer/compose.go
@@ -1007,7 +1007,7 @@ func (r *runner) composeUpAndFindContainer(
 ) (*config.ContainerDetails, error) {
 	upArgs := []string{composeProjectNameFlag, params.project.Name}
 	upArgs = append(upArgs, params.composeGlobalArgs...)
-	upArgs = append(upArgs, "up", "-d")
+	upArgs = append(upArgs, "up", "--wait")
 	if params.hasExistingContainer {
 		upArgs = append(upArgs, "--no-recreate")
 	}
@@ -1019,7 +1019,6 @@ func (r *runner) composeUpAndFindContainer(
 		return nil, fmt.Errorf("docker-compose run: %w", err)
 	}
 
-	// TODO wait for started event?
 	containerDetails, err := params.composeHelper.FindDevContainer(
 		ctx,
 		params.project.Name,


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced the `"-d"` flag with `"--wait"` in `docker compose up` arguments in `composeUpAndFindContainer` and removed the corresponding "wait for started event" `TODO`.

💡 **Why:** How this improves maintainability
This natively leverages the Docker Compose API's `--wait` functionality (which also implies `-d` / detached mode). This avoids the need to implement complex, error-prone event listening or polling mechanisms manually in Go.

✅ **Verification:** How you confirmed the change is safe
Ran the `pkg/devcontainer` tests (`go test ./pkg/devcontainer/...`) locally. The tests passed successfully, confirming no regressions.

✨ **Result:** The improvement achieved
A cleaner implementation where Docker Compose itself handles the wait state natively, completely resolving the code health TODO.

---
*PR created automatically by Jules for task [8696876523650183922](https://jules.google.com/task/8696876523650183922) started by @skevetter*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved development container startup reliability by waiting until the container is running before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->