### PR TITLE
fix(ci): update automatic-approve-action to v2.2.0 with PR scoping

### DIFF
--- a/.github/workflows/workflow-approval.yml
+++ b/.github/workflows/workflow-approval.yml
@@ -16,7 +16,9 @@ jobs:
           client-id: ${{ secrets.DEVSY_GITHUB_APP_ID }}
           private-key: ${{ secrets.DEVSY_GITHUB_APP_PRIVATE_KEY }}
 
-      - uses: skevetter/automatic-approve-action@80f16f6e6bea1dfc0f613df222390ee143a4d8e9 # v2
+      - uses: skevetter/automatic-approve-action@e9a649e3353c1d4a93197dbf78087c9f80f8f70a # v2.2.0
         with:
           token: ${{ steps.app-token.outputs.token }}
           workflows: "commit.yml,pr-ci.yml"
+          pull-request-number: ${{ github.event.pull_request.number }}
+          head-sha: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
### Summary

Update `skevetter/automatic-approve-action` to release `v2.2.0` (`e9a649e3353c1d4a93197dbf78087c9f80f8f70a`) in `.github/workflows/workflow-approval.yml` and provide explicit `pull-request-number` and `head-sha` context.

### Context

Resolves the HTTP 403 regression in automatic workflow approvals where stale `action_required` runs from other pull requests (such as PR #1179) were rediscovered and sent to GitHub's REST approval endpoint.

### Changes

- Update `skevetter/automatic-approve-action` to `v2.2.0` (`e9a649e3353c1d4a93197dbf78087c9f80f8f70a`).
- Pass explicit `pull-request-number: ${{ github.event.pull_request.number }}`.
- Pass explicit `head-sha: ${{ github.event.pull_request.head.sha }}`.
- Prevents cross-PR contamination and safely skips non-API-approvable same-repository/security holds.
