### PR TITLE
test(e2e): stabilize config-read id-label test

### DIFF
--- a/e2e/tests/configread/configread.go
+++ b/e2e/tests/configread/configread.go
@@ -314,7 +314,7 @@ var _ = ginkgo.Describe("config read command", ginkgo.Label("config-read"), func
 	ginkgo.It("should read configuration using custom id-label",
 		func(ctx context.Context) {
 			tempDir, err := framework.CopyToTempDirWithoutChdir(
-				"tests/configread/testdata",
+				"tests/configread/testdata-id-label",
 			)
 			framework.ExpectNoError(err)
 			ginkgo.DeferCleanup(func() { _ = os.RemoveAll(tempDir) })

--- a/e2e/tests/configread/testdata-id-label/.devcontainer/devcontainer.json
+++ b/e2e/tests/configread/testdata-id-label/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "Config Read Custom ID Label",
+  "image": "ghcr.io/devsy-org/test-images/base:ubuntu"
+}


### PR DESCRIPTION
## Summary
- add a minimal runtime fixture for the config-read custom ID-label integration test
- keep the feature-rich fixture for parser coverage
- remove the incidental Node feature installation path from DevsyUp

## Validation
- static fixture checks passed
- CodeRabbit CLI review passed with no findings
- GitLab runner validation is expected to run on this draft PR

The local Go/E2E check was blocked by the host toolchain mismatch (Go 1.27.1 versus cached Go 1.25.5 artifacts).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated configuration-read end-to-end testing to use dedicated fixtures for custom ID-label scenarios.
  - Added a container configuration to support consistent execution of these test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->