### PR TITLE
feat(workspace): add down alias for workspace delete

### DIFF
--- a/cmd/workspace/delete.go
+++ b/cmd/workspace/delete.go
@@ -17,6 +17,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	aliasRm   = "rm"
+	aliasDown = "down"
+)
+
 // DeleteCmd holds the delete cmd flags.
 type DeleteCmd struct {
 	*flags.GlobalFlags
@@ -30,9 +35,13 @@ func NewDeleteCmd(globalFlags *flags.GlobalFlags) *cobra.Command {
 	}
 	deleteCmd := &cobra.Command{
 		Use:     "delete [flags] [workspace-path|workspace-name]",
-		Aliases: []string{"rm"},
+		Aliases: []string{aliasRm, aliasDown},
 		Short:   "Delete a workspace",
 		Long: `Delete a workspace by path or name.
+
+Aliases "rm" and "down" perform the same full Devsy workspace teardown.
+For Docker Compose workspaces, teardown uses Docker/Podman Compose down.
+
 Use --ignore-not-found to treat a missing workspace as success.`,
 		RunE: func(cobraCmd *cobra.Command, args []string) error {
 			return cmd.Run(cobraCmd, args)

--- a/cmd/workspace/delete_test.go
+++ b/cmd/workspace/delete_test.go
@@ -1,0 +1,84 @@
+package workspace
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/devsy-org/devsy/cmd/flags"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteCmd_Aliases(t *testing.T) {
+	deleteCmd := NewDeleteCmd(&flags.GlobalFlags{})
+
+	assert.ElementsMatch(t, []string{aliasRm, aliasDown}, deleteCmd.Aliases)
+}
+
+func TestDeleteCmd_Resolution(t *testing.T) {
+	workspaceCmd := NewWorkspaceCmd(&flags.GlobalFlags{})
+
+	testCases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "canonical delete",
+			args: []string{"delete"},
+		},
+		{
+			name: "rm alias",
+			args: []string{aliasRm},
+		},
+		{
+			name: "down alias",
+			args: []string{aliasDown},
+		},
+		{
+			name: "down alias with positional workspace",
+			args: []string{aliasDown, "my-workspace"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resolved, remainingArgs, err := workspaceCmd.Find(tc.args)
+			require.NoError(t, err)
+			require.NotNil(t, resolved)
+			assert.Equal(t, "delete", resolved.Name())
+			if len(tc.args) > 1 {
+				assert.Equal(t, tc.args[1:], remainingArgs)
+			} else {
+				assert.Empty(t, remainingArgs)
+			}
+		})
+	}
+}
+
+func TestDeleteCmd_HelpExposesDownAlias(t *testing.T) {
+	deleteCmd := NewDeleteCmd(&flags.GlobalFlags{})
+
+	var buf bytes.Buffer
+	deleteCmd.SetOut(&buf)
+	err := deleteCmd.Help()
+	require.NoError(t, err)
+
+	helpOutput := buf.String()
+	assert.Contains(t, helpOutput, "Aliases:")
+	assert.Contains(t, helpOutput, aliasDown)
+	assert.Contains(t, helpOutput, aliasRm)
+}
+
+func TestDeleteCmd_Completion(t *testing.T) {
+	workspaceCmd := NewWorkspaceCmd(&flags.GlobalFlags{})
+
+	var buf bytes.Buffer
+	err := workspaceCmd.GenBashCompletion(&buf)
+	require.NoError(t, err)
+
+	completionOutput := buf.String()
+	assert.Contains(t, completionOutput, fmt.Sprintf("%q", aliasDown))
+	assert.Contains(t, completionOutput, fmt.Sprintf("%q", aliasRm))
+	assert.Contains(t, completionOutput, `"delete"`)
+}

--- a/sites/docs-devsy-sh/content/docs/developing-in-workspaces/stop-and-delete-a-workspace.mdx
+++ b/sites/docs-devsy-sh/content/docs/developing-in-workspaces/stop-and-delete-a-workspace.mdx
@@ -49,6 +49,13 @@ Run the following command to delete a workspace:
 devsy workspace delete my-workspace
 ```
 
+`devsy workspace down` (as well as `rm`) is an alias for `devsy workspace delete`. It performs the same full Devsy workspace teardown:
+```
+devsy workspace down my-workspace
+```
+
+For Docker Compose-backed workspaces, teardown uses Compose `down` (with `--remove-volumes` remaining an opt-in flag to remove associated named volumes). Use `devsy workspace stop` when you want to stop a workspace while retaining its configuration and state so it can be started again later.
+
 If deletion fails because the Provider is not reachable anymore or another error has occurred, you can also force delete a workspace via:
 ```
 devsy workspace delete my-workspace --force


### PR DESCRIPTION
### Summary

Implements `devsy workspace down` as an alias of the canonical `devsy workspace delete` command following the design in #1211.

### Motivation

Users familiar with Docker Compose often expect `devsy workspace down` as the inverse of `devsy workspace up`. Devsy's compose-backed teardown already executes Docker Compose `down`, while `workspace stop` owns reversible suspension semantics. Adding `down` as an exact Cobra alias of `workspace delete` aligns ergonomics with user mental models without introducing unnecessary lifecycle or state divergence.

### Changes

1. **CLI Alias & Command Description (`cmd/workspace/delete.go`)**:
   - Added `"down"` to `deleteCmd.Aliases` (`[]string{"rm", "down"}`).
   - Updated `deleteCmd.Long` to clarify that `down` and `rm` perform the same full Devsy workspace teardown, noting Docker/Podman Compose `down` behavior for Compose-backed workspaces.

2. **CLI Contract Tests (`cmd/workspace/delete_test.go`)**:
   - `TestDeleteCmd_Aliases`: Asserts `rm` and `down` are registered aliases.
   - `TestDeleteCmd_Resolution`: Asserts `delete`, `rm`, `down`, and `down <workspace>` resolve to the canonical `delete` command.
   - `TestDeleteCmd_HelpExposesDownAlias`: Asserts command help output exposes `down` and `rm` under `Aliases:`.
   - `TestDeleteCmd_Completion`: Asserts generated shell completion suggestions include `down`.

3. **Documentation (`sites/docs-devsy-sh/content/docs/developing-in-workspaces/stop-and-delete-a-workspace.mdx`)**:
   - Added documentation for `devsy workspace down` under *Stop or Delete a Workspace*, clarifying its relationship with `delete` and `stop`.

### Verification

- Local unit tests pass: `go test -v -run '^TestDeleteCmd' ./cmd/workspace`
- Formatting verified: `golangci-lint fmt` and `gofmt`
- Linting verified: `golangci-lint run --fast-only`
- Pre-review verified: `coderabbit review` reported no findings (0 issues across all 3 files)

Closes #1211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `devsy workspace rm` and `devsy workspace down` as aliases for fully deleting a workspace.
  * Added command help and shell completion support for both aliases.
* **Documentation**
  * Documented the `devsy workspace down` command, including its teardown behavior and Compose volume handling.
  * Clarified that `devsy workspace stop` preserves workspace configuration and state for later restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->