### PR TITLE
test(e2e): stabilize Podman integration tests

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -430,7 +430,7 @@ jobs:
             install-podman: rootless
             test-timeout: 600s
             job-timeout-minutes: 20
-            flake-attempts: 2
+            flake-attempts: 1
 
           - label: up-provider-podman-rootless-exec
             runner: ubuntu-24.04
@@ -440,7 +440,7 @@ jobs:
             install-podman: rootless
             test-timeout: 600s
             job-timeout-minutes: 20
-            flake-attempts: 2
+            flake-attempts: 1
 
           - label: up-provider-podman-rootless-lifecycle
             runner: ubuntu-24.04
@@ -450,7 +450,7 @@ jobs:
             install-podman: rootless
             test-timeout: 600s
             job-timeout-minutes: 20
-            flake-attempts: 2
+            flake-attempts: 1
 
           - label: up-provider-podman-rootless-config
             runner: ubuntu-24.04
@@ -460,7 +460,7 @@ jobs:
             install-podman: rootless
             test-timeout: 600s
             job-timeout-minutes: 20
-            flake-attempts: 2
+            flake-attempts: 1
 
           - label: up-provider-podman-rootless-features
             runner: ubuntu-24.04
@@ -470,7 +470,7 @@ jobs:
             install-podman: rootless
             test-timeout: 600s
             job-timeout-minutes: 20
-            flake-attempts: 2
+            flake-attempts: 1
 
           - label: up-provider-podman-rootful-basic
             runner: ubuntu-24.04
@@ -480,7 +480,7 @@ jobs:
             install-podman: rootful
             test-timeout: 600s
             job-timeout-minutes: 20
-            flake-attempts: 2
+            flake-attempts: 1
 
           - label: up-provider-podman-rootful-lifecycle
             runner: ubuntu-24.04
@@ -490,7 +490,7 @@ jobs:
             install-podman: rootful
             test-timeout: 600s
             job-timeout-minutes: 20
-            flake-attempts: 2
+            flake-attempts: 1
 
           - label: up-provider-podman-rootful-lifecycle-2
             runner: ubuntu-24.04
@@ -500,7 +500,7 @@ jobs:
             install-podman: rootful
             test-timeout: 600s
             job-timeout-minutes: 20
-            flake-attempts: 2
+            flake-attempts: 1
 
           - label: up-provider-podman-rootful-config
             runner: ubuntu-24.04
@@ -510,7 +510,7 @@ jobs:
             install-podman: rootful
             test-timeout: 600s
             job-timeout-minutes: 20
-            flake-attempts: 2
+            flake-attempts: 1
 
           - label: up-provider-podman-rootful-features
             runner: ubuntu-24.04
@@ -520,7 +520,7 @@ jobs:
             install-podman: rootful
             test-timeout: 600s
             job-timeout-minutes: 20
-            flake-attempts: 2
+            flake-attempts: 1
 
           - label: up-provider-docker
             runner: ubuntu-latest
@@ -863,14 +863,28 @@ jobs:
           FLAKE_ATTEMPTS: ${{ matrix.flake-attempts || '1' }}
         run: |
           if [ "${{ runner.os }}" == "Linux" ]; then
-            sudo \
+            if [ "${{ matrix.install-podman || '' }}" = "rootless" ]; then
+              echo "Podman rootless test identity:"
+              id
+              printf 'HOME=%s\n' "${HOME}"
+              printf 'XDG_RUNTIME_DIR=%s\n' "${XDG_RUNTIME_DIR:-}"
+              podman info
               GH_USERNAME="${GH_USERNAME}" \
-              GH_ACCESS_TOKEN="${GH_ACCESS_TOKEN}" \
-              GH_CREDENTIAL_USERNAME="${GH_CREDENTIAL_USERNAME}" \
-              KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
-              ${DOCKER_HOST:+DOCKER_HOST="${DOCKER_HOST}"} \
-              PATH="${PATH}" \
-              ./e2e.test -test.v -ginkgo.v -test.timeout "${TEST_TIMEOUT}" -ginkgo.fail-on-empty -ginkgo.flake-attempts="${FLAKE_ATTEMPTS}" --ginkgo.label-filter="${{ matrix.label }}"
+                GH_ACCESS_TOKEN="${GH_ACCESS_TOKEN}" \
+                GH_CREDENTIAL_USERNAME="${GH_CREDENTIAL_USERNAME}" \
+                KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
+                PATH="${PATH}" \
+                ./e2e.test -test.v -ginkgo.v -test.timeout "${TEST_TIMEOUT}" -ginkgo.fail-on-empty -ginkgo.flake-attempts="${FLAKE_ATTEMPTS}" --ginkgo.label-filter="${{ matrix.label }}"
+            else
+              sudo \
+                GH_USERNAME="${GH_USERNAME}" \
+                GH_ACCESS_TOKEN="${GH_ACCESS_TOKEN}" \
+                GH_CREDENTIAL_USERNAME="${GH_CREDENTIAL_USERNAME}" \
+                KUBECONFIG="${KUBECONFIG:-$HOME/.kube/config}" \
+                ${DOCKER_HOST:+DOCKER_HOST="${DOCKER_HOST}"} \
+                PATH="${PATH}" \
+                ./e2e.test -test.v -ginkgo.v -test.timeout "${TEST_TIMEOUT}" -ginkgo.fail-on-empty -ginkgo.flake-attempts="${FLAKE_ATTEMPTS}" --ginkgo.label-filter="${{ matrix.label }}"
+            fi
           else
             GH_USERNAME="${GH_USERNAME}" \
               GH_ACCESS_TOKEN="${GH_ACCESS_TOKEN}" \

--- a/e2e/framework/command.go
+++ b/e2e/framework/command.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/devsy-org/devsy/pkg/client"
 	"github.com/devsy-org/devsy/pkg/flags/names"
@@ -214,6 +215,23 @@ func (f *Framework) DevsySSH(
 	return out, nil
 }
 
+// DevsySSHOnce performs a single SSH attempt. It is intended for readiness
+// polling, where retrying inside the polling callback can outlive the polling
+// window and consume the enclosing spec's deadline.
+func (f *Framework) DevsySSHOnce(
+	ctx context.Context,
+	workspace string,
+	command string,
+) (string, error) {
+	out, _, err := f.ExecCommandCapture(ctx, []string{
+		cmdWorkspace, cmdSSH, workspace, flagCommand, command, flagDebug,
+	})
+	if err != nil {
+		return "", fmt.Errorf("devsy ssh failed: %w", err)
+	}
+	return out, nil
+}
+
 func (f *Framework) DevsySSHEchoTestString(ctx context.Context, workspace string) error {
 	err := f.ExecCommand(
 		ctx,
@@ -317,13 +335,7 @@ func (f *Framework) DevsyProviderAdd(ctx context.Context, args ...string) error 
 	baseArgs = append(baseArgs, args...)
 	_, stderr, err := f.ExecCommandCapture(ctx, baseArgs)
 	if err != nil {
-		// Skip "already exists" errors to make this idempotent
-		// This occurs when another test begins before ginkgo.DeferCleanup
-		// is called to delete the workspace. The workspace is linked to the
-		// provider and the provider cannot be deleted until the workspace is deleted.
-		if !strings.Contains(stderr, "already exists") {
-			return fmt.Errorf("devsy provider add failed: %s", stderr)
-		}
+		return fmt.Errorf("devsy provider add failed: %s", stderr)
 	}
 	return nil
 }
@@ -434,6 +446,15 @@ func (f *Framework) DevsyWorkspaceDelete(
 	baseArgs = append(baseArgs, extraArgs...)
 
 	return f.ExecCommand(ctx, false, true, fmt.Sprintf("deleted workspace %s", workspace), baseArgs)
+}
+
+// CleanupWorkspace gives cleanup a fresh, bounded context. Ginkgo cleanup may
+// run after the spec context has expired, so inheriting its cancellation can
+// silently skip the workspace deletion.
+func (f *Framework) CleanupWorkspace(ctx context.Context, workspace string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), time.Minute)
+	defer cancel()
+	return f.DevsyWorkspaceDelete(cleanupCtx, workspace)
 }
 
 func (f *Framework) SetupGPG(tmpDir string) error {

--- a/e2e/framework/retry.go
+++ b/e2e/framework/retry.go
@@ -115,7 +115,8 @@ func execWithDockerRetry(
 		delay := nextBackoffDelay(dockerPullBackoff, attempt)
 		if !retryFitsBudget(ctx, delay) {
 			return lastStdout, lastStderr, fmt.Errorf(
-				"after %d attempts: retryable Docker error; retry not attempted because remaining deadline budget was insufficient (next retry delay: %s): %w",
+				"after %d attempts: retryable Docker error; retry not attempted because "+
+					"remaining deadline budget was insufficient (next retry delay: %s): %w",
 				attempt, delay, lastErr,
 			)
 		}
@@ -157,7 +158,8 @@ func execWithSSHRetry(
 		delay := nextBackoffDelay(sshBackoff, attempt)
 		if !retryFitsBudget(ctx, delay) {
 			return lastOut, fmt.Errorf(
-				"after %d attempts: retryable SSH error; retry not attempted because remaining deadline budget was insufficient (next retry delay: %s): %w",
+				"after %d attempts: retryable SSH error; retry not attempted because "+
+					"remaining deadline budget was insufficient (next retry delay: %s): %w",
 				attempt, delay, lastErr,
 			)
 		}
@@ -188,7 +190,7 @@ func retryFitsBudget(ctx context.Context, delay time.Duration) bool {
 func nextBackoffDelay(backoff wait.Backoff, retryNumber int) time.Duration {
 	delay := backoff.DelayFunc()
 	var next time.Duration
-	for i := 0; i < retryNumber; i++ {
+	for range retryNumber {
 		next = delay()
 	}
 	return next

--- a/e2e/framework/retry.go
+++ b/e2e/framework/retry.go
@@ -13,10 +13,11 @@ import (
 )
 
 // dockerPullBackoff defines retry timing for transient Docker registry errors.
-// 4 total attempts (1 initial + 3 retries) with waits of ~30s, ~60s, ~120s.
+// The waits are deliberately short so retries consume only a minority of a
+// short spec's deadline.
 var dockerPullBackoff = wait.Backoff{
 	Steps:    4,
-	Duration: 30 * time.Second,
+	Duration: 5 * time.Second,
 	Factor:   2.0,
 	Jitter:   0.1,
 }
@@ -100,30 +101,33 @@ func execWithDockerRetry(
 	var lastErr error
 	attempt := 0
 
-	err := wait.ExponentialBackoffWithContext(ctx, dockerPullBackoff,
-		func(ctx context.Context) (bool, error) {
-			attempt++
-			lastStdout, lastStderr, lastErr = fn(ctx)
-			if lastErr == nil {
-				return true, nil // success
-			}
-			if isRetryableDockerError(lastStderr) {
-				ginkgo.GinkgoWriter.Printf(
-					"[retry] attempt %d failed with transient Docker error, retrying: %s\n",
-					attempt, lastErr,
-				)
-				return false, nil // retry
-			}
-			return false, lastErr // non-retryable, stop immediately
-		},
-	)
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return lastStdout, lastStderr, err
+	for attempt = 1; attempt <= dockerPullBackoff.Steps; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return lastStdout, lastStderr, err
+		}
+		lastStdout, lastStderr, lastErr = fn(ctx)
+		if lastErr == nil {
+			return lastStdout, lastStderr, nil
+		}
+		if !isRetryableDockerError(lastStderr) || attempt == dockerPullBackoff.Steps {
+			break
+		}
+		delay := nextBackoffDelay(dockerPullBackoff, attempt)
+		if !retryFitsBudget(ctx, delay) {
+			return lastStdout, lastStderr, fmt.Errorf(
+				"after %d attempts: retryable Docker error; retry not attempted because remaining deadline budget was insufficient (next retry delay: %s): %w",
+				attempt, delay, lastErr,
+			)
+		}
+		ginkgo.GinkgoWriter.Printf(
+			"[retry] attempt %d failed with transient Docker error, retrying after %s: %s\n",
+			attempt, delay, lastErr,
+		)
+		if err := waitForRetry(ctx, delay); err != nil {
+			return lastStdout, lastStderr, err
+		}
 	}
-	if err != nil && lastErr != nil {
-		return lastStdout, lastStderr, fmt.Errorf("after %d attempts: %w", attempt, lastErr)
-	}
-	return lastStdout, lastStderr, err
+	return lastStdout, lastStderr, fmt.Errorf("after %d attempts: %w", attempt, lastErr)
 }
 
 // execWithSSHRetry runs fn and retries if the error indicates a transient SSH
@@ -139,27 +143,33 @@ func execWithSSHRetry(
 	var lastErr error
 	attempt := 0
 
-	err := wait.ExponentialBackoffWithContext(ctx, sshBackoff,
-		func(ctx context.Context) (bool, error) {
-			attempt++
-			lastOut, lastStderr, lastErr = fn(ctx)
-			if lastErr == nil {
-				return true, nil // success
-			}
-			if isRetryableSSHError(lastErr, lastStderr) {
-				ginkgo.GinkgoWriter.Printf(
-					"[retry] ssh %s: attempt %d failed with transient error, retrying: %s\n",
-					workspace, attempt, lastErr,
-				)
-				return false, nil // retry
-			}
-			return false, lastErr // non-retryable, stop immediately
-		},
-	)
-	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-		return lastOut, err
+	for attempt = 1; attempt <= sshBackoff.Steps; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return lastOut, err
+		}
+		lastOut, lastStderr, lastErr = fn(ctx)
+		if lastErr == nil {
+			return lastOut, nil
+		}
+		if !isRetryableSSHError(lastErr, lastStderr) || attempt == sshBackoff.Steps {
+			break
+		}
+		delay := nextBackoffDelay(sshBackoff, attempt)
+		if !retryFitsBudget(ctx, delay) {
+			return lastOut, fmt.Errorf(
+				"after %d attempts: retryable SSH error; retry not attempted because remaining deadline budget was insufficient (next retry delay: %s): %w",
+				attempt, delay, lastErr,
+			)
+		}
+		ginkgo.GinkgoWriter.Printf(
+			"[retry] ssh %s: attempt %d failed with transient error, retrying after %s: %s\n",
+			workspace, attempt, delay, lastErr,
+		)
+		if err := waitForRetry(ctx, delay); err != nil {
+			return lastOut, err
+		}
 	}
-	if err != nil && lastErr != nil {
+	if lastErr != nil {
 		if lastStderr != "" {
 			return lastOut, fmt.Errorf(
 				"after %d attempts: %w (stderr: %s)", attempt, lastErr, lastStderr,
@@ -167,5 +177,30 @@ func execWithSSHRetry(
 		}
 		return lastOut, fmt.Errorf("after %d attempts: %w", attempt, lastErr)
 	}
-	return lastOut, err
+	return lastOut, lastErr
+}
+
+func retryFitsBudget(ctx context.Context, delay time.Duration) bool {
+	deadline, ok := ctx.Deadline()
+	return !ok || time.Until(deadline) > delay
+}
+
+func nextBackoffDelay(backoff wait.Backoff, retryNumber int) time.Duration {
+	delay := backoff.DelayFunc()
+	var next time.Duration
+	for i := 0; i < retryNumber; i++ {
+		next = delay()
+	}
+	return next
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }

--- a/e2e/framework/retry_test.go
+++ b/e2e/framework/retry_test.go
@@ -305,8 +305,8 @@ func TestExecWithDockerRetry_ContextDeadlineExceeded(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.NotContains(t, err.Error(), "after")
+	assert.Contains(t, err.Error(), "remaining deadline budget was insufficient")
+	assert.Contains(t, err.Error(), "next retry delay")
 }
 
 func TestExecWithSSHRetry_SuccessFirstTry(t *testing.T) {
@@ -402,6 +402,6 @@ func TestExecWithSSHRetry_ContextDeadlineExceeded(t *testing.T) {
 		},
 	)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.NotContains(t, err.Error(), "after")
+	assert.Contains(t, err.Error(), "remaining deadline budget was insufficient")
+	assert.Contains(t, err.Error(), "next retry delay")
 }

--- a/e2e/tests/up/helper.go
+++ b/e2e/tests/up/helper.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/devsy-org/devsy/e2e/framework"
 	pkgconfig "github.com/devsy-org/devsy/pkg/config"
@@ -87,6 +88,19 @@ func (btc *baseTestContext) execSSH(ctx context.Context, tempDir, command string
 
 type dockerTestContext struct {
 	baseTestContext
+}
+
+// probeSSH bounds one readiness attempt. The polling window owns the overall
+// wait; a probe must not start the framework's multi-attempt SSH retry loop.
+func probeSSH(
+	f *framework.Framework,
+	ctx context.Context,
+	workspace string,
+	command string,
+) (string, error) {
+	probeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	return f.DevsySSHOnce(probeCtx, workspace, command)
 }
 
 func (dtc *dockerTestContext) setupAndUp(
@@ -174,7 +188,7 @@ func setupWorkspace(testdataPath, initialDir string, f *framework.Framework) (st
 		return "", err
 	}
 	ginkgo.DeferCleanup(framework.CleanupTempDir, initialDir, tempDir)
-	ginkgo.DeferCleanup(f.DevsyWorkspaceDelete, tempDir)
+	ginkgo.DeferCleanup(f.CleanupWorkspace, tempDir)
 	return tempDir, nil
 }
 

--- a/e2e/tests/up/provider_podman_rootful_lifecycle.go
+++ b/e2e/tests/up/provider_podman_rootful_lifecycle.go
@@ -144,7 +144,7 @@ var _ = ginkgo.Describe(
 						gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("updateContentDone"))
 
 						gomega.Eventually(func() string {
-							out, err := f.DevsySSH(
+							out, err := probeSSH(f,
 								ctx, tempDir, "cat $HOME/deferred.marker 2>/dev/null",
 							)
 							if err != nil {
@@ -165,7 +165,7 @@ var _ = ginkgo.Describe(
 						gomega.Expect(envPath).NotTo(gomega.ContainSubstring("${containerEnv:"))
 
 						gomega.Eventually(func() string {
-							out, err := f.DevsySSH(
+							out, err := probeSSH(f,
 								ctx,
 								tempDir,
 								"cat $HOME/post-start-deferred.out 2>/dev/null",
@@ -206,7 +206,7 @@ var _ = ginkgo.Describe(
 						framework.ExpectNoError(err)
 
 						gomega.Eventually(func() string {
-							out, err := f.DevsySSH(
+							out, err := probeSSH(f,
 								ctx, tempDir, "cat $HOME/post-attach.out 2>/dev/null",
 							)
 							if err != nil {

--- a/e2e/tests/up/provider_podman_rootful_lifecycle_2.go
+++ b/e2e/tests/up/provider_podman_rootful_lifecycle_2.go
@@ -83,7 +83,7 @@ var _ = ginkgo.Describe(
 						framework.ExpectNoError(err)
 
 						gomega.Eventually(func() string {
-							out, err := f.DevsySSH(
+							out, err := probeSSH(f,
 								ctx, tempDir, "cat $HOME/attach-count.out 2>/dev/null",
 							)
 							if err != nil {
@@ -98,7 +98,7 @@ var _ = ginkgo.Describe(
 						framework.ExpectNoError(err)
 
 						gomega.Eventually(func() string {
-							out, err := f.DevsySSH(
+							out, err := probeSSH(f,
 								ctx, tempDir, "cat $HOME/attach-count.out 2>/dev/null",
 							)
 							if err != nil {

--- a/e2e/tests/up/provider_podman_rootless_lifecycle.go
+++ b/e2e/tests/up/provider_podman_rootless_lifecycle.go
@@ -110,7 +110,7 @@ var _ = ginkgo.Describe(
 						gomega.Expect(strings.TrimSpace(out)).To(gomega.Equal("updateContentDone"))
 
 						gomega.Eventually(func() string {
-							out, err := f.DevsySSH(
+							out, err := probeSSH(f,
 								ctx, tempDir, "cat $HOME/deferred.marker 2>/dev/null",
 							)
 							if err != nil {
@@ -131,7 +131,7 @@ var _ = ginkgo.Describe(
 						gomega.Expect(envPath).NotTo(gomega.ContainSubstring("${containerEnv:"))
 
 						gomega.Eventually(func() string {
-							out, err := f.DevsySSH(
+							out, err := probeSSH(f,
 								ctx,
 								tempDir,
 								"cat $HOME/post-start-deferred.out 2>/dev/null",
@@ -172,7 +172,7 @@ var _ = ginkgo.Describe(
 						framework.ExpectNoError(err)
 
 						gomega.Eventually(func() string {
-							out, err := f.DevsySSH(
+							out, err := probeSSH(f,
 								ctx, tempDir, "cat $HOME/post-attach.out 2>/dev/null",
 							)
 							if err != nil {
@@ -200,7 +200,7 @@ var _ = ginkgo.Describe(
 						framework.ExpectNoError(err)
 
 						gomega.Eventually(func() string {
-							out, err := f.DevsySSH(
+							out, err := probeSSH(f,
 								ctx, tempDir, "cat $HOME/attach-count.out 2>/dev/null",
 							)
 							if err != nil {
@@ -215,7 +215,7 @@ var _ = ginkgo.Describe(
 						framework.ExpectNoError(err)
 
 						gomega.Eventually(func() string {
-							out, err := f.DevsySSH(
+							out, err := probeSSH(f,
 								ctx, tempDir, "cat $HOME/attach-count.out 2>/dev/null",
 							)
 							if err != nil {


### PR DESCRIPTION
## Summary

- Bound Docker and SSH retries by the caller deadline with shorter backoff.
- Added single-attempt, per-probe SSH readiness checks for Podman lifecycle tests.
- Made shared workspace cleanup use a fresh bounded context.
- Removed stale provider "already exists" suppression.
- Disabled same-runtime Ginkgo flake retries for all Podman shards.
- Run rootless Podman E2E tests under the intended non-root identity and log runtime identity details.

## Validation

- CodeRabbit CLI: clean, 0 findings across 8 changed files.
- `go test ./e2e/framework ./e2e/tests/up`
- `go test ./e2e/... -run "^$"`
- Workflow YAML parse check
- `git diff --check`

The full Podman integration suite was not run locally because this host is macOS; CI should provide the Linux Podman validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of container and SSH-based integration tests by handling transient connection failures more consistently.
  - Improved retry behavior with clearer timeout handling and shorter delays for Docker operations.
  - Updated rootless Podman test execution and diagnostics to better support non-privileged environments.
  - Improved workspace cleanup and recovery when existing test environments are detected.

- **Tests**
  - Extended selected lifecycle test timeouts and readiness checks to reduce intermittent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->