### PR TITLE
fix(docker): gate bind-create-src on CLI 29.3.0

### DIFF
--- a/pkg/driver/docker/runargs.go
+++ b/pkg/driver/docker/runargs.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/blang/semver/v4"
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
 	"github.com/devsy-org/devsy/pkg/devcontainer/config"
 	"github.com/devsy-org/devsy/pkg/docker"
@@ -207,13 +208,13 @@ func (d *dockerDriver) addWorkspaceMountArgs(
 	return args
 }
 
-// minBindCreateSrcMajor is the docker CLI major version that added the
-// bind-create-src mount option; older clients reject it at parse time.
-const minBindCreateSrcMajor = 29
+// minBindCreateSrcVersion is the first Docker CLI release that supports
+// bind-create-src on --mount. The option was introduced in Docker CLI 29.3.0.
+var minBindCreateSrcVersion = semver.MustParse("29.3.0")
 
 // shouldBustBindCache reports whether to add bind-create-src to the workspace
 // mount. Gated to Docker (Podman/nerdctl reject it), Docker Desktop
-// (GOOS != linux), and CLI >= v29.
+// (GOOS != linux), and CLI >= v29.3.0.
 func shouldBustBindCache(helper *docker.DockerHelper) bool {
 	if helper.GetRuntime().Name() != docker.RuntimeDocker {
 		return false
@@ -221,21 +222,15 @@ func shouldBustBindCache(helper *docker.DockerHelper) bool {
 	if runtime.GOOS == osLinux {
 		return false
 	}
-	return dockerMajorAtLeast(helper.ClientVersion(context.Background()), minBindCreateSrcMajor)
+	return dockerClientSupportsBindCreateSrc(helper.ClientVersion(context.Background()))
 }
 
-// dockerMajorAtLeast reports whether version's major component is >= minMajor.
-// An unparseable version returns false.
-func dockerMajorAtLeast(version string, minMajor int) bool {
-	major, _, ok := strings.Cut(version, ".")
-	if !ok {
-		return false
-	}
-	n, err := strconv.Atoi(strings.TrimSpace(major))
+func dockerClientSupportsBindCreateSrc(version string) bool {
+	v, err := semver.ParseTolerant(strings.TrimSpace(version))
 	if err != nil {
 		return false
 	}
-	return n >= minMajor
+	return v.GTE(minBindCreateSrcVersion)
 }
 
 // withBindCreateSrc adds bind-create-src=true to a bind --mount whose source

--- a/pkg/driver/docker/runargs_test.go
+++ b/pkg/driver/docker/runargs_test.go
@@ -73,22 +73,27 @@ func (s *DockerDriverTestSuite) TestWithBindCreateSrc() {
 	s.Equal(vol, withBindCreateSrc(vol))
 }
 
-func (s *DockerDriverTestSuite) TestDockerMajorAtLeast() {
+func (s *DockerDriverTestSuite) TestDockerClientSupportsBindCreateSrc() {
 	tests := []struct {
 		version string
 		want    bool
 	}{
-		{"29.5.3", true},
-		{"29.0.0", true},
-		{"30.1.0", true},
-		{"28.0.4", false},
-		{"20.10.21", false},
+		{"28.5.2", false},
+		{"29.0.0", false},
+		{"29.1.0", false},
+		{"29.2.1", false},
+		{"29.2.99", false},
+		{"29.3.0", true},
+		{"29.3.1", true},
+		{"29.7.2", true},
+		{"30.0.0", true},
+		{"v29.3.0", true},
 		{"", false},
 		{"garbage", false},
 	}
 	for _, tt := range tests {
-		s.Equalf(tt.want, dockerMajorAtLeast(tt.version, minBindCreateSrcMajor),
-			"dockerMajorAtLeast(%q)", tt.version)
+		s.Equalf(tt.want, dockerClientSupportsBindCreateSrc(tt.version),
+			"dockerClientSupportsBindCreateSrc(%q)", tt.version)
 	}
 }
 


### PR DESCRIPTION
Fixes #1223\n\n## Summary\n\n- Gate Docker's bind-create-src mount option on CLI version 29.3.0 or newer.\n- Fail closed for invalid or empty Docker CLI versions.\n- Preserve existing Docker runtime and non-Linux host exclusions.\n- Add regression coverage for Docker CLI 29.2.1 and the 29.3.0 boundary.\n\n## Validation\n\n- go test ./pkg/driver/docker/...\n- golangci-lint: 0 issues\n- git diff --check\n- CodeRabbit local review: no findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker version detection for workspace mounts.
  * The `bind-create-src` option is now enabled only for Docker 29.3.0 and later, including support for version prefixes and patch releases.
  * Invalid or incomplete Docker versions continue to safely disable the option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->