### PR TITLE
fix(release): restore macOS signing on macOS 26 runners

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -32,7 +32,7 @@
         "bits-ui": "2.19.0",
         "clsx": "2.1.1",
         "electron": "44.1.0",
-        "electron-builder": "26.15.3",
+        "electron-builder": "26.16.1",
         "electron-vite": "5.0.0",
         "jsdom": "30.0.1",
         "paneforge": "1.0.2",
@@ -1503,29 +1503,19 @@
         "node": "^22.20 || ^24.12 || >=25"
       }
     },
-    "node_modules/@noble/hashes": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
-      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20.19.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
-      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.4.tgz",
+      "integrity": "sha512-GjzePcT9Iw8NzeOPf73iNS9xM+TBhd/FilAfP+RQGkTMQJTVWtytN3JHJACCjf/ABNau5S7mS3g+DcuxmRgYEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/json-schema": {
@@ -2775,9 +2765,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2877,9 +2867,9 @@
       }
     },
     "node_modules/app-builder-lib": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz",
-      "integrity": "sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==",
+      "version": "26.16.1",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.16.1.tgz",
+      "integrity": "sha512-FhaO6YOup01ZfQW0Z6gt3AyukJjv1gW4uFK47jTgwcHZKqyN/fSlK2LqPf9tAeZYLP2bRJLDzeOkRImsw2X4Pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2891,13 +2881,13 @@
         "@electron/rebuild": "^4.0.4",
         "@electron/universal": "2.0.3",
         "@malept/flatpak-bundler": "^0.4.0",
-        "@noble/hashes": "^2.2.0",
+        "@noble/hashes": "^1.8.0",
         "@peculiar/webcrypto": "^1.7.1",
         "@types/fs-extra": "9.0.13",
         "ajv": "^8.18.0",
         "asn1js": "^3.0.10",
         "async-exit-hook": "^2.0.1",
-        "builder-util": "26.15.3",
+        "builder-util": "26.16.0",
         "builder-util-runtime": "9.7.0",
         "chromium-pickle-js": "^0.2.0",
         "ci-info": "4.3.1",
@@ -2905,7 +2895,7 @@
         "dotenv": "^16.4.5",
         "dotenv-expand": "^11.0.6",
         "ejs": "^3.1.8",
-        "electron-publish": "26.15.3",
+        "electron-publish": "26.16.0",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
         "isbinaryfile": "^5.0.0",
@@ -2929,8 +2919,8 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "26.15.3",
-        "electron-builder-squirrel-windows": "26.15.3"
+        "dmg-builder": "26.16.1",
+        "electron-builder-squirrel-windows": "26.16.1"
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/get": {
@@ -2978,6 +2968,19 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/app-builder-lib/node_modules/ci-info": {
@@ -3306,9 +3309,9 @@
       "license": "MIT"
     },
     "node_modules/builder-util": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
-      "integrity": "sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==",
+      "version": "26.16.0",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.16.0.tgz",
+      "integrity": "sha512-RLyJhB7Si3YkzKR9ubQslWuXW3Vhs3CGe1i+SeixBZ0qTd1mk3XBmssvY22TlB6CS5blyko8Gu1JzpYk8UkYAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3886,14 +3889,14 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz",
-      "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
+      "version": "26.16.1",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.16.1.tgz",
+      "integrity": "sha512-pnI/3Qb24Uk+rMTgIUrsVUKosVgwmBUdF8Zeb8TexOSbpq8MWc7v6l+n+FrEqVkjNZwzBN+XpDS9ENgZ/rkWAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.15.3",
-        "builder-util": "26.15.3",
+        "app-builder-lib": "26.16.1",
+        "builder-util": "26.16.0",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0"
       }
@@ -4004,18 +4007,18 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
-      "integrity": "sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==",
+      "version": "26.16.1",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.16.1.tgz",
+      "integrity": "sha512-LrLK65QX5PUYYODXqp23FKrV7CILTtVY7mrJckNknO9jLNSMiqFkKbSMiDRw4CjOADMPVDdWLxY4mezOZWswxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.15.3",
-        "builder-util": "26.15.3",
+        "app-builder-lib": "26.16.1",
+        "builder-util": "26.16.0",
         "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
-        "dmg-builder": "26.15.3",
+        "dmg-builder": "26.16.1",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "simple-update-notifier": "2.0.0",
@@ -4030,28 +4033,28 @@
       }
     },
     "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.3.tgz",
-      "integrity": "sha512-Jc19XPV9y9+2bAdZPkXuVNGNIEFBq9poHC61l8Kv6FdK7DRG3+Ic0rerC0DXOaeHNz8yW0fg/JnF8GQROOF5MA==",
+      "version": "26.16.1",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.16.1.tgz",
+      "integrity": "sha512-w0y44wSaT1l6R7CAGmeHn4nHPfvzDyCAU1xJyi1w9SbPYJpYn76SmHDzqHf8Y7l91cPWTdPYBpGQtB2T5mJ08A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.15.3",
-        "builder-util": "26.15.3",
+        "app-builder-lib": "26.16.1",
+        "builder-util": "26.16.0",
         "electron-winstaller": "5.4.0"
       }
     },
     "node_modules/electron-publish": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
-      "integrity": "sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==",
+      "version": "26.16.0",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.16.0.tgz",
+      "integrity": "sha512-Vt3KzQIiw9BImvNOYtndg9Mjki+tl4+1sQiC/+G5j8khWaENOJFWodiB+sUl6yyHwtd37avehskdtPw7f8y/+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
         "aws4": "^1.13.2",
-        "builder-util": "26.15.3",
+        "builder-util": "26.16.0",
         "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "form-data": "^4.0.5",
@@ -4437,9 +4440,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -6381,9 +6384,9 @@
       }
     },
     "node_modules/pvutils": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+      "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -44,7 +44,7 @@
     "bits-ui": "2.19.0",
     "clsx": "2.1.1",
     "electron": "44.1.0",
-    "electron-builder": "26.15.3",
+    "electron-builder": "26.16.1",
     "electron-vite": "5.0.0",
     "jsdom": "30.0.1",
     "paneforge": "1.0.2",


### PR DESCRIPTION
### Problem
macOS release packaging jobs fail during `electron-builder` keychain setup with:
```text
security: SecKeychainUnlock: The user name or passphrase you entered is not correct.
```

### Root Cause
`electron-builder` 26.15.3 incorrectly passed the `.p12` import password (`CSC_KEY_PASSWORD`) to `security set-key-partition-list -k`, which requires the temporary keychain password. The defect was exposed when GitHub Actions updated `macos-latest` to macOS 26 runner images, which strictly enforce validation of the keychain password.

### Fix
Upgrade `electron-builder` to `26.16.1`, which contains the upstream fix (passing `keychainPassword` to `set-key-partition-list -k`).

### Verification
- `npx electron-builder --version` -> `26.16.1`
- Verified `set-key-partition-list` implementation in `app-builder-lib` uses `keychainPassword`
- `task desktop:check` passed with 0 errors / 0 warnings
- `xvfb-run task desktop:test` passed (38 test files, 328 tests)
- `npm run electron:build` succeeded
- CodeRabbit CLI local review passed with 0 findings
- Pre-commit hooks passed
- Commit is signed

### References
- https://github.com/electron-userland/electron-builder/issues/10066
- https://github.com/electron-userland/electron-builder/pull/10172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the desktop application packaging tooling to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->